### PR TITLE
Account ID fix

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -9,16 +9,16 @@ generates:
         PersonalFinancialEntity: ./financialEntities.types.mjs#IGetFinancialEntitiesByIdsResult
         BankFinancialAccount: ./financialAccounts.types.mjs#IGetFinancialAccountsByFeIdsResult
         CardFinancialAccount: ./financialAccounts.types.mjs#IGetFinancialAccountsByFeIdsResult
-        Charge: ./charges.types.mjs#IGetChargesByFinancialAccountIdsResult
-        LedgerRecord: ./ledgerRecords.types.mjs#IGetLedgerRecordsByFinancialAccountIdsResult
+        Charge: ./charges.types.mjs#IGetChargesByFinancialAccountNumbersResult
+        LedgerRecord: ./ledgerRecords.types.mjs#IGetLedgerRecordsByFinancialAccountNumbersResult
         NamedCounterparty: string
         Invoice: ./sqlQueries.types.mjs#IGetEmailDocsResult
         Proforma: ./sqlQueries.types.mjs#IGetEmailDocsResult
         Receipt: ./sqlQueries.types.mjs#IGetEmailDocsResult
-        WireTransaction: ./charges.types.mjs#IGetChargesByFinancialAccountIdsResult
-        FeeTransaction: ./charges.types.mjs#IGetChargesByFinancialAccountIdsResult
-        ConversionTransaction: ./charges.types.mjs#IGetChargesByFinancialAccountIdsResult
-        CommonTransaction: ./charges.types.mjs#IGetChargesByFinancialAccountIdsResult
+        WireTransaction: ./charges.types.mjs#IGetChargesByFinancialAccountNumbersResult
+        FeeTransaction: ./charges.types.mjs#IGetChargesByFinancialAccountNumbersResult
+        ConversionTransaction: ./charges.types.mjs#IGetChargesByFinancialAccountNumbersResult
+        CommonTransaction: ./charges.types.mjs#IGetChargesByFinancialAccountNumbersResult
         BeneficiaryCounterparty: ../prototypes.mjs#BeneficiaryCounterpartyProto
         Unprocessed: ./sqlQueries.types.mjs#IGetEmailDocsResult
     plugins:

--- a/server/src/providers/charges.mts
+++ b/server/src/providers/charges.mts
@@ -1,15 +1,15 @@
 import pgQuery from '@pgtyped/query';
 import {
-  IGetChargesByFinancialAccountIdsQuery,
+  IGetChargesByFinancialAccountNumbersQuery,
   IGetChargesByFinancialEntityIdsQuery,
 } from '../__generated__/charges.types.mjs';
 
 const { sql } = pgQuery;
 
-export const getChargesByFinancialAccountIds = sql<IGetChargesByFinancialAccountIdsQuery>`
+export const getChargesByFinancialAccountNumbers = sql<IGetChargesByFinancialAccountNumbersQuery>`
     SELECT *
     FROM accounter_schema.all_transactions
-    WHERE account_number IN $$financialAccountIds
+    WHERE account_number IN $$financialAccountNumbers
     AND ($fromDate ::TEXT IS NULL OR event_date::TEXT::DATE >= date_trunc('day', $fromDate ::DATE))
     AND ($toDate ::TEXT IS NULL OR event_date::TEXT::DATE <= date_trunc('day', $toDate ::DATE))
     ORDER BY event_date DESC;`;

--- a/server/src/providers/financialAccounts.mts
+++ b/server/src/providers/financialAccounts.mts
@@ -1,5 +1,8 @@
 import pgQuery from '@pgtyped/query';
-import { IGetFinancialAccountsByFeIdsQuery } from '../__generated__/financialAccounts.types.mjs';
+import {
+  IGetFinancialAccountsByFeIdsQuery,
+  IGetFinancialAccountsByAccountNumbersQuery,
+} from '../__generated__/financialAccounts.types.mjs';
 
 const { sql } = pgQuery;
 
@@ -7,3 +10,8 @@ export const getFinancialAccountsByFeIds = sql<IGetFinancialAccountsByFeIdsQuery
     SELECT *
     FROM accounter_schema.financial_accounts
     WHERE owner IN $$financialEntityIds;`;
+
+export const getFinancialAccountsByAccountNumbers = sql<IGetFinancialAccountsByAccountNumbersQuery>`
+SELECT *
+FROM accounter_schema.financial_accounts
+WHERE account_number IN $$accountNumbers;`;

--- a/server/src/providers/ledgerRecords.mts
+++ b/server/src/providers/ledgerRecords.mts
@@ -1,7 +1,7 @@
 import pgQuery from '@pgtyped/query';
 import {
   IGetLedgerRecordsByChargeIdsQuery,
-  IGetLedgerRecordsByFinancialAccountIdsQuery,
+  IGetLedgerRecordsByFinancialAccountNumbersQuery,
   IGetLedgerRecordsByFinancialEntityIdsQuery,
 } from '../__generated__/ledgerRecords.types.mjs';
 
@@ -12,13 +12,13 @@ export const getLedgerRecordsByChargeIds = sql<IGetLedgerRecordsByChargeIdsQuery
     FROM accounter_schema.ledger
     WHERE original_id IN $$chargeIds;`;
 
-export const getLedgerRecordsByFinancialAccountIds = sql<IGetLedgerRecordsByFinancialAccountIdsQuery>`
+export const getLedgerRecordsByFinancialAccountNumbers = sql<IGetLedgerRecordsByFinancialAccountNumbersQuery>`
     SELECT *
     FROM accounter_schema.ledger
     WHERE original_id IN (
         SELECT id
         FROM accounter_schema.all_transactions
-        WHERE account_number IN $$financialAccountIds
+        WHERE account_number IN $$financialAccountNumbers
     );`;
 
 export const getLedgerRecordsByFinancialEntityIds = sql<IGetLedgerRecordsByFinancialEntityIdsQuery>`


### PR DESCRIPTION
Fix `invalid input syntax for type uuid` error on accounts
Better semantics for account numbers/IDs
(Not in the PR's scope but related: added `id` column to `financial_accounts` DB table)