### PR TITLE
Fix: remove "missing" VAT indication for credit card charges

### DIFF
--- a/packages/client/src/components/all-charges/cells/vat.tsx
+++ b/packages/client/src/components/all-charges/cells/vat.tsx
@@ -69,7 +69,7 @@ export const Vat = ({ data }: Props): ReactElement => {
     <td>
       <div style={{ color: vatIssueFlag ? 'red' : 'green', whiteSpace: 'nowrap' }}>
         <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
-          {vat ? vat.formatted : vatIssueFlag ? 'Missing' : null}
+          {vat?.formatted}
         </Indicator>
       </div>
     </td>


### PR DESCRIPTION
closes #545