### PR TITLE
Convert all buttons to shadcn

### DIFF
--- a/packages/client/src/components/common/buttons/button-image.tsx
+++ b/packages/client/src/components/common/buttons/button-image.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, MouseEventHandler, ReactElement } from 'react';
-import { Button } from '@mantine/core';
+import { Button } from '../../ui/button.js';
 
 export interface ButtonProps {
   onClick?: MouseEventHandler<HTMLButtonElement>;
@@ -28,7 +28,8 @@ export const ButtonImage = ({
       type={type}
       disabled={buttonDisabled}
       onClick={onClick}
-      style={{ width: 100, height: 100, backgroundColor: 'transparent', cursor: 'pointer' }}
+      variant="ghost"
+      className="w-[100px] h-[100px] bg-transparent cursor-pointer"
     >
       {children}
     </Button>

--- a/packages/client/src/components/common/buttons/button-with-label.tsx
+++ b/packages/client/src/components/common/buttons/button-with-label.tsx
@@ -1,4 +1,5 @@
 import { CSSProperties, MouseEventHandler, ReactElement } from 'react';
+import { Button } from '../../ui/button.js';
 
 export interface ButtonWithLabelProps {
   onClick?: MouseEventHandler<HTMLButtonElement>;
@@ -25,16 +26,22 @@ export const ButtonWithLabel = ({
     <div>
       <label className="text-sm font-medium text-gray-700">{textLabel}</label>
       <div>
-        <button
+        <Button
           style={style}
           type={type}
           onClick={onClick}
-          className="bg-gray-100 border focus:ring-2 focus:ring-indigo-200 focus:bg-transparent hover:bg-indigo-500 hover:text-white text-base outline-hidden text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out sm:text-sm rounded-md"
+          variant="outline"
+          className="w-full"
+          asChild={!!url}
         >
-          <a rel={rel} target={target} href={url} type={type}>
-            {title}
-          </a>
-        </button>
+          {url ? (
+            <a rel={rel} target={target} href={url}>
+              {title}
+            </a>
+          ) : (
+            title
+          )}
+        </Button>
       </div>
     </div>
   );

--- a/packages/client/src/components/common/buttons/button.tsx
+++ b/packages/client/src/components/common/buttons/button.tsx
@@ -5,6 +5,7 @@ import {
   MouseEventHandler,
   ReactElement,
 } from 'react';
+import { Button as ShadcnButton } from '../../ui/button.js';
 
 export interface Props
   extends DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
@@ -29,16 +30,21 @@ export const Button = ({
   ...props
 }: Props): ReactElement => {
   return (
-    <button
+    <ShadcnButton
       style={style}
       type={type}
       onClick={onClick}
-      className="cursor: pointer text-align: center flex ml-auto text-white bg-indigo-500 border-0 py-1.5 px-3 focus:outline-hidden hover:bg-indigo-600 rounded-sm;"
+      className="ml-auto"
+      asChild={!!herf}
       {...props}
     >
-      <a rel={rel} target={target} href={herf} type={type}>
-        {title}
-      </a>
-    </button>
+      {herf ? (
+        <a rel={rel} target={target} href={herf}>
+          {title}
+        </a>
+      ) : (
+        title
+      )}
+    </ShadcnButton>
   );
 };

--- a/packages/client/src/components/common/buttons/charge-navigate-button.tsx
+++ b/packages/client/src/components/common/buttons/charge-navigate-button.tsx
@@ -1,15 +1,13 @@
 import { ReactElement } from 'react';
 import { ExternalLink } from 'tabler-icons-react';
-import { ActionIcon, ActionIconProps, Tooltip } from '@mantine/core';
-import { PolymorphicComponentProps } from '@mantine/utils';
+import { Tooltip } from '@mantine/core';
+import { ActionIcon } from '../../ui/action-icon.js';
 
-export function ChargeNavigateButton(
-  props: PolymorphicComponentProps<'button', ActionIconProps> & { chargeId: string },
-): ReactElement {
+export function ChargeNavigateButton(props: { chargeId: string }): ReactElement {
   return (
     <Tooltip label="To Charge">
       <ActionIcon
-        onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+        onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
           event.stopPropagation();
           window.open(`/charges/${props.chargeId}`, '_blank', 'noreferrer');
         }}

--- a/packages/client/src/components/common/buttons/confirm-mini-button.tsx
+++ b/packages/client/src/components/common/buttons/confirm-mini-button.tsx
@@ -1,13 +1,10 @@
 import { ReactElement } from 'react';
 import { Check } from 'tabler-icons-react';
-import { ActionIcon, ActionIconProps } from '@mantine/core';
-import { PolymorphicComponentProps } from '@mantine/utils';
+import { ActionIcon } from '../../ui/action-icon.js';
 
-export function ConfirmMiniButton(
-  props: PolymorphicComponentProps<'button', ActionIconProps> & {
-    onClick: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
-  },
-): ReactElement {
+export function ConfirmMiniButton(props: {
+  onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}): ReactElement {
   return (
     <ActionIcon color="green" {...props}>
       <Check size={20} />

--- a/packages/client/src/components/common/buttons/copy-to-clipboard-button.tsx
+++ b/packages/client/src/components/common/buttons/copy-to-clipboard-button.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from 'react';
 import { Copy, Link } from 'tabler-icons-react';
-import { ActionIcon } from '@mantine/core';
 import { writeToClipboard } from '../../../helpers/index.js';
+import { ActionIcon } from '../../ui/action-icon.js';
 
 interface Props {
   content: string;
@@ -10,7 +10,7 @@ interface Props {
 
 export const CopyToClipboardButton = ({ content, isLink }: Props): ReactElement => {
   return (
-    <ActionIcon variant="default" onClick={(): void => writeToClipboard(content)} size={30}>
+    <ActionIcon variant="outline" onClick={(): void => writeToClipboard(content)} size={30}>
       {isLink ? <Link size={20} /> : <Copy size={20} />}
     </ActionIcon>
   );

--- a/packages/client/src/components/common/buttons/delete-charge-button.tsx
+++ b/packages/client/src/components/common/buttons/delete-charge-button.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, useState } from 'react';
 import { Trash } from 'tabler-icons-react';
-import { ActionIcon } from '@mantine/core';
 import { useDeleteCharge } from '../../../hooks/use-delete-charge.js';
+import { ActionIcon } from '../../ui/action-icon.js';
 import { ConfirmationModal } from '../index.js';
 
 interface Props {

--- a/packages/client/src/components/common/buttons/delete-document-button.tsx
+++ b/packages/client/src/components/common/buttons/delete-document-button.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, useState } from 'react';
 import { Trash } from 'tabler-icons-react';
-import { ActionIcon } from '@mantine/core';
 import { useDeleteDocument } from '../../../hooks/use-delete-document.js';
+import { ActionIcon } from '../../ui/action-icon.js';
 import { ConfirmationModal } from '../index.js';
 
 interface Props {

--- a/packages/client/src/components/common/buttons/delete-misc-expense-button.tsx
+++ b/packages/client/src/components/common/buttons/delete-misc-expense-button.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, useState } from 'react';
 import { Trash } from 'tabler-icons-react';
-import { ActionIcon } from '@mantine/core';
 import { useDeleteMiscExpense } from '../../../hooks/use-delete-misc-expense.js';
+import { ActionIcon } from '../../ui/action-icon.js';
 import { ConfirmationModal } from '../index.js';
 
 interface Props {

--- a/packages/client/src/components/common/buttons/edit-mini-button.tsx
+++ b/packages/client/src/components/common/buttons/edit-mini-button.tsx
@@ -1,13 +1,12 @@
 import { ReactElement } from 'react';
 import { Edit } from 'tabler-icons-react';
-import { ActionIcon, Tooltip } from '@mantine/core';
+import { Tooltip } from '@mantine/core';
+import { ActionIcon } from '../../ui/action-icon.js';
 
-export function EditMiniButton(
-  props: React.ComponentProps<typeof ActionIcon> & {
-    tooltip?: string;
-    onClick: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void;
-  },
-): ReactElement {
+export function EditMiniButton(props: {
+  tooltip?: string;
+  onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}): ReactElement {
   return (
     <Tooltip disabled={!props.tooltip} label={props.tooltip}>
       <ActionIcon {...props}>

--- a/packages/client/src/components/common/buttons/info-mini-button.tsx
+++ b/packages/client/src/components/common/buttons/info-mini-button.tsx
@@ -1,11 +1,8 @@
 import { ReactElement } from 'react';
 import { InfoCircle } from 'tabler-icons-react';
-import { ActionIcon, ActionIconProps } from '@mantine/core';
-import { PolymorphicComponentProps } from '@mantine/utils';
+import { ActionIcon } from '../../ui/action-icon.js';
 
-export function InfoMiniButton(
-  props: PolymorphicComponentProps<'button', ActionIconProps>,
-): ReactElement {
+export function InfoMiniButton(props: React.ComponentProps<typeof ActionIcon>): ReactElement {
   return (
     <ActionIcon {...props}>
       <InfoCircle size={20} />

--- a/packages/client/src/components/common/buttons/insert-mini-button.tsx
+++ b/packages/client/src/components/common/buttons/insert-mini-button.tsx
@@ -1,11 +1,12 @@
 import { ReactElement } from 'react';
 import { RowInsertTop } from 'tabler-icons-react';
-import { ActionIcon, ActionIconProps, Tooltip } from '@mantine/core';
-import { PolymorphicComponentProps } from '@mantine/utils';
+import { Tooltip } from '@mantine/core';
+import { ActionIcon } from '../../ui/action-icon.js';
 
-export function InsertMiniButton(
-  props: PolymorphicComponentProps<'button', ActionIconProps> & { tooltip?: string },
-): ReactElement {
+export function InsertMiniButton(props: {
+  tooltip?: string;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}): ReactElement {
   return (
     <Tooltip disabled={!props.tooltip} label={props.tooltip}>
       <ActionIcon {...props}>

--- a/packages/client/src/components/common/buttons/regenerate-ledger-records-button.tsx
+++ b/packages/client/src/components/common/buttons/regenerate-ledger-records-button.tsx
@@ -1,19 +1,16 @@
 import { ReactElement, useState } from 'react';
 import { RefreshDot } from 'tabler-icons-react';
-import { ActionIcon, ActionIconProps, Tooltip } from '@mantine/core';
+import { Tooltip } from '@mantine/core';
 import { useRegenerateLedgerRecords } from '../../../hooks/use-regenerate-ledger-records.js';
+import { ActionIcon } from '../../ui/action-icon.js';
 import { ConfirmationModal } from '../index.js';
 
 type Props = {
   chargeId: string;
   onChange: () => void;
-} & ActionIconProps;
+};
 
-export function RegenerateLedgerRecordsButton({
-  chargeId,
-  onChange,
-  ...buttonProps
-}: Props): ReactElement {
+export function RegenerateLedgerRecordsButton({ chargeId, onChange }: Props): ReactElement {
   const [opened, setOpened] = useState(false);
   const { regenerateLedgerRecords } = useRegenerateLedgerRecords();
 
@@ -34,11 +31,10 @@ export function RegenerateLedgerRecordsButton({
       />
       <Tooltip label="Regenerate Ledger">
         <ActionIcon
-          onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
+          onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
             event.stopPropagation();
             setOpened(true);
           }}
-          {...buttonProps}
         >
           <RefreshDot size={20} />
         </ActionIcon>

--- a/packages/client/src/components/common/buttons/toggle-expansion-button.tsx
+++ b/packages/client/src/components/common/buttons/toggle-expansion-button.tsx
@@ -1,6 +1,7 @@
 import { ReactElement } from 'react';
 import { LayoutNavbarCollapse, LayoutNavbarExpand } from 'tabler-icons-react';
-import { ActionIcon, Tooltip } from '@mantine/core';
+import { Tooltip } from '@mantine/core';
+import { ActionIcon } from '../../ui/action-icon.js';
 
 export function ToggleExpansionButton(props: {
   toggleExpansion: (value: React.SetStateAction<boolean>) => void;
@@ -12,8 +13,8 @@ export function ToggleExpansionButton(props: {
   return (
     <Tooltip label="Expand info">
       <ActionIcon
-        variant="default"
-        onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
+        variant="outline"
+        onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
           event.stopPropagation();
           toggleExpansion(i => {
             if (onClickAction) {

--- a/packages/client/src/components/common/buttons/toggle-merge-selected.tsx
+++ b/packages/client/src/components/common/buttons/toggle-merge-selected.tsx
@@ -1,26 +1,25 @@
 import { ReactElement, useEffect, useState } from 'react';
 import { ArrowsJoin2 } from 'tabler-icons-react';
-import { ActionIcon, ActionIconProps, Tooltip } from '@mantine/core';
+import { Tooltip } from '@mantine/core';
+import { ActionIcon } from '../../ui/action-icon.js';
 
 export function ToggleMergeSelected(props: {
   toggleMergeSelected: () => void;
   mergeSelected: boolean;
 }): ReactElement {
   const { mergeSelected, toggleMergeSelected } = props;
-  const [variant, setVariant] = useState<ActionIconProps['variant']>(
-    mergeSelected ? 'filled' : 'subtle',
-  );
+  const [variant, setVariant] = useState<'ghost' | 'default'>(mergeSelected ? 'default' : 'ghost');
   const [color, setColor] = useState<'blue' | 'gray'>(mergeSelected ? 'blue' : 'gray');
 
   useEffect(() => {
-    setVariant(mergeSelected ? 'filled' : 'subtle');
+    setVariant(mergeSelected ? 'default' : 'ghost');
     setColor(mergeSelected ? 'blue' : 'gray');
   }, [mergeSelected]);
 
   return (
     <Tooltip label="Select for merge">
       <ActionIcon
-        onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
+        onClick={(event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
           event.stopPropagation();
           toggleMergeSelected();
         }}
@@ -28,7 +27,7 @@ export function ToggleMergeSelected(props: {
         color={color}
         className={mergeSelected ? 'bg-blue-500' : undefined}
       >
-        <ArrowsJoin2 size={20} color={color} />
+        <ArrowsJoin2 size={20} />
       </ActionIcon>
     </Tooltip>
   );

--- a/packages/client/src/components/common/buttons/unlink-document-button.tsx
+++ b/packages/client/src/components/common/buttons/unlink-document-button.tsx
@@ -1,8 +1,8 @@
 import { ReactElement, useState } from 'react';
 import { PlugConnectedX } from 'tabler-icons-react';
-import { ActionIcon } from '@mantine/core';
 import { EMPTY_UUID } from '../../../helpers/index.js';
 import { useUpdateDocument } from '../../../hooks/use-update-document.js';
+import { ActionIcon } from '../../ui/action-icon.js';
 import { ConfirmationModal } from '../index.js';
 
 interface Props {

--- a/packages/client/src/components/common/modals/confirmation-modal.tsx
+++ b/packages/client/src/components/common/modals/confirmation-modal.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
 import { Modal, ModalProps } from '@mantine/core';
+import { Button } from '../../ui/button.js';
 
 interface Props extends ModalProps {
   labels?: { cancel?: string; confirm?: string };
@@ -23,18 +24,12 @@ export function ConfirmationModal({
           )}
           {children}
           <div className="flex mx-auto flex-row justify-evenly">
-            <button
-              onClick={props.onClose}
-              className="flex mt-6 text-white bg-red-500 border-0 py-2 px-5 focus:outline-hidden hover:bg-red-600 rounded-sm"
-            >
+            <Button onClick={props.onClose} variant="destructive" className="mt-6">
               {labels.cancel}
-            </button>
-            <button
-              onClick={onConfirm}
-              className="flex mt-6 text-white bg-indigo-500 border-0 py-2 px-5 focus:outline-hidden hover:bg-indigo-600 rounded-sm"
-            >
+            </Button>
+            <Button onClick={onConfirm} className="mt-6">
               {labels.confirm}
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/packages/client/src/components/common/modals/insert-business-trip-modal.tsx
+++ b/packages/client/src/components/common/modals/insert-business-trip-modal.tsx
@@ -1,7 +1,8 @@
 import { ReactElement } from 'react';
 import { WorldUpload } from 'tabler-icons-react';
-import { ActionIcon, Modal, Tooltip } from '@mantine/core';
+import { Modal, Tooltip } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
+import { ActionIcon } from '../../ui/action-icon.js';
 import { InsertBusinessTrip } from '../index.js';
 
 interface Props {

--- a/packages/client/src/components/ui/action-icon.tsx
+++ b/packages/client/src/components/ui/action-icon.tsx
@@ -1,0 +1,36 @@
+import { ReactElement } from 'react';
+import { cn } from '../../lib/utils.js';
+import { Button, ButtonProps } from './button.js';
+
+export interface ActionIconProps extends Omit<ButtonProps, 'size'> {
+  size?: number;
+  color?: 'default' | 'blue' | 'red' | 'green' | 'gray';
+}
+
+const colorVariants = {
+  default: '',
+  blue: 'text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-500',
+  red: 'text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-500',
+  green: 'text-green-500 hover:text-green-600 dark:text-green-400 dark:hover:text-green-500',
+  gray: 'text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-500',
+};
+
+export function ActionIcon({
+  children,
+  className,
+  size = 30,
+  color = 'default',
+  variant = 'ghost',
+  ...props
+}: ActionIconProps): ReactElement {
+  return (
+    <Button
+      variant={variant}
+      size="icon"
+      className={cn(`w-[${size}px] h-[${size}px] p-0`, colorVariants[color], className)}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
+}


### PR DESCRIPTION
Use Cursor to do this for me. We'll need to check over in the UI more that it all makes sense.

Can do the same thing for more complicated mantine components later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a custom Action Icon component that offers enhanced styling and flexible integration into interactive elements.

- **Refactor**
  - Updated various button and modal components to utilize a unified, internally maintained UI system.
  - Simplified properties and event handling across interactive elements for a more consistent experience.

- **Style**
  - Refined button appearance using variant-based styling, ensuring a cohesive look and feel throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->