### PR TITLE
Don't crash app if hive/drive not set up

### DIFF
--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -57,14 +57,14 @@ const AuthorizationModel = zod.object({
 
 const HiveModel = zod.union([
   zod.object({
-    HIVE_TOKEN: zod.string(),
+    HIVE_TOKEN: zod.string().optional(),
   }),
   zod.void(),
 ]);
 
 const GoogleModel = zod.union([
   zod.object({
-    GOOGLE_DRIVE_API_KEY: zod.string(),
+    GOOGLE_DRIVE_API_KEY: zod.string().optional(),
   }),
   zod.void(),
 ]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced configuration handling: Integration tokens for Hive and Google Drive are now optional, reducing errors during deployment when these values aren’t provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->