### PR TITLE
Fix: generate exchange rates where multiple businesses are unbalanced but only one unflagged by DB

### DIFF
--- a/packages/server/src/modules/ledger/resolvers/ledger-generation/common-ledger-generation.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger-generation/common-ledger-generation.resolver.ts
@@ -374,8 +374,10 @@ export const generateLedgerRecordsForCommonCharge: ResolverFn<
 
       const mightRequireExchangeRateRecord =
         (hasMultipleDates && !!foreignCurrencyCount) || foreignCurrencyCount >= 2;
-      const unbalancedBusinesses = unbalancedEntities.filter(({ entityId }) =>
-        financialEntities.some(fe => fe.id === entityId && fe.type === 'business'),
+      const unbalancedBusinesses = unbalancedEntities.filter(
+        ({ entityId }) =>
+          financialEntities.some(fe => fe.id === entityId && fe.type === 'business') &&
+          !allowedUnbalancedBusinesses.has(entityId),
       );
 
       if (mightRequireExchangeRateRecord && unbalancedBusinesses.length === 1) {


### PR DESCRIPTION
close #1797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined the ledger generation process to more accurately filter out certain business entries, ensuring that only truly unbalanced records are flagged. This update improves the consistency and reliability of financial reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->