### PR TITLE
Enable filtering charges without receipts

### DIFF
--- a/packages/client/src/components/charges/charges-filters.tsx
+++ b/packages/client/src/components/charges/charges-filters.tsx
@@ -367,6 +367,12 @@ function ChargesFiltersForm({
             />
 
             <Switch
+              defaultChecked={filter.withoutReceipt ?? false}
+              onChange={(event): void => setValue('withoutReceipt', event.currentTarget.checked)}
+              label="Without Receipts"
+            />
+
+            <Switch
               defaultChecked={filter.withoutDocuments ?? false}
               onChange={(event): void => setValue('withoutDocuments', event.currentTarget.checked)}
               label="Without Documents"

--- a/packages/server/src/modules/charges/providers/charges.provider.ts
+++ b/packages/server/src/modules/charges/providers/charges.provider.ts
@@ -165,6 +165,7 @@ const getChargesByFilters = sql<IGetChargesByFiltersQuery>`
   AND ($toAnyDate ::TEXT IS NULL OR LEAST(ec.documents_min_date, ec.transactions_min_event_date, ec.transactions_min_debit_date, ec.ledger_min_invoice_date, ec.ledger_min_value_date)::TEXT::DATE <= date_trunc('day', $toAnyDate ::DATE))
   AND ($chargeType = 'ALL' OR ($chargeType = 'INCOME' AND ec.transactions_event_amount > 0) OR ($chargeType = 'EXPENSE' AND ec.transactions_event_amount <= 0))
   AND ($withoutInvoice = FALSE OR COALESCE(ec.invoices_count, 0) = 0)
+  AND ($withoutReceipt = FALSE OR COALESCE(ec.receipts_count, 0) = 0)
   AND ($withoutDocuments = FALSE OR COALESCE(ec.documents_count, 0) = 0)
   AND ($withoutTransactions = FALSE OR COALESCE(ec.transactions_count, 0) = 0)
   AND ($withoutLedger = FALSE OR COALESCE(ec.ledger_count, 0) = 0)
@@ -340,6 +341,7 @@ export class ChargesProvider {
       tags: isTags ? (params.tags! as string[]) : null,
       chargeType: params.chargeType ?? 'ALL',
       withoutInvoice: params.withoutInvoice ?? false,
+      withoutReceipt: params.withoutReceipt ?? false,
       withoutDocuments: params.withoutDocuments ?? false,
       withoutTransactions: params.withoutTransactions ?? false,
       withoutLedger: params.withoutLedger ?? false,

--- a/packages/server/src/modules/charges/resolvers/charges.resolver.ts
+++ b/packages/server/src/modules/charges/resolvers/charges.resolver.ts
@@ -82,6 +82,7 @@ export const chargesResolvers: ChargesModule.Resolvers &
           chargeType: filters?.chargesType,
           businessIds: filters?.byBusinesses,
           withoutInvoice: filters?.withoutInvoice,
+          withoutReceipt: filters?.withoutReceipt,
           withoutDocuments: filters?.withoutDocuments,
           withoutTransactions: filters?.withoutTransactions,
           withoutLedger: filters?.withoutLedger,

--- a/packages/server/src/modules/charges/typeDefs/charge-validation.graphql.ts
+++ b/packages/server/src/modules/charges/typeDefs/charge-validation.graphql.ts
@@ -72,6 +72,8 @@ export default gql`
     withoutDocuments: Boolean
     " Include only charges that doesn't have invoice document linked "
     withoutInvoice: Boolean
+    " Include only charges that doesn't have receipt document linked "
+    withoutReceipt: Boolean
     " Include only charges that are not balances "
     unbalanced: Boolean
     " Include only charges that doesn't have ledger records linked "

--- a/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
@@ -58,6 +58,7 @@ export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'Generate
           chargeType: filters?.chargesType,
           businessIds: filters?.byBusinesses,
           withoutInvoice: filters?.withoutInvoice,
+          withoutReceipt: filters?.withoutReceipt,
           withoutDocuments: filters?.withoutDocuments,
           withoutLedger: filters?.withoutLedger,
           tags: filters?.byTags,


### PR DESCRIPTION
close #1807


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new toggle in the charges filter that lets users include or exclude charges based on receipt presence.
  - Enhanced the filtering logic across the system to support this option, ensuring a more tailored view of charge records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->