### PR TITLE
Introduce optional-documents flag for charges

### DIFF
--- a/packages/client/src/components/common/forms/edit-charge.tsx
+++ b/packages/client/src/components/common/forms/edit-charge.tsx
@@ -287,6 +287,14 @@ export const EditCharge = ({ charge, close, onChange }: Props): ReactElement => 
               <Switch {...field} checked={value === true} label="Optional VAT" />
             )}
           />
+          <Controller
+            name="optionalDocuments"
+            control={chargeControl}
+            defaultValue={charge.optionalDocuments ?? false}
+            render={({ field: { value, ...field } }): ReactElement => (
+              <Switch {...field} checked={value === true} label="Optional Documents" />
+            )}
+          />
           <ChargeSpreadInput formManager={formManager} chargeSpreadPath="yearsOfRelevance" />
         </SimpleGrid>
       </div>

--- a/packages/client/src/components/common/merge-charges/merge-charges-selection-form.tsx
+++ b/packages/client/src/components/common/merge-charges/merge-charges-selection-form.tsx
@@ -34,6 +34,7 @@ import { AccounterLoader, ListCapsule } from '../index.js';
       isInvoicePaymentDifferentCurrency
       userDescription
       optionalVAT
+      optionalDocuments
     }
   }
 `;
@@ -65,6 +66,9 @@ export function MergeChargesSelectionForm({ chargeIds, onDone, resetMerge }: Pro
     { id: string; value: boolean } | undefined
   >(undefined);
   const [selectedOptionalVAT, setSelectedOptionalVAT] = useState<
+    { id: string; value: boolean } | undefined
+  >(undefined);
+  const [selectedOptionalDocuments, setSelectedOptionalDocuments] = useState<
     { id: string; value: boolean } | undefined
   >(undefined);
   const [selectedConversion, setSelectedConversion] = useState<
@@ -128,11 +132,21 @@ export function MergeChargesSelectionForm({ chargeIds, onDone, resetMerge }: Pro
         isProperty: selectedProperty.value,
       };
     }
-    if (selectedOptionalVAT && selectedOptionalVAT.value !== mainCharge.property) {
+    if (selectedOptionalVAT && selectedOptionalVAT.value !== mainCharge.optionalVAT) {
       fields ??= {};
       fields = {
         ...fields,
         optionalVAT: selectedOptionalVAT.value,
+      };
+    }
+    if (
+      selectedOptionalDocuments &&
+      selectedOptionalDocuments.value !== mainCharge.optionalDocuments
+    ) {
+      fields ??= {};
+      fields = {
+        ...fields,
+        optionalDocuments: selectedOptionalDocuments.value,
       };
     }
     if (selectedTags && selectedTags.value !== mainCharge.tags.map(tag => tag.name).join(',')) {
@@ -219,6 +233,10 @@ export function MergeChargesSelectionForm({ chargeIds, onDone, resetMerge }: Pro
                         setSelectedOptionalVAT({
                           id: charge.id,
                           value: charge.optionalVAT ?? false,
+                        });
+                        setSelectedOptionalDocuments({
+                          id: charge.id,
+                          value: charge.optionalDocuments ?? false,
                         });
                         setSelectedCurrencyDiff({
                           id: charge.id,
@@ -377,6 +395,41 @@ export function MergeChargesSelectionForm({ chargeIds, onDone, resetMerge }: Pro
                       }
                     >
                       {charge.optionalVAT ? (
+                        <SquareCheck size={20} color="green" />
+                      ) : (
+                        <SquareX size={20} color="red" />
+                      )}
+                    </div>
+                  </button>
+                </td>
+              ))}
+            </tr>
+            <tr>
+              <th>Optional Documents</th>
+              {charges.map(charge => (
+                <td key={charge.id}>
+                  <button
+                    className="w-full px-2"
+                    disabled={
+                      charge.optionalDocuments == null ||
+                      charge.optionalDocuments === selectedOptionalDocuments?.value
+                    }
+                    onClick={(): void => {
+                      setSelectedOptionalDocuments({
+                        id: charge.id,
+                        value: charge.optionalDocuments ?? false,
+                      });
+                    }}
+                  >
+                    <div
+                      className="flex items-center justify-center px-2 py-2 border-x-2"
+                      style={
+                        selectedOptionalDocuments?.id === charge.id
+                          ? { background: '#228be633' }
+                          : {}
+                      }
+                    >
+                      {charge.optionalDocuments ? (
                         <SquareCheck size={20} color="green" />
                       ) : (
                         <SquareX size={20} color="red" />

--- a/packages/client/src/components/common/modals/edit-charge-modal.tsx
+++ b/packages/client/src/components/common/modals/edit-charge-modal.tsx
@@ -29,6 +29,7 @@ import { CopyToClipboardButton, EditCharge, PopUpDrawer } from '../index.js';
         id
       }
       optionalVAT
+      optionalDocuments
       ... on BusinessTripCharge {
         businessTrip {
           id

--- a/packages/migrations/src/actions/2025-03-10T16-21-31.charge-no-docs-flag.ts
+++ b/packages/migrations/src/actions/2025-03-10T16-21-31.charge-no-docs-flag.ts
@@ -1,0 +1,239 @@
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+export default {
+  name: '2025-03-10T16-21-31.charge-no-docs-flag.sql',
+  run: ({ sql }) => sql`
+alter table accounter_schema.charges
+       add documents_optional_flag boolean default FALSE not null;
+
+       create or replace view accounter_schema.extended_charges
+            (id, owner_id, is_property, accountant_status, user_description, created_at, updated_at, tax_category_id,
+             event_amount, transactions_min_event_date, transactions_max_event_date, transactions_min_debit_date,
+             transactions_max_debit_date, transactions_event_amount, transactions_currency, transactions_count,
+             invalid_transactions, documents_min_date, documents_max_date, documents_event_amount, documents_vat_amount,
+             documents_currency, invoices_count, receipts_count, documents_count, invalid_documents, business_array,
+             business_id, can_settle_with_receipt, tags, business_trip_id, ledger_count, ledger_financial_entities,
+             ledger_min_value_date, ledger_max_value_date, ledger_min_invoice_date, ledger_max_invoice_date,
+             years_of_relevance, invoice_payment_currency_diff, type, optional_vat, no_invoices_required, documents_optional_flag)
+as
+WITH years_of_relevance AS (SELECT charge_spread.charge_id,
+                                   array_agg(charge_spread.year_of_relevance) AS years_of_relevance
+                            FROM accounter_schema.charge_spread
+                            GROUP BY charge_spread.charge_id),
+     transactions_by_charge AS (SELECT extended_transactions.charge_id,
+                                       min(extended_transactions.event_date)                                AS min_event_date,
+                                       max(extended_transactions.event_date)                                AS max_event_date,
+                                       min(extended_transactions.debit_date)                                AS min_debit_date,
+                                       max(extended_transactions.debit_date)                                AS max_debit_date,
+                                       sum(extended_transactions.amount)                                    AS event_amount,
+                                       count(*)                                                             AS transactions_count,
+                                       count(*) FILTER (WHERE extended_transactions.business_id IS NULL OR
+                                                              extended_transactions.debit_date IS NULL) >
+                                       0                                                                    AS invalid_transactions,
+                                       array_agg(DISTINCT extended_transactions.currency)                   AS currency_array,
+                                       array_agg(extended_transactions.account_id)                          AS account
+                                FROM accounter_schema.extended_transactions
+                                GROUP BY extended_transactions.charge_id),
+     documents_by_charge AS (SELECT documents.charge_id,
+                                    min(documents.date) FILTER (WHERE documents.type = ANY
+                                                                      (ARRAY ['INVOICE'::accounter_schema.document_type, 'INVOICE_RECEIPT'::accounter_schema.document_type, 'RECEIPT'::accounter_schema.document_type, 'CREDIT_INVOICE'::accounter_schema.document_type])) AS min_event_date,
+                                    max(documents.date) FILTER (WHERE documents.type = ANY
+                                                                      (ARRAY ['INVOICE'::accounter_schema.document_type, 'INVOICE_RECEIPT'::accounter_schema.document_type, 'RECEIPT'::accounter_schema.document_type, 'CREDIT_INVOICE'::accounter_schema.document_type])) AS max_event_date,
+                                    sum(documents.total_amount *
+                                        CASE
+                                            WHEN documents.creditor_id = charges.owner_id THEN 1
+                                            ELSE '-1'::integer
+                                            END::double precision)
+                                    FILTER (WHERE businesses.can_settle_with_receipt = true AND (documents.type = ANY
+                                                                                                 (ARRAY ['RECEIPT'::accounter_schema.document_type, 'INVOICE_RECEIPT'::accounter_schema.document_type])))                                                                  AS receipt_event_amount,
+                                    sum(documents.total_amount *
+                                        CASE
+                                            WHEN documents.creditor_id = charges.owner_id THEN 1
+                                            ELSE '-1'::integer
+                                            END::double precision) FILTER (WHERE documents.type = ANY
+                                                                                 (ARRAY ['INVOICE'::accounter_schema.document_type, 'INVOICE_RECEIPT'::accounter_schema.document_type, 'CREDIT_INVOICE'::accounter_schema.document_type]))                                 AS invoice_event_amount,
+                                    sum(documents.vat_amount *
+                                        CASE
+                                            WHEN documents.creditor_id = charges.owner_id THEN 1
+                                            ELSE '-1'::integer
+                                            END::double precision)
+                                    FILTER (WHERE businesses.can_settle_with_receipt = true AND (documents.type = ANY
+                                                                                                 (ARRAY ['RECEIPT'::accounter_schema.document_type, 'INVOICE_RECEIPT'::accounter_schema.document_type])))                                                                  AS receipt_vat_amount,
+                                    sum(documents.vat_amount *
+                                        CASE
+                                            WHEN documents.creditor_id = charges.owner_id THEN 1
+                                            ELSE '-1'::integer
+                                            END::double precision) FILTER (WHERE documents.type = ANY
+                                                                                 (ARRAY ['INVOICE'::accounter_schema.document_type, 'INVOICE_RECEIPT'::accounter_schema.document_type, 'CREDIT_INVOICE'::accounter_schema.document_type]))                                 AS invoice_vat_amount,
+                                    count(*) FILTER (WHERE documents.type = ANY
+                                                           (ARRAY ['INVOICE'::accounter_schema.document_type, 'INVOICE_RECEIPT'::accounter_schema.document_type, 'CREDIT_INVOICE'::accounter_schema.document_type]))                                                       AS invoices_count,
+                                    count(*) FILTER (WHERE documents.type = ANY
+                                                           (ARRAY ['RECEIPT'::accounter_schema.document_type, 'INVOICE_RECEIPT'::accounter_schema.document_type]))                                                                                                         AS receipts_count,
+                                    count(*)                                                                                                                                                                                                                               AS documents_count,
+                                    count(*) FILTER (WHERE (documents.type = ANY
+                                                            (ARRAY ['INVOICE'::accounter_schema.document_type, 'INVOICE_RECEIPT'::accounter_schema.document_type, 'RECEIPT'::accounter_schema.document_type, 'CREDIT_INVOICE'::accounter_schema.document_type])) AND
+                                                           (documents.debtor_id IS NULL OR
+                                                            documents.creditor_id IS NULL OR documents.date IS NULL OR
+                                                            documents.serial_number IS NULL OR
+                                                            documents.vat_amount IS NULL OR
+                                                            documents.total_amount IS NULL OR
+                                                            documents.charge_id IS NULL OR
+                                                            documents.currency_code IS NULL) OR documents.type =
+                                                                                                'UNPROCESSED'::accounter_schema.document_type) >
+                                    0                                                                                                                                                                                                                                      AS invalid_documents,
+                                    array_agg(documents.currency_code) FILTER (WHERE
+                                        businesses.can_settle_with_receipt = true AND (documents.type = ANY
+                                                                                       (ARRAY ['RECEIPT'::accounter_schema.document_type, 'INVOICE_RECEIPT'::accounter_schema.document_type])) OR
+                                        (documents.type = ANY
+                                         (ARRAY ['INVOICE'::accounter_schema.document_type, 'INVOICE_RECEIPT'::accounter_schema.document_type, 'CREDIT_INVOICE'::accounter_schema.document_type])))                                                                        AS currency_array
+                             FROM accounter_schema.documents
+                                      LEFT JOIN accounter_schema.charges ON documents.charge_id = charges.id
+                                      LEFT JOIN accounter_schema.businesses
+                                                ON documents.creditor_id = charges.owner_id AND
+                                                   documents.debtor_id = businesses.id OR
+                                                   documents.creditor_id = businesses.id AND
+                                                   documents.debtor_id = charges.owner_id
+                             GROUP BY documents.charge_id),
+     businesses_by_charge AS (SELECT base.charge_id,
+                                     array_remove(base.business_array, charges.owner_id)          AS business_array,
+                                     array_remove(base.filtered_business_array, charges.owner_id) AS filtered_business_array
+                              FROM (SELECT b_1.charge_id,
+                                           array_agg(DISTINCT b_1.business_id)          AS business_array,
+                                           array_remove(array_agg(DISTINCT
+                                                                  CASE
+                                                                      WHEN b_1.is_fee THEN NULL::uuid
+                                                                      ELSE b_1.business_id
+                                                                      END), NULL::uuid) AS filtered_business_array
+                                    FROM (SELECT transactions.charge_id,
+                                                 transactions.business_id,
+                                                 CASE
+                                                     WHEN transactions_fees.id IS NULL THEN false
+                                                     ELSE true
+                                                     END AS is_fee
+                                          FROM accounter_schema.transactions
+                                                   LEFT JOIN accounter_schema.transactions_fees
+                                                             ON transactions.id = transactions_fees.id
+                                          WHERE transactions.business_id IS NOT NULL
+                                          UNION
+                                          SELECT documents.charge_id,
+                                                 documents.creditor_id,
+                                                 false AS bool
+                                          FROM accounter_schema.documents
+                                          WHERE documents.creditor_id IS NOT NULL
+                                          UNION
+                                          SELECT documents.charge_id,
+                                                 documents.debtor_id,
+                                                 false AS bool
+                                          FROM accounter_schema.documents
+                                          WHERE documents.debtor_id IS NOT NULL
+                                          UNION
+                                          SELECT ledger_records.charge_id,
+                                                 ledger_records.credit_entity1,
+                                                 true AS bool
+                                          FROM accounter_schema.ledger_records
+                                          WHERE ledger_records.credit_entity1 IS NOT NULL
+                                          UNION
+                                          SELECT ledger_records.charge_id,
+                                                 ledger_records.credit_entity2,
+                                                 true AS bool
+                                          FROM accounter_schema.ledger_records
+                                          WHERE ledger_records.credit_entity2 IS NOT NULL
+                                          UNION
+                                          SELECT ledger_records.charge_id,
+                                                 ledger_records.debit_entity1,
+                                                 true AS bool
+                                          FROM accounter_schema.ledger_records
+                                          WHERE ledger_records.debit_entity1 IS NOT NULL
+                                          UNION
+                                          SELECT ledger_records.charge_id,
+                                                 ledger_records.debit_entity2,
+                                                 true AS bool
+                                          FROM accounter_schema.ledger_records
+                                          WHERE ledger_records.debit_entity2 IS NOT NULL) b_1
+                                    GROUP BY b_1.charge_id) base
+                                       LEFT JOIN accounter_schema.charges ON base.charge_id = charges.id),
+     tags_by_charge AS (SELECT tags_1.charge_id,
+                               array_agg(tags_1.tag_id) AS tags_array
+                        FROM accounter_schema.charge_tags tags_1
+                        GROUP BY tags_1.charge_id),
+     ledger_by_charge AS (SELECT count(DISTINCT l2.id)                                             AS ledger_count,
+                                 array_remove(array_agg(DISTINCT l2.financial_entity), NULL::uuid) AS ledger_financial_entities,
+                                 min(l2.value_date)                                                AS min_value_date,
+                                 max(l2.value_date)                                                AS max_value_date,
+                                 min(l2.invoice_date)                                              AS min_invoice_date,
+                                 max(l2.invoice_date)                                              AS max_invoice_date,
+                                 l2.charge_id
+                          FROM (SELECT ledger_records.charge_id,
+                                       ledger_records.id,
+                                       ledger_records.value_date,
+                                       ledger_records.invoice_date,
+                                       unnest(ARRAY [ledger_records.credit_entity1, ledger_records.credit_entity2, ledger_records.debit_entity1, ledger_records.debit_entity2]) AS financial_entity
+                                FROM accounter_schema.ledger_records) l2
+                          GROUP BY l2.charge_id)
+SELECT c.id,
+       c.owner_id,
+       d.id IS NOT NULL                                                                             AS is_property,
+       c.accountant_status,
+       c.user_description,
+       c.created_at,
+       c.updated_at,
+       COALESCE(c.tax_category_id, tcm.tax_category_id)                                             AS tax_category_id,
+       COALESCE(documents_by_charge.invoice_event_amount::numeric, documents_by_charge.receipt_event_amount::numeric,
+                transactions_by_charge.event_amount)                                                AS event_amount,
+       transactions_by_charge.min_event_date                                                        AS transactions_min_event_date,
+       transactions_by_charge.max_event_date                                                        AS transactions_max_event_date,
+       transactions_by_charge.min_debit_date                                                        AS transactions_min_debit_date,
+       transactions_by_charge.max_debit_date                                                        AS transactions_max_debit_date,
+       transactions_by_charge.event_amount                                                          AS transactions_event_amount,
+       CASE
+           WHEN array_length(transactions_by_charge.currency_array, 1) = 1 THEN transactions_by_charge.currency_array[1]
+           ELSE NULL::accounter_schema.currency
+           END                                                                                      AS transactions_currency,
+       transactions_by_charge.transactions_count,
+       transactions_by_charge.invalid_transactions,
+       documents_by_charge.min_event_date                                                           AS documents_min_date,
+       documents_by_charge.max_event_date                                                           AS documents_max_date,
+       COALESCE(documents_by_charge.invoice_event_amount,
+                documents_by_charge.receipt_event_amount)                                           AS documents_event_amount,
+       COALESCE(documents_by_charge.invoice_vat_amount,
+                documents_by_charge.receipt_vat_amount)                                             AS documents_vat_amount,
+       CASE
+           WHEN array_length(documents_by_charge.currency_array, 1) = 1 THEN documents_by_charge.currency_array[1]
+           ELSE NULL::accounter_schema.currency
+           END                                                                                      AS documents_currency,
+       documents_by_charge.invoices_count,
+       documents_by_charge.receipts_count,
+       documents_by_charge.documents_count,
+       documents_by_charge.invalid_documents,
+       businesses_by_charge.business_array,
+       b.id                                                                                         AS business_id,
+       COALESCE(b.can_settle_with_receipt, false)                                                   AS can_settle_with_receipt,
+       tags_by_charge.tags_array                                                                    AS tags,
+       btc.business_trip_id,
+       ledger_by_charge.ledger_count,
+       ledger_by_charge.ledger_financial_entities,
+       ledger_by_charge.min_value_date                                                              AS ledger_min_value_date,
+       ledger_by_charge.max_value_date                                                              AS ledger_max_value_date,
+       ledger_by_charge.min_invoice_date                                                            AS ledger_min_invoice_date,
+       ledger_by_charge.max_invoice_date                                                            AS ledger_max_invoice_date,
+       y.years_of_relevance,
+       c.invoice_payment_currency_diff,
+       c.type,
+       c.optional_vat,
+       COALESCE(b.no_invoices_required, false)                                                      AS no_invoices_required,
+       c.documents_optional_flag
+FROM accounter_schema.charges c
+         LEFT JOIN transactions_by_charge ON transactions_by_charge.charge_id = c.id
+         LEFT JOIN documents_by_charge ON documents_by_charge.charge_id = c.id
+         LEFT JOIN businesses_by_charge ON businesses_by_charge.charge_id = c.id
+         LEFT JOIN accounter_schema.businesses b ON b.id = businesses_by_charge.filtered_business_array[1] AND
+                                                    array_length(businesses_by_charge.filtered_business_array, 1) = 1
+         LEFT JOIN accounter_schema.business_tax_category_match tcm
+                   ON tcm.business_id = b.id AND tcm.owner_id = c.owner_id
+         LEFT JOIN tags_by_charge ON c.id = tags_by_charge.charge_id
+         LEFT JOIN accounter_schema.business_trip_charges btc ON btc.charge_id = c.id
+         LEFT JOIN ledger_by_charge ON ledger_by_charge.charge_id = c.id
+         LEFT JOIN years_of_relevance y ON y.charge_id = c.id
+         LEFT JOIN accounter_schema.depreciation d ON d.charge_id = c.id;
+`,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -78,6 +78,7 @@ import migration_2025_02_13T14_40_22_update_poalim_column_length_restriction fro
 import migration_2025_02_19T15_12_33_add_to_context_salary_excess_expenses from './actions/2025-02-19T15-12-33.add-to-context-salary-excess-expenses.js';
 import migration_2025_02_26T19_27_56_add_to_context_ledger_lock from './actions/2025-02-26T19-27-56.add-to-context-ledger-lock.js';
 import migration_2025_03_04T16_29_18_update_charges_view_add_no_doc_req_flag from './actions/2025-03-04T16-29-18.update-charges-view-add-no-doc-req-flag.js';
+import migration_2025_03_10T16_21_31_charge_no_docs_flag from './actions/2025-03-10T16-21-31.charge-no-docs-flag.js';
 import { runMigrations } from './pg-migrator.js';
 
 export const runPGMigrations = (args: { slonik: DatabasePool }) =>
@@ -163,5 +164,6 @@ export const runPGMigrations = (args: { slonik: DatabasePool }) =>
       migration_2025_02_19T15_12_33_add_to_context_salary_excess_expenses,
       migration_2025_02_26T19_27_56_add_to_context_ledger_lock,
       migration_2025_03_04T16_29_18_update_charges_view_add_no_doc_req_flag,
+      migration_2025_03_10T16_21_31_charge_no_docs_flag,
     ],
   });

--- a/packages/server/src/modules/charges/helpers/validate.helper.ts
+++ b/packages/server/src/modules/charges/helpers/validate.helper.ts
@@ -39,6 +39,7 @@ export const validateCharge = async (
   const dbDocumentsAreValid = !charge.invalid_documents;
   const documentsNotRequired =
     business?.no_invoices_required === true ||
+    charge.documents_optional_flag ||
     [
       ChargeTypeEnum.Salary,
       ChargeTypeEnum.InternalTransfer,

--- a/packages/server/src/modules/charges/providers/charges.provider.ts
+++ b/packages/server/src/modules/charges/providers/charges.provider.ts
@@ -127,6 +127,10 @@ const updateCharge = sql<IUpdateChargeQuery>`
   optional_vat = COALESCE(
     $optionalVAT,
     optional_vat
+  ),
+  documents_optional_flag = COALESCE(
+    $optionalDocuments,
+    documents_optional_flag
   )
   WHERE
     id = $chargeId
@@ -143,8 +147,8 @@ const updateAccountantApproval = sql<IUpdateAccountantApprovalQuery>`
 `;
 
 const generateCharge = sql<IGenerateChargeQuery>`
-  INSERT INTO accounter_schema.charges (owner_id, type, is_property, accountant_status, user_description, tax_category_id, optional_vat)
-  VALUES ($ownerId, $type, $isProperty, $accountantStatus, $userDescription, $taxCategoryId, $optionalVAT)
+  INSERT INTO accounter_schema.charges (owner_id, type, is_property, accountant_status, user_description, tax_category_id, optional_vat, documents_optional_flag)
+  VALUES ($ownerId, $type, $isProperty, $accountantStatus, $userDescription, $taxCategoryId, $optionalVAT, $optionalDocuments)
   RETURNING *;
 `;
 
@@ -307,6 +311,7 @@ export class ChargesProvider {
       isProperty: false,
       userDescription: null,
       optionalVAT: false,
+      optionalDocuments: false,
       accountantStatus: 'UNAPPROVED' as accountant_status,
       ...params,
     };

--- a/packages/server/src/modules/charges/resolvers/charges.resolver.ts
+++ b/packages/server/src/modules/charges/resolvers/charges.resolver.ts
@@ -212,6 +212,7 @@ export const chargesResolvers: ChargesModule.Resolvers &
         userDescription: fields.userDescription,
         taxCategoryId: fields.defaultTaxCategoryID,
         optionalVAT: fields.optionalVAT,
+        optionalDocuments: fields.optionalDocuments,
         chargeId,
       };
       try {
@@ -353,6 +354,7 @@ export const chargesResolvers: ChargesModule.Resolvers &
             isProperty: fields?.isProperty,
             isInvoicePaymentDifferentCurrency: fields?.isInvoicePaymentDifferentCurrency,
             optionalVAT: fields?.optionalVAT,
+            optionalDocuments: fields?.optionalDocuments,
             ownerId: fields?.ownerId,
             userDescription: fields?.userDescription,
             chargeId: baseChargeID,

--- a/packages/server/src/modules/charges/resolvers/common.ts
+++ b/packages/server/src/modules/charges/resolvers/common.ts
@@ -34,6 +34,8 @@ export const commonChargeFields: ChargesModule.ChargeResolvers = {
       })) ?? null
     );
   },
+  optionalVAT: DbCharge => DbCharge.optional_vat,
+  optionalDocuments: DbCharge => DbCharge.documents_optional_flag,
 };
 
 export const commonDocumentsFields: ChargesModule.DocumentResolvers = {

--- a/packages/server/src/modules/charges/typeDefs/charges.graphql.ts
+++ b/packages/server/src/modules/charges/typeDefs/charges.graphql.ts
@@ -52,6 +52,8 @@ export default gql`
     yearsOfRelevance: [YearOfRelevance!]
     " flag for optional VAT "
     optionalVAT: Boolean
+    " flag for optional documents "
+    optionalDocuments: Boolean
   }
 
   " common charge "
@@ -71,6 +73,7 @@ export default gql`
     metadata: ChargeMetadata
     yearsOfRelevance: [YearOfRelevance!]
     optionalVAT: Boolean
+    optionalDocuments: Boolean
   }
 
   " charge with conversion transactions "
@@ -90,6 +93,7 @@ export default gql`
     metadata: ChargeMetadata
     yearsOfRelevance: [YearOfRelevance!]
     optionalVAT: Boolean
+    optionalDocuments: Boolean
   }
 
   " charge with conversion transactions "
@@ -109,6 +113,7 @@ export default gql`
     metadata: ChargeMetadata
     yearsOfRelevance: [YearOfRelevance!]
     optionalVAT: Boolean
+    optionalDocuments: Boolean
   }
 
   " charge of internal transfer "
@@ -128,6 +133,7 @@ export default gql`
     metadata: ChargeMetadata
     yearsOfRelevance: [YearOfRelevance!]
     optionalVAT: Boolean
+    optionalDocuments: Boolean
   }
 
   " charge of dividends "
@@ -147,6 +153,7 @@ export default gql`
     metadata: ChargeMetadata
     yearsOfRelevance: [YearOfRelevance!]
     optionalVAT: Boolean
+    optionalDocuments: Boolean
   }
 
   " charge of dividends "
@@ -166,6 +173,7 @@ export default gql`
     metadata: ChargeMetadata
     yearsOfRelevance: [YearOfRelevance!]
     optionalVAT: Boolean
+    optionalDocuments: Boolean
   }
 
   " charge of monthly VAT payment "
@@ -185,6 +193,7 @@ export default gql`
     metadata: ChargeMetadata
     yearsOfRelevance: [YearOfRelevance!]
     optionalVAT: Boolean
+    optionalDocuments: Boolean
   }
 
   " charge of bank deposits "
@@ -204,6 +213,7 @@ export default gql`
     metadata: ChargeMetadata
     yearsOfRelevance: [YearOfRelevance!]
     optionalVAT: Boolean
+    optionalDocuments: Boolean
   }
 
   " charge of creditcard over bank account "
@@ -223,6 +233,7 @@ export default gql`
     metadata: ChargeMetadata
     yearsOfRelevance: [YearOfRelevance!]
     optionalVAT: Boolean
+    optionalDocuments: Boolean
   }
 
   " input variables for charge filtering "
@@ -296,6 +307,7 @@ export default gql`
     businessTripID: UUID
     yearsOfRelevance: [YearOfRelevanceInput!]
     optionalVAT: Boolean
+    optionalDocuments: Boolean
   }
 
   " input variables for charge spread "

--- a/packages/server/src/modules/charges/typeDefs/financial-charges.graphql.ts
+++ b/packages/server/src/modules/charges/typeDefs/financial-charges.graphql.ts
@@ -38,5 +38,6 @@ export default gql`
     metadata: ChargeMetadata
     yearsOfRelevance: [YearOfRelevance!]
     optionalVAT: Boolean
+    optionalDocuments: Boolean
   }
 `;

--- a/packages/server/src/modules/ledger/resolvers/ledger-generation/business-trip-ledger-generation.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger-generation/business-trip-ledger-generation.resolver.ts
@@ -338,7 +338,8 @@ export const generateLedgerRecordsForBusinessTrip: ResolverFn<
 
     if (
       Math.abs(transactionsTotalLocalAmount) > AMOUNT_REQUIRING_DOCUMENT &&
-      accountingLedgerEntries.length === 0
+      accountingLedgerEntries.length === 0 &&
+      !charge.documents_optional_flag
     ) {
       errors.add(
         `Charge of more than ${AMOUNT_REQUIRING_DOCUMENT} ${defaultLocalCurrency} requires a document`,

--- a/packages/server/src/modules/ledger/resolvers/ledger-generation/common-ledger-generation.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger-generation/common-ledger-generation.resolver.ts
@@ -49,7 +49,7 @@ export const generateLedgerRecordsForCommonCharge: ResolverFn<
       defaultLocalCurrency,
       defaultTaxCategoryId,
       general: {
-        taxCategories: { incomeExchangeRateTaxCategoryId },
+        taxCategories: { incomeExchangeRateTaxCategoryId, exchangeRateTaxCategoryId },
       },
     },
   } = context;
@@ -405,6 +405,8 @@ export const generateLedgerRecordsForCommonCharge: ResolverFn<
           if (isIncomeCharge) {
             exchangeRateTaxCategory = incomeExchangeRateTaxCategoryId;
           }
+        } else if (charge.documents_optional_flag) {
+          exchangeRateTaxCategory = exchangeRateTaxCategoryId;
         }
 
         // validate exchange rate


### PR DESCRIPTION
related #1795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an "Optional Documents" toggle in the charge editing interface for improved input.
  - Enhanced the charge merge selection view with an additional row for managing optional documents.
  - Expanded GraphQL schema to include `optionalDocuments` field across various charge types and inputs.

- **Chores**
  - Upgraded backend functionality and data handling to support the optional documents flag seamlessly through system migrations and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->