### PR TITLE
Merge charges: handle misc expenses

### DIFF
--- a/packages/server/src/modules/charges/helpers/merge-charges.hepler.ts
+++ b/packages/server/src/modules/charges/helpers/merge-charges.hepler.ts
@@ -3,6 +3,7 @@ import { Injector } from 'graphql-modules';
 import { BusinessTripEmployeePaymentsProvider } from '@modules/business-trips/providers/business-trips-employee-payments.provider.js';
 import { DocumentsProvider } from '@modules/documents/providers/documents.provider.js';
 import { LedgerProvider } from '@modules/ledger/providers/ledger.provider.js';
+import { MiscExpensesProvider } from '@modules/misc-expenses/providers/misc-expenses.provider.js';
 import { TransactionsProvider } from '@modules/transactions/providers/transactions.provider.js';
 import { deleteCharges } from './delete-charges.helper.js';
 
@@ -37,6 +38,14 @@ export const mergeChargesExecutor = async (
           assertChargeID: baseChargeID,
         });
 
+      // update linked misc expenses
+      const replaceMiscExpensesChargeIdPromise = injector
+        .get(MiscExpensesProvider)
+        .replaceMiscExpensesChargeId({
+          replaceChargeID: id,
+          assertChargeID: baseChargeID,
+        });
+
       // update linked business trips employee payments
       const replaceBusinessTripsEmployeePaymentsChargeIdPromise = injector
         .get(BusinessTripEmployeePaymentsProvider)
@@ -49,6 +58,7 @@ export const mergeChargesExecutor = async (
         replaceDocumentsChargeIdPromise,
         replaceTransactionsChargeIdPromise,
         replaceLedgerRecordsChargeIdPromise,
+        replaceMiscExpensesChargeIdPromise,
         replaceBusinessTripsEmployeePaymentsChargeIdPromise,
       ]);
     });

--- a/packages/server/src/modules/misc-expenses/providers/misc-expenses.provider.ts
+++ b/packages/server/src/modules/misc-expenses/providers/misc-expenses.provider.ts
@@ -14,6 +14,8 @@ import type {
   IInsertExpenseQuery,
   IInsertExpensesParams,
   IInsertExpensesQuery,
+  IReplaceMiscExpensesChargeIdParams,
+  IReplaceMiscExpensesChargeIdQuery,
   IUpdateExpenseParams,
   IUpdateExpenseQuery,
 } from '../types.js';
@@ -71,6 +73,15 @@ const updateExpense = sql<IUpdateExpenseQuery>`
   WHERE
     id = $miscExpenseId
   RETURNING *;`;
+
+const replaceMiscExpensesChargeId = sql<IReplaceMiscExpensesChargeIdQuery>`
+    UPDATE accounter_schema.misc_expenses
+      SET
+      charge_id = $assertChargeID
+    WHERE
+      charge_id = $replaceChargeID
+    RETURNING *
+  `;
 
 const insertExpense = sql<IInsertExpenseQuery>`
   INSERT INTO accounter_schema.misc_expenses (charge_id, creditor_id, debtor_id, amount, currency, description, invoice_date, value_date)
@@ -165,6 +176,16 @@ export class MiscExpensesProvider {
   public async updateExpense(params: IUpdateExpenseParams) {
     if (params.miscExpenseId) await this.invalidateById(params.miscExpenseId);
     return updateExpense.run(params, this.dbProvider);
+  }
+
+  public async replaceMiscExpensesChargeId(params: IReplaceMiscExpensesChargeIdParams) {
+    if (params.assertChargeID) {
+      await this.invalidateByChargeId(params.assertChargeID);
+    }
+    if (params.replaceChargeID) {
+      await this.invalidateByChargeId(params.replaceChargeID);
+    }
+    return replaceMiscExpensesChargeId.run(params, this.dbProvider);
   }
 
   public async insertExpense(params: IInsertExpenseParams) {


### PR DESCRIPTION
closes #2054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Linked miscellaneous expenses are now automatically updated when merging charges, ensuring all related expenses are correctly associated with the merged charge.

- **Bug Fixes**
	- Resolved issues where miscellaneous expenses were not properly linked after merging charges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->