### PR TITLE
Add nontaxable linkage attribute to tax report

### DIFF
--- a/packages/client/src/components/reports/tax-report/index.tsx
+++ b/packages/client/src/components/reports/tax-report/index.tsx
@@ -57,6 +57,12 @@ import { TaxReportFilter } from './tax-report-filters.js';
           }
           ...ReportCommentaryTableFields
         }
+        nontaxableLinkage {
+          amount {
+            formatted
+          }
+          ...ReportCommentaryTableFields
+        }
         taxableIncome {
           formatted
         }
@@ -98,6 +104,11 @@ import { TaxReportFilter } from './tax-report-filters.js';
           formatted
         }
         reserves {
+          amount {
+            formatted
+          }
+        }
+        nontaxableLinkage {
           amount {
             formatted
           }
@@ -262,6 +273,19 @@ export const TaxReport = (): ReactElement => {
                     </tr>
                   )}
                   commentaryData={report.reserves}
+                />
+                <ReportCommentaryRow
+                  dataRow={button => (
+                    <tr>
+                      <td>Nontaxable Linkage</td>
+                      <td>{report.nontaxableLinkage.amount.formatted}</td>
+                      <th>{button}</th>
+                      {referenceYearsData.map(report => (
+                        <td key={report.year}>{report.nontaxableLinkage.amount.formatted}</td>
+                      ))}
+                    </tr>
+                  )}
+                  commentaryData={report.nontaxableLinkage}
                 />
                 <tr>
                   <th>Taxable Income</th>

--- a/packages/server/src/modules/reports/helpers/tax.helper.ts
+++ b/packages/server/src/modules/reports/helpers/tax.helper.ts
@@ -158,7 +158,7 @@ export async function calculateTaxAmounts(
     .then(res => res.filter(tc => !!tc.tax_excluded).map(tc => tc.id));
 
   const filterBusinessTripsExcludedRecords = (financialEntityId: string, sortCode: number) => {
-    return sortCode === 945 && !excludedTaxCategories.includes(financialEntityId);
+    return sortCode === 945 && excludedTaxCategories.includes(financialEntityId);
   };
   const businessTripsExcludedAmount = amountByFinancialEntityIdAndSortCodeValidation(
     decoratedLedgerRecords,
@@ -186,7 +186,7 @@ export async function calculateTaxAmounts(
   );
 
   const filterYearlyRndExcludedRecords = (financialEntityId: string, sortCode: number) => {
-    return sortCode === 922 && !excludedTaxCategories.includes(financialEntityId);
+    return sortCode === 922 && excludedTaxCategories.includes(financialEntityId);
   };
   const yearlyRndExcludedRnd = amountByFinancialEntityIdAndSortCodeValidation(
     decoratedLedgerRecords,

--- a/packages/server/src/modules/reports/resolvers/reports/tax-report.ts
+++ b/packages/server/src/modules/reports/resolvers/reports/tax-report.ts
@@ -101,6 +101,7 @@ export const taxReport: ResolverFn<
       businessTripsExcessExpensesAmount,
       salaryExcessExpensesAmount,
       reserves,
+      nontaxableLinkage,
       taxableIncomeAmount,
       taxRate,
       annualTaxExpenseAmount,
@@ -136,6 +137,7 @@ export const taxReport: ResolverFn<
       businessTripsExcessExpensesAmount,
       salaryExcessExpensesAmount,
       reserves,
+      nontaxableLinkage,
 
       taxableIncome: taxableIncomeAmount,
       taxRate,
@@ -186,6 +188,10 @@ export const taxReportYearMapper: TaxReportYearResolvers = {
   reserves: (parent, _, { adminContext: { defaultLocalCurrency } }) => ({
     amount: formatFinancialAmount(parent.reserves.amount, defaultLocalCurrency),
     records: parent.reserves.records,
+  }),
+  nontaxableLinkage: (parent, _, { adminContext: { defaultLocalCurrency } }) => ({
+    amount: formatFinancialAmount(parent.nontaxableLinkage.amount, defaultLocalCurrency),
+    records: parent.nontaxableLinkage.records,
   }),
   taxableIncome: (parent, _, { adminContext: { defaultLocalCurrency } }) =>
     formatFinancialAmount(parent.taxableIncome, defaultLocalCurrency),

--- a/packages/server/src/modules/reports/typeDefs/tax-report.graphql.ts
+++ b/packages/server/src/modules/reports/typeDefs/tax-report.graphql.ts
@@ -26,6 +26,7 @@ export default gql`
     businessTripsExcessExpensesAmount: FinancialAmount!
     salaryExcessExpensesAmount: FinancialAmount!
     reserves: ReportCommentary!
+    nontaxableLinkage: ReportCommentary!
 
     taxableIncome: FinancialAmount!
     taxRate: Float!

--- a/packages/server/src/modules/reports/types.ts
+++ b/packages/server/src/modules/reports/types.ts
@@ -47,6 +47,7 @@ export type TaxReportYearProto = {
   businessTripsExcessExpensesAmount: number;
   salaryExcessExpensesAmount: number;
   reserves: CommentaryProto;
+  nontaxableLinkage: CommentaryProto;
 
   taxableIncome: number;
   taxRate: number;


### PR DESCRIPTION
closes #2062

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "Nontaxable Linkage" row to the tax report, displaying formatted amounts and commentary for the current and reference years.
  - Introduced a new "Nontaxable Linkage" field in the tax report, available in both the user interface and exported reports.

- **Bug Fixes**
  - Corrected filtering logic for excluded tax categories in tax calculations to ensure accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->