### PR TITLE
Exchange rates UI for financial charges

### DIFF
--- a/packages/client/src/components/charges/charge-extended-info.tsx
+++ b/packages/client/src/components/charges/charge-extended-info.tsx
@@ -9,6 +9,7 @@ import {
   ConversionChargeInfoFragmentDoc,
   CreditcardBankChargeInfoFragmentDoc,
   DocumentsGalleryFieldsFragmentDoc,
+  ExchangeRatesInfoFragmentDoc,
   FetchChargeDocument,
   FetchChargeQuery,
   TableDocumentsFieldsFragmentDoc,
@@ -25,6 +26,7 @@ import { ChargeErrors } from './charge-errors.jsx';
 import { ChargeTransactionsTable } from './charge-transactions-table.jsx';
 import { ConversionInfo } from './extended-info/conversion-info.jsx';
 import { CreditcardTransactionsInfo } from './extended-info/creditcard-transactions-info.jsx';
+import { ExchangeRates } from './extended-info/exchange-rates.js';
 import { ChargeMiscExpensesTable } from './extended-info/misc-expenses.jsx';
 import { SalariesTable } from './extended-info/salaries-info.jsx';
 
@@ -60,6 +62,7 @@ import { SalariesTable } from './extended-info/salaries-info.jsx';
         id
       }
       ...TableMiscExpensesFields @defer
+      ...ExchangeRatesInfo @defer
     }
   }
 `;
@@ -185,6 +188,13 @@ export function ChargeExtendedInfo({
     );
   }, [charge, chargeType]);
 
+  const exchangeRatesAreReady = useMemo(() => {
+    return (
+      chargeType === 'FinancialCharge' &&
+      isFragmentReady(FetchChargeDocument, ExchangeRatesInfoFragmentDoc, charge)
+    );
+  }, [charge, chargeType]);
+
   const salariesAreReady =
     chargeType === 'SalaryCharge' &&
     isFragmentReady(FetchChargeDocument, TableSalariesFieldsFragmentDoc, charge);
@@ -231,6 +241,24 @@ export function ChargeExtendedInfo({
                   {conversionIsReady && (
                     <ConversionInfo
                       chargeProps={charge as FragmentType<typeof ConversionChargeInfoFragmentDoc>}
+                    />
+                  )}
+                </Accordion.Panel>
+              </Accordion.Item>
+            )}
+
+            {chargeType === 'FinancialCharge' && (
+              <Accordion.Item value="exchangeRates">
+                <Accordion.Control
+                  disabled={!exchangeRatesAreReady}
+                  onClick={() => toggleAccordionItem('exchangeRates')}
+                >
+                  Exchange Rates
+                </Accordion.Control>
+                <Accordion.Panel>
+                  {exchangeRatesAreReady && (
+                    <ExchangeRates
+                      chargeProps={charge as FragmentType<typeof ExchangeRatesInfoFragmentDoc>}
                     />
                   )}
                 </Accordion.Panel>

--- a/packages/client/src/components/charges/extended-info/exchange-rates.tsx
+++ b/packages/client/src/components/charges/extended-info/exchange-rates.tsx
@@ -37,7 +37,7 @@ export const ExchangeRates = ({ chargeProps }: Props): ReactElement => {
     if (charge.__typename !== 'FinancialCharge') {
       return [];
     }
-    return Object.entries(charge.exchangeRates ?? []).sort((a, b) => a[0].localeCompare(b[0]));
+    return Object.entries(charge.exchangeRates ?? {}).sort((a, b) => a[0].localeCompare(b[0]));
   }, [charge]);
 
   if (charge.__typename !== 'FinancialCharge') {

--- a/packages/client/src/components/charges/extended-info/exchange-rates.tsx
+++ b/packages/client/src/components/charges/extended-info/exchange-rates.tsx
@@ -1,0 +1,68 @@
+import { ReactElement, useMemo } from 'react';
+import { Currency, ExchangeRatesInfoFragmentDoc } from '../../../gql/graphql.js';
+import { FragmentType, getFragmentData } from '../../../gql/index.js';
+import { currencyCodeToSymbol } from '../../../helpers/index.js';
+import { Badge } from '../../ui/badge.js';
+import { Card, CardContent, CardTitle } from '../../ui/card.js';
+
+// import { currencyCodeToSymbol } from '../../../helpers/index.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  fragment ExchangeRatesInfo on Charge {
+    id
+    __typename
+    ... on FinancialCharge {
+      exchangeRates {
+        usd
+        gbp
+        eur
+        cad
+        ils
+        eth
+        grt
+        usdc
+      }
+    }
+  }
+`;
+
+type Props = {
+  chargeProps: FragmentType<typeof ExchangeRatesInfoFragmentDoc>;
+};
+
+export const ExchangeRates = ({ chargeProps }: Props): ReactElement => {
+  const charge = getFragmentData(ExchangeRatesInfoFragmentDoc, chargeProps);
+  const exchangeRates = useMemo(() => {
+    if (charge.__typename !== 'FinancialCharge') {
+      return [];
+    }
+    return Object.entries(charge.exchangeRates ?? []).sort((a, b) => a[0].localeCompare(b[0]));
+  }, [charge]);
+
+  if (charge.__typename !== 'FinancialCharge') {
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    return <></>;
+  }
+
+  return (
+    <div className="flex flex-row flex-wrap gap-2 px-2">
+      {exchangeRates.map(([currency, rate]) => (
+        <Card key={currency} className="gap-0 py-2">
+          <CardContent className="flex flex-col px-2">
+            <CardTitle className="text-xl font-semibold">{currency.toLocaleUpperCase()}</CardTitle>
+            <div className="flex items-center space-x-2">
+              <span className="whitespace-nowrap">
+                {currencyCodeToSymbol(currency.toLocaleUpperCase() as Currency)}1=
+              </span>
+              <Badge variant="default" className="flex gap-1 rounded-lg text-md">
+                {currencyCodeToSymbol(Currency.Ils)}
+                {rate}
+              </Badge>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};

--- a/packages/client/src/components/charts/index.tsx
+++ b/packages/client/src/components/charts/index.tsx
@@ -34,49 +34,17 @@ import { StatsCard } from './stats-card.js';
             raw
           }
           eventExchangeRates {
-            cad {
-              currency
-              formatted
-              raw
-            }
-            eur {
-              currency
-              formatted
-              raw
-            }
-            gbp {
-              currency
-              formatted
-              raw
-            }
-            usd {
-              currency
-              formatted
-              raw
-            }
+            cad
+            eur
+            gbp
+            usd
             date
           }
           debitExchangeRates {
-            cad {
-              currency
-              formatted
-              raw
-            }
-            eur {
-              currency
-              formatted
-              raw
-            }
-            gbp {
-              currency
-              formatted
-              raw
-            }
-            usd {
-              currency
-              formatted
-              raw
-            }
+            cad
+            eur
+            gbp
+            usd
             date
           }
         }
@@ -159,7 +127,7 @@ export const ChartPage = (): ReactElement => {
           return item;
         }
         if (item.amount.currency === Currency.Ils) {
-          const rate = item.debitExchangeRates?.usd?.raw || item.eventExchangeRates?.usd?.raw;
+          const rate = item.debitExchangeRates?.usd || item.eventExchangeRates?.usd;
           if (!rate) {
             return null;
           }
@@ -175,8 +143,8 @@ export const ChartPage = (): ReactElement => {
           };
         }
         if (item.amount.currency === Currency.Eur) {
-          const rateToILS = item.debitExchangeRates?.eur?.raw || item.eventExchangeRates?.eur?.raw;
-          const rateToUSD = item.debitExchangeRates?.usd?.raw || item.eventExchangeRates?.usd?.raw;
+          const rateToILS = item.debitExchangeRates?.eur || item.eventExchangeRates?.eur;
+          const rateToUSD = item.debitExchangeRates?.usd || item.eventExchangeRates?.usd;
           if (!rateToILS || !rateToUSD) {
             return null;
           }
@@ -193,8 +161,8 @@ export const ChartPage = (): ReactElement => {
           };
         }
         if (item.amount.currency === Currency.Gbp) {
-          const rateToILS = item.debitExchangeRates?.gbp?.raw || item.eventExchangeRates?.gbp?.raw;
-          const rateToUSD = item.debitExchangeRates?.usd?.raw || item.eventExchangeRates?.usd?.raw;
+          const rateToILS = item.debitExchangeRates?.gbp || item.eventExchangeRates?.gbp;
+          const rateToUSD = item.debitExchangeRates?.usd || item.eventExchangeRates?.usd;
           if (!rateToILS || !rateToUSD) {
             return null;
           }
@@ -211,8 +179,8 @@ export const ChartPage = (): ReactElement => {
           };
         }
         if (item.amount.currency === Currency.Cad) {
-          const rateToILS = item.debitExchangeRates?.cad?.raw || item.eventExchangeRates?.cad?.raw;
-          const rateToUSD = item.debitExchangeRates?.usd?.raw || item.eventExchangeRates?.usd?.raw;
+          const rateToILS = item.debitExchangeRates?.cad || item.eventExchangeRates?.cad;
+          const rateToUSD = item.debitExchangeRates?.usd || item.eventExchangeRates?.usd;
           if (!rateToILS || !rateToUSD) {
             return null;
           }

--- a/packages/client/src/helpers/currency.ts
+++ b/packages/client/src/helpers/currency.ts
@@ -18,7 +18,7 @@ export function currencyCodeToSymbol(currency_code: Currency): string {
   } else if (currency_code === 'EUR') {
     currencySymbol = '€';
   } else if (currency_code === 'GBP') {
-    currencySymbol = '&#163;';
+    currencySymbol = '£';
   } else if (currency_code === 'CAD') {
     currencySymbol = 'C$';
   } else if (currency_code === 'GRT') {

--- a/packages/server/src/modules/exchange-rates/resolvers/exchange.resolver.ts
+++ b/packages/server/src/modules/exchange-rates/resolvers/exchange.resolver.ts
@@ -65,7 +65,7 @@ export const exchangeResolvers: ExchangeRatesModule.Resolvers = {
       if (!exchangeRates) {
         return null;
       }
-      return exchangeRates;
+      return typeof exchangeRates === 'string' ? parseFloat(exchangeRates) : exchangeRates;
     },
     eth: async (timelessDate, _, { injector, adminContext: { defaultLocalCurrency } }) => {
       const exchangeRates = await injector
@@ -74,7 +74,7 @@ export const exchangeResolvers: ExchangeRatesModule.Resolvers = {
       if (!exchangeRates) {
         return null;
       }
-      return exchangeRates;
+      return typeof exchangeRates === 'string' ? parseFloat(exchangeRates) : exchangeRates;
     },
     usdc: async (timelessDate, _, { injector, adminContext: { defaultLocalCurrency } }) => {
       const exchangeRates = await injector
@@ -83,7 +83,7 @@ export const exchangeResolvers: ExchangeRatesModule.Resolvers = {
       if (!exchangeRates) {
         return null;
       }
-      return exchangeRates;
+      return typeof exchangeRates === 'string' ? parseFloat(exchangeRates) : exchangeRates;
     },
     date: timelessDate => timelessDate,
   },

--- a/packages/server/src/modules/exchange-rates/resolvers/exchange.resolver.ts
+++ b/packages/server/src/modules/exchange-rates/resolvers/exchange.resolver.ts
@@ -1,7 +1,7 @@
 import { GraphQLError } from 'graphql';
 import { TransactionsProvider } from '@modules/transactions/providers/transactions.provider.js';
 import { Currency } from '@shared/gql-types';
-import { formatCurrency, formatFinancialAmount } from '@shared/helpers';
+import { formatCurrency } from '@shared/helpers';
 import { TimelessDateString } from '@shared/types';
 import { defineConversionBaseAndQuote } from '../helpers/exchange.helper.js';
 import { ExchangeProvider } from '../providers/exchange.provider.js';
@@ -26,7 +26,7 @@ export const exchangeResolvers: ExchangeRatesModule.Resolvers = {
       if (!exchangeRates?.usd) {
         return null;
       }
-      return formatFinancialAmount(exchangeRates.usd, Currency.Usd) ?? null;
+      return parseFloat(exchangeRates.usd);
     },
     gbp: async (timelessDate, _, { injector }) => {
       const exchangeRates = await injector
@@ -35,7 +35,7 @@ export const exchangeResolvers: ExchangeRatesModule.Resolvers = {
       if (!exchangeRates?.gbp) {
         return null;
       }
-      return formatFinancialAmount(exchangeRates.gbp, Currency.Gbp) ?? null;
+      return parseFloat(exchangeRates.gbp);
     },
     eur: async (timelessDate, _, { injector }) => {
       const exchangeRates = await injector
@@ -44,7 +44,7 @@ export const exchangeResolvers: ExchangeRatesModule.Resolvers = {
       if (!exchangeRates?.eur) {
         return null;
       }
-      return formatFinancialAmount(exchangeRates.eur, Currency.Eur) ?? null;
+      return parseFloat(exchangeRates.eur);
     },
     cad: async (timelessDate, _, { injector }) => {
       const exchangeRates = await injector
@@ -53,7 +53,37 @@ export const exchangeResolvers: ExchangeRatesModule.Resolvers = {
       if (!exchangeRates?.cad) {
         return null;
       }
-      return formatFinancialAmount(exchangeRates.cad, Currency.Cad) ?? null;
+      return parseFloat(exchangeRates.cad);
+    },
+    ils: () => {
+      return 1;
+    },
+    grt: async (timelessDate, _, { injector, adminContext: { defaultLocalCurrency } }) => {
+      const exchangeRates = await injector
+        .get(ExchangeProvider)
+        .getExchangeRates(Currency.Grt, defaultLocalCurrency, new Date(timelessDate));
+      if (!exchangeRates) {
+        return null;
+      }
+      return exchangeRates;
+    },
+    eth: async (timelessDate, _, { injector, adminContext: { defaultLocalCurrency } }) => {
+      const exchangeRates = await injector
+        .get(ExchangeProvider)
+        .getExchangeRates(Currency.Eth, defaultLocalCurrency, new Date(timelessDate));
+      if (!exchangeRates) {
+        return null;
+      }
+      return exchangeRates;
+    },
+    usdc: async (timelessDate, _, { injector, adminContext: { defaultLocalCurrency } }) => {
+      const exchangeRates = await injector
+        .get(ExchangeProvider)
+        .getExchangeRates(Currency.Usdc, defaultLocalCurrency, new Date(timelessDate));
+      if (!exchangeRates) {
+        return null;
+      }
+      return exchangeRates;
     },
     date: timelessDate => timelessDate,
   },

--- a/packages/server/src/modules/exchange-rates/typeDefs/exchange.graphql.ts
+++ b/packages/server/src/modules/exchange-rates/typeDefs/exchange.graphql.ts
@@ -9,10 +9,14 @@ export default gql`
 
   " represent a financial amount in a specific currency "
   type ExchangeRates {
-    usd: FinancialAmount
-    gbp: FinancialAmount
-    eur: FinancialAmount
-    cad: FinancialAmount
+    usd: Float
+    gbp: Float
+    eur: Float
+    cad: Float
+    ils: Float
+    eth: Float
+    grt: Float
+    usdc: Float
     date: TimelessDate!
   }
 


### PR DESCRIPTION
closes #1882


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying exchange rates for multiple currencies (USD, GBP, EUR, CAD, ILS, ETH, GRT, USDC) in the charge details view for financial charges.
  - Introduced a new exchange rates section in the charge details accordion, visible for applicable charges.

- **Improvements**
  - Exchange rates are now shown as numeric values for easier comparison.
  - Updated currency symbols for improved clarity.

- **Bug Fixes**
  - Simplified and corrected currency symbol display for GBP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->