### PR TITLE
Pcn record type override

### DIFF
--- a/.changeset/sweet-cycles-lose.md
+++ b/.changeset/sweet-cycles-lose.md
@@ -1,0 +1,7 @@
+---
+'@accounter/client': patch
+'@accounter/server': patch
+---
+
+New business attribute: PCN874 record type override (to force generator create spcific type of
+entries)

--- a/.changeset/sweet-cycles-lose.md
+++ b/.changeset/sweet-cycles-lose.md
@@ -3,5 +3,5 @@
 '@accounter/server': patch
 ---
 
-New business attribute: PCN874 record type override (to force generator create spcific type of
-entries)
+New business attribute: PCN874 record type override (to force the generator to create a specific
+type of PCN874 entry)

--- a/.changeset/three-cooks-marry.md
+++ b/.changeset/three-cooks-marry.md
@@ -1,0 +1,5 @@
+---
+'@accounter/pcn874-generator': patch
+---
+
+Stricter transactions sort logic to make output more consistent

--- a/packages/client/src/components/common/inputs/combo-box.tsx
+++ b/packages/client/src/components/common/inputs/combo-box.tsx
@@ -26,7 +26,7 @@ type ComboBoxProps = {
   triggerProps?: Omit<React.ComponentProps<typeof Button>, 'disabled'>;
   disabled?: boolean;
   onChange?: (...event: unknown[]) => void;
-  value?: string;
+  value?: string | null;
   formPart?: boolean;
 };
 
@@ -132,7 +132,7 @@ function DatumList({
   onChange?: (datum: string | null) => void;
   placeholder?: string;
   data: Array<Datum>;
-  value?: string;
+  value?: string | null;
 }) {
   return (
     <Command>

--- a/packages/migrations/src/actions/2025-05-19T15-45-46.override-pcn874-record-type.ts
+++ b/packages/migrations/src/actions/2025-05-19T15-45-46.override-pcn874-record-type.ts
@@ -1,0 +1,11 @@
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+export default {
+  name: '2025-05-19T15-45-46.override-pcn874-record-type.sql',
+  run: ({ sql }) => sql`
+create type accounter_schema.pcn874_record_type as enum ('S1', 'S2', 'L1', 'L2', 'M', 'Y', 'I', 'T', 'K', 'R', 'P', 'H', 'C');
+
+alter table accounter_schema.businesses
+    add if not exists pcn874_record_type_override accounter_schema.pcn874_record_type;
+`,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -91,6 +91,7 @@ import migration_2025_04_10T15_44_07_tax_excluded_flag from './actions/2025-04-1
 import migration_2025_04_15T17_27_28_pcn874 from './actions/2025-04-15T17-27-28.pcn874.js';
 import migration_2025_05_13T12_28_00_corporate_special_tax_rate from './actions/2025-05-13T12-28-00.corporate-special-tax-rate.js';
 import migration_2025_05_18T13_02_20_override_documents_exchange_rate from './actions/2025-05-18T13-02-20.override-documents-exchange-rate.js';
+import migration_2025_05_19T15_45_46_override_pcn874_record_type from './actions/2025-05-19T15-45-46.override-pcn874-record-type.js';
 import { runMigrations } from './pg-migrator.js';
 
 export const runPGMigrations = (args: { slonik: DatabasePool }) =>
@@ -189,5 +190,6 @@ export const runPGMigrations = (args: { slonik: DatabasePool }) =>
       migration_2025_04_15T17_27_28_pcn874,
       migration_2025_05_13T12_28_00_corporate_special_tax_rate,
       migration_2025_05_18T13_02_20_override_documents_exchange_rate,
+      migration_2025_05_19T15_45_46_override_pcn874_record_type,
     ],
   });

--- a/packages/pcn874-generator/src/utils/data-handlers.ts
+++ b/packages/pcn874-generator/src/utils/data-handlers.ts
@@ -66,13 +66,19 @@ export function sortTransactions(transactions: Transaction[], options: Options) 
   }
 
   return transactions.sort((a, b) => {
-    if (a.entryType > b.entryType) {
-      return 1;
+    const entryTypeCompare = a.entryType.localeCompare(b.entryType);
+    if (entryTypeCompare) {
+      return entryTypeCompare;
     }
-    if (a.entryType < b.entryType) {
-      return -1;
+    const invoiceDateCompare = a.invoiceDate.localeCompare(b.invoiceDate);
+    if (invoiceDateCompare) {
+      return invoiceDateCompare;
     }
-    return a.invoiceDate > b.invoiceDate ? 1 : -1;
+    const vatIdCompare = (a.vatId ?? '0').localeCompare(b.vatId ?? '0');
+    if (vatIdCompare) {
+      return vatIdCompare;
+    }
+    return a.invoiceSum > b.invoiceSum ? 1 : -1;
   });
 }
 

--- a/packages/server/src/modules/financial-entities/providers/businesses.provider.ts
+++ b/packages/server/src/modules/financial-entities/providers/businesses.provider.ts
@@ -174,6 +174,10 @@ const updateBusiness = sql<IUpdateBusinessQuery>`
   optional_vat = COALESCE(
     $optionalVat,
     optional_vat
+  ),
+  pcn874_record_type_override = COALESCE(
+    $pcn874RecordTypeOverride,
+    pcn874_record_type_override
   )
   WHERE
     id = $businessId
@@ -181,8 +185,8 @@ const updateBusiness = sql<IUpdateBusinessQuery>`
 `;
 
 const insertBusinesses = sql<IInsertBusinessesQuery>`
-  INSERT INTO accounter_schema.businesses (id, hebrew_name, address, email, website, phone_number, vat_number, exempt_dealer, suggestion_data, optional_vat, country)
-  VALUES $$businesses(id, hebrewName, address, email, website, phoneNumber, governmentId, exemptDealer, suggestions, optionalVat, country)
+  INSERT INTO accounter_schema.businesses (id, hebrew_name, address, email, website, phone_number, vat_number, exempt_dealer, suggestion_data, optional_vat, country, pcn874_record_type_override)
+  VALUES $$businesses(id, hebrewName, address, email, website, phoneNumber, governmentId, exemptDealer, suggestions, optionalVat, country, pcn874RecordTypeOverride)
   RETURNING *;`;
 
 const deleteBusiness = sql<IDeleteBusinessQuery>`

--- a/packages/server/src/modules/financial-entities/resolvers/businesses.resolver.ts
+++ b/packages/server/src/modules/financial-entities/resolvers/businesses.resolver.ts
@@ -99,6 +99,7 @@ export const businessesResolvers: FinancialEntitiesModule.Resolvers &
         optionalVat: fields.optionalVAT,
         country: fields.country,
         suggestionData,
+        pcn874RecordTypeOverride: fields.pcn874RecordType,
       };
       try {
         if (
@@ -110,7 +111,8 @@ export const businessesResolvers: FinancialEntitiesModule.Resolvers &
           fields.website ||
           fields.exemptDealer != null ||
           fields.suggestions ||
-          fields.optionalVAT != null
+          fields.optionalVAT != null ||
+          fields.pcn874RecordType
         ) {
           await injector
             .get(BusinessesProvider)
@@ -202,6 +204,7 @@ export const businessesResolvers: FinancialEntitiesModule.Resolvers &
           optionalVat: fields.optionalVAT,
           country: fields.country,
           suggestions,
+          pcn874RecordTypeOverride: fields.pcn874RecordType,
         });
 
         let taxCategoryPromise: Promise<IInsertBusinessTaxCategoryResult | void> =
@@ -425,6 +428,7 @@ export const businessesResolvers: FinancialEntitiesModule.Resolvers &
             governmentId: undefined,
             exemptDealer: false,
             optionalVat: false,
+            pcn874RecordTypeOverride: null,
           });
 
           if (!business) {
@@ -503,11 +507,13 @@ export const businessesResolvers: FinancialEntitiesModule.Resolvers &
       return null;
     },
     optionalVAT: DbBusiness => DbBusiness.optional_vat,
+    pcn874RecordType: DbBusiness => DbBusiness.pcn874_record_type_override,
   },
   PersonalFinancialEntity: {
     ...commonFinancialEntityFields,
     name: DbBusiness => DbBusiness.name,
     email: DbBusiness => DbBusiness.email ?? '', // TODO: remove alternative ''
+    pcn874RecordType: DbBusiness => DbBusiness.pcn874_record_type_override,
   },
   UpdateBusinessResponse: {
     __resolveType: (obj, _context, _info) => {

--- a/packages/server/src/modules/financial-entities/typeDefs/businesses.graphql.ts
+++ b/packages/server/src/modules/financial-entities/typeDefs/businesses.graphql.ts
@@ -12,6 +12,8 @@ export default gql`
   interface Business implements FinancialEntity {
     id: UUID!
     name: String!
+
+    pcn874RecordType: Pcn874RecordType
   }
 
   " response for paginated Financial Entities "
@@ -36,6 +38,8 @@ export default gql`
     optionalVAT: Boolean
 
     suggestions: Suggestions
+
+    pcn874RecordType: Pcn874RecordType
   }
 
   " input for business suggestions "
@@ -50,6 +54,8 @@ export default gql`
     id: UUID!
     name: String!
     email: String!
+
+    pcn874RecordType: Pcn874RecordType
   }
 
   extend type Mutation {
@@ -84,6 +90,8 @@ export default gql`
     exemptDealer: Boolean
     suggestions: SuggestionsInput
     optionalVAT: Boolean
+
+    pcn874RecordType: Pcn874RecordType
   }
 
   " input for insertNewBusiness "
@@ -102,6 +110,7 @@ export default gql`
     exemptDealer: Boolean
     suggestions: SuggestionsInput
     optionalVAT: Boolean
+    pcn874RecordType: Pcn874RecordType
   }
 
   " input for business suggestions "

--- a/packages/server/src/modules/reports/helpers/pcn.helper.ts
+++ b/packages/server/src/modules/reports/helpers/pcn.helper.ts
@@ -1,6 +1,7 @@
 import { format, startOfMonth } from 'date-fns';
 import { EntryType, pcnGenerator } from '@accounter/pcn874-generator';
 import { BusinessesProvider } from '@modules/financial-entities/providers/businesses.provider.js';
+import { Pcn874RecordType } from '@shared/gql-types';
 import { idValidator, yearMonthValidator } from '@shared/helpers';
 import { TimelessDateString } from '@shared/types';
 import { getVatRecords } from '../resolvers/get-vat-records.resolver.js';
@@ -90,6 +91,92 @@ const headerPropsFromTransactions = (
   return header;
 };
 
+const safeParseEntryType = (entryType: Pcn874RecordType | undefined): EntryType | undefined => {
+  if (!entryType) {
+    return undefined;
+  }
+  switch (entryType) {
+    case EntryType.SALE_REGULAR:
+      return EntryType.SALE_REGULAR;
+    case EntryType.SALE_UNIDENTIFIED_ZERO_OR_EXEMPT:
+      return EntryType.SALE_UNIDENTIFIED_ZERO_OR_EXEMPT;
+    case EntryType.INPUT_REGULAR:
+      return EntryType.INPUT_REGULAR;
+    case EntryType.INPUT_PETTY_CASH:
+      return EntryType.INPUT_PETTY_CASH;
+    case EntryType.SALE_SELF_INVOICE:
+      return EntryType.SALE_SELF_INVOICE;
+    case EntryType.SALE_EXPORT:
+      return EntryType.SALE_EXPORT;
+    case EntryType.SALE_PALESTINIAN_CUSTOMER:
+      return EntryType.SALE_PALESTINIAN_CUSTOMER;
+    case EntryType.SALE_ZERO_OR_EXEMPT:
+      return EntryType.SALE_ZERO_OR_EXEMPT;
+    case EntryType.SALE_UNIDENTIFIED_CUSTOMER:
+      return EntryType.SALE_UNIDENTIFIED_CUSTOMER;
+    case EntryType.INPUT_IMPORT:
+      return EntryType.INPUT_IMPORT;
+    case EntryType.INPUT_PALESTINIAN_SUPPLIER:
+      return EntryType.INPUT_PALESTINIAN_SUPPLIER;
+    case EntryType.INPUT_SINGLE_DOC_BY_LAW:
+      return EntryType.INPUT_SINGLE_DOC_BY_LAW;
+    case EntryType.INPUT_SELF_INVOICE:
+      return EntryType.INPUT_SELF_INVOICE;
+    default:
+      console.debug(`Entry type ${entryType} is not implemented yet`);
+      return undefined;
+  }
+};
+
+const NO_VAT_ID_ENTRIES: string[] = [
+  EntryType.SALE_UNIDENTIFIED_CUSTOMER,
+  EntryType.SALE_UNIDENTIFIED_ZERO_OR_EXEMPT,
+  EntryType.INPUT_PETTY_CASH,
+] as const;
+
+// TODO: migrate helper functions to PCN874 generator
+function getVatId(t: RawVatReportRecord): string {
+  if (t.pcn874RecordType && NO_VAT_ID_ENTRIES.includes(t.pcn874RecordType)) {
+    return '0';
+  }
+
+  if (!t.vatNumber && t.pcn874RecordType === EntryType.INPUT_REGULAR) {
+    return '999999999';
+  }
+
+  return t.vatNumber ?? '0';
+}
+
+function getRefNumber(t: RawVatReportRecord): string {
+  if (t.pcn874RecordType === EntryType.INPUT_IMPORT) {
+    return '0';
+  }
+  if (t.pcn874RecordType === EntryType.INPUT_PETTY_CASH) {
+    return '1';
+  }
+  if (t.documentSerial) {
+    return t.documentSerial;
+  }
+  if (
+    t.pcn874RecordType === EntryType.SALE_UNIDENTIFIED_CUSTOMER ||
+    t.pcn874RecordType === EntryType.SALE_UNIDENTIFIED_ZERO_OR_EXEMPT
+  ) {
+    return '1';
+  }
+  return '0';
+}
+
+function getTotalVat(t: RawVatReportRecord): number {
+  if (
+    t.pcn874RecordType === EntryType.SALE_ZERO_OR_EXEMPT ||
+    t.pcn874RecordType === EntryType.SALE_UNIDENTIFIED_ZERO_OR_EXEMPT ||
+    t.pcn874RecordType === EntryType.SALE_EXPORT
+  ) {
+    return 0;
+  }
+  return Math.round(Math.abs(Number(t.roundedVATToAdd ?? 0)));
+}
+
 const transformTransactions = (vatRecords: RawVatReportRecord[]): ExtendedPCNTransaction[] => {
   const transactions: ExtendedPCNTransaction[] = [];
   for (const t of vatRecords) {
@@ -97,26 +184,30 @@ const transformTransactions = (vatRecords: RawVatReportRecord[]): ExtendedPCNTra
       console.debug(`Document ${t.documentId} has no tax_invoice_date. Skipping it.`);
       continue;
     }
-    let entryType = EntryType.INPUT_REGULAR;
-    if (!t.isExpense) {
-      if (Number(t.foreignVatAfterDeduction) > 0) {
-        entryType = EntryType.SALE_REGULAR;
-      } else {
-        entryType = EntryType.SALE_UNIDENTIFIED_ZERO_OR_EXEMPT;
+    let entryType = safeParseEntryType(t.pcn874RecordType);
+    if (!entryType) {
+      entryType = EntryType.INPUT_REGULAR;
+      if (!t.isExpense) {
+        if (Number(t.foreignVatAfterDeduction) > 0) {
+          entryType = EntryType.SALE_REGULAR;
+        } else {
+          entryType = EntryType.SALE_UNIDENTIFIED_ZERO_OR_EXEMPT;
+        }
       }
     }
 
-    transactions.push({
+    const transaction: ExtendedPCNTransaction = {
       entryType,
-      vatId: t.vatNumber ?? '0',
+      vatId: getVatId(t),
       invoiceDate: format(new Date(t.documentDate!), 'yyyyMMdd'),
       refGroup: '0000',
-      refNumber: t.documentSerial ?? undefined,
-      totalVat: Math.round(Math.abs(Number(t.roundedVATToAdd ?? 0))),
+      refNumber: getRefNumber(t),
+      totalVat: getTotalVat(t),
       invoiceSum: Math.round(Number(t.localAmountBeforeVAT)),
       isProperty: t.isProperty,
       allocationNumber: t.allocationNumber ?? undefined,
-    });
+    };
+    transactions.push(transaction);
   }
   return transactions.sort((a, b) => a.invoiceDate.localeCompare(b.invoiceDate));
 };

--- a/packages/server/src/modules/reports/helpers/vat-report.helper.ts
+++ b/packages/server/src/modules/reports/helpers/vat-report.helper.ts
@@ -5,7 +5,7 @@ import type { IGetBusinessesByIdsResult } from '@modules/financial-entities/type
 import { VatProvider } from '@modules/vat/providers/vat.provider.js';
 import { DECREASED_VAT_RATIO } from '@shared/constants';
 import { Currency, DocumentType } from '@shared/enums';
-import type { AccountantStatus } from '@shared/gql-types';
+import type { AccountantStatus, Pcn874RecordType } from '@shared/gql-types';
 import { dateToTimelessDateString, formatCurrency } from '@shared/helpers';
 
 export type VatReportRecordSources = {
@@ -37,6 +37,7 @@ export type RawVatReportRecord = {
   localVatAfterDeduction?: number;
   vatNumber?: string | null;
   allocationNumber?: string | null;
+  pcn874RecordType?: Pcn874RecordType;
 };
 
 export async function adjustTaxRecord(
@@ -97,6 +98,7 @@ export async function adjustTaxRecord(
           ? doc.debtor_id !== charge.owner_id
           : doc.debtor_id === charge.owner_id,
       allocationNumber: doc.allocation_number,
+      pcn874RecordType: business.pcn874_record_type_override ?? undefined,
     };
 
     // set default amountBeforeVAT

--- a/packages/server/src/modules/reports/typeDefs/pcn.graphql.ts
+++ b/packages/server/src/modules/reports/typeDefs/pcn.graphql.ts
@@ -40,4 +40,21 @@ export default gql`
     content: String!
     diffContent: String
   }
+
+  " record type of PCN874 report "
+  enum Pcn874RecordType {
+    S1
+    S2
+    L1
+    L2
+    M
+    Y
+    I
+    T
+    K
+    R
+    P
+    H
+    C
+  }
 `;


### PR DESCRIPTION
closes #2142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting and displaying a new PCN874 record type field for businesses throughout the app, including forms and business details.
  - Introduced a new dropdown for PCN874 record type selection in business forms with updated styling.
  - Added new enum options for PCN874 record types in reports and GraphQL API.

- **Improvements**
  - Unified form layouts and inputs under a custom design system with updated styling.
  - Enhanced sorting of transactions in PCN874 reports for more accurate ordering.
  - Improved modularity and clarity in PCN874 report generation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->