### PR TITLE
Support JPY currency

### DIFF
--- a/.changeset/grumpy-kids-change.md
+++ b/.changeset/grumpy-kids-change.md
@@ -1,0 +1,6 @@
+---
+'@accounter/client': patch
+'@accounter/server': patch
+---
+
+Support JPY currency

--- a/packages/client/src/components/business-transactions/business-extended-info.tsx
+++ b/packages/client/src/components/business-transactions/business-extended-info.tsx
@@ -123,6 +123,7 @@ export function BusinessExtendedInfo({ businessID, filter }: Props): ReactElemen
   const isUsd = isExtendAllCurrencies || currencies.has(Currency.Usd);
   const isGbp = isExtendAllCurrencies || currencies.has(Currency.Gbp);
   const isCad = isExtendAllCurrencies || currencies.has(Currency.Cad);
+  const isJpy = isExtendAllCurrencies || currencies.has(Currency.Jpy);
 
   const businessName = transactions[0]?.business.name ?? 'unknown';
 
@@ -160,6 +161,12 @@ export function BusinessExtendedInfo({ businessID, filter }: Props): ReactElemen
                 <>
                   <th>CAD Amount</th>
                   <th>CAD Balance</th>
+                </>
+              )}
+              {isJpy && (
+                <>
+                  <th>JPY Amount</th>
+                  <th>JPY Balance</th>
                 </>
               )}
               <th>
@@ -242,6 +249,7 @@ export function BusinessExtendedInfo({ businessID, filter }: Props): ReactElemen
                 {isUsd && <CurrencyCells data={row} currency={Currency.Usd} />}
                 {isGbp && <CurrencyCells data={row} currency={Currency.Gbp} />}
                 {isCad && <CurrencyCells data={row} currency={Currency.Cad} />}
+                {isJpy && <CurrencyCells data={row} currency={Currency.Jpy} />}
                 <td />
                 {isExtendAllCurrencies && <ExtendedCurrencyCells data={row} />}
                 <td>{row.reference}</td>
@@ -304,7 +312,9 @@ export function CurrencyCells({
 
 const currenciesToExtend = Object.values(Currency).filter(
   currency =>
-    ![Currency.Ils, Currency.Eur, Currency.Usd, Currency.Gbp, Currency.Cad].includes(currency),
+    ![Currency.Ils, Currency.Eur, Currency.Usd, Currency.Gbp, Currency.Cad, Currency.Jpy].includes(
+      currency,
+    ),
 );
 
 export function ExtendedCurrencyCells({ data }: { data: ExtendedTransaction }): ReactElement {

--- a/packages/client/src/components/business-transactions/business-transactions-single.tsx
+++ b/packages/client/src/components/business-transactions/business-transactions-single.tsx
@@ -98,6 +98,7 @@ export const BusinessTransactionsSingle = ({ businessId }: Props): ReactElement 
         ...getCurrencyCells(Currency.Usd),
         ...getCurrencyCells(Currency.Gbp),
         ...getCurrencyCells(Currency.Cad),
+        ...getCurrencyCells(Currency.Jpy),
       ]}
     />
   );

--- a/packages/client/src/components/business-transactions/index.tsx
+++ b/packages/client/src/components/business-transactions/index.tsx
@@ -182,6 +182,7 @@ export const BusinessTransactionsSummery = (): ReactElement => {
     ...getCurrencyCells(Currency.Usd),
     ...getCurrencyCells(Currency.Gbp),
     ...getCurrencyCells(Currency.Cad),
+    ...getCurrencyCells(Currency.Jpy),
     ...getExtendedCurrencies(isExpandedCurrencies),
   ];
 
@@ -263,7 +264,14 @@ function getExtendedCurrencies(isExpandedCurrencies: boolean): CellInfo[] {
 
   const currenciesToExtend = Object.values(Currency).filter(
     currency =>
-      ![Currency.Ils, Currency.Eur, Currency.Usd, Currency.Gbp, Currency.Cad].includes(currency),
+      ![
+        Currency.Ils,
+        Currency.Eur,
+        Currency.Usd,
+        Currency.Gbp,
+        Currency.Cad,
+        Currency.Jpy,
+      ].includes(currency),
   );
 
   return currenciesToExtend.map(getCurrencyCells).flat();

--- a/packages/client/src/components/charges/extended-info/exchange-rates.tsx
+++ b/packages/client/src/components/charges/extended-info/exchange-rates.tsx
@@ -18,6 +18,7 @@ import { Card, CardContent, CardTitle } from '../../ui/card.js';
         gbp
         eur
         cad
+        jpy
         ils
         eth
         grt

--- a/packages/client/src/helpers/currency.ts
+++ b/packages/client/src/helpers/currency.ts
@@ -21,6 +21,8 @@ export function currencyCodeToSymbol(currency_code: Currency): string {
     currencySymbol = '£';
   } else if (currency_code === 'CAD') {
     currencySymbol = 'C$';
+  } else if (currency_code === 'JPY') {
+    currencySymbol = '¥';
   } else if (currency_code === 'GRT') {
     currencySymbol = 'GRT';
   } else if (currency_code === 'USDC') {

--- a/packages/migrations/src/actions/2025-06-29T12-27-18.support-jpy-currency.ts
+++ b/packages/migrations/src/actions/2025-06-29T12-27-18.support-jpy-currency.ts
@@ -1,0 +1,11 @@
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+export default {
+  name: '2025-06-29T12-27-18.support-jpy-currency.sql',
+  run: ({ sql }) => sql`
+ALTER TYPE accounter_schema.currency ADD VALUE 'JPY';
+
+alter table accounter_schema.exchange_rates
+    add jpy numeric(5, 4);
+`,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -100,6 +100,7 @@ import migration_2025_06_09T18_11_34_convert_irs_codes_array_column_to_single fr
 import migration_2025_06_10T10_45_37_convert_irs_codes_array_column_to_single2 from './actions/2025-06-10T10-45-37.convert-irs-codes-array-column-to-single2.js';
 import migration_2025_06_26T20_52_26_migrate_from_multiple_tables_to_single_poalim_foreign_table from './actions/2025-06-26T20-52-26.migrate-from-multiple-tables-to-single-poalim-foreign-table.js';
 import migration_2025_06_28T13_12_45_fix_poalim_swift_trigger_function from './actions/2025-06-28T13-12-45.fix-poalim-swift-trigger-function.js';
+import migration_2025_06_29T12_27_18_support_jpy_currency from './actions/2025-06-29T12-27-18.support-jpy-currency.js';
 import { runMigrations } from './pg-migrator.js';
 
 export const runPGMigrations = (args: { slonik: DatabasePool }) =>
@@ -207,5 +208,6 @@ export const runPGMigrations = (args: { slonik: DatabasePool }) =>
       migration_2025_06_10T10_45_37_convert_irs_codes_array_column_to_single2,
       migration_2025_06_26T20_52_26_migrate_from_multiple_tables_to_single_poalim_foreign_table,
       migration_2025_06_28T13_12_45_fix_poalim_swift_trigger_function,
+      migration_2025_06_29T12_27_18_support_jpy_currency,
     ],
   });

--- a/packages/scraper-local-app/src/scrapers/poalim/foreign-transactions.ts
+++ b/packages/scraper-local-app/src/scrapers/poalim/foreign-transactions.ts
@@ -28,7 +28,7 @@ export type ForeignTransaction = (
   | ForeignTransactionsPersonalSchema
   | ForeignTransactionsBusinessSchema
 )['balancesAndLimitsDataList'][number]['transactions'][number];
-type ForeignCurrency = 'USD' | 'EUR' | 'GBP' | 'CAD';
+type ForeignCurrency = 'USD' | 'EUR' | 'GBP' | 'CAD' | 'JPY';
 export type NormalizedForeignTransaction = ForeignTransaction & {
   currency: ForeignCurrency;
   metadataAttributesOriginalEventKey?: Json | null;
@@ -179,7 +179,7 @@ const PoalimForeignTransactionSchema = z.object({
   originalSystemId: z.number().int(),
   activityDescription: z.string().max(30),
   eventAmount: z.number().refine(n => n >= -99_999_999.99 && n <= 99_999_999.99),
-  currency: z.enum(['USD', 'EUR', 'GBP', 'CAD']),
+  currency: z.enum(['USD', 'EUR', 'GBP', 'CAD', 'JPY']),
   currentBalance: z.number().refine(n => n >= -99_999_999.99 && n <= 99_999_999.99),
   referenceCatenatedNumber: z.number().int(),
   referenceNumber: z.number().int(),
@@ -305,6 +305,9 @@ async function normalizeForeignTransactionsForAccount(
           break;
         case 140:
           accountCurrency = 'CAD';
+          break;
+        case 248:
+          accountCurrency = 'JPY';
           break;
         default:
           throw new Error(`New Poalim account currency - ${foreignAccountsArray.currencyCode}`);

--- a/packages/server/src/modules/common/typeDefs/common.graphql.ts
+++ b/packages/server/src/modules/common/typeDefs/common.graphql.ts
@@ -85,6 +85,7 @@ export default gql`
     GBP
     EUR
     CAD
+    JPY
     GRT
     USDC
     ETH

--- a/packages/server/src/modules/exchange-rates/helpers/exchange.helper.ts
+++ b/packages/server/src/modules/exchange-rates/helpers/exchange.helper.ts
@@ -60,9 +60,9 @@ export function getRateForCurrency(
   }
   if (
     currencyCode &&
-    [Currency.Usd, Currency.Eur, Currency.Gbp, Currency.Cad].includes(currencyCode)
+    [Currency.Usd, Currency.Eur, Currency.Gbp, Currency.Cad, Currency.Jpy].includes(currencyCode)
   ) {
-    const currencyKey = currencyCode.toLowerCase() as 'usd' | 'eur' | 'gbp' | 'cad';
+    const currencyKey = currencyCode.toLowerCase() as 'usd' | 'eur' | 'gbp' | 'cad' | 'jpy';
     const rate = parseFloat(exchangeRates[currencyKey] ?? '');
     if (Number.isNaN(rate)) {
       throw new Error(

--- a/packages/server/src/modules/exchange-rates/resolvers/exchange.resolver.ts
+++ b/packages/server/src/modules/exchange-rates/resolvers/exchange.resolver.ts
@@ -55,6 +55,15 @@ export const exchangeResolvers: ExchangeRatesModule.Resolvers = {
       }
       return parseFloat(exchangeRates.cad);
     },
+    jpy: async (timelessDate, _, { injector }) => {
+      const exchangeRates = await injector
+        .get(FiatExchangeProvider)
+        .getExchangeRatesByDatesLoader.load(new Date(timelessDate));
+      if (!exchangeRates?.jpy) {
+        return null;
+      }
+      return parseFloat(exchangeRates.jpy);
+    },
     ils: () => {
       return 1;
     },

--- a/packages/server/src/modules/exchange-rates/typeDefs/exchange.graphql.ts
+++ b/packages/server/src/modules/exchange-rates/typeDefs/exchange.graphql.ts
@@ -13,6 +13,7 @@ export default gql`
     gbp: Float
     eur: Float
     cad: Float
+    jpy: Float
     ils: Float
     eth: Float
     grt: Float

--- a/packages/server/src/modules/green-invoice/helpers/green-invoice.helper.ts
+++ b/packages/server/src/modules/green-invoice/helpers/green-invoice.helper.ts
@@ -78,8 +78,6 @@ export function convertCurrencyToGreenInvoice(currency: Currency): GreenInvoiceC
       return 'ILS';
     case Currency.Usd:
       return 'USD';
-    case Currency.Jpy:
-      return 'JPY';
     case Currency.Eth:
     case Currency.Grt:
     case Currency.Usdc:

--- a/packages/server/src/modules/green-invoice/helpers/green-invoice.helper.ts
+++ b/packages/server/src/modules/green-invoice/helpers/green-invoice.helper.ts
@@ -72,10 +72,14 @@ export function convertCurrencyToGreenInvoice(currency: Currency): GreenInvoiceC
       return 'GBP';
     case Currency.Cad:
       return 'CAD';
+    case Currency.Jpy:
+      return 'JPY';
     case Currency.Ils:
       return 'ILS';
     case Currency.Usd:
       return 'USD';
+    case Currency.Jpy:
+      return 'JPY';
     case Currency.Eth:
     case Currency.Grt:
     case Currency.Usdc:

--- a/packages/server/src/modules/reports/providers/balance-report.provider.ts
+++ b/packages/server/src/modules/reports/providers/balance-report.provider.ts
@@ -27,18 +27,19 @@ with transactions AS (SELECT
         WHEN t.currency = 'EUR' THEN t.amount * (lr.eur / lr.usd) -- Convert EUR => ILS => USD
         WHEN t.currency = 'GBP' THEN t.amount * (lr.gbp / lr.usd) -- Convert GBP => ILS => USD
         WHEN t.currency = 'CAD' THEN t.amount * (lr.cad / lr.usd) -- Convert CAD => ILS => USD
+        WHEN t.currency = 'JPY' THEN t.amount * (lr.jpy / lr.usd) -- Convert JPY => ILS => USD
         WHEN t.currency = 'USDC' OR t.currency = 'GRT' OR t.currency = 'ETH' THEN t.amount * lr2.value -- Convert Crypto => USD
         ELSE NULL
     END AS amount_usd
 FROM accounter_schema.transactions t
 LEFT JOIN accounter_schema.charges c ON t.charge_id = c.id
 LEFT JOIN LATERAL (
-    SELECT er.usd, er.eur, er.gbp, er.cad
+    SELECT er.usd, er.eur, er.gbp, er.cad, er.jpy
     FROM accounter_schema.exchange_rates er
     WHERE er.exchange_date <= t.debit_date
     ORDER BY er.exchange_date DESC
     LIMIT 1
-) lr ON t.currency = 'ILS' OR t.currency = 'EUR' OR t.currency ='GBP' OR t.currency = 'CAD'
+) lr ON t.currency = 'ILS' OR t.currency = 'EUR' OR t.currency ='GBP' OR t.currency = 'CAD' OR t.currency = 'JPY'
 LEFT JOIN LATERAL (
     SELECT cer.value
     FROM accounter_schema.crypto_exchange_rates cer

--- a/packages/server/src/shared/enums.ts
+++ b/packages/server/src/shared/enums.ts
@@ -24,6 +24,7 @@ export enum Currency {
   Eur = 'EUR',
   Gbp = 'GBP',
   Cad = 'CAD',
+  Jpy = 'JPY',
   Grt = 'GRT',
   Ils = 'ILS',
   Usd = 'USD',

--- a/packages/server/src/shared/helpers/amount.ts
+++ b/packages/server/src/shared/helpers/amount.ts
@@ -56,6 +56,8 @@ export function formatCurrency<T extends boolean = false>(
       return Currency.Eur;
     case 'CAD':
       return Currency.Cad;
+    case 'JPY':
+      return Currency.Jpy;
     case 'ILS':
       return Currency.Ils;
     case 'GRT':
@@ -87,6 +89,8 @@ export function getCurrencySymbol(currency: Currency) {
       return '€';
     case Currency.Cad:
       return 'C$';
+    case Currency.Jpy:
+      return '¥';
     case Currency.Ils:
       return '₪';
     case Currency.Grt:


### PR DESCRIPTION
closes #2251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support for the Japanese Yen (JPY) currency across the platform, including transaction tables, charts, reports, and exchange rates.
  * JPY is now available as a primary currency option in business transactions and summaries.
  * JPY exchange rates are fetched, stored, and displayed alongside other supported currencies.
  * Yen symbol (¥) is now shown where appropriate.

* **Bug Fixes**
  * Enhanced normalization and validation to properly handle JPY in foreign transactions. 

* **Chores**
  * Database and schema updated to support JPY currency and exchange rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->