### PR TITLE
Move couterparty to first in transactions table

### DIFF
--- a/packages/client/src/components/transactions-table/cells/account.tsx
+++ b/packages/client/src/components/transactions-table/cells/account.tsx
@@ -12,7 +12,7 @@ export const Account = ({ transaction }: Props): ReactElement => {
   const accountName = account.name;
 
   return (
-    <div className="flex flex-col gap-2 items-center">
+    <div className="flex flex-col justify-center">
       <p>{accountType}</p>
       <p>{accountName}</p>
     </div>

--- a/packages/client/src/components/transactions-table/cells/counterparty.tsx
+++ b/packages/client/src/components/transactions-table/cells/counterparty.tsx
@@ -93,7 +93,7 @@ export function Counterparty({ transaction, onChange }: Props): ReactElement {
 
   return (
     <>
-      <div className="flex flex-wrap gap-1 items-center justify-center">
+      <div className="flex flex-wrap flex-col justify-center">
         {counterparty?.id ? (
           <a href={getHref(counterparty.id)} target="_blank" rel="noreferrer">
             {name}

--- a/packages/client/src/components/transactions-table/columns.tsx
+++ b/packages/client/src/components/transactions-table/columns.tsx
@@ -58,6 +58,28 @@ export type TransactionsTableRowType = TransactionForTransactionsTableFieldsFrag
 
 export const columns: ColumnDef<TransactionsTableRowType>[] = [
   {
+    accessorKey: 'counterparty.name',
+    header: ({ column }) => {
+      return (
+        <Button
+          variant="ghost"
+          // onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+        >
+          Counterparty
+          {column.getIsSorted() &&
+            (column.getIsSorted() === 'asc' ? (
+              <ChevronUp className="ml-2 h-4 w-4" />
+            ) : (
+              <ChevronDown className="ml-2 h-4 w-4" />
+            ))}
+        </Button>
+      );
+    },
+    cell: ({ row }) => {
+      return <Counterparty transaction={row.original} />;
+    },
+  },
+  {
     accessorKey: 'eventDate',
     sortingFn: row => {
       return 'eventDate' in row.original && row.original.eventDate
@@ -197,28 +219,6 @@ export const columns: ColumnDef<TransactionsTableRowType>[] = [
     },
     cell: ({ row }) => {
       return <SourceID transaction={row.original} />;
-    },
-  },
-  {
-    accessorKey: 'counterparty.name',
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          // onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
-        >
-          Counterparty
-          {column.getIsSorted() &&
-            (column.getIsSorted() === 'asc' ? (
-              <ChevronUp className="ml-2 h-4 w-4" />
-            ) : (
-              <ChevronDown className="ml-2 h-4 w-4" />
-            ))}
-        </Button>
-      );
-    },
-    cell: ({ row }) => {
-      return <Counterparty transaction={row.original} />;
     },
   },
   {

--- a/packages/client/src/components/ui/table.tsx
+++ b/packages/client/src/components/ui/table.tsx
@@ -58,7 +58,7 @@ function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
     <th
       data-slot="table-head"
       className={cn(
-        'text-gray-500 h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px] dark:text-gray-400',
+        'text-gray-500 h-10 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px] dark:text-gray-400',
         className,
       )}
       {...props}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated layout and alignment of account and counterparty cells in the transactions table for improved visual consistency.
  * Adjusted table header cell padding for a cleaner appearance.

* **Refactor**
  * Reordered and removed a duplicate "Counterparty" column in the transactions table to streamline the column layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->