### PR TITLE
feat(scraper-app): add GET /api/vault/download endpoint (Prompt 2)

### DIFF
--- a/packages/scraper-app/src/server/__tests__/vault-routes.test.ts
+++ b/packages/scraper-app/src/server/__tests__/vault-routes.test.ts
@@ -167,6 +167,57 @@ describe('GET /api/vault/env-path', () => {
   });
 });
 
+describe('GET /api/vault/download', () => {
+  describe('when vault file exists', () => {
+    let vaultPath: string;
+    let app: FastifyInstance;
+
+    beforeEach(async () => {
+      vaultPath = makeTmpPath();
+      await saveVaultFile(vaultPath, defaultVault(), PASSWORD);
+      app = await buildApp(vaultPath);
+    });
+
+    afterEach(async () => {
+      lockVault();
+      await app.close();
+      await rm(vaultPath, { force: true });
+      delete process.env['VAULT_PATH'];
+    });
+
+    it('returns 200 with octet-stream content-type when vault file exists', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/vault/download' });
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['content-type']).toMatch(/application\/octet-stream/);
+      expect(res.headers['content-disposition']).toBe('attachment; filename=".vault"');
+      expect(res.rawPayload.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('when vault file does not exist', () => {
+    let vaultPath: string;
+    let app: FastifyInstance;
+
+    beforeEach(async () => {
+      vaultPath = makeTmpPath();
+      app = await buildApp(vaultPath);
+    });
+
+    afterEach(async () => {
+      lockVault();
+      await app.close();
+      await rm(vaultPath, { force: true });
+      delete process.env['VAULT_PATH'];
+    });
+
+    it('returns 404 when no vault file exists', async () => {
+      const res = await app.inject({ method: 'GET', url: '/api/vault/download' });
+      expect(res.statusCode).toBe(404);
+      expect(res.json().error).toBe('no-vault-file');
+    });
+  });
+});
+
 describe('POST /api/vault/unlock', () => {
   let vaultPath: string;
   let app: FastifyInstance;

--- a/packages/scraper-app/src/server/vault-routes.ts
+++ b/packages/scraper-app/src/server/vault-routes.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import type { FastifyInstance } from 'fastify';
 import { registerAccountsRoutes } from './accounts-routes.js';
 import { registerSettingsRoutes } from './settings-routes.js';
@@ -65,6 +66,20 @@ export async function registerVaultRoutes(app: FastifyInstance): Promise<void> {
   app.get('/api/vault/env-path', async () => ({
     path: getVaultPath(),
   }));
+
+  app.get('/api/vault/download', async (_req, reply) => {
+    try {
+      const fileBuffer = await readFile(getVaultPath());
+      reply.header('Content-Type', 'application/octet-stream');
+      reply.header('Content-Disposition', 'attachment; filename=".vault"');
+      return reply.send(fileBuffer);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return reply.status(404).send({ error: 'no-vault-file' });
+      }
+      throw err;
+    }
+  });
 
   app.get('/api/vault/path', async (_req, reply) => {
     if (isLocked()) return reply.status(401).send({ error: 'vault-locked' });


### PR DESCRIPTION
## Summary

- Adds `GET /api/vault/download` to `vault-routes.ts` — no auth required, streams the raw encrypted vault blob as `application/octet-stream` with `Content-Disposition: attachment; filename=".vault"`
- Returns `404 { error: 'no-vault-file' }` when the vault file is absent (ENOENT)
- Uses atomic `readFile` from `node:fs/promises`; vault-store is intentionally not involved (the encrypted blob is useless without the password)

## Test plan

- [ ] `GET /api/vault/download > when vault file exists > returns 200 with octet-stream content-type` ✓
- [ ] `GET /api/vault/download > when vault file does not exist > returns 404 when no vault file exists` ✓
- [ ] All 163 pre-existing tests still pass (165 total with 2 new) ✓

https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS)_