### PR TITLE
feat(scraper-app): add POST /api/vault/upload endpoint (Prompt 3)

### DIFF
--- a/packages/scraper-app/src/server/__tests__/vault-routes.test.ts
+++ b/packages/scraper-app/src/server/__tests__/vault-routes.test.ts
@@ -1,11 +1,11 @@
 import { randomBytes } from 'node:crypto';
-import { rm } from 'node:fs/promises';
+import { access, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { defaultVault, saveVaultFile } from '../vault.js';
-import { lockVault } from '../vault-store.js';
+import { defaultVault, encryptVault, saveVaultFile } from '../vault.js';
+import { isLocked, lockVault } from '../vault-store.js';
 import { registerVaultRoutes } from '../vault-routes.js';
 
 const PASSWORD = 'test-password-123';
@@ -252,5 +252,72 @@ describe('POST /api/vault/unlock', () => {
       payload: { password: 'wrong-password' },
     });
     expect(res.statusCode).toBe(401);
+  });
+});
+
+// ── Tests for POST /api/vault/upload ─────────────────────────────────────────
+
+async function uploadVault(
+  app: FastifyInstance,
+  opts: { force?: boolean } = {},
+): Promise<ReturnType<FastifyInstance['inject']>> {
+  const blob = await encryptVault(defaultVault(), PASSWORD);
+  return app.inject({
+    method: 'POST',
+    url: '/api/vault/upload' + (opts.force ? '?force=true' : ''),
+    payload: Buffer.from(blob, 'base64'),
+    headers: { 'content-type': 'application/octet-stream' },
+  });
+}
+
+describe('POST /api/vault/upload', () => {
+  let vaultPath: string;
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    vaultPath = makeTmpPath();
+    app = await buildApp(vaultPath);
+  });
+
+  afterEach(async () => {
+    lockVault();
+    await app.close();
+    await rm(vaultPath, { force: true });
+    await rm(vaultPath + '.tmp', { force: true });
+    delete process.env['VAULT_PATH'];
+  });
+
+  it('returns 200 and writes the vault file when no file exists', async () => {
+    const res = await uploadVault(app);
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true });
+    const exists = await access(vaultPath).then(() => true).catch(() => false);
+    expect(exists).toBe(true);
+  });
+
+  it('returns 409 when vault already exists and force is not set', async () => {
+    await saveVaultFile(vaultPath, defaultVault(), PASSWORD);
+    const res = await uploadVault(app);
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toBe('vault-already-exists');
+  });
+
+  it('overwrites and returns 200 when force=true and vault exists', async () => {
+    await saveVaultFile(vaultPath, defaultVault(), PASSWORD);
+    const res = await uploadVault(app, { force: true });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('locks the vault after successful upload even if it was unlocked', async () => {
+    await saveVaultFile(vaultPath, defaultVault(), PASSWORD);
+    await app.inject({
+      method: 'POST',
+      url: '/api/vault/unlock',
+      payload: { password: PASSWORD },
+    });
+    expect(isLocked()).toBe(false);
+    await uploadVault(app, { force: true });
+    const res = await app.inject({ method: 'GET', url: '/api/vault/status' });
+    expect(res.json()).toMatchObject({ locked: true });
   });
 });

--- a/packages/scraper-app/src/server/vault-routes.ts
+++ b/packages/scraper-app/src/server/vault-routes.ts
@@ -91,7 +91,7 @@ export async function registerVaultRoutes(app: FastifyInstance): Promise<void> {
     '/api/vault/upload',
     { config: { rawBody: false } },
     async (req, reply) => {
-      const force = Boolean(req.query.force);
+      const force = req.query.force === 'true';
       const vaultPath = getVaultPath();
       try {
         const exists = await hasVaultFile();
@@ -102,7 +102,8 @@ export async function registerVaultRoutes(app: FastifyInstance): Promise<void> {
         await rename(vaultPath + '.tmp', vaultPath);
         lockVault();
         return reply.status(200).send({ ok: true });
-      } catch {
+      } catch (err) {
+        req.log.error(err, 'Vault upload failed');
         return reply.status(500).send({ error: 'write-failed' });
       }
     },

--- a/packages/scraper-app/src/server/vault-routes.ts
+++ b/packages/scraper-app/src/server/vault-routes.ts
@@ -81,10 +81,8 @@ export async function registerVaultRoutes(app: FastifyInstance): Promise<void> {
     }
   });
 
-  app.addContentTypeParser(
-    'application/octet-stream',
-    { parseAs: 'buffer' },
-    (_req, body, done) => done(null, body),
+  app.addContentTypeParser('application/octet-stream', { parseAs: 'buffer' }, (_req, body, done) =>
+    done(null, body),
   );
 
   app.post<{ Querystring: { force?: string }; Body: Buffer }>(

--- a/packages/scraper-app/src/server/vault-routes.ts
+++ b/packages/scraper-app/src/server/vault-routes.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, rename, writeFile } from 'node:fs/promises';
 import type { FastifyInstance } from 'fastify';
 import { registerAccountsRoutes } from './accounts-routes.js';
 import { registerSettingsRoutes } from './settings-routes.js';
@@ -80,6 +80,33 @@ export async function registerVaultRoutes(app: FastifyInstance): Promise<void> {
       throw err;
     }
   });
+
+  app.addContentTypeParser(
+    'application/octet-stream',
+    { parseAs: 'buffer' },
+    (_req, body, done) => done(null, body),
+  );
+
+  app.post<{ Querystring: { force?: string }; Body: Buffer }>(
+    '/api/vault/upload',
+    { config: { rawBody: false } },
+    async (req, reply) => {
+      const force = Boolean(req.query.force);
+      const vaultPath = getVaultPath();
+      try {
+        const exists = await hasVaultFile();
+        if (exists && !force) {
+          return reply.status(409).send({ error: 'vault-already-exists' });
+        }
+        await writeFile(vaultPath + '.tmp', req.body as Buffer);
+        await rename(vaultPath + '.tmp', vaultPath);
+        lockVault();
+        return reply.status(200).send({ ok: true });
+      } catch {
+        return reply.status(500).send({ error: 'write-failed' });
+      }
+    },
+  );
 
   app.get('/api/vault/path', async (_req, reply) => {
     if (isLocked()) return reply.status(401).send({ error: 'vault-locked' });


### PR DESCRIPTION
## Summary

- Adds `POST /api/vault/upload` to `vault-routes.ts` — accepts a raw `application/octet-stream` body, writes it atomically via a `.tmp` rename, and always calls `lockVault()` so the user must re-unlock after replacing the file
- Registers an `application/octet-stream` content-type parser so Fastify accepts the binary body
- `?force=true` query param allows overwriting an existing vault; without it a pre-existing vault returns 409 `vault-already-exists`
- Any fs error returns 500 `write-failed`

## Test plan

- [ ] `returns 200 and writes the vault file when no file exists` ✓
- [ ] `returns 409 when vault already exists and force is not set` ✓
- [ ] `overwrites and returns 200 when force=true and vault exists` ✓
- [ ] `locks the vault after successful upload even if it was unlocked` ✓
- [ ] All 165 pre-existing tests still pass (169 total with 4 new) ✓

https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS)_