### PR TITLE
feat(scraper-app): add _vaultPath cache and moveVaultFile to vault-store (Prompt 5)

### DIFF
--- a/packages/scraper-app/src/server/__tests__/vault-store.test.ts
+++ b/packages/scraper-app/src/server/__tests__/vault-store.test.ts
@@ -1,0 +1,63 @@
+import { randomBytes } from 'node:crypto';
+import { access, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { defaultVault, saveVaultFile } from '../vault.js';
+import { getCurrentVaultPath, lockVault, moveVaultFile, unlockVault } from '../vault-store.js';
+
+const PASSWORD = 'test-password-123';
+
+function makeTmpPath() {
+  return join(tmpdir(), `vault-store-test-${randomBytes(4).toString('hex')}.vault`);
+}
+
+describe('vault-store', () => {
+  let vaultPath: string;
+
+  beforeEach(async () => {
+    vaultPath = makeTmpPath();
+    await saveVaultFile(vaultPath, defaultVault(), PASSWORD);
+  });
+
+  afterEach(async () => {
+    lockVault();
+    await rm(vaultPath, { force: true });
+    delete process.env['VAULT_PATH'];
+  });
+
+  it('getCurrentVaultPath returns env default before unlock', () => {
+    delete process.env['VAULT_PATH'];
+    expect(getCurrentVaultPath()).toBe('.vault');
+  });
+
+  it('getCurrentVaultPath returns the path set at unlock', async () => {
+    process.env['VAULT_PATH'] = vaultPath;
+    await unlockVault(PASSWORD);
+    expect(getCurrentVaultPath()).toBe(vaultPath);
+  });
+
+  it('moveVaultFile moves the file and updates getCurrentVaultPath', async () => {
+    process.env['VAULT_PATH'] = vaultPath;
+    await unlockVault(PASSWORD);
+    const newPath = makeTmpPath();
+    try {
+      await moveVaultFile(newPath);
+      expect(getCurrentVaultPath()).toBe(newPath);
+      const exists = await access(newPath).then(() => true).catch(() => false);
+      expect(exists).toBe(true);
+    } finally {
+      await rm(newPath, { force: true });
+    }
+  });
+
+  it('moveVaultFile is a no-op when paths are the same', async () => {
+    process.env['VAULT_PATH'] = vaultPath;
+    await unlockVault(PASSWORD);
+    await expect(moveVaultFile(vaultPath)).resolves.not.toThrow();
+  });
+
+  it('moveVaultFile throws when vault is locked', async () => {
+    await expect(moveVaultFile('/some/path')).rejects.toThrow('Vault is locked');
+  });
+});

--- a/packages/scraper-app/src/server/vault-store.ts
+++ b/packages/scraper-app/src/server/vault-store.ts
@@ -10,7 +10,7 @@ export function getCurrentVaultPath(): string {
 }
 
 export async function hasVaultFile(): Promise<boolean> {
-  return access(getVaultPath())
+  return access(getCurrentVaultPath())
     .then(() => true)
     .catch(() => false);
 }

--- a/packages/scraper-app/src/server/vault-store.ts
+++ b/packages/scraper-app/src/server/vault-store.ts
@@ -1,8 +1,13 @@
-import { access } from 'node:fs/promises';
+import { access, rename } from 'node:fs/promises';
 import { getVaultPath, loadVaultFile, saveVaultFile, type Vault } from './vault.js';
 
 let _vault: Vault | null = null;
 let _password: string | null = null;
+let _vaultPath: string | null = null;
+
+export function getCurrentVaultPath(): string {
+  return _vaultPath ?? getVaultPath();
+}
 
 export async function hasVaultFile(): Promise<boolean> {
   return access(getVaultPath())
@@ -18,6 +23,7 @@ export async function unlockVault(
   if (vault === null) return 'wrong-password';
   _vault = vault;
   _password = password;
+  _vaultPath = getVaultPath();
   return 'ok';
 }
 
@@ -29,7 +35,7 @@ export function getVault(): Vault {
 export async function updateVault(fn: (v: Vault) => Vault): Promise<void> {
   if (_vault === null || _password === null) throw new Error('Vault is locked');
   _vault = fn(_vault);
-  await saveVaultFile(getVaultPath(), _vault, _password);
+  await saveVaultFile(getCurrentVaultPath(), _vault, _password);
 }
 
 export function isLocked(): boolean {
@@ -39,4 +45,13 @@ export function isLocked(): boolean {
 export function lockVault(): void {
   _vault = null;
   _password = null;
+  _vaultPath = null;
+}
+
+export async function moveVaultFile(newPath: string): Promise<void> {
+  if (_vault === null || _password === null) throw new Error('Vault is locked');
+  const oldPath = getCurrentVaultPath();
+  if (oldPath === newPath) return;
+  await rename(oldPath, newPath);
+  _vaultPath = newPath;
 }


### PR DESCRIPTION
## Summary

Changes to `vault-store.ts`:
- Adds `let _vaultPath: string | null = null` — captured from `getVaultPath()` at unlock time so the active path is decoupled from the env var once unlocked
- Exports `getCurrentVaultPath(): string` — returns `_vaultPath ?? getVaultPath()`, now the single source of truth for where the live vault file lives
- `unlockVault()` sets `_vaultPath = getVaultPath()` after a successful unlock
- `lockVault()` resets `_vaultPath = null`
- `updateVault()` now calls `saveVaultFile(getCurrentVaultPath(), ...)` instead of `getVaultPath()`
- Exports `moveVaultFile(newPath)` — throws if locked, no-ops if same path, otherwise `rename`s and updates `_vaultPath`

New test file `vault-store.test.ts` covers all five behaviours.

## Test plan

- [ ] `getCurrentVaultPath returns env default before unlock` ✓
- [ ] `getCurrentVaultPath returns the path set at unlock` ✓
- [ ] `moveVaultFile moves the file and updates getCurrentVaultPath` ✓
- [ ] `moveVaultFile is a no-op when paths are the same` ✓
- [ ] `moveVaultFile throws when vault is locked` ✓
- [ ] All 171 pre-existing tests still pass (176 total with 5 new) ✓

https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS)_