### PR TITLE
feat(scraper-app): wire moveVaultFile into PUT /api/vault/settings

### DIFF
--- a/packages/scraper-app/src/server/__tests__/settings-routes.test.ts
+++ b/packages/scraper-app/src/server/__tests__/settings-routes.test.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto';
-import { rm } from 'node:fs/promises';
+import { access, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Fastify, { type FastifyInstance } from 'fastify';
@@ -10,11 +10,15 @@ import { registerVaultRoutes } from '../vault-routes.js';
 
 const PASSWORD = 'test-password-123';
 
+function makeTmpPath() {
+  return join(tmpdir(), `vault-test-${randomBytes(4).toString('hex')}.vault`);
+}
+
 let vaultPath: string;
 let app: FastifyInstance;
 
 beforeEach(async () => {
-  vaultPath = join(tmpdir(), `vault-test-${randomBytes(4).toString('hex')}.vault`);
+  vaultPath = makeTmpPath();
   process.env['VAULT_PATH'] = vaultPath;
   await saveVaultFile(vaultPath, defaultVault(), PASSWORD);
 
@@ -113,5 +117,43 @@ describe('PUT /api/vault/settings', () => {
       payload: { showBrowser: 'not-a-boolean' },
     });
     expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('PUT /api/vault/settings — vaultPath change', () => {
+  let newPath: string;
+
+  beforeEach(() => {
+    newPath = makeTmpPath();
+  });
+
+  afterEach(async () => {
+    await rm(newPath, { force: true });
+  });
+
+  it('moves the vault file and returns updated settings when vaultPath changes', async () => {
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/vault/settings',
+      payload: { vaultPath: newPath },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().vaultPath).toBe(newPath);
+
+    const oldExists = await access(vaultPath).then(() => true).catch(() => false);
+    expect(oldExists).toBe(false);
+
+    const newExists = await access(newPath).then(() => true).catch(() => false);
+    expect(newExists).toBe(true);
+  });
+
+  it('returns 200 without moving anything when vaultPath is not in the payload', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: '/api/vault/settings',
+      payload: { showBrowser: true },
+    });
+    const exists = await access(vaultPath).then(() => true).catch(() => false);
+    expect(exists).toBe(true);
   });
 });

--- a/packages/scraper-app/src/server/__tests__/settings-routes.test.ts
+++ b/packages/scraper-app/src/server/__tests__/settings-routes.test.ts
@@ -156,4 +156,17 @@ describe('PUT /api/vault/settings — vaultPath change', () => {
     const exists = await access(vaultPath).then(() => true).catch(() => false);
     expect(exists).toBe(true);
   });
+
+  it('returns 500 when destination file already exists', async () => {
+    await saveVaultFile(newPath, defaultVault(), 'other-password');
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/vault/settings',
+      payload: { vaultPath: newPath },
+    });
+    expect(res.statusCode).toBe(500);
+    expect(res.json()).toMatchObject({ error: 'move-failed' });
+    const originalExists = await access(vaultPath).then(() => true).catch(() => false);
+    expect(originalExists).toBe(true);
+  });
 });

--- a/packages/scraper-app/src/server/__tests__/vault-store.test.ts
+++ b/packages/scraper-app/src/server/__tests__/vault-store.test.ts
@@ -60,4 +60,31 @@ describe('vault-store', () => {
   it('moveVaultFile throws when vault is locked', async () => {
     await expect(moveVaultFile('/some/path')).rejects.toThrow('Vault is locked');
   });
+
+  it('moveVaultFile throws when destination already exists', async () => {
+    process.env['VAULT_PATH'] = vaultPath;
+    await unlockVault(PASSWORD);
+    const destPath = makeTmpPath();
+    await saveVaultFile(destPath, defaultVault(), PASSWORD);
+    try {
+      await expect(moveVaultFile(destPath)).rejects.toThrow('Destination already exists');
+    } finally {
+      await rm(destPath, { force: true });
+    }
+  });
+
+  it('moveVaultFile updates VAULT_PATH env so re-unlock uses the new path', async () => {
+    process.env['VAULT_PATH'] = vaultPath;
+    await unlockVault(PASSWORD);
+    const newPath = makeTmpPath();
+    try {
+      await moveVaultFile(newPath);
+      lockVault();
+      const result = await unlockVault(PASSWORD);
+      expect(result).toBe('ok');
+      expect(getCurrentVaultPath()).toBe(newPath);
+    } finally {
+      await rm(newPath, { force: true });
+    }
+  });
 });

--- a/packages/scraper-app/src/server/settings-routes.ts
+++ b/packages/scraper-app/src/server/settings-routes.ts
@@ -1,5 +1,11 @@
 import type { FastifyInstance } from 'fastify';
-import { getVault, isLocked, updateVault } from './vault-store.js';
+import {
+  getCurrentVaultPath,
+  getVault,
+  isLocked,
+  moveVaultFile,
+  updateVault,
+} from './vault-store.js';
 import { SettingsSchema, type Settings } from './vault.js';
 
 function guardLocked(reply: { status(code: number): { send(body: unknown): unknown } }) {
@@ -20,6 +26,15 @@ export async function registerSettingsRoutes(app: FastifyInstance): Promise<void
 
     const parsed = SettingsSchema.partial().safeParse(req.body);
     if (!parsed.success) return reply.status(400).send({ error: parsed.error.issues });
+
+    const newPath = parsed.data.vaultPath;
+    if (newPath !== undefined && newPath !== getCurrentVaultPath()) {
+      try {
+        await moveVaultFile(newPath);
+      } catch {
+        return reply.status(500).send({ error: 'move-failed' });
+      }
+    }
 
     await updateVault(v => ({ ...v, settings: { ...v.settings, ...parsed.data } }));
     return getVault().settings;

--- a/packages/scraper-app/src/server/vault-store.ts
+++ b/packages/scraper-app/src/server/vault-store.ts
@@ -52,6 +52,11 @@ export async function moveVaultFile(newPath: string): Promise<void> {
   if (_vault === null || _password === null) throw new Error('Vault is locked');
   const oldPath = getCurrentVaultPath();
   if (oldPath === newPath) return;
+  const destExists = await access(newPath)
+    .then(() => true)
+    .catch(() => false);
+  if (destExists) throw new Error('Destination already exists');
   await rename(oldPath, newPath);
   _vaultPath = newPath;
+  process.env['VAULT_PATH'] = newPath;
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `PUT /api/vault/settings` now detects when `vaultPath` changes and calls `moveVaultFile` to atomically rename the vault file to the new location before persisting settings
- Returns `500 { error: 'move-failed' }` if the rename fails
- Adds tests covering: file-moves-and-old-deleted, no-move-when-path-not-in-payload, plus the existing lock/unlock persistence tests

## Test plan

- [ ] `PUT /api/vault/settings` with `vaultPath` change moves file and old path no longer exists
- [ ] `PUT /api/vault/settings` without `vaultPath` leaves file in place
- [ ] Locked vault returns 401
- [ ] Invalid field types return 400
- [ ] Settings survive re-lock/re-unlock (persisted to disk)

https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS)_