### PR TITLE
feat(scraper-app): add vaultUpload, vaultDownload, getEnvVaultPath API helpers

### DIFF
--- a/packages/scraper-app/src/ui/__tests__/api.test.ts
+++ b/packages/scraper-app/src/ui/__tests__/api.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, getEnvVaultPath, vaultDownload, vaultUpload } from '../lib/api.js';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('getEnvVaultPath', () => {
+  it('returns the path from the server', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ path: '/custom/.vault' }) }),
+    );
+    const result = await getEnvVaultPath();
+    expect(result.path).toBe('/custom/.vault');
+  });
+});
+
+describe('vaultUpload', () => {
+  it('POSTs to /api/vault/upload with octet-stream', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
+    vi.stubGlobal('fetch', fetchMock);
+    const file = new File(['data'], 'vault');
+    await vaultUpload(file);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/vault/upload',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ 'Content-Type': 'application/octet-stream' }),
+      }),
+    );
+  });
+
+  it('appends ?force=true when force=true', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
+    vi.stubGlobal('fetch', fetchMock);
+    await vaultUpload(new File(['d'], 'v'), true);
+    expect(fetchMock.mock.calls[0][0]).toContain('force=true');
+  });
+
+  it('throws ApiError with status 409 on conflict', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 409,
+        json: async () => ({ error: 'vault-already-exists' }),
+      }),
+    );
+    await expect(vaultUpload(new File(['d'], 'v'))).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe('vaultDownload', () => {
+  it('creates and clicks a download link', async () => {
+    const blob = new Blob(['data']);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, blob: async () => blob }));
+    const clickSpy = vi.fn();
+    vi.spyOn(document, 'createElement').mockReturnValue(
+      Object.assign(document.createElement('a'), { click: clickSpy }),
+    );
+    await vaultDownload('.vault');
+    expect(clickSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/scraper-app/src/ui/lib/api.ts
+++ b/packages/scraper-app/src/ui/lib/api.ts
@@ -104,6 +104,41 @@ export function getVaultPath(): Promise<{ path: string }> {
   return apiFetch('/api/vault/path');
 }
 
+export function getEnvVaultPath(): Promise<{ path: string }> {
+  return apiFetch('/api/vault/env-path');
+}
+
+export async function vaultUpload(file: File, force = false): Promise<{ ok: boolean }> {
+  const url = force ? '/api/vault/upload?force=true' : '/api/vault/upload';
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: file,
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new ApiError(res.status, body.error ?? `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<{ ok: boolean }>;
+}
+
+export async function vaultDownload(suggestedName = '.vault'): Promise<void> {
+  const res = await fetch('/api/vault/download');
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new ApiError(res.status, body.error ?? `HTTP ${res.status}`);
+  }
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = suggestedName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
 // ── Connection test ───────────────────────────────────────────────────────────
 
 export function testConnection(): Promise<{ ok: boolean; latencyMs?: number; error?: string }> {

--- a/packages/scraper-app/src/ui/lib/api.ts
+++ b/packages/scraper-app/src/ui/lib/api.ts
@@ -108,18 +108,13 @@ export function getEnvVaultPath(): Promise<{ path: string }> {
   return apiFetch('/api/vault/env-path');
 }
 
-export async function vaultUpload(file: File, force = false): Promise<{ ok: boolean }> {
+export function vaultUpload(file: File, force = false): Promise<{ ok: boolean }> {
   const url = force ? '/api/vault/upload?force=true' : '/api/vault/upload';
-  const res = await fetch(url, {
+  return apiFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/octet-stream' },
     body: file,
   });
-  if (!res.ok) {
-    const body = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new ApiError(res.status, body.error ?? `HTTP ${res.status}`);
-  }
-  return res.json() as Promise<{ ok: boolean }>;
 }
 
 export async function vaultDownload(suggestedName = '.vault'): Promise<void> {


### PR DESCRIPTION
## Summary

Pure client-side data layer additions to `packages/scraper-app/src/ui/lib/api.ts` — no UI changes yet:

- `getEnvVaultPath()` — fetches `{ path }` from `GET /api/vault/env-path` via the existing `apiFetch` helper
- `vaultUpload(file, force?)` — POSTs a `File` as `application/octet-stream` to `/api/vault/upload`, appends `?force=true` when requested, throws `ApiError` on non-2xx
- `vaultDownload(suggestedName?)` — fetches `/api/vault/download`, converts to a `Blob`, and triggers a browser download via a temporary anchor element

Creates `src/ui/__tests__/api.test.ts` (`@vitest-environment happy-dom`) covering all three functions with stubbed `fetch`.

## Test plan

- [ ] `getEnvVaultPath` resolves to the mocked path value
- [ ] `vaultUpload` calls fetch with correct URL, method, and `Content-Type: application/octet-stream`
- [ ] `vaultUpload` with `force=true` includes `?force=true` in the URL
- [ ] `vaultUpload` throws `ApiError` on non-ok response (e.g. 409)
- [ ] `vaultDownload` creates an anchor element and calls `.click()`

https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS)_