### PR TITLE
feat(scraper-app): add upload() to VaultContext

### DIFF
--- a/packages/scraper-app/src/ui/__tests__/vault-setup.test.tsx
+++ b/packages/scraper-app/src/ui/__tests__/vault-setup.test.tsx
@@ -13,6 +13,7 @@ function makeCtx(create: () => Promise<void> = vi.fn().mockResolvedValue(undefin
     error: null as string | null,
     unlock: vi.fn(),
     create,
+    upload: vi.fn(),
   };
 }
 

--- a/packages/scraper-app/src/ui/__tests__/vault-unlock.test.tsx
+++ b/packages/scraper-app/src/ui/__tests__/vault-unlock.test.tsx
@@ -57,7 +57,7 @@ describe('VaultUnlock', () => {
         setError('Wrong password. Please try again.');
       });
       return (
-        <VaultContext.Provider value={{ status: 'locked', error, unlock, create: vi.fn(), upload: vi.fn() }}>
+        <VaultContext.Provider value={makeCtx({ error, unlock })}>
           <VaultUnlock />
         </VaultContext.Provider>
       );

--- a/packages/scraper-app/src/ui/__tests__/vault-unlock.test.tsx
+++ b/packages/scraper-app/src/ui/__tests__/vault-unlock.test.tsx
@@ -19,6 +19,7 @@ function makeCtx(
     error: null as string | null,
     unlock: vi.fn().mockResolvedValue(undefined),
     create: vi.fn(),
+    upload: vi.fn(),
     ...overrides,
   };
 }
@@ -56,7 +57,7 @@ describe('VaultUnlock', () => {
         setError('Wrong password. Please try again.');
       });
       return (
-        <VaultContext.Provider value={{ status: 'locked', error, unlock, create: vi.fn() }}>
+        <VaultContext.Provider value={{ status: 'locked', error, unlock, create: vi.fn(), upload: vi.fn() }}>
           <VaultUnlock />
         </VaultContext.Provider>
       );
@@ -74,5 +75,23 @@ describe('VaultUnlock', () => {
   it('does not show an error on initial render', () => {
     renderUnlock();
     expect(screen.queryByRole('alert')).toBeNull();
+  });
+});
+
+describe('VaultContext upload shape', () => {
+  it('renders without error when upload is provided in context', () => {
+    function UploadWrapper() {
+      const [status, setStatus] = useState<VaultStatus>('locked');
+      const upload = vi.fn().mockImplementation(async () => setStatus('locked'));
+      return (
+        <VaultContext.Provider
+          value={{ status, error: null, unlock: vi.fn(), create: vi.fn(), upload }}
+        >
+          <VaultUnlock />
+        </VaultContext.Provider>
+      );
+    }
+    render(<UploadWrapper />);
+    expect(screen.getByLabelText(/master password/i)).toBeTruthy();
   });
 });

--- a/packages/scraper-app/src/ui/contexts/vault-context.tsx
+++ b/packages/scraper-app/src/ui/contexts/vault-context.tsx
@@ -12,6 +12,7 @@ import {
   ApiError,
   vaultStatus as apiStatus,
   vaultUnlock as apiUnlock,
+  vaultUpload,
 } from '../lib/api.js';
 
 export type VaultStatus = 'loading' | 'locked' | 'no-file' | 'unlocked';
@@ -21,6 +22,7 @@ type VaultContextValue = {
   error: string | null;
   unlock(password: string): Promise<void>;
   create(password: string, serverUrl: string, apiKey: string): Promise<void>;
+  upload(file: File, force?: boolean): Promise<void>;
 };
 
 export const VaultContext = createContext<VaultContextValue | null>(null);
@@ -63,8 +65,22 @@ export function VaultProvider({ children }: { children: ReactNode }): ReactEleme
     }
   }, []);
 
+  const upload = useCallback(async (file: File, force = false) => {
+    setError(null);
+    try {
+      await vaultUpload(file, force);
+      setStatus('locked');
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 409) {
+        // Re-throw so the caller can handle the conflict (show confirm dialog)
+        throw e;
+      }
+      setError('Failed to upload vault. Please try again.');
+    }
+  }, []);
+
   return (
-    <VaultContext.Provider value={{ status, error, unlock, create }}>
+    <VaultContext.Provider value={{ status, error, unlock, create, upload }}>
       {children}
     </VaultContext.Provider>
   );


### PR DESCRIPTION
## Summary

- Adds `upload(file: File, force?: boolean): Promise<void>` to `VaultContextValue` and `VaultProvider` in `vault-context.tsx`
- Follows the same `useCallback` / `setError(null)` / `setStatus(...)` pattern as `unlock` and `create`
- 409 conflicts are **re-thrown** so the calling screen can intercept them (e.g. to show a "vault already exists — overwrite?" confirm dialog); all other errors set the shared `error` state
- Updates `makeCtx` helpers in `vault-unlock.test.tsx` and `vault-setup.test.tsx` to include `upload: vi.fn()` so the existing tests continue to compile
- Adds a forward-stub describe block in `vault-unlock.test.tsx` verifying the updated context shape renders without error

## Test plan

- [ ] `VaultContext upload shape` test renders the unlock screen with `upload` in context
- [ ] All existing `VaultUnlock` and `VaultSetup` tests still pass (makeCtx now includes upload)
- [ ] 409 from `vaultUpload` is re-thrown (not swallowed into error state)
- [ ] Other errors from `vaultUpload` set `error` and leave status unchanged

https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS)_