### PR TITLE
feat(scraper-app): add upload-existing-vault section to VaultSetup

### DIFF
--- a/packages/scraper-app/src/ui/__tests__/vault-setup.test.tsx
+++ b/packages/scraper-app/src/ui/__tests__/vault-setup.test.tsx
@@ -7,13 +7,16 @@ import { describe, expect, it, vi } from 'vitest';
 import { VaultContext, type VaultStatus } from '../contexts/vault-context.js';
 import { VaultSetup } from '../screens/vault-setup.js';
 
-function makeCtx(create: () => Promise<void> = vi.fn().mockResolvedValue(undefined)) {
+function makeCtx(
+  create: () => Promise<void> = vi.fn().mockResolvedValue(undefined),
+  upload: () => Promise<void> = vi.fn().mockResolvedValue(undefined),
+) {
   return {
     status: 'no-file' as VaultStatus,
     error: null as string | null,
     unlock: vi.fn(),
     create,
-    upload: vi.fn(),
+    upload,
   };
 }
 
@@ -102,5 +105,33 @@ describe('VaultSetup', () => {
     await waitFor(() => {
       expect(screen.getByText(/step 1/i)).toBeTruthy();
     });
+  });
+});
+
+describe('VaultSetup — file upload', () => {
+  it('renders the upload file input alongside the wizard', () => {
+    renderSetup();
+    expect(screen.getByLabelText(/upload existing vault file/i)).toBeTruthy();
+    expect(screen.getByText(/step 1/i)).toBeTruthy();
+  });
+
+  it('calls vault.upload when a file is selected', async () => {
+    const upload = vi.fn().mockResolvedValue(undefined);
+    renderSetup(makeCtx(vi.fn(), upload));
+    const file = new File(['blob'], 'test.vault');
+    await userEvent.upload(screen.getByLabelText(/upload existing vault file/i), file);
+    expect(upload).toHaveBeenCalledWith(file);
+  });
+
+  it('shows uploadError when upload fails', async () => {
+    const upload = vi.fn().mockRejectedValue(new Error('fail'));
+    renderSetup(makeCtx(vi.fn(), upload));
+    await userEvent.upload(
+      screen.getByLabelText(/upload existing vault file/i),
+      new File(['b'], 'v'),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('alert').textContent).toContain('Failed to upload'),
+    );
   });
 });

--- a/packages/scraper-app/src/ui/__tests__/vault-setup.test.tsx
+++ b/packages/scraper-app/src/ui/__tests__/vault-setup.test.tsx
@@ -10,10 +10,11 @@ import { VaultSetup } from '../screens/vault-setup.js';
 function makeCtx(
   create: () => Promise<void> = vi.fn().mockResolvedValue(undefined),
   upload: () => Promise<void> = vi.fn().mockResolvedValue(undefined),
+  error: string | null = null,
 ) {
   return {
     status: 'no-file' as VaultStatus,
-    error: null as string | null,
+    error,
     unlock: vi.fn(),
     create,
     upload,
@@ -111,7 +112,7 @@ describe('VaultSetup', () => {
 describe('VaultSetup — file upload', () => {
   it('renders the upload file input alongside the wizard', () => {
     renderSetup();
-    expect(screen.getByLabelText(/upload existing vault file/i)).toBeTruthy();
+    expect(screen.getByLabelText(/upload an existing vault/i)).toBeTruthy();
     expect(screen.getByText(/step 1/i)).toBeTruthy();
   });
 
@@ -119,7 +120,7 @@ describe('VaultSetup — file upload', () => {
     const upload = vi.fn().mockResolvedValue(undefined);
     renderSetup(makeCtx(vi.fn(), upload));
     const file = new File(['blob'], 'test.vault');
-    await userEvent.upload(screen.getByLabelText(/upload existing vault file/i), file);
+    await userEvent.upload(screen.getByLabelText(/upload an existing vault/i), file);
     expect(upload).toHaveBeenCalledWith(file);
   });
 
@@ -127,7 +128,7 @@ describe('VaultSetup — file upload', () => {
     const upload = vi.fn().mockRejectedValue(new Error('fail'));
     renderSetup(makeCtx(vi.fn(), upload));
     await userEvent.upload(
-      screen.getByLabelText(/upload existing vault file/i),
+      screen.getByLabelText(/upload an existing vault/i),
       new File(['b'], 'v'),
     );
     await waitFor(() =>

--- a/packages/scraper-app/src/ui/screens/vault-setup.tsx
+++ b/packages/scraper-app/src/ui/screens/vault-setup.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react';
+import { useRef, useState, type ReactElement } from 'react';
 import { useVault } from '../contexts/vault-context.js';
 
 type Step = 1 | 2 | 3;
@@ -12,6 +12,8 @@ export function VaultSetup(): ReactElement {
   const [apiKey, setApiKey] = useState('');
   const [localError, setLocalError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   function handleStep1(e: React.FormEvent) {
     e.preventDefault();
@@ -40,9 +42,34 @@ export function VaultSetup(): ReactElement {
     setLoading(false);
   }
 
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploadError(null);
+    try {
+      await vault.upload(file);
+    } catch {
+      setUploadError('Failed to upload vault. Please try again.');
+    }
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }
+
   return (
     <div>
       <h1>Setup Vault</h1>
+
+      <div>
+        <p>Upload an existing vault</p>
+        <input
+          ref={fileInputRef}
+          id="vault-upload-setup"
+          type="file"
+          aria-label="Upload existing vault file"
+          onChange={handleFileChange}
+        />
+        {uploadError && <p role="alert">{uploadError}</p>}
+      </div>
+      <hr />
 
       {step === 1 && (
         <form onSubmit={handleStep1}>

--- a/packages/scraper-app/src/ui/screens/vault-setup.tsx
+++ b/packages/scraper-app/src/ui/screens/vault-setup.tsx
@@ -59,14 +59,8 @@ export function VaultSetup(): ReactElement {
       <h1>Setup Vault</h1>
 
       <div>
-        <p>Upload an existing vault</p>
-        <input
-          ref={fileInputRef}
-          id="vault-upload-setup"
-          type="file"
-          aria-label="Upload existing vault file"
-          onChange={handleFileChange}
-        />
+        <label htmlFor="vault-upload-setup">Upload an existing vault</label>
+        <input ref={fileInputRef} id="vault-upload-setup" type="file" onChange={handleFileChange} />
         {uploadError && <p role="alert">{uploadError}</p>}
       </div>
       <hr />


### PR DESCRIPTION
## Summary

When there is no vault file yet (`status === 'no-file'`), the `VaultSetup` screen now shows an upload section **above** the 3-step creation wizard:

- A file input (labelled "Upload existing vault file") lets the user supply an existing vault instead of creating a new one
- On success `vault.upload()` sets status to `'locked'` and the screen transitions away (handled by the context)
- On failure an inline `uploadError` message is shown; the file input is reset so the same file can be retried
- The handler is simpler than `VaultUnlock`'s — no vault exists so a 409 conflict cannot occur

`vault-setup.test.tsx`:
- `makeCtx` gains a second `upload` parameter (default `vi.fn().mockResolvedValue(undefined)`)
- New `'VaultSetup — file upload'` describe block with 3 tests: render, happy-path, error display

## Test plan

- [ ] Upload file input is visible on the setup screen alongside "Step 1"
- [ ] Selecting a file calls `vault.upload(file)` once
- [ ] On failure, "Failed to upload vault" alert appears
- [ ] File input is reset after each attempt
- [ ] Existing wizard tests (step navigation, create, validation) still pass

https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS)_