### PR TITLE
feat(scraper-app): editable vault path + Download button (Prompt 11)

### DIFF
--- a/packages/scraper-app/src/ui/__tests__/settings-tab.test.tsx
+++ b/packages/scraper-app/src/ui/__tests__/settings-tab.test.tsx
@@ -4,7 +4,13 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { vaultDownload } from '../lib/api.js';
 import { SettingsTab } from '../screens/config/settings-tab.js';
+
+vi.mock('../lib/api.js', async importOriginal => {
+  const mod = await importOriginal<typeof import('../lib/api.js')>();
+  return { ...mod, vaultDownload: vi.fn() };
+});
 
 const DEFAULT_SETTINGS = {
   showBrowser: false,
@@ -108,14 +114,10 @@ describe('SettingsTab', () => {
   });
 
   it('calls vaultDownload when Download is clicked', async () => {
-    vi.mock('../../lib/api.js', async importOriginal => {
-      const mod = await importOriginal<typeof import('../../lib/api.js')>();
-      return { ...mod, vaultDownload: vi.fn().mockResolvedValue(undefined) };
-    });
+    vi.mocked(vaultDownload).mockResolvedValue(undefined);
     render(<SettingsTab />);
     await waitFor(() => screen.getByRole('button', { name: /download/i }));
     await userEvent.click(screen.getByRole('button', { name: /download/i }));
-    const { vaultDownload } = await import('../../lib/api.js');
     expect(vaultDownload).toHaveBeenCalled();
   });
 });

--- a/packages/scraper-app/src/ui/__tests__/settings-tab.test.tsx
+++ b/packages/scraper-app/src/ui/__tests__/settings-tab.test.tsx
@@ -23,6 +23,8 @@ function mockFetch(settings = DEFAULT_SETTINGS) {
       current = { ...current, ...patch };
       return { ok: true, json: async () => ({ ...current }) } as Response;
     }
+    if (url === '/api/vault/path') return { ok: true, json: async () => ({ path: '/data/.vault' }) } as Response;
+    if (url === '/api/vault/env-path') return { ok: true, json: async () => ({ path: '.vault' }) } as Response;
     return { ok: false, json: async () => ({}) } as Response;
   });
   vi.stubGlobal('fetch', fetchMock);
@@ -75,5 +77,45 @@ describe('SettingsTab', () => {
     await waitFor(() => {
       expect((screen.getByLabelText(/show browser/i) as HTMLInputElement).checked).toBe(true);
     });
+  });
+
+  it('renders the vault path input as editable', async () => {
+    render(<SettingsTab />);
+    await waitFor(() => screen.getByLabelText(/vault file path/i));
+    const input = screen.getByLabelText(/vault file path/i) as HTMLInputElement;
+    expect(input.readOnly).toBe(false);
+  });
+
+  it('saves vaultPath to settings on blur', async () => {
+    const fetchMock = mockFetch();
+    render(<SettingsTab />);
+    await waitFor(() => screen.getByLabelText(/vault file path/i));
+    const input = screen.getByLabelText(/vault file path/i);
+    await userEvent.clear(input);
+    await userEvent.type(input, '/new/path/.vault');
+    await userEvent.tab();
+    await waitFor(() => {
+      const putCalls = fetchMock.mock.calls.filter(([, opts]) => (opts as RequestInit | undefined)?.method === 'PUT');
+      const bodies = putCalls.map(([, opts]) => JSON.parse((opts as RequestInit)!.body as string) as Record<string, unknown>);
+      expect(bodies.some(b => b.vaultPath === '/new/path/.vault')).toBe(true);
+    });
+  });
+
+  it('renders the Download button', async () => {
+    render(<SettingsTab />);
+    await waitFor(() => screen.getByRole('button', { name: /download/i }));
+    expect(screen.getByRole('button', { name: /download/i })).toBeTruthy();
+  });
+
+  it('calls vaultDownload when Download is clicked', async () => {
+    vi.mock('../../lib/api.js', async importOriginal => {
+      const mod = await importOriginal<typeof import('../../lib/api.js')>();
+      return { ...mod, vaultDownload: vi.fn().mockResolvedValue(undefined) };
+    });
+    render(<SettingsTab />);
+    await waitFor(() => screen.getByRole('button', { name: /download/i }));
+    await userEvent.click(screen.getByRole('button', { name: /download/i }));
+    const { vaultDownload } = await import('../../lib/api.js');
+    expect(vaultDownload).toHaveBeenCalled();
   });
 });

--- a/packages/scraper-app/src/ui/screens/config/settings-tab.tsx
+++ b/packages/scraper-app/src/ui/screens/config/settings-tab.tsx
@@ -9,6 +9,7 @@ function getBasename(p: string) {
 export function SettingsTab(): ReactElement {
   const [settings, setSettings] = useState<Settings | null>(null);
   const [vaultPath, setVaultPath] = useState<string>('');
+  const [vaultPathLoaded, setVaultPathLoaded] = useState(false);
   const [copied, setCopied] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -22,8 +23,9 @@ export function SettingsTab(): ReactElement {
       .then(r => {
         setVaultPath(r.path);
         savedVaultPathRef.current = r.path;
+        setVaultPathLoaded(true);
       })
-      .catch(() => setVaultPath(''));
+      .catch(() => setVaultPathLoaded(true));
   }, []);
 
   function handleCopyPath() {
@@ -142,7 +144,7 @@ export function SettingsTab(): ReactElement {
         </div>
       </fieldset>
 
-      {vaultPath && (
+      {vaultPathLoaded && (
         <fieldset style={{ border: 'none', padding: 0, margin: '20px 0 0' }}>
           <legend style={{ fontWeight: 'bold', marginBottom: 12 }}>Vault file</legend>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
@@ -153,10 +155,22 @@ export function SettingsTab(): ReactElement {
               onChange={e => setVaultPath(e.target.value)}
               onBlur={async e => {
                 const val = e.target.value.trim();
-                if (!val || val === savedVaultPathRef.current) return;
-                await autoSave({ vaultPath: val });
-                savedVaultPathRef.current = val;
-                setVaultPath(val);
+                if (!val) {
+                  setVaultPath(savedVaultPathRef.current);
+                  return;
+                }
+                if (val === savedVaultPathRef.current) {
+                  setVaultPath(val);
+                  return;
+                }
+                try {
+                  const updated = await saveSettings({ vaultPath: val });
+                  setSettings(updated);
+                  savedVaultPathRef.current = val;
+                  setVaultPath(val);
+                } catch {
+                  setError('Failed to save settings');
+                }
               }}
               aria-label="Vault file path"
               style={{ padding: '4px 8px', width: '100%', maxWidth: 360 }}

--- a/packages/scraper-app/src/ui/screens/config/settings-tab.tsx
+++ b/packages/scraper-app/src/ui/screens/config/settings-tab.tsx
@@ -1,19 +1,28 @@
-import { useEffect, useState, type ChangeEvent, type ReactElement } from 'react';
+import { useEffect, useRef, useState, type ChangeEvent, type ReactElement } from 'react';
 import type { Settings } from '../../../server/vault.js';
-import { getVaultPath, loadSettings, saveSettings } from '../../lib/api.js';
+import { getVaultPath, loadSettings, saveSettings, vaultDownload } from '../../lib/api.js';
+
+function getBasename(p: string) {
+  return p.split('/').pop()?.split('\\').pop() ?? '.vault';
+}
 
 export function SettingsTab(): ReactElement {
   const [settings, setSettings] = useState<Settings | null>(null);
   const [vaultPath, setVaultPath] = useState<string>('');
   const [copied, setCopied] = useState(false);
+  const [downloading, setDownloading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const savedVaultPathRef = useRef<string>('');
 
   useEffect(() => {
     loadSettings()
       .then(s => setSettings(s))
       .catch(() => setError('Failed to load settings'));
     getVaultPath()
-      .then(r => setVaultPath(r.path))
+      .then(r => {
+        setVaultPath(r.path);
+        savedVaultPathRef.current = r.path;
+      })
       .catch(() => setVaultPath(''));
   }, []);
 
@@ -138,16 +147,20 @@ export function SettingsTab(): ReactElement {
           <legend style={{ fontWeight: 'bold', marginBottom: 12 }}>Vault file</legend>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
             <input
-              readOnly
+              id="vaultFilePath"
+              type="text"
               value={vaultPath}
-              style={{
-                padding: '4px 8px',
-                width: '100%',
-                maxWidth: 360,
-                color: '#555',
-                background: '#f9fafb',
+              onChange={e => setVaultPath(e.target.value)}
+              onBlur={async e => {
+                const val = e.target.value.trim();
+                if (!val || val === savedVaultPathRef.current) return;
+                await autoSave({ vaultPath: val });
+                savedVaultPathRef.current = val;
+                setVaultPath(val);
               }}
               aria-label="Vault file path"
+              style={{ padding: '4px 8px', width: '100%', maxWidth: 360 }}
+              placeholder=".vault"
             />
             <button
               type="button"
@@ -155,6 +168,23 @@ export function SettingsTab(): ReactElement {
               style={{ padding: '4px 12px', whiteSpace: 'nowrap' }}
             >
               {copied ? '✓ Copied' : 'Copy path'}
+            </button>
+            <button
+              type="button"
+              disabled={downloading}
+              onClick={async () => {
+                setDownloading(true);
+                try {
+                  await vaultDownload(getBasename(vaultPath || '.vault'));
+                } catch {
+                  setError('Failed to download vault.');
+                } finally {
+                  setDownloading(false);
+                }
+              }}
+              style={{ padding: '4px 12px', whiteSpace: 'nowrap' }}
+            >
+              {downloading ? 'Downloading…' : 'Download'}
             </button>
           </div>
           <p style={{ margin: 0, fontSize: '0.85em', color: '#6b7280' }}>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Makes the vault file path input in `SettingsTab` editable with `onBlur` auto-save
- Tracks the saved path via a `useRef` to correctly detect changes in the controlled input (avoids the always-true `val === vaultPath` bug when using `onChange` state sync)
- Adds a **Download** button that calls `vaultDownload()` to trigger a browser file-save dialog
- Extends `settings-tab.test.tsx` mock to handle `/api/vault/path` and `/api/vault/env-path`, and adds 4 new tests

## Test plan

- [ ] Vault path input is editable (not readOnly)
- [ ] Blurring after changing the path fires a PUT to `/api/vault/settings` with `{ vaultPath }`
- [ ] Blurring without changing the path does NOT fire a PUT
- [ ] Download button renders and calls `vaultDownload` on click
- [ ] All 181 server unit tests pass

https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNb3UJwwrbdg2UdWah1TNS)_