### PR TITLE
Simplify provider credentials tests and export ProviderKey type

### DIFF
--- a/packages/server/src/modules/provider-credentials/providers/__tests__/provider-credentials.integration.test.ts
+++ b/packages/server/src/modules/provider-credentials/providers/__tests__/provider-credentials.integration.test.ts
@@ -7,7 +7,7 @@ import type { Environment } from '../../../../shared/types/index.js';
 const TEST_KEY = 'a'.repeat(64);
 const env = { credentialsEncryptionKey: TEST_KEY } as unknown as Environment;
 
-function createProvider(_options: { businessId: string | null }) {
+function createProvider() {
   const query = vi.fn();
 
   const db = { query } as unknown as Mocked<TenantAwareDBClient>;
@@ -20,7 +20,7 @@ function createProvider(_options: { businessId: string | null }) {
 
 describe('ProviderCredentialsProvider integration', () => {
   it('write + read round-trip: encrypts on set, decrypts on get', async () => {
-    const { provider, query } = createProvider({ businessId: 'tenant-a' });
+    const { provider, query } = createProvider();
 
     const original = { id: 'gi-id', secret: 'gi-secret' };
 
@@ -43,8 +43,8 @@ describe('ProviderCredentialsProvider integration', () => {
     const blobA = encryptCredential(JSON.stringify({ id: 'a-id', secret: 'a-secret' }), TEST_KEY);
     const blobB = encryptCredential(JSON.stringify({ id: 'b-id', secret: 'b-secret' }), TEST_KEY);
 
-    const { provider: providerA, query: queryA } = createProvider({ businessId: 'tenant-a' });
-    const { provider: providerB, query: queryB } = createProvider({ businessId: 'tenant-b' });
+    const { provider: providerA, query: queryA } = createProvider();
+    const { provider: providerB, query: queryB } = createProvider();
 
     queryA.mockResolvedValueOnce({ rows: [{ payload: blobA }], rowCount: 1 });
     queryB.mockResolvedValueOnce({ rows: [{ payload: blobB }], rowCount: 1 });
@@ -59,7 +59,7 @@ describe('ProviderCredentialsProvider integration', () => {
   });
 
   it('delete followed by get returns null', async () => {
-    const { provider, query } = createProvider({ businessId: 'tenant-a' });
+    const { provider, query } = createProvider();
 
     // deleteCredentials
     query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
@@ -72,8 +72,22 @@ describe('ProviderCredentialsProvider integration', () => {
     expect(result).toBeNull();
   });
 
+  it('getProviderStatuses: maps rows to provider + configuredAt ISO string', async () => {
+    const { provider, query } = createProvider();
+    const now = new Date('2026-01-15T10:30:00.000Z');
+
+    query.mockResolvedValueOnce({
+      rows: [{ provider: 'green_invoice', updated_at: now }],
+      rowCount: 1,
+    });
+
+    const statuses = await provider.getProviderStatuses();
+
+    expect(statuses).toEqual([{ provider: 'green_invoice', configuredAt: now.toISOString() }]);
+  });
+
   it('setCredentials with invalid payload throws BAD_USER_INPUT without calling db', async () => {
-    const { provider, query } = createProvider({ businessId: 'tenant-a' });
+    const { provider, query } = createProvider();
 
     await expect(provider.setCredentials('green_invoice', { id: '' })).rejects.toMatchObject({
       extensions: { code: 'BAD_USER_INPUT' },

--- a/packages/server/src/modules/provider-credentials/providers/provider-credentials.provider.ts
+++ b/packages/server/src/modules/provider-credentials/providers/provider-credentials.provider.ts
@@ -16,7 +16,7 @@ const PROVIDER_SCHEMAS = {
   deel: DeelPayloadSchema,
 } as const;
 
-type ProviderKey = keyof typeof PROVIDER_SCHEMAS;
+export type ProviderKey = keyof typeof PROVIDER_SCHEMAS;
 
 @Injectable({ scope: Scope.Operation, global: true })
 export class ProviderCredentialsProvider {


### PR DESCRIPTION
## Summary
This PR simplifies the provider credentials test suite by removing unused parameters and adds a new test case for the `getProviderStatuses` method. It also exports the `ProviderKey` type for external use.

## Key Changes
- **Removed unused `businessId` parameter**: Simplified the `createProvider()` test helper function by removing the unused `_options` parameter that was being passed in all test cases
- **Added `getProviderStatuses` test**: New test case that verifies the method correctly maps database rows to provider statuses with ISO string formatted `configuredAt` timestamps
- **Exported `ProviderKey` type**: Made the `ProviderKey` type public by adding the `export` keyword, allowing it to be imported and used in other modules

## Implementation Details
- The `getProviderStatuses` test validates that the provider correctly transforms the `updated_at` database field into an ISO string `configuredAt` field
- All existing test cases continue to work without the `businessId` parameter, indicating it was not being used in the provider initialization logic

https://claude.ai/code/session_01Di6A3Kf7LBS753nJs1F8AX