### PR TITLE
Per-Tenant Provider Credentials: 7. Wire GreenInvoice and Deel to DB credentials

### DIFF
--- a/packages/server/src/modules/app-providers/deel/deel-client.provider.ts
+++ b/packages/server/src/modules/app-providers/deel/deel-client.provider.ts
@@ -21,6 +21,7 @@ import {
 })
 export class DeelClientProvider {
   private host = 'https://api.letsdeel.com/rest/v2';
+  private tokenPromise: Promise<string> | null = null;
 
   constructor(
     @Inject(ENVIRONMENT) private env: Environment,
@@ -33,7 +34,12 @@ export class DeelClientProvider {
     return addHours(date, 7).toUTCString();
   }
 
-  private async getApiToken(): Promise<string> {
+  private getApiToken(): Promise<string> {
+    this.tokenPromise ??= this._fetchToken();
+    return this.tokenPromise;
+  }
+
+  private async _fetchToken(): Promise<string> {
     const fromDb = await this.credentialsProvider.getDeelCredentials();
     const token = fromDb?.apiToken ?? this.env.deel?.apiToken ?? null;
 

--- a/packages/server/src/modules/app-providers/deel/deel-client.provider.ts
+++ b/packages/server/src/modules/app-providers/deel/deel-client.provider.ts
@@ -1,9 +1,11 @@
 import { addHours, subYears } from 'date-fns';
+import { GraphQLError } from 'graphql';
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import { Currency } from '../../../shared/enums.js';
 import { dateToTimelessDateString } from '../../../shared/helpers/index.js';
 import { ENVIRONMENT } from '../../../shared/tokens.js';
 import type { Environment, TimelessDateString } from '../../../shared/types/index.js';
+import { ProviderCredentialsProvider } from '../../provider-credentials/providers/provider-credentials.provider.js';
 import {
   ContractSchema,
   downloadInvoicePdfSchema,
@@ -18,17 +20,30 @@ import {
   global: true,
 })
 export class DeelClientProvider {
-  private apiToken: string | null;
   private host = 'https://api.letsdeel.com/rest/v2';
 
-  constructor(@Inject(ENVIRONMENT) private env: Environment) {
-    this.apiToken = this.env.deel?.apiToken ?? null;
-  }
+  constructor(
+    @Inject(ENVIRONMENT) private env: Environment,
+    private credentialsProvider: ProviderCredentialsProvider,
+  ) {}
 
   // This is a workaround for the Deel API returning PST dates as UTC dates.
   private timeZoneFix(dateString: string) {
     const date = new Date(dateString);
     return addHours(date, 7).toUTCString();
+  }
+
+  private async getApiToken(): Promise<string> {
+    const fromDb = await this.credentialsProvider.getDeelCredentials();
+    const token = fromDb?.apiToken ?? this.env.deel?.apiToken ?? null;
+
+    if (!token) {
+      throw new GraphQLError('Deel credentials not configured for this tenant', {
+        extensions: { code: 'PROVIDER_NOT_CONFIGURED' },
+      });
+    }
+
+    return token;
   }
 
   public async getPaymentReceipts() {
@@ -49,7 +64,7 @@ export class DeelClientProvider {
       const res = await fetch(url, {
         headers: {
           accept: 'application/json',
-          authorization: `Bearer ${this.apiToken}`,
+          authorization: `Bearer ${await this.getApiToken()}`,
         },
       });
 
@@ -80,7 +95,7 @@ export class DeelClientProvider {
       const res = await fetch(url, {
         headers: {
           accept: 'application/json',
-          authorization: `Bearer ${this.apiToken}`,
+          authorization: `Bearer ${await this.getApiToken()}`,
         },
       });
 
@@ -108,6 +123,7 @@ export class DeelClientProvider {
   public async getSalaryInvoices() {
     const invoices: Invoice[] = [];
     try {
+      const apiToken = await this.getApiToken();
       const queryVars: {
         issued_from_date?: TimelessDateString;
         issued_to_date?: TimelessDateString;
@@ -127,7 +143,7 @@ export class DeelClientProvider {
         const res = await fetch(url, {
           headers: {
             accept: 'application/json',
-            authorization: `Bearer ${this.apiToken}`,
+            authorization: `Bearer ${apiToken}`,
           },
         });
 
@@ -172,7 +188,7 @@ export class DeelClientProvider {
       const res = await fetch(url, {
         headers: {
           accept: 'application/json',
-          authorization: `Bearer ${this.apiToken}`,
+          authorization: `Bearer ${await this.getApiToken()}`,
         },
       });
 
@@ -211,7 +227,7 @@ export class DeelClientProvider {
       const res = await fetch(url, {
         headers: {
           accept: 'application/json',
-          authorization: `Bearer ${this.apiToken}`,
+          authorization: `Bearer ${await this.getApiToken()}`,
         },
       });
 

--- a/packages/server/src/modules/app-providers/green-invoice-client.ts
+++ b/packages/server/src/modules/app-providers/green-invoice-client.ts
@@ -26,6 +26,8 @@ export type ExpenseDraft = NonNullable<
   global: true,
 })
 export class GreenInvoiceClientProvider {
+  private initPromise: ReturnType<typeof init> | null = null;
+
   constructor(
     private adminContextProvider: AdminContextProvider,
     @Inject(ENVIRONMENT) private env: Environment,
@@ -34,7 +36,12 @@ export class GreenInvoiceClientProvider {
 
   public authToken: string | null = null;
 
-  private async init() {
+  private init(): ReturnType<typeof init> {
+    this.initPromise ??= this._doInit();
+    return this.initPromise;
+  }
+
+  private async _doInit(): ReturnType<typeof init> {
     const fromDb = await this.credentialsProvider.getGreenInvoiceCredentials();
     const creds = fromDb ?? this.env.greenInvoice ?? null;
 
@@ -44,9 +51,7 @@ export class GreenInvoiceClientProvider {
       });
     }
 
-    const greenInvoice = await init(creds.id, creds.secret);
-
-    return greenInvoice;
+    return init(creds.id, creds.secret);
   }
 
   public async getSDK(): Promise<Sdk> {

--- a/packages/server/src/modules/app-providers/green-invoice-client.ts
+++ b/packages/server/src/modules/app-providers/green-invoice-client.ts
@@ -1,4 +1,5 @@
 import DataLoader from 'dataloader';
+import { GraphQLError } from 'graphql';
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import {
   _DOLLAR_defs_addClientRequest_Input,
@@ -12,6 +13,7 @@ import { dateToTimelessDateString } from '../../shared/helpers/index.js';
 import { ENVIRONMENT } from '../../shared/tokens.js';
 import type { Environment } from '../../shared/types/index.js';
 import { AdminContextProvider } from '../admin-context/providers/admin-context.provider.js';
+import { ProviderCredentialsProvider } from '../provider-credentials/providers/provider-credentials.provider.js';
 
 export type ExpenseDraft = NonNullable<
   Extract<
@@ -27,19 +29,22 @@ export class GreenInvoiceClientProvider {
   constructor(
     private adminContextProvider: AdminContextProvider,
     @Inject(ENVIRONMENT) private env: Environment,
+    private credentialsProvider: ProviderCredentialsProvider,
   ) {}
 
   public authToken: string | null = null;
 
   private async init() {
-    const id = this.env.greenInvoice?.id;
-    const secret = this.env.greenInvoice?.secret;
+    const fromDb = await this.credentialsProvider.getGreenInvoiceCredentials();
+    const creds = fromDb ?? this.env.greenInvoice ?? null;
 
-    if (!id || !secret) {
-      throw new Error('Environment variables not found');
+    if (!creds) {
+      throw new GraphQLError('Green Invoice credentials not configured for this tenant', {
+        extensions: { code: 'PROVIDER_NOT_CONFIGURED' },
+      });
     }
 
-    const greenInvoice = await init(id, secret);
+    const greenInvoice = await init(creds.id, creds.secret);
 
     return greenInvoice;
   }


### PR DESCRIPTION
## Summary

- **`GreenInvoiceClientProvider`**: injects `ProviderCredentialsProvider`; `init()` tries the DB first (`getGreenInvoiceCredentials()`), falls back to `this.env.greenInvoice`, and throws `PROVIDER_NOT_CONFIGURED` if both are absent.
- **`DeelClientProvider`**: injects `ProviderCredentialsProvider`; replaces the `private apiToken` field with a private async `getApiToken()` that applies the same DB → env fallback. All five fetch call-sites use `await this.getApiToken()`. The pagination loop in `getSalaryInvoices` resolves the token once before the loop to avoid redundant DB calls.
- No changes to `modules-app.ts` — `ProviderCredentialsProvider` is already registered as a global provider from Step 6.

## Backward compatibility

Both providers still keep `@Inject(ENVIRONMENT)` and `this.env` for the fallback path. Existing deployments that have `GREEN_INVOICE_ID` / `GREEN_INVOICE_SECRET` / `DEEL_TOKEN` set in their env continue to work unchanged. The DB credentials take precedence when present.

## Test plan

- [ ] `yarn test` passes (existing unit/integration tests unaffected)
- [ ] TypeScript compiles without errors (`tsc --noEmit`)
- [ ] If `GREEN_INVOICE_ID` / `DEEL_TOKEN` are set in `.env`, existing behaviour is preserved
- [ ] If env vars are absent but a DB row exists (inserted via `setGreenInvoiceCredentials` / `setDeelCredentials` mutation), the provider correctly reads from the DB

https://claude.ai/code/session_01Di6A3Kf7LBS753nJs1F8AX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Di6A3Kf7LBS753nJs1F8AX)_