### PR TITLE
Per-Tenant Provider Credentials: 9. Client UI components

### DIFF
--- a/packages/client/src/components/admin-settings/provider-integrations/deel-card.tsx
+++ b/packages/client/src/components/admin-settings/provider-integrations/deel-card.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog.js';
+import { Badge } from '@/components/ui/badge.js';
+import { Button } from '@/components/ui/button.js';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card.js';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog.js';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form.js';
+import { Input } from '@/components/ui/input.js';
+import { ProviderKey, type ProviderCredentialsQuery } from '@/gql/graphql.js';
+import { useDeleteProviderCredentials } from '@/hooks/use-delete-provider-credentials.js';
+import { useSetDeelCredentials } from '@/hooks/use-set-deel-credentials.js';
+
+type StatusEntry = ProviderCredentialsQuery['providerCredentials'][number];
+
+const formSchema = z.object({
+  apiToken: z.string().min(1, 'Required'),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export function DeelCard({
+  status,
+  onSuccess,
+}: {
+  status?: StatusEntry;
+  onSuccess: () => void;
+}): ReactElement {
+  const [connectOpen, setConnectOpen] = useState(false);
+
+  const { fetching: settingCredentials, setCredentials } = useSetDeelCredentials();
+  const { fetching: deletingCredentials, deleteCredentials } = useDeleteProviderCredentials();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { apiToken: '' },
+  });
+
+  async function onSubmit(values: FormValues) {
+    const result = await setCredentials(values);
+    if (result) {
+      setConnectOpen(false);
+      form.reset();
+      onSuccess();
+    }
+  }
+
+  async function handleDisconnect() {
+    const result = await deleteCredentials({ provider: ProviderKey.Deel });
+    if (result) {
+      onSuccess();
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Deel</CardTitle>
+        <CardDescription>Payment processing and payroll integration</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {status ? (
+          <div className="flex flex-col gap-2">
+            <Badge className="w-fit bg-green-600 text-white hover:bg-green-600">Connected</Badge>
+            <p className="text-sm text-gray-500">
+              Since {new Date(status.configuredAt).toLocaleDateString()}
+            </p>
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500">Not connected</p>
+        )}
+      </CardContent>
+      <CardFooter>
+        {status ? (
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="outline" disabled={deletingCredentials}>
+                Disconnect
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Disconnect Deel?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Are you sure you want to disconnect Deel? You can reconnect at any time.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={handleDisconnect}>Disconnect</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        ) : (
+          <Dialog open={connectOpen} onOpenChange={setConnectOpen}>
+            <DialogTrigger asChild>
+              <Button>Connect</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Connect Deel</DialogTitle>
+                <DialogDescription>
+                  Enter your Deel API token to connect your account.
+                </DialogDescription>
+              </DialogHeader>
+              <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                  <FormField
+                    control={form.control}
+                    name="apiToken"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>API Token</FormLabel>
+                        <FormControl>
+                          <Input type="password" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <DialogFooter>
+                    <Button type="submit" disabled={settingCredentials}>
+                      {settingCredentials ? 'Saving…' : 'Save'}
+                    </Button>
+                  </DialogFooter>
+                </form>
+              </Form>
+            </DialogContent>
+          </Dialog>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/packages/client/src/components/admin-settings/provider-integrations/deel-card.tsx
+++ b/packages/client/src/components/admin-settings/provider-integrations/deel-card.tsx
@@ -98,7 +98,7 @@ export function DeelCard({
           <div className="flex flex-col gap-2">
             <Badge className="w-fit bg-green-600 text-white hover:bg-green-600">Connected</Badge>
             <p className="text-sm text-gray-500">
-              Since {new Date(status.configuredAt).toLocaleDateString()}
+              Since {new Date(status.configuredAt).toLocaleDateString('en-US')}
             </p>
           </div>
         ) : (
@@ -122,12 +122,20 @@ export function DeelCard({
               </AlertDialogHeader>
               <AlertDialogFooter>
                 <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction onClick={handleDisconnect}>Disconnect</AlertDialogAction>
+                <AlertDialogAction onClick={handleDisconnect} disabled={deletingCredentials}>
+                  Disconnect
+                </AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
         ) : (
-          <Dialog open={connectOpen} onOpenChange={setConnectOpen}>
+          <Dialog
+            open={connectOpen}
+            onOpenChange={open => {
+              setConnectOpen(open);
+              if (!open) form.reset();
+            }}
+          >
             <DialogTrigger asChild>
               <Button>Connect</Button>
             </DialogTrigger>

--- a/packages/client/src/components/admin-settings/provider-integrations/green-invoice-card.tsx
+++ b/packages/client/src/components/admin-settings/provider-integrations/green-invoice-card.tsx
@@ -99,7 +99,7 @@ export function GreenInvoiceCard({
           <div className="flex flex-col gap-2">
             <Badge className="w-fit bg-green-600 text-white hover:bg-green-600">Connected</Badge>
             <p className="text-sm text-gray-500">
-              Since {new Date(status.configuredAt).toLocaleDateString()}
+              Since {new Date(status.configuredAt).toLocaleDateString('en-US')}
             </p>
           </div>
         ) : (
@@ -123,12 +123,20 @@ export function GreenInvoiceCard({
               </AlertDialogHeader>
               <AlertDialogFooter>
                 <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction onClick={handleDisconnect}>Disconnect</AlertDialogAction>
+                <AlertDialogAction onClick={handleDisconnect} disabled={deletingCredentials}>
+                  Disconnect
+                </AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
         ) : (
-          <Dialog open={connectOpen} onOpenChange={setConnectOpen}>
+          <Dialog
+            open={connectOpen}
+            onOpenChange={open => {
+              setConnectOpen(open);
+              if (!open) form.reset();
+            }}
+          >
             <DialogTrigger asChild>
               <Button>Connect</Button>
             </DialogTrigger>

--- a/packages/client/src/components/admin-settings/provider-integrations/green-invoice-card.tsx
+++ b/packages/client/src/components/admin-settings/provider-integrations/green-invoice-card.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import type { ReactElement } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog.js';
+import { Badge } from '@/components/ui/badge.js';
+import { Button } from '@/components/ui/button.js';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card.js';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog.js';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form.js';
+import { Input } from '@/components/ui/input.js';
+import { ProviderKey, type ProviderCredentialsQuery } from '@/gql/graphql.js';
+import { useDeleteProviderCredentials } from '@/hooks/use-delete-provider-credentials.js';
+import { useSetGreenInvoiceCredentials } from '@/hooks/use-set-green-invoice-credentials.js';
+
+type StatusEntry = ProviderCredentialsQuery['providerCredentials'][number];
+
+const formSchema = z.object({
+  id: z.string().min(1, 'Required'),
+  secret: z.string().min(1, 'Required'),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export function GreenInvoiceCard({
+  status,
+  onSuccess,
+}: {
+  status?: StatusEntry;
+  onSuccess: () => void;
+}): ReactElement {
+  const [connectOpen, setConnectOpen] = useState(false);
+
+  const { fetching: settingCredentials, setCredentials } = useSetGreenInvoiceCredentials();
+  const { fetching: deletingCredentials, deleteCredentials } = useDeleteProviderCredentials();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { id: '', secret: '' },
+  });
+
+  async function onSubmit(values: FormValues) {
+    const result = await setCredentials(values);
+    if (result) {
+      setConnectOpen(false);
+      form.reset();
+      onSuccess();
+    }
+  }
+
+  async function handleDisconnect() {
+    const result = await deleteCredentials({ provider: ProviderKey.GreenInvoice });
+    if (result) {
+      onSuccess();
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Green Invoice</CardTitle>
+        <CardDescription>Automated invoice creation and document sync</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {status ? (
+          <div className="flex flex-col gap-2">
+            <Badge className="w-fit bg-green-600 text-white hover:bg-green-600">Connected</Badge>
+            <p className="text-sm text-gray-500">
+              Since {new Date(status.configuredAt).toLocaleDateString()}
+            </p>
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500">Not connected</p>
+        )}
+      </CardContent>
+      <CardFooter>
+        {status ? (
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="outline" disabled={deletingCredentials}>
+                Disconnect
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Disconnect Green Invoice?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Are you sure you want to disconnect Green Invoice? You can reconnect at any time.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={handleDisconnect}>Disconnect</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        ) : (
+          <Dialog open={connectOpen} onOpenChange={setConnectOpen}>
+            <DialogTrigger asChild>
+              <Button>Connect</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Connect Green Invoice</DialogTitle>
+                <DialogDescription>
+                  Enter your Green Invoice API credentials to connect your account.
+                </DialogDescription>
+              </DialogHeader>
+              <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                  <FormField
+                    control={form.control}
+                    name="id"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>API ID</FormLabel>
+                        <FormControl>
+                          <Input type="text" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="secret"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>API Secret</FormLabel>
+                        <FormControl>
+                          <Input type="password" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <DialogFooter>
+                    <Button type="submit" disabled={settingCredentials}>
+                      {settingCredentials ? 'Saving…' : 'Save'}
+                    </Button>
+                  </DialogFooter>
+                </form>
+              </Form>
+            </DialogContent>
+          </Dialog>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/packages/client/src/components/admin-settings/provider-integrations/index.tsx
+++ b/packages/client/src/components/admin-settings/provider-integrations/index.tsx
@@ -1,0 +1,28 @@
+import type { ReactElement } from 'react';
+import { Spinner } from '@/components/ui/spinner.js';
+import { ProviderKey } from '@/gql/graphql.js';
+import { useProviderCredentials } from '@/hooks/use-provider-credentials.js';
+import { DeelCard } from './deel-card.js';
+import { GreenInvoiceCard } from './green-invoice-card.js';
+
+export function ProviderIntegrations(): ReactElement {
+  const { data, fetching, refetch } = useProviderCredentials();
+
+  if (fetching) {
+    return (
+      <div className="flex justify-center p-8">
+        <Spinner className="h-10 w-10" />
+      </div>
+    );
+  }
+
+  const greenInvoiceStatus = data?.find(s => s.provider === ProviderKey.GreenInvoice);
+  const deelStatus = data?.find(s => s.provider === ProviderKey.Deel);
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <GreenInvoiceCard status={greenInvoiceStatus} onSuccess={refetch} />
+      <DeelCard status={deelStatus} onSuccess={refetch} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Three new components that expose the connect/disconnect flow to users:

- **`ProviderIntegrations`** (`index.tsx`) — parent component, fetches `useProviderCredentials`, renders a loading spinner while fetching, then a 2-column grid passing each provider's status down to its card.
- **`GreenInvoiceCard`** — disconnected state: Connect button → Dialog with react-hook-form/zod form (API ID + API Secret). Connected state: green "Connected" badge, `configuredAt` date, Disconnect button → AlertDialog confirmation.
- **`DeelCard`** — same structure for Deel with a single API Token password field.

## Design decisions

- Dialog open/close state managed locally with `useState`; form is reset on success.
- `onSuccess` prop (the parent's `refetch`) is called after any mutation completes so the status list re-fetches automatically.
- `ProviderKey` enum values (`GREEN_INVOICE`, `DEEL`) from generated types used for both filtering the status list and as mutation arguments.
- `new Date(status.configuredAt).toLocaleDateString()` handles the DateTime scalar whether it arrives as a `Date` or an ISO string at runtime.
- Green "Connected" badge uses inline Tailwind (`bg-green-600`) since shadcn's default badge variants don't include a success/green variant.

## Test plan

- [ ] TypeScript (`tsc --noEmit`) passes on `packages/client`
- [ ] ESLint passes on all three new files
- [ ] Navigate to wherever `<ProviderIntegrations />` is rendered; both cards are visible
- [ ] Click "Connect" on Green Invoice: dialog opens, form validation fires on empty submit, successful submit closes dialog and card shows "Connected"
- [ ] Click "Disconnect": AlertDialog confirmation appears, confirming removes the connection
- [ ] Same flow works for Deel card

https://claude.ai/code/session_01Di6A3Kf7LBS753nJs1F8AX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Di6A3Kf7LBS753nJs1F8AX)_