### PR TITLE
fix(client): graceful re-auth on expired refresh token

### DIFF
--- a/.changeset/petite-clouds-accept.md
+++ b/.changeset/petite-clouds-accept.md
@@ -1,0 +1,15 @@
+---
+'@accounter/client': patch
+---
+
+- **Classify refresh-token failures correctly.** New `isReauthRequiredAuth0Error` helper treats
+  `invalid_grant` and `missing_refresh_token` (alongside `login_required`/`invalid_token`) as
+  session-expiry, returning `{ status: 'unauthenticated' }`. Genuine network/transient errors stay
+  `error`.
+- **In-place re-authentication.** A new `SessionExpiryDialog` shows "Session expired — Sign in to
+  continue", re-authenticates via `loginWithPopup()`, and lets `refreshAuth` resume the queued
+  request(s) with the fresh token — no lost page state.
+- **Robust fallback.** A small `reauth-coordinator` bridges the framework-agnostic urql singleton to
+  the React modal (single-flight, so N concurrent failed ops share one prompt). When no handler is
+  registered (route loaders before React mounts) or the popup is blocked/declined, it falls back to
+  the existing full-page `/login?reauth=1` redirect.

--- a/packages/client/src/__tests__/urql-client.test.ts
+++ b/packages/client/src/__tests__/urql-client.test.ts
@@ -178,6 +178,53 @@ describe('URQL auth exchange hardening', () => {
     expect(globalThis.location.href).toBe(`${ROUTES.LOGIN}?reauth=1`);
   });
 
+  it('resumes with a fresh token after interactive re-auth instead of redirecting', async () => {
+    vi.stubGlobal('location', { href: 'http://localhost/' });
+
+    const provider = vi
+      .fn<TestAccessTokenProvider>()
+      .mockResolvedValueOnce('initial-token')
+      .mockResolvedValueOnce({ status: 'unauthenticated' })
+      .mockResolvedValueOnce('fresh-token');
+
+    const { setReauthHandler } = await import('../lib/reauth-coordinator.js');
+    setReauthHandler(async () => 'authenticated');
+
+    try {
+      const { authConfig } = await initializeAuth(provider);
+
+      await authConfig.refreshAuth();
+
+      expect(globalThis.location.href).toBe('http://localhost/');
+      const operation = authConfig.addAuthToOperation({ context: {} });
+      expect(operation.context.fetchOptions.headers.Authorization).toBe('Bearer fresh-token');
+    } finally {
+      setReauthHandler(null);
+    }
+  });
+
+  it('redirects to login when interactive re-auth is declined', async () => {
+    vi.stubGlobal('location', { href: 'http://localhost/' });
+
+    const provider = vi
+      .fn<TestAccessTokenProvider>()
+      .mockResolvedValueOnce('initial-token')
+      .mockResolvedValueOnce({ status: 'unauthenticated' });
+
+    const { setReauthHandler } = await import('../lib/reauth-coordinator.js');
+    setReauthHandler(async () => 'redirect');
+
+    try {
+      const { authConfig } = await initializeAuth(provider);
+
+      await authConfig.refreshAuth();
+
+      expect(globalThis.location.href).toBe(`${ROUTES.LOGIN}?reauth=1`);
+    } finally {
+      setReauthHandler(null);
+    }
+  });
+
   it('redirects to /login?reauth=1 only once when repeated unauthenticated refresh attempts fail', async () => {
     vi.stubGlobal('location', { href: 'http://localhost/' });
 

--- a/packages/client/src/components/session-expiry-dialog.tsx
+++ b/packages/client/src/components/session-expiry-dialog.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useAuth0 } from '@auth0/auth0-react';
+import { clearStoredAuth0Session } from '../lib/auth0-session.js';
+import { setReauthHandler, type ReauthOutcome } from '../lib/reauth-coordinator.js';
+import { Button } from './ui/button.js';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog.js';
+
+export function SessionExpiryDialog(): ReactElement {
+  const { loginWithPopup } = useAuth0();
+  const [open, setOpen] = useState(false);
+  const [signingIn, setSigningIn] = useState(false);
+  const resolveRef = useRef<((outcome: ReauthOutcome) => void) | null>(null);
+
+  const settle = useCallback((outcome: ReauthOutcome) => {
+    const resolve = resolveRef.current;
+    resolveRef.current = null;
+    setSigningIn(false);
+    setOpen(false);
+    resolve?.(outcome);
+  }, []);
+
+  useEffect(() => {
+    setReauthHandler(
+      () =>
+        new Promise<ReauthOutcome>(resolve => {
+          resolveRef.current = resolve;
+          setOpen(true);
+        }),
+    );
+    return () => {
+      setReauthHandler(null);
+    };
+  }, []);
+
+  const handleSignIn = useCallback(async () => {
+    setSigningIn(true);
+    try {
+      // Drop the stale/rotated refresh token so the popup mints a fresh session.
+      clearStoredAuth0Session();
+      await loginWithPopup({
+        authorizationParams: {
+          audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+          scope: 'openid profile email offline_access',
+          prompt: 'login',
+        },
+      });
+      settle('authenticated');
+    } catch {
+      // Popup blocked, closed, or failed — fall back to the full-page login flow.
+      settle('redirect');
+    }
+  }, [loginWithPopup, settle]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={next => {
+        // Any dismissal without signing in falls back to the login page.
+        if (!next && !signingIn) {
+          settle('redirect');
+        }
+      }}
+    >
+      <DialogContent showCloseButton={false} onInteractOutside={event => event.preventDefault()}>
+        <DialogHeader>
+          <DialogTitle>Session expired</DialogTitle>
+          <DialogDescription>
+            Your session expired. Sign in to continue where you left off.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => settle('redirect')} disabled={signingIn}>
+            Go to login page
+          </Button>
+          <Button onClick={handleSignIn} disabled={signingIn}>
+            {signingIn ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Sign in'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -6,7 +6,8 @@ import { routes } from './router/config.js';
 import './index.css';
 import 'json-bigint-patch';
 import { ROUTES } from '@/router/routes.js';
-import { isNetworkError } from './lib/auth0-errors.js';
+import { SessionExpiryDialog } from './components/session-expiry-dialog.js';
+import { isReauthRequiredAuth0Error } from './lib/auth0-errors.js';
 import { setUrqlAccessTokenProvider } from './providers/urql.js';
 
 const rootElement = document.getElementById('root');
@@ -45,13 +46,11 @@ function Auth0UrqlTokenBridge() {
     } catch (error) {
       const auth0Error = error as Error & { error?: string };
 
-      // Auth0 uses these codes to indicate the user must authenticate interactively.
-      if (auth0Error.error === 'login_required' || auth0Error.error === 'invalid_token') {
+      // An expired/invalid/missing refresh token means silent renewal can never succeed —
+      // signal "unauthenticated" so the user is re-authenticated instead of seeing a
+      // misleading network error. Genuine transient/network failures stay as errors.
+      if (isReauthRequiredAuth0Error(auth0Error)) {
         return { status: 'unauthenticated' };
-      }
-
-      if (isNetworkError(auth0Error)) {
-        return { status: 'error', error: auth0Error };
       }
 
       return { status: 'error', error: auth0Error };
@@ -64,7 +63,12 @@ function Auth0UrqlTokenBridge() {
     };
   }, []);
 
-  return <RouterProvider router={router} />;
+  return (
+    <>
+      <RouterProvider router={router} />
+      <SessionExpiryDialog />
+    </>
+  );
 }
 
 function DevAuthApp() {

--- a/packages/client/src/lib/__tests__/auth0-errors.test.ts
+++ b/packages/client/src/lib/__tests__/auth0-errors.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { AUTH0_ERROR_MESSAGES, getAuth0ErrorMessage } from '../auth0-errors.js';
+import {
+  AUTH0_ERROR_MESSAGES,
+  getAuth0ErrorMessage,
+  isReauthRequiredAuth0Error,
+} from '../auth0-errors.js';
 
 describe('AUTH0_ERROR_MESSAGES', () => {
   it('maps all expected Auth0 error codes to human-readable messages', () => {
@@ -41,5 +45,29 @@ describe('getAuth0ErrorMessage', () => {
     const error = new Error('Something unexpected happened');
 
     expect(getAuth0ErrorMessage(error)).toBe('An unexpected error occurred. Please try again.');
+  });
+});
+
+describe('isReauthRequiredAuth0Error', () => {
+  it.each(['login_required', 'invalid_token', 'invalid_grant', 'missing_refresh_token'])(
+    'treats %s as requiring interactive re-authentication',
+    code => {
+      const error = Object.assign(new Error('refresh failed'), { error: code });
+
+      expect(isReauthRequiredAuth0Error(error)).toBe(true);
+    },
+  );
+
+  it('does not treat network errors as requiring re-authentication', () => {
+    const error = Object.assign(new Error('Network request failed'), { error: 'network_error' });
+
+    expect(isReauthRequiredAuth0Error(error)).toBe(false);
+  });
+
+  it('returns false for unknown or missing error codes', () => {
+    expect(isReauthRequiredAuth0Error(new Error('no code'))).toBe(false);
+    expect(
+      isReauthRequiredAuth0Error(Object.assign(new Error('weird'), { error: 'something_else' })),
+    ).toBe(false);
   });
 });

--- a/packages/client/src/lib/__tests__/reauth-coordinator.test.ts
+++ b/packages/client/src/lib/__tests__/reauth-coordinator.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  requestInteractiveReauth,
+  setReauthHandler,
+  type ReauthOutcome,
+} from '../reauth-coordinator.js';
+
+describe('reauth-coordinator', () => {
+  afterEach(() => {
+    setReauthHandler(null);
+  });
+
+  it("falls back to 'redirect' when no handler is registered", async () => {
+    await expect(requestInteractiveReauth()).resolves.toBe('redirect');
+  });
+
+  it('delegates to the registered handler', async () => {
+    const handler = vi.fn<() => Promise<ReauthOutcome>>().mockResolvedValue('authenticated');
+    setReauthHandler(handler);
+
+    await expect(requestInteractiveReauth()).resolves.toBe('authenticated');
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('is single-flight: concurrent requests share one handler invocation', async () => {
+    let resolveHandler: ((outcome: ReauthOutcome) => void) | undefined;
+    const handler = vi.fn<() => Promise<ReauthOutcome>>(
+      () =>
+        new Promise<ReauthOutcome>(resolve => {
+          resolveHandler = resolve;
+        }),
+    );
+    setReauthHandler(handler);
+
+    const first = requestInteractiveReauth();
+    const second = requestInteractiveReauth();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    resolveHandler?.('authenticated');
+    await expect(first).resolves.toBe('authenticated');
+    await expect(second).resolves.toBe('authenticated');
+
+    // A subsequent request after settling triggers a fresh handler invocation.
+    const third = requestInteractiveReauth();
+    expect(handler).toHaveBeenCalledTimes(2);
+    resolveHandler?.('redirect');
+    await expect(third).resolves.toBe('redirect');
+  });
+});

--- a/packages/client/src/lib/auth0-errors.ts
+++ b/packages/client/src/lib/auth0-errors.ts
@@ -7,6 +7,19 @@ export const AUTH0_ERROR_MESSAGES: Record<string, string> = {
   invalid_token: 'Your session has expired. Please log in again.',
 };
 
+// Auth0 error codes that mean the user must authenticate interactively again:
+// the refresh token is unknown/invalid/expired/missing, so silent renewal can never succeed.
+const REAUTH_REQUIRED_ERROR_CODES = new Set([
+  'login_required',
+  'invalid_token',
+  'invalid_grant',
+  'missing_refresh_token',
+]);
+
+export function isReauthRequiredAuth0Error(error: Error & { error?: string }): boolean {
+  return error.error != null && REAUTH_REQUIRED_ERROR_CODES.has(error.error);
+}
+
 export function isNetworkError(error: Error & { error?: string }): boolean {
   return (
     error.error === 'network_error' ||

--- a/packages/client/src/lib/reauth-coordinator.ts
+++ b/packages/client/src/lib/reauth-coordinator.ts
@@ -1,0 +1,27 @@
+export type ReauthOutcome = 'authenticated' | 'redirect';
+
+type ReauthHandler = () => Promise<ReauthOutcome>;
+
+let handler: ReauthHandler | null = null;
+let inFlight: Promise<ReauthOutcome> | null = null;
+
+export function setReauthHandler(fn: ReauthHandler | null): void {
+  handler = fn;
+}
+
+/**
+ * Asks the React layer to interactively re-authenticate the user (modal + Auth0 popup).
+ * Single-flight: concurrent failed operations share one prompt. Falls back to 'redirect'
+ * when no handler is registered (e.g. route loaders running before React mounts).
+ */
+export function requestInteractiveReauth(): Promise<ReauthOutcome> {
+  if (!handler) {
+    return Promise.resolve('redirect');
+  }
+
+  inFlight ||= handler().finally(() => {
+    inFlight = null;
+  });
+
+  return inFlight;
+}

--- a/packages/client/src/providers/urql.tsx
+++ b/packages/client/src/providers/urql.tsx
@@ -9,6 +9,7 @@ import {
   type Operation,
 } from 'urql';
 import { authExchange } from '@urql/exchange-auth';
+import { requestInteractiveReauth } from '../lib/reauth-coordinator.js';
 import { ROUTES } from '../router/routes.js';
 import { handleUrqlError } from './urql-error-handler.js';
 
@@ -218,6 +219,19 @@ export function getUrqlClient(): Client {
 
             if (refreshedToken.status === 'unauthenticated') {
               bearerToken = null;
+
+              // Offer in-place re-authentication (modal + Auth0 popup) so queued operations
+              // can resume without losing page state. Falls back to a full-page redirect.
+              const outcome = await requestInteractiveReauth();
+              if (outcome === 'authenticated') {
+                const fresh = await getAccessToken({ cacheMode: 'off' });
+                if (fresh.status === 'token') {
+                  loginRedirectInProgress = false;
+                  bearerToken = `Bearer ${fresh.token}`;
+                  return;
+                }
+              }
+
               redirectToLogin();
               return;
             }


### PR DESCRIPTION
## Problem

When a deployed client tab goes stale in production, the user's Auth0 refresh token eventually expires or is rotated out. When the user returns and performs an action, they see a misleading toast:

> **Network Error. Failed to connect to the server. Please check your connection.**

…even though the server is perfectly reachable. The browser network tab shows a `POST https://…auth0.com/oauth/token` failing with **403 `invalid_grant` — "Unknown or invalid refresh token."**

## Root cause

The failure chain:

1. A GraphQL request goes out with a stale access token → server replies `UNAUTHENTICATED`.
2. urql's `authExchange` calls `refreshAuth` → `getAccessTokenSilently({ cacheMode: 'off' })`.
3. Auth0 does `POST /oauth/token` with the dead refresh token → **403 `invalid_grant`**.
4. The Auth0→urql token bridge (`packages/client/src/index.tsx`) only mapped `login_required`/`invalid_token` to `unauthenticated`. **`invalid_grant` fell through to `error`.**
5. `refreshAuth` *throws* on `error`, which urql surfaces as a `networkError` → the generic "Network Error" toast.

The existing graceful recovery (`/login?reauth=1`, "Your session expired…", stale-cache clear, `prompt: 'login'`) is only reached on `unauthenticated`, so it never fired.

## Fix

- **Classify refresh-token failures correctly.** New `isReauthRequiredAuth0Error` helper treats `invalid_grant` and `missing_refresh_token` (alongside `login_required`/`invalid_token`) as session-expiry, returning `{ status: 'unauthenticated' }`. Genuine network/transient errors stay `error`.
- **In-place re-authentication.** A new `SessionExpiryDialog` shows "Session expired — Sign in to continue", re-authenticates via `loginWithPopup()`, and lets `refreshAuth` resume the queued request(s) with the fresh token — no lost page state.
- **Robust fallback.** A small `reauth-coordinator` bridges the framework-agnostic urql singleton to the React modal (single-flight, so N concurrent failed ops share one prompt). When no handler is registered (route loaders before React mounts) or the popup is blocked/declined, it falls back to the existing full-page `/login?reauth=1` redirect.

## Files

- `lib/auth0-errors.ts` — `isReauthRequiredAuth0Error` + code set
- `index.tsx` — use the helper in the token bridge; mount `<SessionExpiryDialog />`
- `providers/urql.tsx` — `refreshAuth` requests interactive re-auth, redirect fallback
- `lib/reauth-coordinator.ts` *(new)* — React↔urql bridge (single-flight)
- `components/session-expiry-dialog.tsx` *(new)* — the modal

## Test plan

- [x] `vitest` unit tests pass (25): error classification, coordinator fallback/single-flight, and urql `refreshAuth` resume-vs-redirect paths.
- [x] `eslint` + `prettier` clean on changed files.
- [ ] Manual: sign in, delete `@@auth0spajs@@*` keys from localStorage to simulate a dead refresh token, trigger a GraphQL action → expect the re-auth modal (no "Network Error" toast); "Sign in" opens the Auth0 popup and the original action completes; with the popup blocked, falls back to `/login?reauth=1` ("Your session expired. Please sign in again.").

https://claude.ai/code/session_011hcEd8jsvjUhdd4jHiFkCB

---
_Generated by [Claude Code](https://claude.ai/code/session_011hcEd8jsvjUhdd4jHiFkCB)_