### PR TITLE
docs(multi-business): close gaps in plan and blueprint

### DIFF
--- a/docs/multi-business-request/blueprint.md
+++ b/docs/multi-business-request/blueprint.md
@@ -33,8 +33,8 @@
 11. Charges migration.
 12. Reports migration.
 13. Ledger migration.
-14. Salaries plus admin-context migration.
-14a. Remaining modules migration (transactions, tags, contracts, green-invoice, charges-matcher).
+14. Salaries plus admin-context migration. 14a. Remaining modules migration (transactions, tags,
+    contracts, green-invoice, charges-matcher).
 15. Cache isolation, full wiring, release validation.
 
 ### Prompt 01: Baseline Guardrails

--- a/docs/multi-business-request/blueprint.md
+++ b/docs/multi-business-request/blueprint.md
@@ -34,6 +34,7 @@
 12. Reports migration.
 13. Ledger migration.
 14. Salaries plus admin-context migration.
+14a. Remaining modules migration (transactions, tags, contracts, green-invoice, charges-matcher).
 15. Cache isolation, full wiring, release validation.
 
 ### Prompt 01: Baseline Guardrails
@@ -102,7 +103,9 @@ Context files:
 Tasks:
 1. Add provider methods that return all memberships for an authenticated user.
 2. Preserve existing method compatibility where still needed.
-3. Add provider-level tests for no-membership, one-membership, multi-membership cases.
+3. Update the three single-business lookup sites in auth-context.provider.ts that currently use LIMIT 1: the JWT path (~line 328), the API key path (~line 200), and the dev bypass path (~line 31). Each must resolve the full membership set.
+4. Note that BusinessUsersProvider already has a DataLoader (`getBusinessUsersByAuth0IdsLoader`) returning all rows per Auth0 ID — wire that in rather than adding a new query.
+5. Add provider-level tests for no-membership, one-membership, multi-membership cases on each auth path.
 
 Validation:
 Run provider tests and verify existing call sites still compile.
@@ -121,13 +124,14 @@ Context files:
 - [packages/server/src/shared/types/auth.ts](packages/server/src/shared/types/auth.ts)
 
 Tasks:
-1. Implement parser utility for comma-separated business IDs from request header.
-2. Normalize whitespace and duplicates.
-3. Return typed validation errors for malformed IDs.
-4. Add unit tests for valid, empty, malformed, duplicate, and mixed input cases.
+1. Implement parser utility for the `X-Business-Scope` request header — a comma-separated list of business UUIDs.
+2. Normalize whitespace and duplicates; preserve insertion order for deterministic logging.
+3. Return typed validation errors for malformed IDs (non-UUID, empty entry after split, etc.).
+4. Treat absent / empty header as "no narrowing" (i.e. default-all upstream). Distinguish empty-after-split (malformed) from absent.
+5. Add unit tests for valid, empty, absent, malformed, duplicate, whitespace, and mixed input cases.
 
 Constraints:
-Do not wire parser into auth decisions yet.
+Do not wire parser into auth decisions yet. Header name is pinned: `X-Business-Scope`.
 
 Validation:
 Run parser unit tests only; no behavior change outside parser layer.
@@ -147,10 +151,12 @@ Context files:
 - [packages/server/src/shared/types/auth.ts](packages/server/src/shared/types/auth.ts)
 
 Tasks:
-1. Replace single-membership mapping with full membership resolution.
+1. Replace single-membership mapping with full membership resolution in all three auth paths (JWT, API key, dev bypass).
 2. Apply requested header scope as a validated subset of memberships.
-3. Reject out-of-membership requested scope.
-4. Add integration-style provider tests for default-all and subset validation.
+3. Reject out-of-membership requested scope (do not silently drop unknown IDs).
+4. For API-key auth specifically: ignore `X-Business-Scope` and pin the scope to the key's stored `business_id`. Reject the request if args scope is provided and doesn't equal the pinned business.
+5. Super-admin status does NOT auto-expand scope here — same membership rules apply.
+6. Add integration-style provider tests for default-all, subset validation, API-key pinning, and super-admin behavior.
 
 Validation:
 Run auth provider tests and ensure unauthorized flows still fail correctly.
@@ -165,7 +171,9 @@ Goal:
 Define and test request-scope precedence across transport layers.
 
 Precedence rule:
-GraphQL args scope (if provided) narrows the request; otherwise use header scope; if neither exists, use all accessible businesses.
+- Read scope: GraphQL args scope (if provided) narrows the request; otherwise use `X-Business-Scope` header; if neither exists, use all accessible businesses. Args ⊆ header ⊆ memberships at every step.
+- Write target: a separate input — every write mutation takes an explicit `businessId: UUID!` argument and never infers from read scope.
+- API-key auth is a third precedence input: it pins scope to one business; header is ignored and args must agree.
 
 Context files:
 - [packages/server/src/plugins/auth-plugin.ts](packages/server/src/plugins/auth-plugin.ts)
@@ -192,13 +200,15 @@ Context files:
 - [packages/migrations](packages/migrations)
 
 Tasks:
-1. Add migration(s) for helper function(s) reading current request business scope from session settings.
-2. Update relevant RLS policies to use scope arrays for reads.
-3. Keep writes constrained to explicit single target business semantics.
-4. Add migration verification tests/assertions where existing project patterns allow.
+1. Add migration introducing session variable `app.current_business_scope` (UUID array) alongside the existing `app.current_business_id`.
+2. Add helper `accounter_schema.get_current_business_scope()` returning `uuid[]` from `current_setting('app.current_business_scope', true)`, parsing the JSON/text-array form chosen in step 8.
+3. Update read policies on all RLS-enabled tables to use `owner_id = ANY (accounter_schema.get_current_business_scope())` in `USING`.
+4. Keep write policies (`WITH CHECK`) on `owner_id = accounter_schema.get_current_business_id()` so writes remain pinned to a single explicit target.
+5. Do NOT remove `get_current_business_id()` — it stays as the write-target helper.
+6. Add `packages/server/src/__tests__/rls-multi-business.integration.test.ts`: open two connections, set distinct scope arrays, assert each sees the expected union of rows and that out-of-target inserts are rejected.
 
 Validation:
-Run migration verification checks and related integration tests.
+Run migration verification checks and the new RLS integration test. Ensure migrations are applied first via `yarn workspace @accounter/migrations migration:run`.
 ```
 
 ### Prompt 08: Tenant DB Client Session Wiring
@@ -214,9 +224,11 @@ Context files:
 - [packages/server/src/shared/types/auth.ts](packages/server/src/shared/types/auth.ts)
 
 Tasks:
-1. Add session-setting logic for read business scope and write target business.
-2. Ensure values are propagated in nested transactions and reset safely.
-3. Add tests for missing auth, invalid scope, valid scope propagation, nested transaction behavior.
+1. Set both `app.current_business_id` (single write target, when a write is in progress) and `app.current_business_scope` (UUID array, every operation) via `set_config(..., true)` inside the operation's transaction.
+2. Pick a stable serialization for the array — recommend Postgres text-array literal (`'{uuid1,uuid2}'`) so `current_setting()::uuid[]` parses cleanly in the helper; pin this in code and tests.
+3. Ensure values are propagated in nested transactions: an inner-tx rollback must restore the outer-tx scope, not clear it. Document and test the savepoint behavior.
+4. Reject operations with no authenticated context (no scope can be set).
+5. Add tests for: missing auth, invalid scope (non-UUID, non-member), valid scope propagation, nested transaction rollback behavior, pooled-connection isolation (two requests on the same pool connection don't bleed scope).
 
 Validation:
 Run tenant DB client tests and any affected integration tests.
@@ -235,10 +247,12 @@ Context files:
 - [packages/server/src/modules/common/resolvers/user-context.resolver.ts](packages/server/src/modules/common/resolvers/user-context.resolver.ts)
 
 Tasks:
-1. Update GraphQL schema for memberships and active read scope fields.
-2. Update resolver payload accordingly.
-3. Remove legacy adminBusinessId response field from server contract.
-4. Add resolver/schema tests for new shape and authorization behavior.
+1. Update GraphQL schema: replace `adminBusinessId: UUID!` with `memberships: [BusinessMembership!]!` (each carrying `businessId`, `role`, display fields) and `activeReadScope: [UUID!]!` (the resolved scope for this request).
+2. `userContext` body fields that today derive from a single business (e.g. tax preferences, default local currency) resolve from the row matching the active read target when scope is singular, and return null when scope is multi-business — callers must narrow. This matches the `user_context` table's current single-`owner_id` keying; no schema migration of the table here.
+3. Update resolver payload accordingly; remove legacy `adminBusinessId` field with no compatibility shim.
+4. Run `yarn generate` and update any server-side consumers that broke.
+5. Update `bootstrap-client.integration.test.ts` if it asserts on `adminBusinessId`.
+6. Add resolver/schema tests for new shape, multi-membership users, super-admin behavior, and the singular-scope vs. multi-scope `userContext` rules.
 
 Validation:
 Run GraphQL code generation and targeted tests for userContext.
@@ -257,9 +271,13 @@ Context files:
 - [packages/server/src/modules/financial-entities/providers/businesses.provider.ts](packages/server/src/modules/financial-entities/providers/businesses.provider.ts)
 
 Tasks:
-1. Implement shared scope resolution helper: authorized scope, requested narrowing, and write target validation.
-2. Integrate helper into businesses resolver/provider flow as reference implementation.
-3. Add tests proving default-all, narrowed scope, and out-of-scope rejection.
+1. Create `packages/server/src/modules/auth/providers/scope.provider.ts` (new `@Injectable()` provider) with:
+   - `getReadScope(context): UUID[]` — args ∩ header ∩ memberships, defaulting to all memberships.
+   - `resolveWriteTarget(context, requestedBusinessId): UUID` — throws if missing or not a member; returns the validated UUID.
+   - `getBusinessPreference(businessId, key)` — replaces per-field `adminContext.defaultLocalCurrency` reads so multi-business reads can resolve preferences per row's owning business.
+2. Integrate helper into businesses resolver/provider flow as reference implementation. Remove `adminContext.ownerId` reads from this module.
+3. Audit `businesses.provider.ts`'s `insertBusinessLoader` and `batchGenerateBusinessesOutOfTransactions` — they must take an explicit `businessId` arg, not derive from admin-context.
+4. Add tests proving default-all, narrowed scope, out-of-scope rejection, and write-target validation.
 
 Validation:
 Run financial-entities tests plus any helper unit tests.
@@ -353,6 +371,33 @@ Validation:
 Run salaries and admin-context tests plus affected integrations.
 ```
 
+### Prompt 14a: Remaining Modules Migration
+
+```text
+You are implementing Step 14a. Assume Steps 1-14 are merged.
+
+Goal:
+Migrate the remaining modules that depend on admin-context.ownerId / defaultLocalCurrency. The plan misses these in Prompts 11-14; they must reach zero before Prompt 15's cache audit, otherwise the audit will find live admin-context fallbacks.
+
+Context files:
+- [packages/server/src/modules/transactions/resolvers/transactions.resolver.ts](packages/server/src/modules/transactions/resolvers/transactions.resolver.ts)
+- [packages/server/src/modules/tags/providers/tags.provider.ts](packages/server/src/modules/tags/providers/tags.provider.ts)
+- [packages/server/src/modules/contracts/providers/contracts.provider.ts](packages/server/src/modules/contracts/providers/contracts.provider.ts)
+- [packages/server/src/modules/green-invoice/resolvers/green-invoice.resolvers.ts](packages/server/src/modules/green-invoice/resolvers/green-invoice.resolvers.ts)
+- charges-matcher helpers (e.g. `document-business.helper.ts`)
+
+Tasks:
+1. transactions: replace `ownerIDs: [adminContext.ownerId]` in `getTransactionsByFilters` with the shared scope helper's read scope.
+2. tags: `addNewTag` must take an explicit `businessId` write target; remove the `reassureOwnerIdExists(params, adminContext.ownerId)` fallback.
+3. contracts: re-key the DataLoader (currently keyed on `adminBusinessIds`) so cache keys include the full scope, or convert the provider to `Scope.Operation`.
+4. green-invoice: remove the `ownerId = inputOwnerId ?? adminContext.ownerId` fallback; require explicit `businessId`.
+5. charges-matcher / `document-business.helper.ts`: route any admin-context reads through the shared scope helper.
+6. Grep one more time for `adminContext.ownerId` and `adminContext.defaultLocalCurrency` across `packages/server/src/modules/` — the result must be zero outside of `admin-context` itself and field resolvers that have moved to `getBusinessPreference`.
+
+Validation:
+Run module tests, lint, and a repository-wide grep guard test (added in Prompt 15) that fails if any module under `packages/server/src/modules/` (excluding admin-context) references `adminContext.ownerId`.
+```
+
 ### Prompt 15: Cache Isolation and Final Wiring
 
 ```text
@@ -368,11 +413,12 @@ Context files:
 - [docs/multi-business-request/plan.md](docs/multi-business-request/plan.md)
 
 Tasks:
-1. Audit DataLoader/provider caches for scope-safe keys and operation boundaries.
-2. Add or update cache isolation integration tests for multi-business requests.
-3. Run final server verification matrix: lint, integration tests, and manual two-business GraphQL scenario.
-4. Update the plan document with implementation status and any residual risk notes.
+1. Audit DataLoader/provider caches for scope-safe keys and operation boundaries. Concrete rule: any DataLoader that can fire during a multi-business read either is `Scope.Operation` (re-instantiated per request) or includes the scope in its cache key. Specifically verify the loaders in `ledger.provider.ts` (`getLedgerRecordsByIdLoader`, `batchLedgerRecordsByChargesIds`, `batchLedgerRecordsByFinancialEntityIds`) and the loader in `contracts.provider.ts` that today keys on `adminBusinessIds`.
+2. Add or update cache isolation integration tests for multi-business requests in `packages/server/src/__tests__/cache-isolation.integration.test.ts` — one request must not see another's cached rows even when entity IDs overlap.
+3. Add a lint/test guard that fails if any file under `packages/server/src/modules/` (except `admin-context/`) references `adminContext.ownerId` or `adminContext.defaultLocalCurrency`.
+4. Run final server verification matrix: `yarn workspace @accounter/migrations migration:run`, `yarn lint`, `yarn test:integration`, and a manual two-business GraphQL scenario (multi-business read aggregation, single-target write success, out-of-scope write rejection).
+5. Update the plan document with implementation status and any residual risk notes, especially around the `user_context` table's single-`owner_id` model (still out of scope for this phase) and the client refactor's status.
 
 Validation:
-All automated checks pass, manual scenario passes, and no orphaned migration code remains.
+All automated checks pass, manual scenario passes, no orphaned migration code remains, and the repo-wide grep guard returns zero hits.
 ```

--- a/docs/multi-business-request/plan.md
+++ b/docs/multi-business-request/plan.md
@@ -42,9 +42,11 @@ contract cut and no temporary legacy field compatibility.
    - financial-entities (`businesses.resolver.ts`, `businesses.provider.ts`)
    - admin-context (`admin-context.provider.ts`)
    - auth (`invitations.resolver.ts`)
-   - transactions (`transactions.resolver.ts` — `getTransactionsByFilters({ ownerIDs: [adminContext.ownerId] })`)
+   - transactions (`transactions.resolver.ts` —
+     `getTransactionsByFilters({ ownerIDs: [adminContext.ownerId] })`)
    - tags (`tags.provider.ts` — `reassureOwnerIdExists` fallback in `addNewTag`)
-   - contracts (`contracts.provider.ts` — DataLoader keyed by `adminBusinessIds`; cross-business leak risk)
+   - contracts (`contracts.provider.ts` — DataLoader keyed by `adminBusinessIds`; cross-business
+     leak risk)
    - green-invoice (`green-invoice.resolvers.ts` — `ownerId = inputOwnerId ?? adminContext.ownerId`)
    - charges-matcher / `document-business.helper.ts` (indirect admin-context use)
 
@@ -53,6 +55,7 @@ contract cut and no temporary legacy field compatibility.
    resolve that value from the row's owning business via the shared scope helper, not from the
    request's active context. Multi-business reads can return rows from businesses with different
    defaults; relying on a single request-level default silently corrupts formatting.
+
 8. Phase 7: Provider and cache isolation audit (parallel with step 6). Audit operation scope and
    in-memory caching for tenant leakage under multi-business reads, especially broad fetch providers
    and DataLoader usage. Concrete rule: any DataLoader that can be invoked during a multi-business
@@ -60,7 +63,8 @@ contract cut and no temporary legacy field compatibility.
    `(scope, entityId)` rather than `entityId` alone. Specifically audit the loaders in
    `ledger.provider.ts` (`getLedgerRecordsByIdLoader`, `batchLedgerRecordsByChargesIds`,
    `batchLedgerRecordsByFinancialEntityIds`) and the `adminBusinessIds`-keyed loader in
-   `contracts.provider.ts`. See [docs/architecture/provider-cache-patterns.md](../architecture/provider-cache-patterns.md).
+   `contracts.provider.ts`. See
+   [docs/architecture/provider-cache-patterns.md](../architecture/provider-cache-patterns.md).
 9. Phase 8: Verification and rollout readiness (depends on steps 5-8). Execute focused
    auth/RLS/integration suites, then full integration/lint gates, plus manual GraphQL scenario
    validation for multi-business reads and single-business writes.
@@ -128,19 +132,19 @@ contract cut and no temporary legacy field compatibility.
    must return the full membership set.
 2. Add and run TenantAwareDBClient tests covering: session variable propagation for the new
    `app.current_business_scope` array, nested transaction behavior (inner-tx rollback must restore
-   outer-tx scope, not clear it), single-write-target enforcement via `app.current_business_id`,
-   and isolation across pooled connections.
-3. Add a new integration test
-   `packages/server/src/__tests__/rls-multi-business.integration.test.ts` that opens two
-   connections with different scope arrays and asserts the read policies show the expected union
-   while write policies reject out-of-target inserts. (Replaces Prompt 07's hedge wording.)
+   outer-tx scope, not clear it), single-write-target enforcement via `app.current_business_id`, and
+   isolation across pooled connections.
+3. Add a new integration test `packages/server/src/__tests__/rls-multi-business.integration.test.ts`
+   that opens two connections with different scope arrays and asserts the read policies show the
+   expected union while write policies reject out-of-target inserts. (Replaces Prompt 07's hedge
+   wording.)
 4. Add integration tests for read/write semantics: multi-business query aggregation, scoped
    narrowing via header, write mutation fails without explicit business, write mutation fails for
    out-of-scope business.
 5. Run focused integration tests for cache isolation with multi-business scenarios in
    [packages/server/src/**tests**/cache-isolation.integration.test.ts](packages/server/src/__tests__/cache-isolation.integration.test.ts).
-6. Confirm `bootstrap-client.integration.test.ts` still passes after the Step 9 contract cut;
-   update it if it asserts on the removed `adminBusinessId` field.
+6. Confirm `bootstrap-client.integration.test.ts` still passes after the Step 9 contract cut; update
+   it if it asserts on the removed `adminBusinessId` field.
 7. Before running any integration test, ensure migrations are applied:
    `yarn workspace @accounter/migrations migration:run`.
 8. Run repository gates from root: `yarn lint`, `yarn test:integration`.
@@ -153,8 +157,8 @@ contract cut and no temporary legacy field compatibility.
 - Read behavior: default to all accessible businesses when no explicit scope is provided.
 - Write behavior: always single-business target.
 - Scope encoding: both header and GraphQL args.
-- Read scope header name: `X-Business-Scope`, comma-separated UUIDs. Empty / absent means
-  "all memberships".
+- Read scope header name: `X-Business-Scope`, comma-separated UUIDs. Empty / absent means "all
+  memberships".
 - Write target transport: every write mutation takes an explicit `businessId: UUID!` argument.
   Writes never infer the target from the read scope, even when the read scope contains exactly one
   business — the contract is unambiguous on purpose.
@@ -163,17 +167,17 @@ contract cut and no temporary legacy field compatibility.
 - API-key authentication: API keys remain pinned to their stored `business_id`. The
   `X-Business-Scope` header is ignored when authenticating with an API key, and any args scope must
   equal the pinned business or the request is rejected.
-- Super-admin scope: super-admin status (per `super_admins` table) does NOT auto-expand read
-  scope. Super-admins still pass through normal membership scoping; cross-tenant operations
-  continue to go through explicit mutations (e.g. `bootstrapNewClient`).
+- Super-admin scope: super-admin status (per `super_admins` table) does NOT auto-expand read scope.
+  Super-admins still pass through normal membership scoping; cross-tenant operations continue to go
+  through explicit mutations (e.g. `bootstrapNewClient`).
 - `user_context` table model: one row per `(owner_id)` (i.e. per business). The GraphQL
-  `userContext` resolver returns the row matching the active read target when scope is singular,
-  or null when scope spans multiple businesses (callers must narrow). Schema migration of
-  `user_context` to a (user_id, business_id) composite is out of scope for this phase; this
-  decision is recorded so the contract cut in Step 9 doesn't paint into a corner.
-- RLS mechanism: two session variables. `app.current_business_id` (UUID, used by write policies
-  via `WITH CHECK`) + `app.current_business_scope` (UUID array, used by read policies via
-  `USING`). Helper `get_current_business_scope()` is added; `get_current_business_id()` stays.
+  `userContext` resolver returns the row matching the active read target when scope is singular, or
+  null when scope spans multiple businesses (callers must narrow). Schema migration of
+  `user_context` to a (user_id, business_id) composite is out of scope for this phase; this decision
+  is recorded so the contract cut in Step 9 doesn't paint into a corner.
+- RLS mechanism: two session variables. `app.current_business_id` (UUID, used by write policies via
+  `WITH CHECK`) + `app.current_business_scope` (UUID array, used by read policies via `USING`).
+  Helper `get_current_business_scope()` is added; `get_current_business_id()` stays.
 - Active-business persistence strategy: client-side persistence.
 - Compatibility strategy: hard cut (no temporary adminBusinessId compatibility layer).
 
@@ -184,19 +188,21 @@ contract cut and no temporary legacy field compatibility.
    concentrated in:
    - `packages/client/src/providers/user-provider.tsx` (root consumer of `adminBusinessId`)
    - `packages/client/src/hooks/use-update-admin-business.ts`
-   - every `*-filters.tsx` under `components/` (charges, business-ledger, salaries, reports/*)
-   - `components/business/admin/admin-business-section.tsx`, `components/layout/user-nav.tsx`
-   A sibling client plan must exist and be merged before the Step 9 contract cut ships.
+   - every `*-filters.tsx` under `components/` (charges, business-ledger, salaries, reports/\*)
+   - `components/business/admin/admin-business-section.tsx`, `components/layout/user-nav.tsx` A
+     sibling client plan must exist and be merged before the Step 9 contract cut ships.
 2. Prefer introducing a shared scope-resolution helper/provider early to avoid inconsistent
    per-module enforcement during the step-6 module rollout. Concrete shape:
    `packages/server/src/modules/auth/providers/scope.provider.ts`, exposing
    - `getReadScope(context): UUID[]` — args ∩ header ∩ memberships, defaulting to all memberships
-   - `resolveWriteTarget(context, requestedBusinessId): UUID` — throws if not in memberships or missing
-   - `getBusinessPreference(businessId, key)` — replaces field-level `adminContext.defaultLocalCurrency` reads
+   - `resolveWriteTarget(context, requestedBusinessId): UUID` — throws if not in memberships or
+     missing
+   - `getBusinessPreference(businessId, key)` — replaces field-level
+     `adminContext.defaultLocalCurrency` reads
 3. Prioritize charges/reports/ledger first in step 6 since they have the highest concentration of
    ownerId fallback logic and the greatest tenant-safety risk.
-4. Out-of-scope packages for this phase (no admin-context coupling found, but flag for follow-up
-   if behavior changes): `packages/gmail-listener`, `packages/scraper-app`,
-   `packages/*-generator`, `packages/modern-poalim-scraper` and other scrapers. They do not
-   consume `adminBusinessId` directly today; if they ever start calling the GraphQL server with
-   user context, the same gate applies.
+4. Out-of-scope packages for this phase (no admin-context coupling found, but flag for follow-up if
+   behavior changes): `packages/gmail-listener`, `packages/scraper-app`, `packages/*-generator`,
+   `packages/modern-poalim-scraper` and other scrapers. They do not consume `adminBusinessId`
+   directly today; if they ever start calling the GraphQL server with user context, the same gate
+   applies.

--- a/docs/multi-business-request/plan.md
+++ b/docs/multi-business-request/plan.md
@@ -32,10 +32,35 @@ contract cut and no temporary legacy field compatibility.
 7. Phase 6: Refactor read paths to scoped multi-business defaults (depends on step 4, parallel by
    module group). Apply a shared scope resolver rule: explicit args intersect with authorized scope,
    otherwise default to all accessible businesses. Prioritize high-traffic modules first (charges,
-   reports, ledger, salaries), then propagate to remaining modules.
+   reports, ledger, salaries), then propagate to remaining modules. The full module inventory that
+   reaches into `adminContext.ownerId` / `defaultLocalCurrency` and must migrate (or be explicitly
+   deferred) is:
+   - charges (`financial-charges.resolver.ts`, `charges.resolver.ts`)
+   - reports (`annual-revenue.resover.ts`, `shaam6111.resolver.ts`, `reports.resolver.ts`)
+   - ledger (`ledger.resolver.ts`, `ledger.provider.ts`)
+   - salaries (`salaries.resolvers.ts`)
+   - financial-entities (`businesses.resolver.ts`, `businesses.provider.ts`)
+   - admin-context (`admin-context.provider.ts`)
+   - auth (`invitations.resolver.ts`)
+   - transactions (`transactions.resolver.ts` — `getTransactionsByFilters({ ownerIDs: [adminContext.ownerId] })`)
+   - tags (`tags.provider.ts` — `reassureOwnerIdExists` fallback in `addNewTag`)
+   - contracts (`contracts.provider.ts` — DataLoader keyed by `adminBusinessIds`; cross-business leak risk)
+   - green-invoice (`green-invoice.resolvers.ts` — `ownerId = inputOwnerId ?? adminContext.ownerId`)
+   - charges-matcher / `document-business.helper.ts` (indirect admin-context use)
+
+   Sub-rule for field-level admin-context values: any field resolver that today reads
+   `adminContext.defaultLocalCurrency` (or other per-business preference) must be migrated to
+   resolve that value from the row's owning business via the shared scope helper, not from the
+   request's active context. Multi-business reads can return rows from businesses with different
+   defaults; relying on a single request-level default silently corrupts formatting.
 8. Phase 7: Provider and cache isolation audit (parallel with step 6). Audit operation scope and
    in-memory caching for tenant leakage under multi-business reads, especially broad fetch providers
-   and DataLoader usage.
+   and DataLoader usage. Concrete rule: any DataLoader that can be invoked during a multi-business
+   read must either be `Scope.Operation` (re-instantiated per request) or key its cache by
+   `(scope, entityId)` rather than `entityId` alone. Specifically audit the loaders in
+   `ledger.provider.ts` (`getLedgerRecordsByIdLoader`, `batchLedgerRecordsByChargesIds`,
+   `batchLedgerRecordsByFinancialEntityIds`) and the `adminBusinessIds`-keyed loader in
+   `contracts.provider.ts`. See [docs/architecture/provider-cache-patterns.md](../architecture/provider-cache-patterns.md).
 9. Phase 8: Verification and rollout readiness (depends on steps 5-8). Execute focused
    auth/RLS/integration suites, then full integration/lint gates, plus manual GraphQL scenario
    validation for multi-business reads and single-business writes.
@@ -74,8 +99,21 @@ contract cut and no temporary legacy field compatibility.
   heavy use of verified admin context ownerId; requires explicit targeting updates.
 - [packages/server/src/modules/ledger/resolvers/ledger.resolver.ts](packages/server/src/modules/ledger/resolvers/ledger.resolver.ts) -
   broad ownerId assumptions and generation flows to migrate.
+- [packages/server/src/modules/ledger/providers/ledger.provider.ts](packages/server/src/modules/ledger/providers/ledger.provider.ts) -
+  DataLoader cache keys do not include `owner_id`; audit and re-key under multi-business reads.
+- [packages/server/src/modules/transactions/resolvers/transactions.resolver.ts](packages/server/src/modules/transactions/resolvers/transactions.resolver.ts) -
+  hard-codes `ownerIDs: [adminContext.ownerId]` in `getTransactionsByFilters`.
+- [packages/server/src/modules/tags/providers/tags.provider.ts](packages/server/src/modules/tags/providers/tags.provider.ts) -
+  `reassureOwnerIdExists(params, adminContext.ownerId)` fallback in `addNewTag`.
+- [packages/server/src/modules/contracts/providers/contracts.provider.ts](packages/server/src/modules/contracts/providers/contracts.provider.ts) -
+  DataLoader keyed on `adminBusinessIds`; must re-key for multi-business safety.
+- [packages/server/src/modules/green-invoice/resolvers/green-invoice.resolvers.ts](packages/server/src/modules/green-invoice/resolvers/green-invoice.resolvers.ts) -
+  `ownerId = inputOwnerId ?? adminContext.ownerId` fallback.
 - [packages/migrations](packages/migrations) - add migration(s) for multi-business RLS helper
-  function/policy updates.
+  function/policy updates. Concrete shape: keep `app.current_business_id` as the write-target
+  session variable (set per-mutation transaction, used by `WITH CHECK`) and add
+  `app.current_business_scope` (UUID array, used by `USING` on reads); helper
+  `get_current_business_scope()` returns the array, `get_current_business_id()` stays unchanged.
 - [docs/user-authentication-plan/spec.md](docs/user-authentication-plan/spec.md) - source
   requirements for active business context and business switch behavior.
 - [docs/architecture/provider-cache-patterns.md](docs/architecture/provider-cache-patterns.md) -
@@ -85,15 +123,28 @@ contract cut and no temporary legacy field compatibility.
 
 1. Add and run focused auth-context tests covering: user with multiple memberships, default read
    scope = all memberships, invalid requested scope rejection, and write-target validation.
-2. Add and run TenantAwareDBClient tests covering: session variable propagation for business-id
-   arrays, nested transaction behavior, and single-write-target enforcement.
-3. Add integration tests for read/write semantics: multi-business query aggregation, scoped
+   Explicitly exercise all three auth paths in `auth-context.provider.ts` (JWT ~line 328, API key
+   ~line 200, dev bypass ~line 31) — each currently returns a single membership via `LIMIT 1` and
+   must return the full membership set.
+2. Add and run TenantAwareDBClient tests covering: session variable propagation for the new
+   `app.current_business_scope` array, nested transaction behavior (inner-tx rollback must restore
+   outer-tx scope, not clear it), single-write-target enforcement via `app.current_business_id`,
+   and isolation across pooled connections.
+3. Add a new integration test
+   `packages/server/src/__tests__/rls-multi-business.integration.test.ts` that opens two
+   connections with different scope arrays and asserts the read policies show the expected union
+   while write policies reject out-of-target inserts. (Replaces Prompt 07's hedge wording.)
+4. Add integration tests for read/write semantics: multi-business query aggregation, scoped
    narrowing via header, write mutation fails without explicit business, write mutation fails for
    out-of-scope business.
-4. Run focused integration tests for cache isolation with multi-business scenarios in
+5. Run focused integration tests for cache isolation with multi-business scenarios in
    [packages/server/src/**tests**/cache-isolation.integration.test.ts](packages/server/src/__tests__/cache-isolation.integration.test.ts).
-5. Run repository gates from root: yarn lint, yarn test:integration.
-6. Manual GraphQL validation in dev: same user reads data from businesses A+B in one request, then
+6. Confirm `bootstrap-client.integration.test.ts` still passes after the Step 9 contract cut;
+   update it if it asserts on the removed `adminBusinessId` field.
+7. Before running any integration test, ensure migrations are applied:
+   `yarn workspace @accounter/migrations migration:run`.
+8. Run repository gates from root: `yarn lint`, `yarn test:integration`.
+9. Manual GraphQL validation in dev: same user reads data from businesses A+B in one request, then
    write to A succeeds and write to B fails when targeting rules are not met.
 
 **Decisions**
@@ -102,14 +153,50 @@ contract cut and no temporary legacy field compatibility.
 - Read behavior: default to all accessible businesses when no explicit scope is provided.
 - Write behavior: always single-business target.
 - Scope encoding: both header and GraphQL args.
+- Read scope header name: `X-Business-Scope`, comma-separated UUIDs. Empty / absent means
+  "all memberships".
+- Write target transport: every write mutation takes an explicit `businessId: UUID!` argument.
+  Writes never infer the target from the read scope, even when the read scope contains exactly one
+  business — the contract is unambiguous on purpose.
+- Precedence (read scope): GraphQL args ⊆ header ⊆ memberships. Args narrow; out-of-membership
+  values are rejected at the auth layer, never silently dropped.
+- API-key authentication: API keys remain pinned to their stored `business_id`. The
+  `X-Business-Scope` header is ignored when authenticating with an API key, and any args scope must
+  equal the pinned business or the request is rejected.
+- Super-admin scope: super-admin status (per `super_admins` table) does NOT auto-expand read
+  scope. Super-admins still pass through normal membership scoping; cross-tenant operations
+  continue to go through explicit mutations (e.g. `bootstrapNewClient`).
+- `user_context` table model: one row per `(owner_id)` (i.e. per business). The GraphQL
+  `userContext` resolver returns the row matching the active read target when scope is singular,
+  or null when scope spans multiple businesses (callers must narrow). Schema migration of
+  `user_context` to a (user_id, business_id) composite is out of scope for this phase; this
+  decision is recorded so the contract cut in Step 9 doesn't paint into a corner.
+- RLS mechanism: two session variables. `app.current_business_id` (UUID, used by write policies
+  via `WITH CHECK`) + `app.current_business_scope` (UUID array, used by read policies via
+  `USING`). Helper `get_current_business_scope()` is added; `get_current_business_id()` stays.
 - Active-business persistence strategy: client-side persistence.
 - Compatibility strategy: hard cut (no temporary adminBusinessId compatibility layer).
 
 **Further Considerations**
 
 1. Because compatibility is a hard cut, keep deployment gated until client contract updates are
-   merged and validated in the same release window.
+   merged and validated in the same release window. Known client breakage (22+ files) is
+   concentrated in:
+   - `packages/client/src/providers/user-provider.tsx` (root consumer of `adminBusinessId`)
+   - `packages/client/src/hooks/use-update-admin-business.ts`
+   - every `*-filters.tsx` under `components/` (charges, business-ledger, salaries, reports/*)
+   - `components/business/admin/admin-business-section.tsx`, `components/layout/user-nav.tsx`
+   A sibling client plan must exist and be merged before the Step 9 contract cut ships.
 2. Prefer introducing a shared scope-resolution helper/provider early to avoid inconsistent
-   per-module enforcement during the step-6 module rollout.
+   per-module enforcement during the step-6 module rollout. Concrete shape:
+   `packages/server/src/modules/auth/providers/scope.provider.ts`, exposing
+   - `getReadScope(context): UUID[]` — args ∩ header ∩ memberships, defaulting to all memberships
+   - `resolveWriteTarget(context, requestedBusinessId): UUID` — throws if not in memberships or missing
+   - `getBusinessPreference(businessId, key)` — replaces field-level `adminContext.defaultLocalCurrency` reads
 3. Prioritize charges/reports/ledger first in step 6 since they have the highest concentration of
    ownerId fallback logic and the greatest tenant-safety risk.
+4. Out-of-scope packages for this phase (no admin-context coupling found, but flag for follow-up
+   if behavior changes): `packages/gmail-listener`, `packages/scraper-app`,
+   `packages/*-generator`, `packages/modern-poalim-scraper` and other scrapers. They do not
+   consume `adminBusinessId` directly today; if they ever start calling the GraphQL server with
+   user context, the same gate applies.


### PR DESCRIPTION
Add module-inventory completeness (transactions, tags, contracts, green-invoice, charges-matcher), pin the read header name (`X-Business-Scope`) and write transport (explicit `businessId` arg), specify the two-session-variable RLS mechanism
(`app.current_business_id` + `app.current_business_scope`), name the shared scope provider, and add new Prompt 14a covering the modules the original rollout missed. Tighten verification (RLS integration test, nested-tx behavior, migrations prerequisite) and record decisions for API-key pinning, super-admin scope, and the `user_context` table model.