### PR TITLE
Multi-business step 1: baseline guardrails

### DIFF
--- a/packages/server/src/modules/app-providers/__tests__/tenant-db-client.test.ts
+++ b/packages/server/src/modules/app-providers/__tests__/tenant-db-client.test.ts
@@ -268,5 +268,28 @@ describe('TenantAwareDBClient', () => {
 
       await expect(tenantDBClient.query('SELECT 1')).rejects.toThrow('Missing businessId in AuthContext');
     });
+
+    // Baseline guardrail: today the session is scoped to a SINGLE business via
+    // `app.current_business_id`. The migration will add a read-scope array
+    // (e.g. `app.current_business_scope`). Locking the current variable set makes
+    // that addition an intentional, reviewable change.
+    it('should set exactly the single-business RLS variables and no read-scope array', async () => {
+      vi.mocked(mockPoolClient.query).mockResolvedValue({ rows: [] } as any);
+
+      await tenantDBClient.query('SELECT 1');
+
+      const setCall = vi.mocked(mockPoolClient.query).mock.calls.find((call: any[]) =>
+        call[0].includes('set_config('),
+      );
+
+      expect(setCall).toBeDefined();
+      const sql = setCall![0] as string;
+      expect(sql).toContain("set_config('app.current_business_id', $1, true)");
+      expect(sql).toContain("set_config('app.current_user_id', $2, true)");
+      expect(sql).toContain("set_config('app.auth_type', $3, true)");
+      // No multi-business read scope is wired yet.
+      expect(sql).not.toContain('app.current_business_scope');
+      expect(setCall![1]).toHaveLength(3);
+    });
   });
 });

--- a/packages/server/src/modules/auth/providers/__tests__/auth-context.test.ts
+++ b/packages/server/src/modules/auth/providers/__tests__/auth-context.test.ts
@@ -240,4 +240,68 @@ describe('handleDevBypassAuth', () => {
 
     expect(result).toBeNull();
   });
+
+  it('returns null for an empty/whitespace user id without querying', async () => {
+    const db = {
+      query: vi.fn(),
+    } as unknown as Pick<DBProvider, 'query'>;
+
+    expect(await handleDevBypassAuth(db, '   ')).toBeNull();
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  // Baseline guardrail: dev-bypass collapses a user's memberships to a single
+  // business via `ORDER BY updated_at DESC LIMIT 1`. The migration will replace
+  // this single-row lookup with full membership resolution.
+  it('resolves a single business via LIMIT 1 (single-membership baseline)', async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [
+        {
+          user_id: 'user-1',
+          business_id: 'biz-1',
+          role_id: 'business_owner',
+          auth0_user_id: null,
+        },
+      ],
+    });
+    const db = { query } as unknown as Pick<DBProvider, 'query'>;
+
+    const result = await handleDevBypassAuth(db, 'user-1');
+
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('LIMIT 1'), ['user-1']);
+    expect(result?.tenant.businessId).toBe('biz-1');
+    expect(Array.isArray(result?.tenant.businessId)).toBe(false);
+  });
+});
+
+// Baseline guardrail: JWT auth maps an Auth0 subject to a single local business
+// via a `LIMIT 1` lookup. The migration will resolve all memberships instead.
+describe('AuthContextProvider single-membership baseline', () => {
+  it('maps the Auth0 user to one business using a LIMIT 1 query', async () => {
+    const mockDb = {
+      query: vi.fn().mockResolvedValue({
+        rowCount: 1,
+        rows: [{ user_id: 'u-1', business_id: 'b-1', role_id: 'admin' }],
+      }),
+    } as any;
+    const mockEnv = { auth0: { domain: 'test.auth0.com', audience: 'aud' } } as any;
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue({} as any);
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: { sub: 'auth0|123', exp: 1, email: null, email_verified: false, permissions: [] },
+    } as any);
+
+    const provider = new AuthContextProvider(
+      mockEnv,
+      { authType: 'jwt', token: 'valid-token' } as any,
+      mockDb,
+    );
+    const result = await provider.getAuthContext();
+
+    expect(mockDb.query).toHaveBeenCalledWith(
+      expect.stringContaining('LIMIT 1'),
+      ['auth0|123'],
+    );
+    expect(result?.tenant.businessId).toBe('b-1');
+    expect(Array.isArray(result?.tenant.businessId)).toBe(false);
+  });
 });

--- a/packages/server/src/modules/common/__tests__/user-context.resolver.test.ts
+++ b/packages/server/src/modules/common/__tests__/user-context.resolver.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { userContextResolvers } from '../resolvers/user-context.resolver.js';
+
+// Baseline guardrails for the multi-business migration.
+// These lock the CURRENT single-business `userContext` contract so the hard-cut
+// in a later step (memberships + active read scope replacing `adminBusinessId`)
+// is visible as an intentional change rather than a silent regression.
+
+type AdminContextFixture = {
+  ownerId: string;
+  defaultLocalCurrency: string;
+  defaultCryptoConversionFiatCurrency: string;
+  ledgerLock?: string;
+  locality: string;
+  financialAccounts: { internalWalletsIds: string[] };
+  bankDeposits: { bankDepositBusinessId: string | null };
+};
+
+function buildInjector(adminContext: AdminContextFixture) {
+  return {
+    get: vi.fn().mockReturnValue({
+      getVerifiedAdminContext: vi.fn().mockResolvedValue(adminContext),
+    }),
+  };
+}
+
+async function runResolver(adminContext: AdminContextFixture) {
+  const injector = buildInjector(adminContext);
+  // The resolver only reads `injector` from the context.
+  const resolver = userContextResolvers.Query!.userContext as (
+    parent: unknown,
+    args: unknown,
+    context: { injector: ReturnType<typeof buildInjector> },
+    info: unknown,
+  ) => Promise<Record<string, unknown>>;
+  return resolver(undefined, undefined, { injector }, undefined);
+}
+
+const baseContext: AdminContextFixture = {
+  ownerId: 'owner-1',
+  defaultLocalCurrency: 'ILS',
+  defaultCryptoConversionFiatCurrency: 'USD',
+  ledgerLock: '2024-01-01',
+  locality: 'ISRAEL',
+  financialAccounts: { internalWalletsIds: ['wallet-1', 'wallet-2'] },
+  bankDeposits: { bankDepositBusinessId: null },
+};
+
+describe('userContext resolver (single-business baseline)', () => {
+  it('exposes the single admin business as adminBusinessId', async () => {
+    const result = await runResolver(baseContext);
+
+    // Single-business contract: exactly one business id, scalar (not an array).
+    expect(result.adminBusinessId).toBe('owner-1');
+    expect(Array.isArray(result.adminBusinessId)).toBe(false);
+  });
+
+  it('passes through currency, ledger lock, and locality unchanged', async () => {
+    const result = await runResolver(baseContext);
+
+    expect(result.defaultLocalCurrency).toBe('ILS');
+    expect(result.defaultCryptoConversionFiatCurrency).toBe('USD');
+    expect(result.ledgerLock).toBe('2024-01-01');
+    expect(result.locality).toBe('ISRAEL');
+  });
+
+  it('returns internal wallet ids when there is no bank deposit business', async () => {
+    const result = await runResolver(baseContext);
+
+    expect(result.financialAccountsBusinessesIds).toEqual(['wallet-1', 'wallet-2']);
+  });
+
+  it('appends the bank deposit business id to financial accounts when present', async () => {
+    const result = await runResolver({
+      ...baseContext,
+      bankDeposits: { bankDepositBusinessId: 'bank-deposit-1' },
+    });
+
+    expect(result.financialAccountsBusinessesIds).toEqual([
+      'wallet-1',
+      'wallet-2',
+      'bank-deposit-1',
+    ]);
+  });
+});

--- a/packages/server/src/modules/common/__tests__/user-context.resolver.test.ts
+++ b/packages/server/src/modules/common/__tests__/user-context.resolver.test.ts
@@ -1,20 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 import { userContextResolvers } from '../resolvers/user-context.resolver.js';
+import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
 
 // Baseline guardrails for the multi-business migration.
 // These lock the CURRENT single-business `userContext` contract so the hard-cut
 // in a later step (memberships + active read scope replacing `adminBusinessId`)
 // is visible as an intentional change rather than a silent regression.
 
-type AdminContextFixture = {
-  ownerId: string;
-  defaultLocalCurrency: string;
-  defaultCryptoConversionFiatCurrency: string;
-  ledgerLock?: string;
-  locality: string;
-  financialAccounts: { internalWalletsIds: string[] };
-  bankDeposits: { bankDepositBusinessId: string | null };
-};
+type AdminContextFixture = Awaited<ReturnType<AdminContextProvider['getVerifiedAdminContext']>>;
 
 function buildInjector(adminContext: AdminContextFixture) {
   return {
@@ -36,7 +29,7 @@ async function runResolver(adminContext: AdminContextFixture) {
   return resolver(undefined, undefined, { injector }, undefined);
 }
 
-const baseContext: AdminContextFixture = {
+const baseContext = {
   ownerId: 'owner-1',
   defaultLocalCurrency: 'ILS',
   defaultCryptoConversionFiatCurrency: 'USD',
@@ -44,7 +37,7 @@ const baseContext: AdminContextFixture = {
   locality: 'ISRAEL',
   financialAccounts: { internalWalletsIds: ['wallet-1', 'wallet-2'] },
   bankDeposits: { bankDepositBusinessId: null },
-};
+} as AdminContextFixture;
 
 describe('userContext resolver (single-business baseline)', () => {
   it('exposes the single admin business as adminBusinessId', async () => {


### PR DESCRIPTION
## Summary

Step 1 of the multi-business tenancy migration (Prompt 01: Baseline Guardrails). Adds focused tests that lock current single-business behavior **before** any refactor, so later behavior changes surface as intentional diffs rather than silent regressions. No runtime behavior changes.

- **userContext resolver** (`user-context.resolver.test.ts`, new — no prior coverage): asserts the single-business `adminBusinessId` contract and the financial-accounts business-id merging (internal wallets + optional bank-deposit business). Guards the later hard-cut to memberships + active read scope.
- **auth-context** (`auth-context.test.ts`): asserts dev-bypass and JWT membership lookups collapse to one business via `LIMIT 1`, and that dev-bypass ignores empty/whitespace user ids without querying. Guards the later switch to full membership resolution.
- **tenant-db-client** (`tenant-db-client.test.ts`): asserts exactly the three single-business RLS session variables (`app.current_business_id`, `app.current_user_id`, `app.auth_type`) are set and no read-scope array exists yet. Guards the later RLS scope-array addition.

## Test plan

- [x] `vitest run --project unit` for the three touched files — 31 tests pass
- [x] `prettier --check` clean on touched files
- [x] eslint: test files are excluded by the lint ignore config (no regression)

> Note: `yarn install` in CI/this environment is blocked because `xlsx@0.20.2` resolves only from `cdn.sheetjs.com`, which the sandbox network policy returns 403 for. Tests were validated locally via a temporary `xlsx` resolution override that is **not** included in this PR. This is a pre-existing dependency-sourcing concern, unrelated to these test changes.

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_