### PR TITLE
Multi-business step 2: auth scope types

### DIFF
--- a/packages/server/src/modules/common/__tests__/user-context.resolver.test.ts
+++ b/packages/server/src/modules/common/__tests__/user-context.resolver.test.ts
@@ -66,7 +66,7 @@ describe('userContext resolver (single-business baseline)', () => {
   it('appends the bank deposit business id to financial accounts when present', async () => {
     const result = await runResolver({
       ...baseContext,
-      bankDeposits: { bankDepositBusinessId: 'bank-deposit-1' },
+      bankDeposits: { bankDepositBusinessId: 'bank-deposit-1', bankDepositInterestIncomeTaxCategoryId: null },
     });
 
     expect(result.financialAccountsBusinessesIds).toEqual([

--- a/packages/server/src/shared/helpers/__tests__/auth-scope.test.ts
+++ b/packages/server/src/shared/helpers/__tests__/auth-scope.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { BusinessMembership } from '../../types/auth.js';
+import {
+  isBusinessInScope,
+  membershipFromTenant,
+  readScopeFromMemberships,
+  tenantFromMembership,
+} from '../auth-scope.js';
+
+describe('membershipFromTenant', () => {
+  it('maps a tenant with role and name to a membership', () => {
+    expect(
+      membershipFromTenant({ businessId: 'b-1', roleId: 'admin', businessName: 'Acme' }),
+    ).toEqual({ businessId: 'b-1', roleId: 'admin', businessName: 'Acme' });
+  });
+
+  it('defaults a missing role to an empty string and omits the name', () => {
+    expect(membershipFromTenant({ businessId: 'b-1' })).toEqual({
+      businessId: 'b-1',
+      roleId: '',
+    });
+  });
+});
+
+describe('tenantFromMembership', () => {
+  it('round-trips back to a tenant context', () => {
+    const membership: BusinessMembership = { businessId: 'b-1', roleId: 'owner' };
+    expect(tenantFromMembership(membership)).toEqual({ businessId: 'b-1', roleId: 'owner' });
+  });
+
+  it('preserves the business name when present', () => {
+    expect(
+      tenantFromMembership({ businessId: 'b-1', roleId: 'owner', businessName: 'Acme' }),
+    ).toEqual({ businessId: 'b-1', roleId: 'owner', businessName: 'Acme' });
+  });
+});
+
+describe('readScopeFromMemberships', () => {
+  it('returns all membership business ids in order', () => {
+    expect(
+      readScopeFromMemberships([
+        { businessId: 'b-1', roleId: 'owner' },
+        { businessId: 'b-2', roleId: 'accountant' },
+      ]),
+    ).toEqual({ businessIds: ['b-1', 'b-2'] });
+  });
+
+  it('de-duplicates repeated business ids', () => {
+    expect(
+      readScopeFromMemberships([
+        { businessId: 'b-1', roleId: 'owner' },
+        { businessId: 'b-1', roleId: 'accountant' },
+        { businessId: 'b-2', roleId: 'owner' },
+      ]),
+    ).toEqual({ businessIds: ['b-1', 'b-2'] });
+  });
+
+  it('returns an empty scope for a user with no memberships', () => {
+    expect(readScopeFromMemberships([])).toEqual({ businessIds: [] });
+  });
+});
+
+describe('isBusinessInScope', () => {
+  const scope = { businessIds: ['b-1', 'b-2'] };
+
+  it('is true for a business inside the scope', () => {
+    expect(isBusinessInScope(scope, 'b-2')).toBe(true);
+  });
+
+  it('is false for a business outside the scope', () => {
+    expect(isBusinessInScope(scope, 'b-3')).toBe(false);
+  });
+});

--- a/packages/server/src/shared/helpers/auth-scope.ts
+++ b/packages/server/src/shared/helpers/auth-scope.ts
@@ -29,19 +29,17 @@ export function tenantFromMembership(membership: BusinessMembership): TenantCont
  * Default read scope = every business the user belongs to, de-duplicated and
  * order-preserving.
  */
-export function readScopeFromMemberships(memberships: BusinessMembership[]): AuthorizedReadScope {
-  const seen = new Set<string>();
-  const businessIds: string[] = [];
-  for (const membership of memberships) {
-    if (!seen.has(membership.businessId)) {
-      seen.add(membership.businessId);
-      businessIds.push(membership.businessId);
-    }
-  }
+export function readScopeFromMemberships(
+  memberships: BusinessMembership[] | undefined | null,
+): AuthorizedReadScope {
+  const businessIds = memberships ? [...new Set(memberships.map(m => m.businessId))] : [];
   return { businessIds };
 }
 
 /** Whether a business id is part of an authorized read scope. */
-export function isBusinessInScope(scope: AuthorizedReadScope, businessId: string): boolean {
-  return scope.businessIds.includes(businessId);
+export function isBusinessInScope(
+  scope: AuthorizedReadScope | undefined | null,
+  businessId: string,
+): boolean {
+  return scope?.businessIds.includes(businessId) ?? false;
 }

--- a/packages/server/src/shared/helpers/auth-scope.ts
+++ b/packages/server/src/shared/helpers/auth-scope.ts
@@ -1,0 +1,47 @@
+import type { AuthorizedReadScope, BusinessMembership, TenantContext } from '../types/auth.js';
+
+/**
+ * Adapter helpers bridging the legacy single-business `TenantContext` and the
+ * multi-business membership / read-scope types. These let existing code keep
+ * compiling while the migration introduces membership-aware auth, before any
+ * provider/resolver is switched over.
+ */
+
+/** Build a membership from the legacy single-business tenant context. */
+export function membershipFromTenant(tenant: TenantContext): BusinessMembership {
+  return {
+    businessId: tenant.businessId,
+    roleId: tenant.roleId ?? '',
+    ...(tenant.businessName ? { businessName: tenant.businessName } : {}),
+  };
+}
+
+/** Collapse a membership back into the legacy single-business tenant context. */
+export function tenantFromMembership(membership: BusinessMembership): TenantContext {
+  return {
+    businessId: membership.businessId,
+    roleId: membership.roleId,
+    ...(membership.businessName ? { businessName: membership.businessName } : {}),
+  };
+}
+
+/**
+ * Default read scope = every business the user belongs to, de-duplicated and
+ * order-preserving.
+ */
+export function readScopeFromMemberships(memberships: BusinessMembership[]): AuthorizedReadScope {
+  const seen = new Set<string>();
+  const businessIds: string[] = [];
+  for (const membership of memberships) {
+    if (!seen.has(membership.businessId)) {
+      seen.add(membership.businessId);
+      businessIds.push(membership.businessId);
+    }
+  }
+  return { businessIds };
+}
+
+/** Whether a business id is part of an authorized read scope. */
+export function isBusinessInScope(scope: AuthorizedReadScope, businessId: string): boolean {
+  return scope.businessIds.includes(businessId);
+}

--- a/packages/server/src/shared/helpers/index.ts
+++ b/packages/server/src/shared/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from './amount.js';
+export * from './auth-scope.js';
 export * from './cache.js';
 export * from './deterministic-uuid.js';
 export * from './misc.js';

--- a/packages/server/src/shared/types/auth.ts
+++ b/packages/server/src/shared/types/auth.ts
@@ -16,10 +16,39 @@ export interface TenantContext {
   roleId?: string;
 }
 
+/**
+ * A single business a user belongs to, with the role they hold in it.
+ * The multi-business migration resolves all of a user's memberships rather
+ * than collapsing to a single active business.
+ */
+export interface BusinessMembership {
+  businessId: string;
+  roleId: string;
+  businessName?: string;
+}
+
+/**
+ * The set of businesses a request is authorized to read from. Defaults to all
+ * of the user's memberships and can be narrowed (never broadened) per request.
+ */
+export interface AuthorizedReadScope {
+  businessIds: string[];
+}
+
 export interface AuthContext {
   authType: AuthType | null;
   token?: string | null;
   user?: AuthUser;
   tenant: TenantContext;
+  /**
+   * All businesses the authenticated user belongs to. Optional during the
+   * multi-business migration; populated once membership resolution lands.
+   */
+  memberships?: BusinessMembership[];
+  /**
+   * The resolved read scope for the current request. Optional during the
+   * migration; populated once scope plumbing lands.
+   */
+  activeReadScope?: AuthorizedReadScope;
   accessTokenExpiresAt?: number;
 }


### PR DESCRIPTION
## Summary

Step 2 of the multi-business migration (Prompt 02: Add Auth Scope Types). Introduces the membership and request-scope vocabulary **without changing any runtime behavior** — no provider or resolver is switched over yet.

- **Types** (`shared/types/auth.ts`): adds `BusinessMembership` and `AuthorizedReadScope`, plus optional `memberships` and `activeReadScope` fields on `AuthContext` (optional so existing constructions keep compiling).
- **Adapter helpers** (`shared/helpers/auth-scope.ts`): pure functions bridging the legacy single-business `TenantContext` and the membership model — `membershipFromTenant`, `tenantFromMembership`, `readScopeFromMemberships` (dedupes, order-preserving), `isBusinessInScope`. Re-exported from `shared/helpers/index.ts`.
- **Tests** (`shared/helpers/__tests__/auth-scope.test.ts`): 9 unit tests covering role defaulting, round-tripping, de-duplication, empty memberships, and scope membership checks.

Stacked on top of step 1 (`multi-business-request-1-baseline-guardrails`).

## Test plan

- [x] `vitest run --project unit` for the helper tests — 9 pass
- [x] Isolated strict `tsc --noEmit` on the new/edited source files — clean
- [x] `prettier --check` clean; `eslint` clean on source files

> Note: a full server `tsc` and `yarn test:integration` could not run in this environment — SQL (pgtyped) codegen and integration tests require Postgres, and the Docker daemon is unavailable. GraphQL codegen (DB-free) was run to confirm the schema side. Same `xlsx@0.20.2` CDN-install caveat as step 1 applies.

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_