### PR TITLE
Multi-business step 3: resolve full business memberships

### DIFF
--- a/packages/server/src/modules/auth/providers/__tests__/auth-context.test.ts
+++ b/packages/server/src/modules/auth/providers/__tests__/auth-context.test.ts
@@ -93,6 +93,7 @@ describe('AuthContextProvider', () => {
            businessId: 'b-1',
            roleId: 'admin',
          },
+         memberships: [{ businessId: 'b-1', roleId: 'admin' }],
          accessTokenExpiresAt: 1234567890,
        });
     });
@@ -134,12 +135,23 @@ describe('AuthContextProvider', () => {
         vi.mocked(jose.jwtVerify).mockResolvedValue({ payload: mockPayload } as any);
 
         mockDBProvider.query
+          // byAuth0: no rows for the new subject
           .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+          // byVerifiedEmail: identifies the local user
           .mockResolvedValueOnce({
             rowCount: 1,
-            rows: [{ user_id: 'u-42', business_id: 'b-42', role_id: 'employee' }],
+            rows: [{ user_id: 'u-42' }],
           })
-          .mockResolvedValueOnce({ rowCount: 2, rows: [] });
+          // relink UPDATE
+          .mockResolvedValueOnce({ rowCount: 2, rows: [] })
+          // byUserId: ALL memberships for the relinked user
+          .mockResolvedValueOnce({
+            rowCount: 2,
+            rows: [
+              { user_id: 'u-42', business_id: 'b-42', role_id: 'employee' },
+              { user_id: 'u-42', business_id: 'b-99', role_id: 'accountant' },
+            ],
+          });
 
         const result = await provider.getAuthContext();
 
@@ -158,6 +170,11 @@ describe('AuthContextProvider', () => {
           expect.stringContaining('UPDATE accounter_schema.business_users'),
           ['google-oauth2|new-subject', 'u-42'],
         );
+        expect(mockDBProvider.query).toHaveBeenNthCalledWith(
+          4,
+          expect.stringContaining('WHERE bu.user_id = $1'),
+          ['u-42'],
+        );
 
         expect(result).toEqual({
           authType: 'jwt',
@@ -175,6 +192,10 @@ describe('AuthContextProvider', () => {
             businessId: 'b-42',
             roleId: 'employee',
           },
+          memberships: [
+            { businessId: 'b-42', roleId: 'employee' },
+            { businessId: 'b-99', roleId: 'accountant' },
+          ],
           accessTokenExpiresAt: 1234567890,
         });
       });
@@ -228,6 +249,7 @@ describe('handleDevBypassAuth', () => {
         businessId: 'biz-456',
         roleId: 'business_owner',
       },
+      memberships: [{ businessId: 'biz-456', roleId: 'business_owner' }],
     });
   });
 
@@ -250,38 +272,39 @@ describe('handleDevBypassAuth', () => {
     expect(db.query).not.toHaveBeenCalled();
   });
 
-  // Baseline guardrail: dev-bypass collapses a user's memberships to a single
-  // business via `ORDER BY updated_at DESC LIMIT 1`. The migration will replace
-  // this single-row lookup with full membership resolution.
-  it('resolves a single business via LIMIT 1 (single-membership baseline)', async () => {
+  // dev-bypass now resolves ALL memberships (no LIMIT 1); the primary (most
+  // recently updated) membership still backs the single-business tenant context.
+  it('resolves all memberships and selects the primary as tenant', async () => {
     const query = vi.fn().mockResolvedValue({
       rows: [
-        {
-          user_id: 'user-1',
-          business_id: 'biz-1',
-          role_id: 'business_owner',
-          auth0_user_id: null,
-        },
+        { user_id: 'user-1', business_id: 'biz-1', role_id: 'business_owner', auth0_user_id: null },
+        { user_id: 'user-1', business_id: 'biz-2', role_id: 'accountant', auth0_user_id: null },
       ],
     });
     const db = { query } as unknown as Pick<DBProvider, 'query'>;
 
     const result = await handleDevBypassAuth(db, 'user-1');
 
-    expect(query).toHaveBeenCalledWith(expect.stringContaining('LIMIT 1'), ['user-1']);
+    expect(query).toHaveBeenCalledWith(expect.not.stringContaining('LIMIT 1'), ['user-1']);
     expect(result?.tenant.businessId).toBe('biz-1');
-    expect(Array.isArray(result?.tenant.businessId)).toBe(false);
+    expect(result?.memberships).toEqual([
+      { businessId: 'biz-1', roleId: 'business_owner' },
+      { businessId: 'biz-2', roleId: 'accountant' },
+    ]);
   });
 });
 
-// Baseline guardrail: JWT auth maps an Auth0 subject to a single local business
-// via a `LIMIT 1` lookup. The migration will resolve all memberships instead.
-describe('AuthContextProvider single-membership baseline', () => {
-  it('maps the Auth0 user to one business using a LIMIT 1 query', async () => {
+// JWT auth now resolves all of a user's memberships (no LIMIT 1 on the auth0
+// lookup); the primary membership still backs the single-business tenant context.
+describe('AuthContextProvider membership resolution', () => {
+  it('resolves all memberships for the Auth0 subject without a LIMIT 1 lookup', async () => {
     const mockDb = {
       query: vi.fn().mockResolvedValue({
-        rowCount: 1,
-        rows: [{ user_id: 'u-1', business_id: 'b-1', role_id: 'admin' }],
+        rowCount: 2,
+        rows: [
+          { user_id: 'u-1', business_id: 'b-1', role_id: 'admin' },
+          { user_id: 'u-1', business_id: 'b-2', role_id: 'accountant' },
+        ],
       }),
     } as any;
     const mockEnv = { auth0: { domain: 'test.auth0.com', audience: 'aud' } } as any;
@@ -298,10 +321,13 @@ describe('AuthContextProvider single-membership baseline', () => {
     const result = await provider.getAuthContext();
 
     expect(mockDb.query).toHaveBeenCalledWith(
-      expect.stringContaining('LIMIT 1'),
+      expect.not.stringContaining('LIMIT 1'),
       ['auth0|123'],
     );
     expect(result?.tenant.businessId).toBe('b-1');
-    expect(Array.isArray(result?.tenant.businessId)).toBe(false);
+    expect(result?.memberships).toEqual([
+      { businessId: 'b-1', roleId: 'admin' },
+      { businessId: 'b-2', roleId: 'accountant' },
+    ]);
   });
 });

--- a/packages/server/src/modules/auth/providers/__tests__/business-users.provider.test.ts
+++ b/packages/server/src/modules/auth/providers/__tests__/business-users.provider.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BusinessUsersProvider } from '../business-users.provider.js';
+
+function buildProvider(loadedRows: Array<{ business_id: string; role_id: string }>) {
+  const provider = new BusinessUsersProvider({} as never);
+  (provider as unknown as { getBusinessUsersByAuth0IdsLoader: { load: ReturnType<typeof vi.fn> } }).getBusinessUsersByAuth0IdsLoader =
+    { load: vi.fn().mockResolvedValue(loadedRows) };
+  return provider;
+}
+
+describe('BusinessUsersProvider.getMembershipsByAuth0UserId', () => {
+  it('returns an empty array for a user with no memberships', async () => {
+    const provider = buildProvider([]);
+    await expect(provider.getMembershipsByAuth0UserId('auth0|none')).resolves.toEqual([]);
+  });
+
+  it('returns a single membership', async () => {
+    const provider = buildProvider([{ business_id: 'b-1', role_id: 'business_owner' }]);
+    await expect(provider.getMembershipsByAuth0UserId('auth0|one')).resolves.toEqual([
+      { businessId: 'b-1', roleId: 'business_owner' },
+    ]);
+  });
+
+  it('returns all memberships for a multi-business user', async () => {
+    const provider = buildProvider([
+      { business_id: 'b-1', role_id: 'business_owner' },
+      { business_id: 'b-2', role_id: 'accountant' },
+    ]);
+    await expect(provider.getMembershipsByAuth0UserId('auth0|many')).resolves.toEqual([
+      { businessId: 'b-1', roleId: 'business_owner' },
+      { businessId: 'b-2', roleId: 'accountant' },
+    ]);
+  });
+});

--- a/packages/server/src/modules/auth/providers/auth-context.provider.ts
+++ b/packages/server/src/modules/auth/providers/auth-context.provider.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable, Scope } from 'graphql-modules';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import type { RawAuth } from '../../../plugins/auth-plugin.js';
 import { ENVIRONMENT, RAW_AUTH } from '../../../shared/tokens.js';
-import type { AuthContext } from '../../../shared/types/auth.js';
+import type { AuthContext, BusinessMembership } from '../../../shared/types/auth.js';
 import type { Environment } from '../../../shared/types/index.js';
 import { DBProvider } from '../../app-providers/db.provider.js';
 import { ALLOWED_API_KEY_ROLES } from '../helpers/api-keys.helper.js';
@@ -22,6 +22,9 @@ export async function handleDevBypassAuth(
     return null;
   }
 
+  // Resolve ALL memberships for the user (previously LIMIT 1). The primary
+  // membership (most recently updated) still backs the single-business tenant
+  // context for now; scope rules are applied in a later step.
   const { rows } = await db.query<{
     user_id: string;
     business_id: string;
@@ -31,8 +34,7 @@ export async function handleDevBypassAuth(
     `SELECT user_id, business_id, role_id, auth0_user_id
      FROM accounter_schema.business_users
      WHERE user_id = $1
-     ORDER BY updated_at DESC
-     LIMIT 1`,
+     ORDER BY updated_at DESC`,
     [normalizedUserId],
   );
 
@@ -40,24 +42,29 @@ export async function handleDevBypassAuth(
     return null;
   }
 
-  const user = rows[0];
+  const primary = rows[0];
+  const memberships: BusinessMembership[] = rows.map(row => ({
+    businessId: row.business_id,
+    roleId: row.role_id,
+  }));
 
   return {
     authType: 'devBypass',
     token: normalizedUserId,
     user: {
-      userId: user.user_id,
-      auth0UserId: user.auth0_user_id,
+      userId: primary.user_id,
+      auth0UserId: primary.auth0_user_id,
       email: 'dev-user',
-      roleId: user.role_id,
+      roleId: primary.role_id,
       permissions: [],
       emailVerified: true,
       permissionsVersion: 0,
     },
     tenant: {
-      businessId: user.business_id,
-      roleId: user.role_id,
+      businessId: primary.business_id,
+      roleId: primary.role_id,
     },
+    memberships,
   };
 }
 
@@ -238,6 +245,9 @@ export class AuthContextProvider {
         emailVerified: true,
         permissionsVersion: 0,
       },
+      // API keys are pinned to a single business, so the membership set is
+      // exactly that one business.
+      memberships: [{ businessId: apiKey.business_id, roleId: apiKey.role_id }],
     };
   }
 
@@ -308,6 +318,7 @@ export class AuthContextProvider {
           businessId: userContext.businessId,
           roleId: userContext.roleId,
         },
+        memberships: userContext.memberships,
         accessTokenExpiresAt: payload.exp,
       };
       this.cachedContext = authContext;
@@ -324,16 +335,23 @@ export class AuthContextProvider {
     auth0UserId: string,
     email: string | null,
     emailVerified: boolean,
-  ): Promise<{ userId: string; businessId: string; roleId: string } | null> {
+  ): Promise<{
+    userId: string;
+    businessId: string;
+    roleId: string;
+    memberships: BusinessMembership[];
+  } | null> {
+    // Resolve ALL memberships for the auth0 subject (previously LIMIT 1).
     const byAuth0Query = `
       SELECT bu.user_id, bu.business_id, bu.role_id
       FROM accounter_schema.business_users bu
       WHERE bu.auth0_user_id = $1
-      LIMIT 1
+      ORDER BY bu.updated_at DESC
     `;
 
+    // Identify the local user by a verified, accepted invitation email.
     const byVerifiedEmailQuery = `
-      SELECT bu.user_id, bu.business_id, bu.role_id
+      SELECT bu.user_id
       FROM accounter_schema.invitations i
       JOIN accounter_schema.business_users bu
         ON bu.user_id = i.user_id
@@ -350,15 +368,32 @@ export class AuthContextProvider {
       WHERE user_id = $2
     `;
 
+    // All memberships for a local user id, after relinking.
+    const byUserIdQuery = `
+      SELECT bu.user_id, bu.business_id, bu.role_id
+      FROM accounter_schema.business_users bu
+      WHERE bu.user_id = $1
+      ORDER BY bu.updated_at DESC
+    `;
+
+    const toResult = (rows: Array<{ user_id: string; business_id: string; role_id: string }>) => {
+      const primary = rows[0];
+      const memberships: BusinessMembership[] = rows.map(row => ({
+        businessId: row.business_id,
+        roleId: row.role_id,
+      }));
+      return {
+        userId: primary.user_id,
+        businessId: primary.business_id,
+        roleId: primary.role_id,
+        memberships,
+      };
+    };
+
     try {
       const byAuth0Result = await this.db.query(byAuth0Query, [auth0UserId]);
       if (byAuth0Result.rowCount && byAuth0Result.rowCount > 0) {
-        const row = byAuth0Result.rows[0];
-        return {
-          userId: row.user_id,
-          businessId: row.business_id,
-          roleId: row.role_id,
-        };
+        return toResult(byAuth0Result.rows);
       }
 
       if (!email || !emailVerified) {
@@ -370,16 +405,17 @@ export class AuthContextProvider {
         return null;
       }
 
-      const row = byEmailResult.rows[0];
+      const userId = byEmailResult.rows[0].user_id;
 
       // Sync newly authenticated Auth0 subject across all memberships of this local user.
-      await this.db.query(relinkAuth0IdQuery, [auth0UserId, row.user_id]);
+      await this.db.query(relinkAuth0IdQuery, [auth0UserId, userId]);
 
-      return {
-        userId: row.user_id,
-        businessId: row.business_id,
-        roleId: row.role_id,
-      };
+      const membershipsResult = await this.db.query(byUserIdQuery, [userId]);
+      if (!membershipsResult.rowCount || membershipsResult.rowCount === 0) {
+        return null;
+      }
+
+      return toResult(membershipsResult.rows);
     } catch (error) {
       console.error('AuthContext: DB lookup failed', error);
       throw error;

--- a/packages/server/src/modules/auth/providers/auth-context.provider.ts
+++ b/packages/server/src/modules/auth/providers/auth-context.provider.ts
@@ -376,7 +376,9 @@ export class AuthContextProvider {
       ORDER BY bu.updated_at DESC
     `;
 
-    const toResult = (rows: Array<{ user_id: string; business_id: string; role_id: string }>) => {
+    type MembershipRow = { user_id: string; business_id: string; role_id: string };
+
+    const toResult = (rows: MembershipRow[]) => {
       const primary = rows[0];
       const memberships: BusinessMembership[] = rows.map(row => ({
         businessId: row.business_id,
@@ -391,7 +393,7 @@ export class AuthContextProvider {
     };
 
     try {
-      const byAuth0Result = await this.db.query(byAuth0Query, [auth0UserId]);
+      const byAuth0Result = await this.db.query<MembershipRow>(byAuth0Query, [auth0UserId]);
       if (byAuth0Result.rowCount && byAuth0Result.rowCount > 0) {
         return toResult(byAuth0Result.rows);
       }
@@ -400,7 +402,7 @@ export class AuthContextProvider {
         return null;
       }
 
-      const byEmailResult = await this.db.query(byVerifiedEmailQuery, [email]);
+      const byEmailResult = await this.db.query<{ user_id: string }>(byVerifiedEmailQuery, [email]);
       if (!byEmailResult.rowCount || byEmailResult.rowCount === 0) {
         return null;
       }
@@ -410,7 +412,7 @@ export class AuthContextProvider {
       // Sync newly authenticated Auth0 subject across all memberships of this local user.
       await this.db.query(relinkAuth0IdQuery, [auth0UserId, userId]);
 
-      const membershipsResult = await this.db.query(byUserIdQuery, [userId]);
+      const membershipsResult = await this.db.query<MembershipRow>(byUserIdQuery, [userId]);
       if (!membershipsResult.rowCount || membershipsResult.rowCount === 0) {
         return null;
       }

--- a/packages/server/src/modules/auth/providers/business-users.provider.ts
+++ b/packages/server/src/modules/auth/providers/business-users.provider.ts
@@ -12,7 +12,8 @@ import type {
 const getBusinessUsersByAuth0Ids = sql<IGetBusinessUsersByAuth0IdsQuery>`
   SELECT user_id, auth0_user_id, business_id, role_id
   FROM accounter_schema.business_users
-  WHERE auth0_user_id IN $$auth0UserIds;
+  WHERE auth0_user_id IN $$auth0UserIds
+  ORDER BY updated_at DESC;
 `;
 
 const insertBusinessUser = sql<IInsertBusinessUserQuery>`

--- a/packages/server/src/modules/auth/providers/business-users.provider.ts
+++ b/packages/server/src/modules/auth/providers/business-users.provider.ts
@@ -1,6 +1,7 @@
 import DataLoader from 'dataloader';
 import { Injectable, Scope } from 'graphql-modules';
 import { sql } from '@pgtyped/runtime';
+import type { BusinessMembership } from '../../../shared/types/auth.js';
 import { TenantAwareDBClient } from '../../app-providers/tenant-db-client.js';
 import type {
   IGetBusinessUsersByAuth0IdsQuery,
@@ -9,7 +10,7 @@ import type {
 } from '../types.js';
 
 const getBusinessUsersByAuth0Ids = sql<IGetBusinessUsersByAuth0IdsQuery>`
-  SELECT user_id, auth0_user_id
+  SELECT user_id, auth0_user_id, business_id, role_id
   FROM accounter_schema.business_users
   WHERE auth0_user_id IN $$auth0UserIds;
 `;
@@ -43,6 +44,19 @@ export class BusinessUsersProvider {
   public getBusinessUsersByAuth0IdsLoader = new DataLoader((auth0UserIds: readonly string[]) =>
     this.batchBusinessUsersByAuth0Ids(auth0UserIds),
   );
+
+  /**
+   * Resolve every business membership for an authenticated Auth0 user.
+   * Reuses the batching loader; returns an empty array when the user has no
+   * memberships.
+   */
+  public async getMembershipsByAuth0UserId(auth0UserId: string): Promise<BusinessMembership[]> {
+    const rows = await this.getBusinessUsersByAuth0IdsLoader.load(auth0UserId);
+    return rows.map(row => ({
+      businessId: row.business_id,
+      roleId: row.role_id,
+    }));
+  }
 
   public async insertBusinessUser(params: IInsertBusinessUserParams) {
     return insertBusinessUser.run(params, this.db);


### PR DESCRIPTION
## Summary

Step 3 of the multi-business migration (Prompt 03: Expand Membership Provider). Resolves **all** of a user's business memberships instead of the legacy single-row lookup, and attaches them to `AuthContext.memberships`. The primary membership still backs the single-business `tenant` context, so external behavior is unchanged — scope rules (validation, narrowing, pinning) land in step 5.

- **auth-context.provider.ts** (raw SQL — runs before the tenant DB client exists, so it can't use the DataLoader): all three auth paths now resolve the full membership set.
  - dev-bypass and the JWT `auth0_user_id` lookup drop `LIMIT 1` and return every membership; the JWT verified-email relink path now fetches all memberships for the resolved user id after relinking.
  - API-key auth attaches its single pinned business as the membership set (no extra query).
- **business-users.provider.ts**: adds `getMembershipsByAuth0UserId`, backed by the existing `getBusinessUsersByAuth0IdsLoader`; the loader's query is expanded to carry `business_id`/`role_id` (the loader had no other consumers, so this is non-breaking).
- **Tests**: new `business-users.provider.test.ts` (0/1/many memberships); the step-1 baseline guardrails and existing auth-context/dev-bypass/relink assertions are updated to reflect full membership resolution (multi-membership cases on each auth path).

Stacked on step 2 (`multi-business-request-2-auth-scope-types`).

## Test plan

- [x] `vitest run --project unit` for auth/common/app-providers/shared — 129 pass (incl. the 25 directly-affected auth tests)
- [x] `prettier --check` clean; `eslint` clean (only pre-existing `no-console` warnings) on source files

> Note: `business-users.provider.ts` change includes expanding a pgtyped query; the generated `*.types.ts` is produced by `yarn generate` against Postgres (regenerated in CI). It could not be regenerated here (Docker/Postgres unavailable), so the provider wasn't full-typechecked locally — its new method is unit-tested by mocking the loader. Integration tests and full server `tsc` likewise require Postgres. Same `xlsx@0.20.2` CDN-install caveat as earlier steps.

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_