### PR TITLE
Multi-business step 4: X-Business-Scope header parser

### DIFF
--- a/packages/server/src/plugins/__tests__/business-scope-header.test.ts
+++ b/packages/server/src/plugins/__tests__/business-scope-header.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BUSINESS_SCOPE_HEADER,
+  parseBusinessScopeHeader,
+} from '../business-scope-header.js';
+
+const A = '11111111-1111-1111-1111-111111111111';
+const B = '22222222-2222-2222-2222-222222222222';
+
+describe('BUSINESS_SCOPE_HEADER', () => {
+  it('is the pinned lower-case header name', () => {
+    expect(BUSINESS_SCOPE_HEADER).toBe('x-business-scope');
+  });
+});
+
+describe('parseBusinessScopeHeader', () => {
+  it('treats a missing header as absent', () => {
+    expect(parseBusinessScopeHeader(undefined)).toEqual({ kind: 'absent' });
+    expect(parseBusinessScopeHeader(null)).toEqual({ kind: 'absent' });
+  });
+
+  it('treats a blank/whitespace header as absent (no narrowing)', () => {
+    expect(parseBusinessScopeHeader('')).toEqual({ kind: 'absent' });
+    expect(parseBusinessScopeHeader('   ')).toEqual({ kind: 'absent' });
+  });
+
+  it('parses a single valid uuid', () => {
+    expect(parseBusinessScopeHeader(A)).toEqual({ kind: 'valid', businessIds: [A] });
+  });
+
+  it('parses multiple valid uuids preserving order', () => {
+    expect(parseBusinessScopeHeader(`${A},${B}`)).toEqual({
+      kind: 'valid',
+      businessIds: [A, B],
+    });
+  });
+
+  it('normalizes surrounding whitespace around entries', () => {
+    expect(parseBusinessScopeHeader(`  ${A} ,  ${B}  `)).toEqual({
+      kind: 'valid',
+      businessIds: [A, B],
+    });
+  });
+
+  it('lower-cases and de-duplicates entries, preserving first-seen order', () => {
+    expect(parseBusinessScopeHeader(`${A.toUpperCase()},${B},${A}`)).toEqual({
+      kind: 'valid',
+      businessIds: [A, B],
+    });
+  });
+
+  it('reports a non-uuid entry as INVALID_UUID', () => {
+    expect(parseBusinessScopeHeader(`${A},not-a-uuid`)).toEqual({
+      kind: 'invalid',
+      errors: [{ code: 'INVALID_UUID', value: 'not-a-uuid' }],
+    });
+  });
+
+  it('reports an empty entry (trailing comma) as EMPTY_ENTRY', () => {
+    expect(parseBusinessScopeHeader(`${A},`)).toEqual({
+      kind: 'invalid',
+      errors: [{ code: 'EMPTY_ENTRY' }],
+    });
+  });
+
+  it('reports an empty middle entry as EMPTY_ENTRY', () => {
+    expect(parseBusinessScopeHeader(`${A},,${B}`)).toEqual({
+      kind: 'invalid',
+      errors: [{ code: 'EMPTY_ENTRY' }],
+    });
+  });
+
+  it('collects multiple errors across a mixed input', () => {
+    const result = parseBusinessScopeHeader(`${A},bad,,${B}`);
+    expect(result).toEqual({
+      kind: 'invalid',
+      errors: [
+        { code: 'INVALID_UUID', value: 'bad' },
+        { code: 'EMPTY_ENTRY' },
+      ],
+    });
+  });
+});

--- a/packages/server/src/plugins/business-scope-header.ts
+++ b/packages/server/src/plugins/business-scope-header.ts
@@ -31,23 +31,33 @@ export function parseBusinessScopeHeader(
   }
 
   const errors: BusinessScopeParseError[] = [];
+  const seenErrors = new Set<string>();
   const seen = new Set<string>();
   const businessIds: string[] = [];
 
   for (const rawEntry of headerValue.split(',')) {
     const entry = rawEntry.trim();
     if (entry === '') {
-      errors.push({ code: 'EMPTY_ENTRY' });
+      if (!seenErrors.has('EMPTY_ENTRY')) {
+        seenErrors.add('EMPTY_ENTRY');
+        errors.push({ code: 'EMPTY_ENTRY' });
+      }
       continue;
     }
     if (!UUID_PATTERN.test(entry)) {
-      errors.push({ code: 'INVALID_UUID', value: entry });
+      const key = `INVALID_UUID:${entry.toLowerCase()}`;
+      if (!seenErrors.has(key)) {
+        seenErrors.add(key);
+        errors.push({ code: 'INVALID_UUID', value: entry });
+      }
       continue;
     }
-    const normalized = entry.toLowerCase();
-    if (!seen.has(normalized)) {
-      seen.add(normalized);
-      businessIds.push(normalized);
+    if (errors.length === 0) {
+      const normalized = entry.toLowerCase();
+      if (!seen.has(normalized)) {
+        seen.add(normalized);
+        businessIds.push(normalized);
+      }
     }
   }
 

--- a/packages/server/src/plugins/business-scope-header.ts
+++ b/packages/server/src/plugins/business-scope-header.ts
@@ -7,8 +7,7 @@ import type { BusinessScopeParseError, BusinessScopeParseResult } from '../share
  */
 export const BUSINESS_SCOPE_HEADER = 'x-business-scope';
 
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i;
+const UUID_PATTERN = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i;
 
 /**
  * Parse the `X-Business-Scope` header value into a requested read scope.

--- a/packages/server/src/plugins/business-scope-header.ts
+++ b/packages/server/src/plugins/business-scope-header.ts
@@ -8,7 +8,7 @@ import type { BusinessScopeParseError, BusinessScopeParseResult } from '../share
 export const BUSINESS_SCOPE_HEADER = 'x-business-scope';
 
 const UUID_PATTERN =
-  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+  /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i;
 
 /**
  * Parse the `X-Business-Scope` header value into a requested read scope.

--- a/packages/server/src/plugins/business-scope-header.ts
+++ b/packages/server/src/plugins/business-scope-header.ts
@@ -1,0 +1,59 @@
+import type { BusinessScopeParseError, BusinessScopeParseResult } from '../shared/types/auth.js';
+
+/**
+ * Request header carrying the requested multi-business read scope: a
+ * comma-separated list of business UUIDs. Read case-insensitively, matching how
+ * other auth headers are read in the auth plugin.
+ */
+export const BUSINESS_SCOPE_HEADER = 'x-business-scope';
+
+const UUID_PATTERN =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/**
+ * Parse the `X-Business-Scope` header value into a requested read scope.
+ *
+ * - A missing or blank header is `absent` (no narrowing — callers default to
+ *   all accessible businesses).
+ * - Entries are split on commas and trimmed. An empty entry (e.g. a trailing
+ *   comma or `a,,b`) is a malformed `EMPTY_ENTRY`; a non-UUID entry is
+ *   `INVALID_UUID`.
+ * - Valid ids are lower-cased and de-duplicated, preserving first-seen order.
+ *
+ * Pure utility — does not consult auth state and is not wired into auth
+ * decisions here.
+ */
+export function parseBusinessScopeHeader(
+  headerValue: string | null | undefined,
+): BusinessScopeParseResult {
+  if (headerValue == null || headerValue.trim() === '') {
+    return { kind: 'absent' };
+  }
+
+  const errors: BusinessScopeParseError[] = [];
+  const seen = new Set<string>();
+  const businessIds: string[] = [];
+
+  for (const rawEntry of headerValue.split(',')) {
+    const entry = rawEntry.trim();
+    if (entry === '') {
+      errors.push({ code: 'EMPTY_ENTRY' });
+      continue;
+    }
+    if (!UUID_PATTERN.test(entry)) {
+      errors.push({ code: 'INVALID_UUID', value: entry });
+      continue;
+    }
+    const normalized = entry.toLowerCase();
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      businessIds.push(normalized);
+    }
+  }
+
+  if (errors.length > 0) {
+    return { kind: 'invalid', errors };
+  }
+
+  return { kind: 'valid', businessIds };
+}

--- a/packages/server/src/shared/types/auth.ts
+++ b/packages/server/src/shared/types/auth.ts
@@ -35,6 +35,22 @@ export interface AuthorizedReadScope {
   businessIds: string[];
 }
 
+/** A malformed entry in the `X-Business-Scope` request header. */
+export type BusinessScopeParseError =
+  | { code: 'EMPTY_ENTRY' }
+  | { code: 'INVALID_UUID'; value: string };
+
+/**
+ * Result of parsing the `X-Business-Scope` header.
+ * - `absent`: header missing or blank — no narrowing requested.
+ * - `valid`: a de-duplicated, order-preserving list of business ids.
+ * - `invalid`: one or more malformed entries.
+ */
+export type BusinessScopeParseResult =
+  | { kind: 'absent' }
+  | { kind: 'valid'; businessIds: string[] }
+  | { kind: 'invalid'; errors: BusinessScopeParseError[] };
+
 export interface AuthContext {
   authType: AuthType | null;
   token?: string | null;


### PR DESCRIPTION
## Summary

Step 4 of the multi-business migration (Prompt 04: Add Header Scope Parser). Adds a robust, **pure** parser for the pinned `X-Business-Scope` request header. Per the constraint, it is **not** wired into auth decisions — that happens in later steps.

- **`plugins/business-scope-header.ts`**: exports the `BUSINESS_SCOPE_HEADER` constant (`x-business-scope`) and `parseBusinessScopeHeader(value)`.
  - Missing or blank header → `{ kind: 'absent' }` (no narrowing; callers default to all accessible businesses).
  - Comma-split entries are trimmed, lower-cased, and de-duplicated preserving first-seen order → `{ kind: 'valid', businessIds }`.
  - Malformed input → `{ kind: 'invalid', errors }`, distinguishing `EMPTY_ENTRY` (empty/trailing/`a,,b`) from `INVALID_UUID` (non-UUID). Errors are collected, not fail-fast.
- **`shared/types/auth.ts`**: adds `BusinessScopeParseError` and `BusinessScopeParseResult` discriminated types.
- **Tests** (`business-scope-header.test.ts`): valid, absent, empty/whitespace, malformed, duplicate, mixed, and the absent-vs-empty-entry distinction — 11 cases.

Stacked on step 3 (`multi-business-request-3-membership-provider`).

## Test plan

- [x] `vitest run --project unit` for the parser — 11 pass
- [x] Isolated strict `tsc --noEmit` on the new source + types — clean
- [x] `prettier --check` clean; `eslint` clean on source files

> Same environment caveats as earlier steps (no Postgres → no full server `tsc`/integration; `xlsx@0.20.2` CDN install).

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_