### PR TITLE
Multi-business step 5: resolve & validate request read scope

### DIFF
--- a/packages/server/src/modules/auth/providers/__tests__/auth-context.test.ts
+++ b/packages/server/src/modules/auth/providers/__tests__/auth-context.test.ts
@@ -94,6 +94,7 @@ describe('AuthContextProvider', () => {
            roleId: 'admin',
          },
          memberships: [{ businessId: 'b-1', roleId: 'admin' }],
+         activeReadScope: { businessIds: ['b-1'] },
          accessTokenExpiresAt: 1234567890,
        });
     });
@@ -196,19 +197,109 @@ describe('AuthContextProvider', () => {
             { businessId: 'b-42', roleId: 'employee' },
             { businessId: 'b-99', roleId: 'accountant' },
           ],
+          activeReadScope: { businessIds: ['b-42', 'b-99'] },
           accessTokenExpiresAt: 1234567890,
         });
       });
 
      it('should return null if sub claim is missing', async () => {
         const mockPayload = {}; // No sub
-   
+
         vi.mocked(jose.jwtVerify).mockResolvedValue({ payload: mockPayload } as any);
-   
+
         const result = await provider.getAuthContext();
-   
+
         expect(result).toBeNull();
     });
+  });
+});
+
+describe('AuthContextProvider read-scope resolution', () => {
+  const makeJwtProvider = (
+    membershipRows: Array<{ user_id: string; business_id: string; role_id: string }>,
+    requestedBusinessScope?: unknown,
+  ) => {
+    const mockDb = {
+      query: vi.fn().mockResolvedValue({ rowCount: membershipRows.length, rows: membershipRows }),
+    } as any;
+    const mockEnv = { auth0: { domain: 'test.auth0.com', audience: 'aud' } } as any;
+    vi.mocked(jose.createRemoteJWKSet).mockReturnValue({} as any);
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: { sub: 'auth0|x', exp: 1, email: null, email_verified: false, permissions: [] },
+    } as any);
+    return new AuthContextProvider(
+      mockEnv,
+      { authType: 'jwt', token: 'valid-token', requestedBusinessScope } as any,
+      mockDb,
+    );
+  };
+
+  const membershipRows = [
+    { user_id: 'u-1', business_id: 'b-1', role_id: 'owner' },
+    { user_id: 'u-1', business_id: 'b-2', role_id: 'accountant' },
+  ];
+
+  it('defaults read scope to all memberships when no header is sent', async () => {
+    const result = await makeJwtProvider(membershipRows).getAuthContext();
+    expect(result?.activeReadScope).toEqual({ businessIds: ['b-1', 'b-2'] });
+  });
+
+  it('narrows read scope to a valid requested subset', async () => {
+    const result = await makeJwtProvider(membershipRows, {
+      kind: 'valid',
+      businessIds: ['b-2'],
+    }).getAuthContext();
+    expect(result?.activeReadScope).toEqual({ businessIds: ['b-2'] });
+    // tenant still reflects the primary membership
+    expect(result?.tenant.businessId).toBe('b-1');
+  });
+
+  it('rejects a requested scope outside the user memberships', async () => {
+    const result = await makeJwtProvider(membershipRows, {
+      kind: 'valid',
+      businessIds: ['b-1', 'b-999'],
+    }).getAuthContext();
+    expect(result).toBeNull();
+  });
+
+  it('rejects a malformed scope header', async () => {
+    const result = await makeJwtProvider(membershipRows, {
+      kind: 'invalid',
+      errors: [{ code: 'INVALID_UUID', value: 'nope' }],
+    }).getAuthContext();
+    expect(result).toBeNull();
+  });
+
+  it('does not expand scope beyond memberships (no super-admin auto-expansion)', async () => {
+    const result = await makeJwtProvider([
+      { user_id: 'u-1', business_id: 'b-1', role_id: 'owner' },
+    ]).getAuthContext();
+    expect(result?.activeReadScope).toEqual({ businessIds: ['b-1'] });
+  });
+
+  it('pins API-key scope to its business and ignores the header', async () => {
+    const mockDb = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({
+          rows: [{ id: 'k1', business_id: 'biz-1', role_id: 'scraper' }],
+        })
+        .mockResolvedValueOnce({ rowCount: 1 }),
+    } as any;
+    const provider = new AuthContextProvider(
+      { auth0: { domain: 'd', audience: 'a' } } as any,
+      {
+        authType: 'apiKey',
+        token: 'key',
+        requestedBusinessScope: { kind: 'valid', businessIds: ['biz-2'] },
+      } as any,
+      mockDb,
+    );
+
+    const result = await provider.getAuthContext();
+
+    expect(result?.tenant.businessId).toBe('biz-1');
+    expect(result?.activeReadScope).toEqual({ businessIds: ['biz-1'] });
   });
 });
 
@@ -250,6 +341,7 @@ describe('handleDevBypassAuth', () => {
         roleId: 'business_owner',
       },
       memberships: [{ businessId: 'biz-456', roleId: 'business_owner' }],
+      activeReadScope: { businessIds: ['biz-456'] },
     });
   });
 

--- a/packages/server/src/modules/auth/providers/auth-context.provider.ts
+++ b/packages/server/src/modules/auth/providers/auth-context.provider.ts
@@ -186,13 +186,20 @@ export class AuthContextProvider {
     }
 
     if (requested.kind === 'invalid') {
-      console.warn('AuthContext: rejecting request with malformed X-Business-Scope header');
+      console.warn('AuthContext: rejecting request with malformed X-Business-Scope header', {
+        errors: requested.errors,
+        userId: context.user?.userId,
+      });
       return null;
     }
 
     const narrowed = narrowReadScope(memberships, requested.businessIds);
     if (!narrowed) {
-      console.warn('AuthContext: rejecting X-Business-Scope outside of user memberships');
+      console.warn('AuthContext: rejecting X-Business-Scope outside of user memberships', {
+        requested: requested.businessIds,
+        allowed: memberships.map(m => m.businessId),
+        userId: context.user?.userId,
+      });
       return null;
     }
 

--- a/packages/server/src/modules/auth/providers/auth-context.provider.ts
+++ b/packages/server/src/modules/auth/providers/auth-context.provider.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import type { RawAuth } from '../../../plugins/auth-plugin.js';
+import { narrowReadScope, readScopeFromMemberships } from '../../../shared/helpers/auth-scope.js';
 import { ENVIRONMENT, RAW_AUTH } from '../../../shared/tokens.js';
 import type { AuthContext, BusinessMembership } from '../../../shared/types/auth.js';
 import type { Environment } from '../../../shared/types/index.js';
@@ -65,6 +66,9 @@ export async function handleDevBypassAuth(
       roleId: primary.role_id,
     },
     memberships,
+    // Default read scope is every accessible business; the provider narrows it
+    // when a valid X-Business-Scope header is requested.
+    activeReadScope: readScopeFromMemberships(memberships),
   };
 }
 
@@ -159,6 +163,42 @@ export class AuthContextProvider {
     return null;
   }
 
+  /**
+   * Resolve the request's read scope and attach it to the context.
+   *
+   * - Defaults to every business the user belongs to.
+   * - When a valid `X-Business-Scope` header is present, narrows to that subset;
+   *   rejects (returns null) if it requests a business outside the memberships
+   *   or if the header was malformed.
+   * - API keys are pinned to their single business and ignore the header.
+   */
+  private applyRequestedReadScope(context: AuthContext): AuthContext | null {
+    const memberships = context.memberships ?? [];
+    const defaultScope = readScopeFromMemberships(memberships);
+
+    if (context.authType === 'apiKey') {
+      return { ...context, activeReadScope: defaultScope };
+    }
+
+    const requested = this.rawAuth.requestedBusinessScope;
+    if (!requested || requested.kind === 'absent') {
+      return { ...context, activeReadScope: defaultScope };
+    }
+
+    if (requested.kind === 'invalid') {
+      console.warn('AuthContext: rejecting request with malformed X-Business-Scope header');
+      return null;
+    }
+
+    const narrowed = narrowReadScope(memberships, requested.businessIds);
+    if (!narrowed) {
+      console.warn('AuthContext: rejecting X-Business-Scope outside of user memberships');
+      return null;
+    }
+
+    return { ...context, activeReadScope: narrowed };
+  }
+
   private async handleDevBypassAuth(): Promise<AuthContext | null> {
     const userId = this.rawAuth.token;
     if (!userId) {
@@ -167,9 +207,10 @@ export class AuthContextProvider {
 
     try {
       const context = await handleDevBypassAuth(this.db, userId);
-      this.cachedContext = context;
+      const scoped = context ? this.applyRequestedReadScope(context) : null;
+      this.cachedContext = scoped;
       this.handlingAuth = null;
-      return context;
+      return scoped;
     } catch (error) {
       console.error('AuthContext: Failed to process dev bypass auth', error);
       this.handlingAuth = null;
@@ -185,9 +226,10 @@ export class AuthContextProvider {
 
     try {
       const context = await this.resolveApiKeyContext(token);
-      this.cachedContext = context;
+      const scoped = context ? this.applyRequestedReadScope(context) : null;
+      this.cachedContext = scoped;
       this.handlingAuth = null;
-      return context;
+      return scoped;
     } catch (error) {
       console.error('AuthContext: Failed to process API key', error);
       this.handlingAuth = null;
@@ -321,9 +363,10 @@ export class AuthContextProvider {
         memberships: userContext.memberships,
         accessTokenExpiresAt: payload.exp,
       };
-      this.cachedContext = authContext;
+      const scoped = this.applyRequestedReadScope(authContext);
+      this.cachedContext = scoped;
       this.handlingAuth = null;
-      return authContext;
+      return scoped;
     } catch (error) {
       console.error('AuthContext: Failed to process authentication token', error);
       this.handlingAuth = null;

--- a/packages/server/src/plugins/auth-plugin.ts
+++ b/packages/server/src/plugins/auth-plugin.ts
@@ -2,10 +2,17 @@ import { useExtendContext, YogaInitialContext } from 'graphql-yoga';
 import type { Plugin } from '@envelop/types';
 import type { DBProvider } from '../modules/app-providers/db.provider.js';
 import { handleDevBypassAuth } from '../modules/auth/providers/auth-context.provider.js';
+import type { BusinessScopeParseResult } from '../shared/types/auth.js';
+import { BUSINESS_SCOPE_HEADER, parseBusinessScopeHeader } from './business-scope-header.js';
 
 export interface RawAuth {
   authType: 'jwt' | 'apiKey' | 'devBypass' | null;
   token: string | null;
+  /**
+   * Parsed `X-Business-Scope` header, present only when the header was sent.
+   * Auth context validates it against the user's memberships.
+   */
+  requestedBusinessScope?: BusinessScopeParseResult;
 }
 
 type QueryablePool = {
@@ -39,6 +46,12 @@ export const authPlugin = (): Plugin<{ rawAuth: RawAuth }> => {
       const authHeader = request.headers.get('authorization');
       const apiKeyHeader = request.headers.get('x-api-key');
 
+      // Parse the requested read scope once. Attach it only when the header was
+      // actually sent, so requests without it keep the original rawAuth shape.
+      const parsedScope = parseBusinessScopeHeader(request.headers.get(BUSINESS_SCOPE_HEADER));
+      const scopeFields: { requestedBusinessScope?: BusinessScopeParseResult } =
+        parsedScope.kind === 'absent' ? {} : { requestedBusinessScope: parsedScope };
+
       // Dev bypass takes precedence when explicitly enabled and user is resolvable.
       if (allowDevAuth && devAuthHeader) {
         const userId = devAuthHeader.trim();
@@ -64,6 +77,7 @@ export const authPlugin = (): Plugin<{ rawAuth: RawAuth }> => {
                 rawAuth: {
                   authType: 'devBypass',
                   token: userId,
+                  ...scopeFields,
                 },
               };
             }
@@ -79,6 +93,7 @@ export const authPlugin = (): Plugin<{ rawAuth: RawAuth }> => {
             rawAuth: {
               authType: 'jwt',
               token,
+              ...scopeFields,
             },
           };
         }
@@ -92,6 +107,7 @@ export const authPlugin = (): Plugin<{ rawAuth: RawAuth }> => {
             rawAuth: {
               authType: 'apiKey',
               token,
+              ...scopeFields,
             },
           };
         }
@@ -102,6 +118,7 @@ export const authPlugin = (): Plugin<{ rawAuth: RawAuth }> => {
         rawAuth: {
           authType: null,
           token: null,
+          ...scopeFields,
         },
       };
     },

--- a/packages/server/src/shared/helpers/__tests__/auth-scope.test.ts
+++ b/packages/server/src/shared/helpers/__tests__/auth-scope.test.ts
@@ -3,6 +3,7 @@ import type { BusinessMembership } from '../../types/auth.js';
 import {
   isBusinessInScope,
   membershipFromTenant,
+  narrowReadScope,
   readScopeFromMemberships,
   tenantFromMembership,
 } from '../auth-scope.js';
@@ -69,5 +70,35 @@ describe('isBusinessInScope', () => {
 
   it('is false for a business outside the scope', () => {
     expect(isBusinessInScope(scope, 'b-3')).toBe(false);
+  });
+});
+
+describe('narrowReadScope', () => {
+  const memberships: BusinessMembership[] = [
+    { businessId: 'b-1', roleId: 'owner' },
+    { businessId: 'b-2', roleId: 'accountant' },
+    { businessId: 'b-3', roleId: 'employee' },
+  ];
+
+  it('narrows to a requested subset, preserving request order', () => {
+    expect(narrowReadScope(memberships, ['b-3', 'b-1'])).toEqual({
+      businessIds: ['b-3', 'b-1'],
+    });
+  });
+
+  it('de-duplicates repeated requested ids', () => {
+    expect(narrowReadScope(memberships, ['b-1', 'b-1', 'b-2'])).toEqual({
+      businessIds: ['b-1', 'b-2'],
+    });
+  });
+
+  it('returns null when any requested id is outside the memberships', () => {
+    expect(narrowReadScope(memberships, ['b-1', 'b-99'])).toBeNull();
+  });
+
+  it('accepts the full membership set', () => {
+    expect(narrowReadScope(memberships, ['b-1', 'b-2', 'b-3'])).toEqual({
+      businessIds: ['b-1', 'b-2', 'b-3'],
+    });
   });
 });

--- a/packages/server/src/shared/helpers/auth-scope.ts
+++ b/packages/server/src/shared/helpers/auth-scope.ts
@@ -43,3 +43,29 @@ export function isBusinessInScope(
 ): boolean {
   return scope?.businessIds.includes(businessId) ?? false;
 }
+
+/**
+ * Narrow a user's memberships to a requested set of business ids.
+ *
+ * Returns the requested ids (de-duplicated, request order preserved) as the
+ * read scope, or `null` if ANY requested id is outside the user's memberships —
+ * callers must reject such requests rather than silently dropping unknown ids.
+ */
+export function narrowReadScope(
+  memberships: BusinessMembership[],
+  requestedBusinessIds: string[],
+): AuthorizedReadScope | null {
+  const allowed = new Set(memberships.map(membership => membership.businessId));
+  const seen = new Set<string>();
+  const businessIds: string[] = [];
+  for (const businessId of requestedBusinessIds) {
+    if (!allowed.has(businessId)) {
+      return null;
+    }
+    if (!seen.has(businessId)) {
+      seen.add(businessId);
+      businessIds.push(businessId);
+    }
+  }
+  return { businessIds };
+}


### PR DESCRIPTION
## Summary

Step 5 of the multi-business migration (Prompt 05: Integrate Auth Context Scope). The auth context now resolves a request's **read scope** and validates it against the user's memberships. (Full membership resolution itself landed in step 3.)

- **`auth-context.provider.ts`**: new `applyRequestedReadScope` runs on all three auth paths and sets `AuthContext.activeReadScope`:
  - defaults to **all** of the user's memberships;
  - with a valid `X-Business-Scope` header, **narrows** to that subset;
  - **rejects** (returns null → downstream `UNAUTHENTICATED`) when the header names a business outside the memberships, or is malformed;
  - **API keys** are pinned to their single business and ignore the header.
  - Super-admin status is not consulted here, so it cannot auto-expand scope.
- **`auth-plugin.ts`**: wires the step-4 parser into `RawAuth.requestedBusinessScope`, attached **only when the header was sent** so requests without it keep the original `rawAuth` shape (existing plugin tests stay green).
- **`shared/helpers/auth-scope.ts`**: adds `narrowReadScope` (intersect-or-reject), with unit tests.
- **Tests**: auth-context gains default-all, subset-narrowing, out-of-membership rejection, malformed-header rejection, API-key pinning, and no-super-admin-expansion cases; exact-shape assertions updated for `activeReadScope`.

Stacked on step 4 (`multi-business-request-4-header-scope-parser`).

> Note on scope split: this step validates the **header** scope. GraphQL **args** scope and the args-over-header precedence are Prompt 06 (the API-key "reject if args disagree" rule lands there, once args are plumbed).

## Test plan

- [x] `vitest run --project unit` across auth providers, plugins, shared helpers — 61 pass
- [x] Isolated strict `tsc --noEmit` on the changed cluster — clean (only an isolation-only `graphql-modules` ambient-types artifact, not present in the real build)
- [x] `prettier --check` clean; `eslint` clean (only pre-existing `no-console` warnings)

> Environment caveats unchanged: no Postgres → no full server `tsc`/integration tests; `xlsx@0.20.2` CDN install blocked.

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_