### PR TITLE
Multi-business step 6: read-scope precedence resolver

### DIFF
--- a/packages/server/src/shared/helpers/__tests__/auth-scope.test.ts
+++ b/packages/server/src/shared/helpers/__tests__/auth-scope.test.ts
@@ -5,6 +5,7 @@ import {
   membershipFromTenant,
   narrowReadScope,
   readScopeFromMemberships,
+  resolveReadScopePrecedence,
   tenantFromMembership,
 } from '../auth-scope.js';
 
@@ -100,5 +101,63 @@ describe('narrowReadScope', () => {
     expect(narrowReadScope(memberships, ['b-1', 'b-2', 'b-3'])).toEqual({
       businessIds: ['b-1', 'b-2', 'b-3'],
     });
+  });
+});
+
+describe('resolveReadScopePrecedence', () => {
+  const memberships: BusinessMembership[] = [
+    { businessId: 'b-1', roleId: 'owner' },
+    { businessId: 'b-2', roleId: 'accountant' },
+    { businessId: 'b-3', roleId: 'employee' },
+  ];
+
+  it('defaults to all memberships when neither header nor args narrow', () => {
+    expect(resolveReadScopePrecedence({ memberships })).toEqual({
+      businessIds: ['b-1', 'b-2', 'b-3'],
+    });
+  });
+
+  it('uses the header scope when no args are provided', () => {
+    expect(
+      resolveReadScopePrecedence({ memberships, headerBusinessIds: ['b-2', 'b-3'] }),
+    ).toEqual({ businessIds: ['b-2', 'b-3'] });
+  });
+
+  it('lets args narrow within the header scope (args over header)', () => {
+    expect(
+      resolveReadScopePrecedence({
+        memberships,
+        headerBusinessIds: ['b-2', 'b-3'],
+        argsBusinessIds: ['b-3'],
+      }),
+    ).toEqual({ businessIds: ['b-3'] });
+  });
+
+  it('lets args narrow the memberships when no header is provided', () => {
+    expect(
+      resolveReadScopePrecedence({ memberships, argsBusinessIds: ['b-1'] }),
+    ).toEqual({ businessIds: ['b-1'] });
+  });
+
+  it('rejects a header scope outside the memberships', () => {
+    expect(
+      resolveReadScopePrecedence({ memberships, headerBusinessIds: ['b-9'] }),
+    ).toBeNull();
+  });
+
+  it('rejects args that fall outside the header scope (args must be a subset, not broaden)', () => {
+    expect(
+      resolveReadScopePrecedence({
+        memberships,
+        headerBusinessIds: ['b-2'],
+        argsBusinessIds: ['b-1'],
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects args outside the memberships when no header is provided', () => {
+    expect(
+      resolveReadScopePrecedence({ memberships, argsBusinessIds: ['b-9'] }),
+    ).toBeNull();
   });
 });

--- a/packages/server/src/shared/helpers/auth-scope.ts
+++ b/packages/server/src/shared/helpers/auth-scope.ts
@@ -45,6 +45,53 @@ export function isBusinessInScope(
 }
 
 /**
+ * Resolve the effective read scope for a request by applying the precedence
+ * rule: GraphQL args narrow the header scope, which narrows the user's
+ * memberships. Formally `args ⊆ header ⊆ memberships`.
+ *
+ * - When neither header nor args narrowing is requested, defaults to all
+ *   accessible businesses.
+ * - The header scope must be a subset of the memberships; the args scope must
+ *   be a subset of the (already header-narrowed) scope.
+ * - Returns `null` to signal rejection when any requested id falls outside the
+ *   scope it is narrowing — callers must reject rather than silently drop ids.
+ *
+ * This is the single, reusable precedence check; resolvers and the scope
+ * provider should use it rather than re-implementing narrowing per module.
+ */
+export function resolveReadScopePrecedence(params: {
+  memberships: BusinessMembership[];
+  headerBusinessIds?: string[];
+  argsBusinessIds?: string[];
+}): AuthorizedReadScope | null {
+  const { memberships, headerBusinessIds, argsBusinessIds } = params;
+
+  let scope = readScopeFromMemberships(memberships);
+
+  if (headerBusinessIds && headerBusinessIds.length > 0) {
+    const narrowed = narrowReadScope(memberships, headerBusinessIds);
+    if (!narrowed) {
+      return null;
+    }
+    scope = narrowed;
+  }
+
+  if (argsBusinessIds && argsBusinessIds.length > 0) {
+    const allowed: BusinessMembership[] = scope.businessIds.map(businessId => ({
+      businessId,
+      roleId: '',
+    }));
+    const narrowed = narrowReadScope(allowed, argsBusinessIds);
+    if (!narrowed) {
+      return null;
+    }
+    scope = narrowed;
+  }
+
+  return scope;
+}
+
+/**
  * Narrow a user's memberships to a requested set of business ids.
  *
  * Returns the requested ids (de-duplicated, request order preserved) as the


### PR DESCRIPTION
## Summary

Step 6 of the multi-business migration (Prompt 06: Header vs Args Precedence). Defines and tests the request-scope precedence rule in one **centralized, reusable** place so modules don't re-implement narrowing.

- **`shared/helpers/auth-scope.ts`**: adds `resolveReadScopePrecedence({ memberships, headerBusinessIds, argsBusinessIds })` implementing `args ⊆ header ⊆ memberships`:
  - no header/args → defaults to all accessible businesses;
  - header narrows the memberships; args narrow the (already header-narrowed) scope;
  - returns `null` (reject) when a requested id falls outside the scope it narrows — never silently dropped or broadened.
  - Reuses the existing `narrowReadScope`/`readScopeFromMemberships` helpers.
- **Tests**: precedence cases — default-all, header-only, args-over-header, args-over-default, and the three rejection paths (header outside memberships, args outside header, args outside memberships).

Stacked on step 5 (`multi-business-request-5-auth-context-scope`).

### Interpretation note
The header transport was already wired into `RawAuth`/auth-context in step 5. GraphQL **args** scope is inherently per-resolver, so rather than add speculative global context plumbing now, this step lands the single precedence function that the scope provider (step 10) and migrating modules (step 11+) call with their args. I kept it non-speculative to avoid throwaway wiring on `userContext`, which is hard-cut in step 9.

## Test plan

- [x] `vitest run --project unit` for the helper — 20 pass
- [x] Isolated strict `tsc --noEmit` clean; `prettier`/`eslint` clean

> Same environment caveats as earlier steps (no Postgres → no full server `tsc`/integration; `xlsx` CDN install).

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_