### PR TITLE
Multi-business step 7: RLS read-scope migration

### DIFF
--- a/packages/migrations/src/actions/2026-05-25T10-00-00.rls-multi-business-scope.ts
+++ b/packages/migrations/src/actions/2026-05-25T10-00-00.rls-multi-business-scope.ts
@@ -1,0 +1,114 @@
+import { sql } from 'slonik';
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+/**
+ * Multi-business read scope for RLS.
+ *
+ * Adds `get_current_business_scope()` (the request's authorized read scope as a
+ * UUID array) and switches every tenant_isolation read predicate (USING) to
+ * `owner_id = ANY (get_current_business_scope())`, while writes (WITH CHECK)
+ * stay pinned to the single `get_current_business_id()` target.
+ *
+ * The scope helper falls back to `ARRAY[get_current_business_id()]` when
+ * `app.current_business_scope` is unset, so this migration is backward
+ * compatible: until the tenant DB client sets the scope (a later step), reads
+ * behave exactly as before.
+ *
+ * The separate `allow_bootstrap_root` (businesses / financial_entities) and
+ * `super_admins_select` policies are intentionally left untouched.
+ */
+export default {
+  name: '2026-05-25T10-00-00.rls-multi-business-scope.sql',
+  run: async ({ connection }) => {
+    await connection.query(sql.unsafe`
+      CREATE OR REPLACE FUNCTION accounter_schema.get_current_business_scope()
+      RETURNS UUID[]
+      LANGUAGE plpgsql
+      STABLE
+      SECURITY DEFINER
+      SET search_path = pg_catalog
+      AS $$
+      DECLARE
+        v_scope_text TEXT;
+      BEGIN
+        -- Read scope is serialized as a Postgres array literal, e.g. '{uuid1,uuid2}'.
+        v_scope_text := NULLIF(current_setting('app.current_business_scope', true), '');
+
+        -- Fallback to the single business context while the scope is not yet set,
+        -- preserving pre-multi-business read behavior.
+        IF v_scope_text IS NULL THEN
+          RETURN ARRAY[accounter_schema.get_current_business_id()];
+        END IF;
+
+        RETURN v_scope_text::uuid[];
+      END;
+      $$;
+    `);
+
+    const tables = [
+      'business_tax_category_match',
+      'business_trip_charges',
+      'business_trips',
+      'business_trips_attendees',
+      'business_trips_employee_payments',
+      'business_trips_transactions',
+      'business_trips_transactions_accommodations',
+      'business_trips_transactions_car_rental',
+      'business_trips_transactions_flights',
+      'business_trips_transactions_match',
+      'business_trips_transactions_other',
+      'business_trips_transactions_tns',
+      'businesses',
+      'businesses_admin',
+      'charge_balance_cancellation',
+      'charge_spread',
+      'charge_tags',
+      'charge_unbalanced_ledger_businesses',
+      'charges',
+      'charges_bank_deposits',
+      'clients',
+      'clients_contracts',
+      'corporate_tax_variables',
+      'deel_invoices',
+      'deel_workers',
+      'depreciation',
+      'dividends',
+      'documents',
+      'documents_issued',
+      'dynamic_report_templates',
+      'employees',
+      'financial_accounts',
+      'financial_accounts_tax_categories',
+      'financial_bank_accounts',
+      'financial_entities',
+      'ledger_records',
+      'misc_expenses',
+      'pcn874',
+      'pension_funds',
+      'salaries',
+      'sort_codes',
+      'tags',
+      'tax_categories',
+      'transactions',
+      'user_context',
+      'annual_audit_step_status',
+    ];
+
+    for (const table of tables) {
+      await connection.query(
+        sql.unsafe`DROP POLICY IF EXISTS tenant_isolation ON accounter_schema.${sql.identifier([table])}`,
+      );
+
+      // Reads (USING): any business in the request's authorized scope.
+      // Writes (WITH CHECK): strictly the single explicit write-target business.
+      await connection.query(
+        sql.unsafe`
+          CREATE POLICY tenant_isolation ON accounter_schema.${sql.identifier([table])}
+          FOR ALL
+          USING (owner_id = ANY (accounter_schema.get_current_business_scope()))
+          WITH CHECK (owner_id = accounter_schema.get_current_business_id())
+        `,
+      );
+    }
+  },
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -179,6 +179,7 @@ import migration_2026_05_24T10_00_00_support_uah_currency from './actions/2026-0
 import migration_2026_05_24T11_00_00_revert_uah_currency from './actions/2026-05-24T11-00-00.revert-uah-currency.js';
 import migration_2026_05_24T12_00_00_add_otsar_hahayal_creditcard_transactions from './actions/2026-05-24T12-00-00.add-otsar-hahayal-creditcard-transactions.js';
 import migration_2026_05_24T13_00_00_update_otsar_hahayal_handlers from './actions/2026-05-24T13-00-00.update-otsar-hahayal-handlers.js';
+import migration_2026_05_25T10_00_00_rls_multi_business_scope from './actions/2026-05-25T10-00-00.rls-multi-business-scope.js';
 import { runMigrations } from './pg-migrator.js';
 
 export const MIGRATIONS = [
@@ -362,6 +363,7 @@ export const MIGRATIONS = [
   migration_2026_05_24T11_00_00_revert_uah_currency,
   migration_2026_05_24T12_00_00_add_otsar_hahayal_creditcard_transactions,
   migration_2026_05_24T13_00_00_update_otsar_hahayal_handlers,
+  migration_2026_05_25T10_00_00_rls_multi_business_scope,
 ] as const;
 
 export const LATEST_MIGRATION_NAME = MIGRATIONS[MIGRATIONS.length - 1]?.name;

--- a/packages/server/src/__tests__/rls-multi-business.integration.test.ts
+++ b/packages/server/src/__tests__/rls-multi-business.integration.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { TestDatabase } from './helpers/db-setup.js';
+
+/**
+ * Verifies the multi-business RLS migration:
+ * - `get_current_business_scope()` parses the `app.current_business_scope`
+ *   array setting and falls back to the single business context when unset.
+ * - tenant_isolation policies read via the scope array (USING) while writes
+ *   stay pinned to the single business (WITH CHECK).
+ *
+ * Note: the test DB connects as a superuser, which bypasses RLS row filtering,
+ * so this asserts the helper behavior and the policy definitions (via
+ * pg_policies) rather than cross-connection row visibility.
+ */
+describe('multi-business RLS scope', () => {
+  let db: TestDatabase;
+
+  const A = '11111111-1111-1111-1111-111111111111';
+  const B = '22222222-2222-2222-2222-222222222222';
+
+  beforeAll(async () => {
+    db = new TestDatabase();
+    await db.connect();
+  });
+
+  afterAll(async () => {
+    // Pool managed by global vitest setup — do not close here.
+  });
+
+  it('parses the business scope array setting', async () => {
+    await db.withTransaction(async client => {
+      await client.query(`SELECT set_config('app.current_business_id', $1, true)`, [A]);
+      await client.query(`SELECT set_config('app.current_business_scope', $1, true)`, [
+        `{${A},${B}}`,
+      ]);
+
+      const res = await client.query(
+        `SELECT accounter_schema.get_current_business_scope() AS scope`,
+      );
+      expect(res.rows[0].scope).toEqual([A, B]);
+    });
+  });
+
+  it('falls back to the single business context when scope is unset', async () => {
+    await db.withTransaction(async client => {
+      await client.query(`SELECT set_config('app.current_business_id', $1, true)`, [A]);
+      await client.query(`SELECT set_config('app.current_business_scope', '', true)`);
+
+      const res = await client.query(
+        `SELECT accounter_schema.get_current_business_scope() AS scope`,
+      );
+      expect(res.rows[0].scope).toEqual([A]);
+    });
+  });
+
+  it('uses the scope array for reads and the single business for writes', async () => {
+    await db.withTransaction(async client => {
+      const res = await client.query(
+        `SELECT qual, with_check
+         FROM pg_policies
+         WHERE schemaname = 'accounter_schema'
+           AND tablename = 'charges'
+           AND policyname = 'tenant_isolation'`,
+      );
+      expect(res.rows).toHaveLength(1);
+      expect(res.rows[0].qual).toContain('get_current_business_scope');
+      expect(res.rows[0].with_check).toContain('get_current_business_id');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Step 7 of the multi-business migration (Prompt 07: RLS Migration). Enables multi-business read scope at the DB policy layer while keeping strict single-target writes.

- **New migration** `2026-05-25T10-00-00.rls-multi-business-scope.ts`:
  - Adds `accounter_schema.get_current_business_scope()` → `UUID[]`, parsing the `app.current_business_scope` session setting (Postgres array literal `'{uuid1,uuid2}'`). **Falls back** to `ARRAY[get_current_business_id()]` when unset, so this migration is backward-compatible — reads behave exactly as before until the tenant DB client sets the scope (step 8).
  - Recreates the `tenant_isolation` policy on all 45 RLS tables with `USING (owner_id = ANY (get_current_business_scope()))` (reads) and `WITH CHECK (owner_id = get_current_business_id())` (writes pinned to one target).
  - Leaves the separate `allow_bootstrap_root` and `super_admins_select` policies untouched.
  - `get_current_business_id()` is unchanged and retained.
- **Integration test** `rls-multi-business.integration.test.ts`: verifies the helper's array parsing and single-business fallback, and asserts the `charges` policy definitions via `pg_policies` (read = scope array, write = single business).

Stacked on step 6 (`multi-business-request-6-scope-precedence`).

### Deviation note (important)
The blueprint suggested a "two connections see the union" RLS-filtering test. The test DB connects as the **`postgres` superuser, which bypasses RLS entirely** (even with `FORCE`), so a row-visibility assertion isn't meaningful here. The test instead verifies the scope helper's behavior and the policy SQL definitions — both robust under superuser and runnable in CI after `migration:run`.

## Test plan

- [x] Isolated `tsc` clean on the migration; `prettier`/`eslint` clean
- [ ] Migration apply + integration test run — **could not run locally** (no Postgres/Docker). First real validation is CI (`migration:run` then the integration project). The migration mirrors the existing `enable-rls-all-tables` patterns exactly to minimize risk.

> Same `xlsx` CDN install caveat as earlier steps.

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_