### PR TITLE
Multi-business step 8: tenant DB client read-scope wiring

### DIFF
--- a/packages/migrations/src/actions/2026-05-25T10-00-00.rls-multi-business-scope.ts
+++ b/packages/migrations/src/actions/2026-05-25T10-00-00.rls-multi-business-scope.ts
@@ -1,0 +1,114 @@
+import { sql } from 'slonik';
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+/**
+ * Multi-business read scope for RLS.
+ *
+ * Adds `get_current_business_scope()` (the request's authorized read scope as a
+ * UUID array) and switches every tenant_isolation read predicate (USING) to
+ * `owner_id = ANY (get_current_business_scope())`, while writes (WITH CHECK)
+ * stay pinned to the single `get_current_business_id()` target.
+ *
+ * The scope helper falls back to `ARRAY[get_current_business_id()]` when
+ * `app.current_business_scope` is unset, so this migration is backward
+ * compatible: until the tenant DB client sets the scope (a later step), reads
+ * behave exactly as before.
+ *
+ * The separate `allow_bootstrap_root` (businesses / financial_entities) and
+ * `super_admins_select` policies are intentionally left untouched.
+ */
+export default {
+  name: '2026-05-25T10-00-00.rls-multi-business-scope.sql',
+  run: async ({ connection }) => {
+    await connection.query(sql.unsafe`
+      CREATE OR REPLACE FUNCTION accounter_schema.get_current_business_scope()
+      RETURNS UUID[]
+      LANGUAGE plpgsql
+      STABLE
+      SECURITY DEFINER
+      SET search_path = pg_catalog
+      AS $$
+      DECLARE
+        v_scope_text TEXT;
+      BEGIN
+        -- Read scope is serialized as a Postgres array literal, e.g. '{uuid1,uuid2}'.
+        v_scope_text := NULLIF(current_setting('app.current_business_scope', true), '');
+
+        -- Fallback to the single business context while the scope is not yet set,
+        -- preserving pre-multi-business read behavior.
+        IF v_scope_text IS NULL THEN
+          RETURN ARRAY[accounter_schema.get_current_business_id()];
+        END IF;
+
+        RETURN v_scope_text::uuid[];
+      END;
+      $$;
+    `);
+
+    const tables = [
+      'business_tax_category_match',
+      'business_trip_charges',
+      'business_trips',
+      'business_trips_attendees',
+      'business_trips_employee_payments',
+      'business_trips_transactions',
+      'business_trips_transactions_accommodations',
+      'business_trips_transactions_car_rental',
+      'business_trips_transactions_flights',
+      'business_trips_transactions_match',
+      'business_trips_transactions_other',
+      'business_trips_transactions_tns',
+      'businesses',
+      'businesses_admin',
+      'charge_balance_cancellation',
+      'charge_spread',
+      'charge_tags',
+      'charge_unbalanced_ledger_businesses',
+      'charges',
+      'charges_bank_deposits',
+      'clients',
+      'clients_contracts',
+      'corporate_tax_variables',
+      'deel_invoices',
+      'deel_workers',
+      'depreciation',
+      'dividends',
+      'documents',
+      'documents_issued',
+      'dynamic_report_templates',
+      'employees',
+      'financial_accounts',
+      'financial_accounts_tax_categories',
+      'financial_bank_accounts',
+      'financial_entities',
+      'ledger_records',
+      'misc_expenses',
+      'pcn874',
+      'pension_funds',
+      'salaries',
+      'sort_codes',
+      'tags',
+      'tax_categories',
+      'transactions',
+      'user_context',
+      'annual_audit_step_status',
+    ];
+
+    for (const table of tables) {
+      await connection.query(
+        sql.unsafe`DROP POLICY IF EXISTS tenant_isolation ON accounter_schema.${sql.identifier([table])}`,
+      );
+
+      // Reads (USING): any business in the request's authorized scope.
+      // Writes (WITH CHECK): strictly the single explicit write-target business.
+      await connection.query(
+        sql.unsafe`
+          CREATE POLICY tenant_isolation ON accounter_schema.${sql.identifier([table])}
+          FOR ALL
+          USING (owner_id = ANY (accounter_schema.get_current_business_scope()))
+          WITH CHECK (owner_id = accounter_schema.get_current_business_id())
+        `,
+      );
+    }
+  },
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -179,6 +179,7 @@ import migration_2026_05_24T10_00_00_support_uah_currency from './actions/2026-0
 import migration_2026_05_24T11_00_00_revert_uah_currency from './actions/2026-05-24T11-00-00.revert-uah-currency.js';
 import migration_2026_05_24T12_00_00_add_otsar_hahayal_creditcard_transactions from './actions/2026-05-24T12-00-00.add-otsar-hahayal-creditcard-transactions.js';
 import migration_2026_05_24T13_00_00_update_otsar_hahayal_handlers from './actions/2026-05-24T13-00-00.update-otsar-hahayal-handlers.js';
+import migration_2026_05_25T10_00_00_rls_multi_business_scope from './actions/2026-05-25T10-00-00.rls-multi-business-scope.js';
 import { runMigrations } from './pg-migrator.js';
 
 export const MIGRATIONS = [
@@ -362,6 +363,7 @@ export const MIGRATIONS = [
   migration_2026_05_24T11_00_00_revert_uah_currency,
   migration_2026_05_24T12_00_00_add_otsar_hahayal_creditcard_transactions,
   migration_2026_05_24T13_00_00_update_otsar_hahayal_handlers,
+  migration_2026_05_25T10_00_00_rls_multi_business_scope,
 ] as const;
 
 export const LATEST_MIGRATION_NAME = MIGRATIONS[MIGRATIONS.length - 1]?.name;

--- a/packages/server/src/__tests__/rls-multi-business.integration.test.ts
+++ b/packages/server/src/__tests__/rls-multi-business.integration.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { TestDatabase } from './helpers/db-setup.js';
+
+/**
+ * Verifies the multi-business RLS migration:
+ * - `get_current_business_scope()` parses the `app.current_business_scope`
+ *   array setting and falls back to the single business context when unset.
+ * - tenant_isolation policies read via the scope array (USING) while writes
+ *   stay pinned to the single business (WITH CHECK).
+ *
+ * Note: the test DB connects as a superuser, which bypasses RLS row filtering,
+ * so this asserts the helper behavior and the policy definitions (via
+ * pg_policies) rather than cross-connection row visibility.
+ */
+describe('multi-business RLS scope', () => {
+  let db: TestDatabase;
+
+  const A = '11111111-1111-1111-1111-111111111111';
+  const B = '22222222-2222-2222-2222-222222222222';
+
+  beforeAll(async () => {
+    db = new TestDatabase();
+    await db.connect();
+  });
+
+  afterAll(async () => {
+    // Pool managed by global vitest setup — do not close here.
+  });
+
+  it('parses the business scope array setting', async () => {
+    await db.withTransaction(async client => {
+      await client.query(`SELECT set_config('app.current_business_id', $1, true)`, [A]);
+      await client.query(`SELECT set_config('app.current_business_scope', $1, true)`, [
+        `{${A},${B}}`,
+      ]);
+
+      const res = await client.query(
+        `SELECT accounter_schema.get_current_business_scope() AS scope`,
+      );
+      expect(res.rows[0].scope).toEqual([A, B]);
+    });
+  });
+
+  it('falls back to the single business context when scope is unset', async () => {
+    await db.withTransaction(async client => {
+      await client.query(`SELECT set_config('app.current_business_id', $1, true)`, [A]);
+      await client.query(`SELECT set_config('app.current_business_scope', '', true)`);
+
+      const res = await client.query(
+        `SELECT accounter_schema.get_current_business_scope() AS scope`,
+      );
+      expect(res.rows[0].scope).toEqual([A]);
+    });
+  });
+
+  it('uses the scope array for reads and the single business for writes', async () => {
+    await db.withTransaction(async client => {
+      const res = await client.query(
+        `SELECT qual, with_check
+         FROM pg_policies
+         WHERE schemaname = 'accounter_schema'
+           AND tablename = 'charges'
+           AND policyname = 'tenant_isolation'`,
+      );
+      expect(res.rows).toHaveLength(1);
+      expect(res.rows[0].qual).toContain('get_current_business_scope');
+      expect(res.rows[0].with_check).toContain('get_current_business_id');
+    });
+  });
+});

--- a/packages/server/src/modules/app-providers/__tests__/tenant-db-client.test.ts
+++ b/packages/server/src/modules/app-providers/__tests__/tenant-db-client.test.ts
@@ -48,6 +48,7 @@ describe('TenantAwareDBClient', () => {
         businessId: 'business-456',
         roleId: 'admin',
       },
+      activeReadScope: { businessIds: ['business-456'] },
     };
 
     const authContextProvider = {getAuthContext: () => Promise.resolve(mockAuthContext)} as AuthContextProvider;
@@ -250,13 +251,14 @@ describe('TenantAwareDBClient', () => {
         'business-456',
         'user-123',
         'jwt',
+        '{"business-456"}',
       ];
-      
+
       // Find the call that sets variables
-      const setCall = vi.mocked(mockPoolClient.query).mock.calls.find((call: any[]) => 
+      const setCall = vi.mocked(mockPoolClient.query).mock.calls.find((call: any[]) =>
         call[0].includes("set_config('app.current_business_id', $1, true)")
       );
-      
+
       expect(setCall).toBeDefined();
       expect(setCall![1]).toEqual(expectedVars);
     });
@@ -269,11 +271,7 @@ describe('TenantAwareDBClient', () => {
       await expect(tenantDBClient.query('SELECT 1')).rejects.toThrow('Missing businessId in AuthContext');
     });
 
-    // Baseline guardrail: today the session is scoped to a SINGLE business via
-    // `app.current_business_id`. The migration will add a read-scope array
-    // (e.g. `app.current_business_scope`). Locking the current variable set makes
-    // that addition an intentional, reviewable change.
-    it('should set exactly the single-business RLS variables and no read-scope array', async () => {
+    it('sets the write target and the read-scope array session variables', async () => {
       vi.mocked(mockPoolClient.query).mockResolvedValue({ rows: [] } as any);
 
       await tenantDBClient.query('SELECT 1');
@@ -287,9 +285,42 @@ describe('TenantAwareDBClient', () => {
       expect(sql).toContain("set_config('app.current_business_id', $1, true)");
       expect(sql).toContain("set_config('app.current_user_id', $2, true)");
       expect(sql).toContain("set_config('app.auth_type', $3, true)");
-      // No multi-business read scope is wired yet.
-      expect(sql).not.toContain('app.current_business_scope');
-      expect(setCall![1]).toHaveLength(3);
+      expect(sql).toContain("set_config('app.current_business_scope', $4, true)");
+      expect(setCall![1]).toHaveLength(4);
+    });
+
+    it('serializes a multi-business read scope as a Postgres array literal', async () => {
+      vi.mocked(mockPoolClient.query).mockResolvedValue({ rows: [] } as any);
+      (tenantDBClient as any).authContext = {
+        ...mockAuthContext,
+        activeReadScope: { businessIds: ['business-456', 'business-789'] },
+      };
+      (tenantDBClient as any).authContextInitialized = true;
+
+      await tenantDBClient.query('SELECT 1');
+
+      const setCall = vi.mocked(mockPoolClient.query).mock.calls.find((call: any[]) =>
+        call[0].includes("set_config('app.current_business_scope', $4, true)"),
+      );
+      expect(setCall).toBeDefined();
+      expect(setCall![1][3]).toBe('{"business-456","business-789"}');
+    });
+
+    it('passes an empty read scope when none is resolved (DB falls back to single business)', async () => {
+      vi.mocked(mockPoolClient.query).mockResolvedValue({ rows: [] } as any);
+      (tenantDBClient as any).authContext = {
+        ...mockAuthContext,
+        activeReadScope: undefined,
+      };
+      (tenantDBClient as any).authContextInitialized = true;
+
+      await tenantDBClient.query('SELECT 1');
+
+      const setCall = vi.mocked(mockPoolClient.query).mock.calls.find((call: any[]) =>
+        call[0].includes("set_config('app.current_business_scope', $4, true)"),
+      );
+      expect(setCall).toBeDefined();
+      expect(setCall![1][3]).toBe('');
     });
   });
 });

--- a/packages/server/src/modules/app-providers/tenant-db-client.ts
+++ b/packages/server/src/modules/app-providers/tenant-db-client.ts
@@ -221,7 +221,7 @@ export class TenantAwareDBClient {
       });
     }
 
-    const { tenant, user, authType } = this.authContext ?? {};
+    const { tenant, user, authType, activeReadScope } = this.authContext ?? {};
 
     const businessIdValue = tenant?.businessId ?? null;
     if (!businessIdValue) {
@@ -234,14 +234,24 @@ export class TenantAwareDBClient {
     // runtime cast error while explicitly clearing the setting.
     const userIdValue = authType === 'apiKey' ? '' : (user?.userId ?? null);
 
+    // Read scope: the businesses this request may read from, serialized as a
+    // Postgres array literal ('{uuid1,uuid2}') for get_current_business_scope().
+    // When empty/absent we pass '' so the DB helper falls back to the single
+    // write-target business. Writes remain pinned to app.current_business_id.
+    const readScopeValue =
+      activeReadScope && activeReadScope.businessIds.length > 0
+        ? `{${activeReadScope.businessIds.map(id => `"${id.replace(/"/g, '\\"')}"`).join(',')}}`
+        : '';
+
     await client.query(
       `
       SELECT
         set_config('app.current_business_id', $1, true),
         set_config('app.current_user_id', $2, true),
-        set_config('app.auth_type', $3, true);
+        set_config('app.auth_type', $3, true),
+        set_config('app.current_business_scope', $4, true);
       `,
-      [businessIdValue, userIdValue, authType],
+      [businessIdValue, userIdValue, authType, readScopeValue],
     );
   }
 


### PR DESCRIPTION
## Summary

Step 8 of the multi-business migration (Prompt 08: Tenant DB Client Session Wiring). Sets the read scope into the DB session for every operation so the step-7 RLS read policies take effect, while writes stay pinned to a single business.

- **`tenant-db-client.ts`** (`setRLSVariables`): now also sets `app.current_business_scope` from `authContext.activeReadScope`, serialized as a Postgres array literal `'{uuid1,uuid2}'` (the form `get_current_business_scope()` parses). When the scope is empty/absent it passes `''`, so the DB helper falls back to the single business. The single write target (`app.current_business_id`) is unchanged.
- **Nested transactions**: the four session variables are set once at transaction start via `set_config(..., true)`; nested work runs under savepoints, so an inner-tx rollback preserves the outer-tx scope (set_config made before a savepoint is not reverted by rolling back to it).
- **Unauthenticated**: still rejected (existing `UNAUTHENTICATED` / missing-`businessId` guards retained).
- **Tests**: the four-variable set; multi-business array serialization (`{business-456,business-789}`); empty-scope fallback (`''`); plus the existing missing-auth/missing-businessId guards. (The step-1 baseline guardrail that locked "exactly 3 vars, no scope array" is repurposed to assert the scope var is now wired.)

Stacked on step 7 (`multi-business-request-7-rls-scope-migration`).

## Test plan

- [x] `vitest run --project unit` tenant-db-client — 17 pass
- [x] `prettier`/`eslint` clean (only pre-existing `no-console` warnings)

> The mocked pool client can't model Postgres `set_config`/savepoint semantics, so the nested-rollback-preserves-scope and pooled-connection isolation behaviors are asserted at the call level here; true DB-level verification needs Postgres (unavailable in this sandbox). Same `xlsx` CDN caveat as earlier steps.

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_