### PR TITLE
Multi-business step 9: hard-cut userContext contract

### DIFF
--- a/packages/client/src/providers/user-provider.tsx
+++ b/packages/client/src/providers/user-provider.tsx
@@ -9,7 +9,12 @@ import { UserContextDocument, type UserContextQuery } from '../gql/graphql.js';
 /* GraphQL */ `
   query UserContext {
     userContext {
-      adminBusinessId
+      memberships {
+        businessId
+        role
+        businessName
+      }
+      activeReadScope
       defaultLocalCurrency
       defaultCryptoConversionFiatCurrency
       ledgerLock
@@ -24,14 +29,44 @@ type ContextType = {
   setUserContext: (filtersContext: UserInfo | null) => void;
 };
 
+export interface BusinessMembershipInfo {
+  businessId: string;
+  role: string;
+  businessName?: string | null;
+}
+
 export interface UserInfo extends User {
   context: {
+    memberships: BusinessMembershipInfo[];
+    activeReadScope: string[];
+    // Derived client-side from the active read scope while the multi-business
+    // client UI is built; kept so existing single-business consumers compile.
     adminBusinessId: string;
     defaultLocalCurrency: string;
     defaultCryptoConversionFiatCurrency: string;
     ledgerLock?: string | null;
     financialAccountsBusinessesIds: string[];
     locality: string;
+  };
+}
+
+// Map the (now multi-business) server payload to the client context shape,
+// deriving the legacy single-business fields used across the app today.
+function toUserInfoContext(
+  userContext: NonNullable<UserContextQuery['userContext']>,
+): UserInfo['context'] {
+  const memberships = userContext.memberships ?? [];
+  const activeReadScope = userContext.activeReadScope ?? [];
+  const adminBusinessId = activeReadScope[0] ?? memberships[0]?.businessId ?? '';
+  return {
+    memberships,
+    activeReadScope,
+    adminBusinessId,
+    defaultLocalCurrency: userContext.defaultLocalCurrency ?? '',
+    defaultCryptoConversionFiatCurrency: userContext.defaultCryptoConversionFiatCurrency ?? '',
+    ledgerLock: userContext.ledgerLock,
+    financialAccountsBusinessesIds: userContext.financialAccountsBusinessesIds ?? [],
+    locality: userContext.locality ?? '',
   };
 }
 
@@ -100,7 +135,7 @@ function Auth0UserProvider({ children }: { children?: ReactNode }): ReactNode {
 
     setUserContext({
       ...user,
-      context: defaults,
+      context: toUserInfoContext(defaults),
     });
   }, [defaults, user]);
 
@@ -137,7 +172,7 @@ function DevAuthUserProvider({ children }: { children?: ReactNode }): ReactNode 
 
     setUserContext({
       username: 'dev-user',
-      context: defaults,
+      context: toUserInfoContext(defaults),
     });
   }, [defaults]);
 

--- a/packages/server/src/modules/common/__tests__/user-context.resolver.test.ts
+++ b/packages/server/src/modules/common/__tests__/user-context.resolver.test.ts
@@ -1,36 +1,34 @@
 import { describe, expect, it, vi } from 'vitest';
-import { userContextResolvers } from '../resolvers/user-context.resolver.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
-
-// Baseline guardrails for the multi-business migration.
-// These lock the CURRENT single-business `userContext` contract so the hard-cut
-// in a later step (memberships + active read scope replacing `adminBusinessId`)
-// is visible as an intentional change rather than a silent regression.
+import { AuthContextProvider } from '../../auth/providers/auth-context.provider.js';
+import { userContextResolvers } from '../resolvers/user-context.resolver.js';
 
 type AdminContextFixture = Awaited<ReturnType<AdminContextProvider['getVerifiedAdminContext']>>;
+type AuthContextValue = Awaited<ReturnType<AuthContextProvider['getAuthContext']>>;
 
-function buildInjector(adminContext: AdminContextFixture) {
-  return {
-    get: vi.fn().mockReturnValue({
-      getVerifiedAdminContext: vi.fn().mockResolvedValue(adminContext),
-    }),
+
+function buildInjector(authContext: AuthContextValue, adminContext: AdminContextFixture) {
+  const adminProvider = { getVerifiedAdminContext: vi.fn().mockResolvedValue(adminContext) };
+  const authProvider = { getAuthContext: vi.fn().mockResolvedValue(authContext) };
+  const injector = {
+    get: vi.fn((token: unknown) => (token === AuthContextProvider ? authProvider : adminProvider)),
   };
+  return { injector, adminProvider, authProvider };
 }
 
-async function runResolver(adminContext: AdminContextFixture) {
-  const injector = buildInjector(adminContext);
-  // The resolver only reads `injector` from the context.
+async function runResolver(authContext: AuthContextValue, adminContext: AdminContextFixture) {
+  const { injector, adminProvider } = buildInjector(authContext, adminContext);
   const resolver = userContextResolvers.Query!.userContext as (
     parent: unknown,
     args: unknown,
-    context: { injector: ReturnType<typeof buildInjector> },
+    context: { injector: { get: (token: unknown) => unknown } },
     info: unknown,
   ) => Promise<Record<string, unknown>>;
-  return resolver(undefined, undefined, { injector }, undefined);
+  const result = await resolver(undefined, undefined, { injector }, undefined);
+  return { result, adminProvider };
 }
 
-const baseContext = {
-  ownerId: 'owner-1',
+const adminContext = {
   defaultLocalCurrency: 'ILS',
   defaultCryptoConversionFiatCurrency: 'USD',
   ledgerLock: '2024-01-01',
@@ -39,40 +37,70 @@ const baseContext = {
   bankDeposits: { bankDepositBusinessId: null },
 } as AdminContextFixture;
 
-describe('userContext resolver (single-business baseline)', () => {
-  it('exposes the single admin business as adminBusinessId', async () => {
-    const result = await runResolver(baseContext);
+const authContext = {
+  authType: 'jwt',
+  tenant: { businessId: 'b-1' },
+  memberships: [
+    { businessId: 'b-1', roleId: 'business_owner', businessName: 'Acme' },
+    { businessId: 'b-2', roleId: 'accountant' },
+  ],
+  activeReadScope: { businessIds: ['b-1'] },
+} as AuthContextValue;
 
-    // Single-business contract: exactly one business id, scalar (not an array).
-    expect(result.adminBusinessId).toBe('owner-1');
-    expect(Array.isArray(result.adminBusinessId)).toBe(false);
+describe('userContext resolver (multi-business)', () => {
+  it('returns the full membership list, mapping role and name', async () => {
+    const { result } = await runResolver(authContext, adminContext);
+    expect(result.memberships).toEqual([
+      { businessId: 'b-1', role: 'business_owner', businessName: 'Acme' },
+      { businessId: 'b-2', role: 'accountant', businessName: null },
+    ]);
   });
 
-  it('passes through currency, ledger lock, and locality unchanged', async () => {
-    const result = await runResolver(baseContext);
+  it('exposes the active read scope and no longer exposes adminBusinessId', async () => {
+    const { result } = await runResolver(authContext, adminContext);
+    expect(result.activeReadScope).toEqual(['b-1']);
+    expect(result).not.toHaveProperty('adminBusinessId');
+  });
 
+  it('populates single-business preference fields when the scope is one business', async () => {
+    const { result, adminProvider } = await runResolver(authContext, adminContext);
+    expect(adminProvider.getVerifiedAdminContext).toHaveBeenCalled();
     expect(result.defaultLocalCurrency).toBe('ILS');
     expect(result.defaultCryptoConversionFiatCurrency).toBe('USD');
     expect(result.ledgerLock).toBe('2024-01-01');
     expect(result.locality).toBe('ISRAEL');
-  });
-
-  it('returns internal wallet ids when there is no bank deposit business', async () => {
-    const result = await runResolver(baseContext);
-
     expect(result.financialAccountsBusinessesIds).toEqual(['wallet-1', 'wallet-2']);
   });
 
-  it('appends the bank deposit business id to financial accounts when present', async () => {
-    const result = await runResolver({
-      ...baseContext,
-      bankDeposits: { bankDepositBusinessId: 'bank-deposit-1', bankDepositInterestIncomeTaxCategoryId: null },
-    });
-
+  it('appends the bank deposit business id when present', async () => {
+    const { result } = await runResolver(authContext, {
+      ...adminContext,
+      bankDeposits: {
+        bankDepositBusinessId: 'bank-deposit-1',
+        bankDepositInterestIncomeTaxCategoryId: null,
+      },
+    } as AdminContextFixture);
     expect(result.financialAccountsBusinessesIds).toEqual([
       'wallet-1',
       'wallet-2',
       'bank-deposit-1',
     ]);
+  });
+
+  it('nulls single-business fields and skips admin context for a multi-business scope', async () => {
+    const multiScope = {
+      ...authContext,
+      activeReadScope: { businessIds: ['b-1', 'b-2'] },
+    } as AuthContextValue;
+
+    const { result, adminProvider } = await runResolver(multiScope, adminContext);
+
+    expect(result.activeReadScope).toEqual(['b-1', 'b-2']);
+    expect(result.defaultLocalCurrency).toBeNull();
+    expect(result.defaultCryptoConversionFiatCurrency).toBeNull();
+    expect(result.ledgerLock).toBeNull();
+    expect(result.financialAccountsBusinessesIds).toBeNull();
+    expect(result.locality).toBeNull();
+    expect(adminProvider.getVerifiedAdminContext).not.toHaveBeenCalled();
   });
 });

--- a/packages/server/src/modules/common/resolvers/user-context.resolver.ts
+++ b/packages/server/src/modules/common/resolvers/user-context.resolver.ts
@@ -1,13 +1,40 @@
+import type { BusinessMembership } from '../../../shared/types/auth.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { AuthContextProvider } from '../../auth/providers/auth-context.provider.js';
 import type { CommonModule } from '../types.js';
 
 export const userContextResolvers: CommonModule.Resolvers = {
   Query: {
     userContext: async (_, __, { injector }) => {
+      const authContext = await injector.get(AuthContextProvider).getAuthContext();
+
+      const memberships = (authContext?.memberships ?? []).map(
+        (membership: BusinessMembership) => ({
+          businessId: membership.businessId,
+          role: membership.roleId,
+          businessName: membership.businessName ?? null,
+        }),
+      );
+      const activeReadScope = authContext?.activeReadScope?.businessIds ?? [];
+
+      // Single-business preference fields only make sense when the request reads
+      // from exactly one business; for multi-business reads they are null and
+      // callers must narrow the scope to obtain them.
+      if (activeReadScope.length !== 1) {
+        return {
+          memberships,
+          activeReadScope,
+          defaultLocalCurrency: null,
+          defaultCryptoConversionFiatCurrency: null,
+          ledgerLock: null,
+          financialAccountsBusinessesIds: null,
+          locality: null,
+        };
+      }
+
       const {
         financialAccounts: { internalWalletsIds },
         bankDeposits: { bankDepositBusinessId },
-        ownerId,
         defaultLocalCurrency,
         defaultCryptoConversionFiatCurrency,
         ledgerLock,
@@ -19,8 +46,10 @@ export const userContextResolvers: CommonModule.Resolvers = {
         // TODO: this should be removed after bank deposit conversion to financial account is done (then - it should be added to internalWalletsIds)
         financialAccountsBusinessesIds.push(bankDepositBusinessId);
       }
+
       return {
-        adminBusinessId: ownerId,
+        memberships,
+        activeReadScope,
         defaultLocalCurrency,
         defaultCryptoConversionFiatCurrency,
         ledgerLock,

--- a/packages/server/src/modules/common/typeDefs/user-context.graphql.ts
+++ b/packages/server/src/modules/common/typeDefs/user-context.graphql.ts
@@ -5,13 +5,24 @@ export default gql`
     userContext: UserContext @requiresAuth
   }
 
+  " a business the authenticated user belongs to " # eslint-disable-next-line @graphql-eslint/strict-id-in-types -- identified by (user, business); no single id
+  type BusinessMembership {
+    businessId: UUID!
+    role: String!
+    businessName: String
+  }
+
   " user context "
   type UserContext {
-    adminBusinessId: UUID!
-    defaultLocalCurrency: Currency!
-    defaultCryptoConversionFiatCurrency: Currency!
+    " all businesses the user belongs to "
+    memberships: [BusinessMembership!]!
+    " the businesses this request is authorized to read from "
+    activeReadScope: [UUID!]!
+    " single-business preference fields are populated only when the active read scope is exactly one business; otherwise null "
+    defaultLocalCurrency: Currency
+    defaultCryptoConversionFiatCurrency: Currency
     ledgerLock: TimelessDate
-    financialAccountsBusinessesIds: [UUID!]!
-    locality: String!
+    financialAccountsBusinessesIds: [UUID!]
+    locality: String
   }
 `;


### PR DESCRIPTION
## Summary

Step 9 of the multi-business migration (Prompt 09: Hard-Cut UserContext Contract). Replaces the single-business `userContext` shape with a multi-business-aware one, no compatibility shim on the server.

- **Schema** (`user-context.graphql.ts`): removes `adminBusinessId: UUID!`; adds `memberships: [BusinessMembership!]!` and `activeReadScope: [UUID!]!`. The single-business preference fields (`defaultLocalCurrency`, `defaultCryptoConversionFiatCurrency`, `ledgerLock`, `financialAccountsBusinessesIds`, `locality`) become **nullable**. New `BusinessMembership { businessId, role, businessName }` type.
- **Resolver**: reads memberships + scope from the auth context; populates the preference fields from admin context **only when the active read scope is exactly one business**, otherwise returns them as null (and skips the admin-context load). This matches the `user_context` table's single-`owner_id` keying — no table migration here.
- **Client** (`user-provider.tsx`): the `UserContext` query now fetches the new fields; the provider derives a single `adminBusinessId` from the active read scope so the ~20 existing single-business consumers keep compiling until the dedicated multi-business client UI is built. (Without this the repo-wide codegen fails on the removed field.)
- **Tests**: rewritten resolver test — membership mapping (`roleId`→`role`), active scope exposure, no `adminBusinessId`, single-business field population, and the multi-business null/skip-admin-context path.

Stacked on step 8 (`multi-business-request-8-tenant-db-session`).

### Notes
- `bootstrap-client.integration.test.ts` does not reference `adminBusinessId`, so no change there (task 5 = no-op).
- `BusinessMembership` has no single natural id (identified by user+business), so it uses the repo's established `eslint-disable @graphql-eslint/strict-id-in-types` pattern.
- The client derivation is a deliberate **client-side** bridge, not a server compat shim — the server contract is fully hard-cut. The broader client multi-business UI remains a separate effort (deployment still gated as per the plan).

## Test plan

- [x] `yarn generate:graphql` succeeds (schema + client documents valid)
- [x] `vitest run --project unit` resolver test — 5 pass
- [x] Isolated `tsc` clean on the resolver; `prettier`/`eslint` clean
- [ ] Full client/server `tsc` build — not runnable here (no Postgres for pgtyped; `xlsx` CDN install). The client interface keeps `adminBusinessId` + preference fields non-null so downstream consumers compile.

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_