### PR TITLE
Multi-business step 10: shared ScopeProvider

### DIFF
--- a/packages/server/src/modules/admin-context/providers/admin-context.provider.ts
+++ b/packages/server/src/modules/admin-context/providers/admin-context.provider.ts
@@ -1,3 +1,4 @@
+import DataLoader from 'dataloader';
 import { GraphQLError } from 'graphql';
 import { Injectable, Scope } from 'graphql-modules';
 import { sql } from '@pgtyped/runtime';
@@ -507,10 +508,19 @@ export class AdminContextProvider {
     return null;
   }
 
-  public async getAdminContextByOwnerId(ownerId: string): Promise<AdminContext | null> {
-    const contexts = await getAdminContexts.run({ ownerIds: [ownerId] }, this.db);
-    return contexts[0] ? this.normalizeContext(contexts[0]) : null;
+  private async batchAdminContextsByOwnerIds(ownerIds: readonly string[]) {
+    const uniqueOwnerIds = Array.from(new Set(ownerIds));
+    const contexts = await getAdminContexts.run({ ownerIds: uniqueOwnerIds }, this.db);
+    const contextsByOwnerId = new Map(contexts.map(c => [c.owner_id, c]));
+    return ownerIds.map(id => {
+      const context = contextsByOwnerId.get(id);
+      return context ? this.normalizeContext(context) : null;
+    });
   }
+
+  public adminContextByOwnerIdLoader = new DataLoader((ownerIds: readonly string[]) =>
+    this.batchAdminContextsByOwnerIds(ownerIds),
+  );
 
   public clearCache() {
     this.cachedContext = null;

--- a/packages/server/src/modules/auth/index.ts
+++ b/packages/server/src/modules/auth/index.ts
@@ -5,6 +5,7 @@ import { Auth0ManagementProvider } from './providers/auth0-management.provider.j
 import { AuthorizationProvider } from './providers/authorization.provider.js';
 import { BusinessUsersProvider } from './providers/business-users.provider.js';
 import { InvitationsProvider } from './providers/invitations.provider.js';
+import { ScopeProvider } from './providers/scope.provider.js';
 import { SuperAdminProvider } from './providers/super-admin.provider.js';
 import { apiKeysResolvers } from './resolvers/api-keys.resolver.js';
 import { invitationsResolvers } from './resolvers/invitations.resolver.js';
@@ -25,6 +26,7 @@ export const authModule = createModule({
     ApiKeysProvider,
     BusinessUsersProvider,
     InvitationsProvider,
+    ScopeProvider,
     SuperAdminProvider,
   ],
 });

--- a/packages/server/src/modules/auth/providers/__tests__/scope.provider.test.ts
+++ b/packages/server/src/modules/auth/providers/__tests__/scope.provider.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthContext } from '../../../../shared/types/auth.js';
+import { AdminContextProvider } from '../../../admin-context/providers/admin-context.provider.js';
+import { AuthContextProvider } from '../auth-context.provider.js';
+import { ScopeProvider } from '../scope.provider.js';
+
+function buildProvider(authContext: AuthContext | null, adminByOwnerId: Record<string, unknown> = {}) {
+  const authContextProvider = {
+    getAuthContext: vi.fn().mockResolvedValue(authContext),
+  } as unknown as AuthContextProvider;
+  const loadFn = vi.fn((ownerId: string) => Promise.resolve(adminByOwnerId[ownerId] ?? null));
+  const adminContextProvider = {
+    adminContextByOwnerIdLoader: { load: loadFn },
+  } as unknown as AdminContextProvider;
+  return {
+    provider: new ScopeProvider(authContextProvider, adminContextProvider),
+    getAdminContextByOwnerId: loadFn,
+  };
+}
+
+const authContext: AuthContext = {
+  authType: 'jwt',
+  tenant: { businessId: 'b-1' },
+  memberships: [
+    { businessId: 'b-1', roleId: 'owner' },
+    { businessId: 'b-2', roleId: 'accountant' },
+  ],
+  activeReadScope: { businessIds: ['b-1', 'b-2'] },
+};
+
+describe('ScopeProvider.getReadScope', () => {
+  it('defaults to the full authorized scope when no args are given', async () => {
+    const { provider } = buildProvider(authContext);
+    await expect(provider.getReadScope()).resolves.toEqual(['b-1', 'b-2']);
+  });
+
+  it('narrows to the requested args within the authorized scope', async () => {
+    const { provider } = buildProvider(authContext);
+    await expect(provider.getReadScope(['b-2'])).resolves.toEqual(['b-2']);
+  });
+
+  it('rejects args outside the authorized scope', async () => {
+    const { provider } = buildProvider(authContext);
+    await expect(provider.getReadScope(['b-9'])).rejects.toThrow(/outside the authorized read scope/);
+  });
+
+  it('throws when unauthenticated', async () => {
+    const { provider } = buildProvider(null);
+    await expect(provider.getReadScope()).rejects.toThrow(/Authentication required/);
+  });
+});
+
+describe('ScopeProvider.resolveWriteTarget', () => {
+  let provider: ScopeProvider;
+  beforeEach(() => {
+    provider = buildProvider(authContext).provider;
+  });
+
+  it('returns the target when it is a membership', async () => {
+    await expect(provider.resolveWriteTarget('b-2')).resolves.toBe('b-2');
+  });
+
+  it('throws when no target is provided', async () => {
+    await expect(provider.resolveWriteTarget(undefined)).rejects.toThrow(/explicit target businessId/);
+  });
+
+  it('throws when the target is not a membership', async () => {
+    await expect(provider.resolveWriteTarget('b-9')).rejects.toThrow(/Not authorized to write/);
+  });
+});
+
+describe('ScopeProvider.getBusinessPreference', () => {
+  it('returns the requested preference for a business within scope', async () => {
+    const { provider, getAdminContextByOwnerId } = buildProvider(authContext, {
+      'b-2': { defaultLocalCurrency: 'USD' },
+    });
+    await expect(provider.getBusinessPreference('b-2', 'defaultLocalCurrency')).resolves.toBe('USD');
+    expect(getAdminContextByOwnerId).toHaveBeenCalledWith('b-2');
+  });
+
+  it('returns null when the business has no admin context', async () => {
+    const { provider } = buildProvider(authContext, {});
+    await expect(provider.getBusinessPreference('b-2', 'defaultLocalCurrency')).resolves.toBeNull();
+  });
+
+  it('rejects a business outside the authorized read scope', async () => {
+    const { provider } = buildProvider(authContext);
+    await expect(
+      provider.getBusinessPreference('b-9', 'defaultLocalCurrency'),
+    ).rejects.toThrow(/outside the authorized read scope/);
+  });
+});

--- a/packages/server/src/modules/auth/providers/scope.provider.ts
+++ b/packages/server/src/modules/auth/providers/scope.provider.ts
@@ -1,0 +1,111 @@
+import { GraphQLError } from 'graphql';
+import { Injectable, Scope } from 'graphql-modules';
+import { narrowReadScope, readScopeFromMemberships } from '../../../shared/helpers/auth-scope.js';
+import type { AuthContext } from '../../../shared/types/auth.js';
+import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import type { AdminContext } from '../../admin-context/types.js';
+import { AuthContextProvider } from './auth-context.provider.js';
+
+/**
+ * Single, reusable entry point for request-level business scope decisions.
+ *
+ * Resolvers and providers should use this rather than re-implementing scope
+ * narrowing or reaching into the admin context per module:
+ * - reads default to all accessible businesses, narrowed by request args;
+ * - writes require an explicit, membership-validated single target;
+ * - per-business preferences are resolved within the authorized read scope.
+ */
+@Injectable({
+  scope: Scope.Operation,
+  global: true,
+})
+export class ScopeProvider {
+  constructor(
+    private authContextProvider: AuthContextProvider,
+    private adminContextProvider: AdminContextProvider,
+  ) {}
+
+  private async requireAuthContext(): Promise<AuthContext> {
+    const authContext = await this.authContextProvider.getAuthContext();
+    if (!authContext) {
+      throw new GraphQLError('Authentication required', {
+        extensions: { code: 'UNAUTHENTICATED' },
+      });
+    }
+    return authContext;
+  }
+
+  /**
+   * The effective read scope: the request's authorized scope
+   * (header ∩ memberships, resolved by the auth context) narrowed by the
+   * optionally-provided args business ids. Defaults to all accessible
+   * businesses. Throws when args request a business outside the authorized
+   * scope (callers must reject, never broaden).
+   */
+  public async getReadScope(argsBusinessIds?: string[]): Promise<string[]> {
+    const authContext = await this.requireAuthContext();
+    const baseScope =
+      authContext.activeReadScope ?? readScopeFromMemberships(authContext.memberships ?? []);
+
+    if (!argsBusinessIds || argsBusinessIds.length === 0) {
+      return baseScope.businessIds;
+    }
+
+    const allowed = baseScope.businessIds.map(businessId => ({ businessId, roleId: '' }));
+    const narrowed = narrowReadScope(allowed, argsBusinessIds);
+    if (!narrowed) {
+      throw new GraphQLError('Requested business scope is outside the authorized read scope', {
+        extensions: { code: 'FORBIDDEN' },
+      });
+    }
+    return narrowed.businessIds;
+  }
+
+  /**
+   * Validate and return the single write-target business. Writes always take an
+   * explicit business id (never inferred from the read scope); the target must
+   * be one of the user's memberships.
+   */
+  public async resolveWriteTarget(requestedBusinessId: string | null | undefined): Promise<string> {
+    const authContext = await this.requireAuthContext();
+
+    if (!requestedBusinessId) {
+      throw new GraphQLError('An explicit target businessId is required for writes', {
+        extensions: { code: 'BAD_USER_INPUT' },
+      });
+    }
+
+    const isMember = (authContext.memberships ?? []).some(
+      membership => membership.businessId === requestedBusinessId,
+    );
+    if (!isMember) {
+      throw new GraphQLError('Not authorized to write to the requested business', {
+        extensions: { code: 'FORBIDDEN' },
+      });
+    }
+
+    return requestedBusinessId;
+  }
+
+  /**
+   * Resolve a single business preference (e.g. `defaultLocalCurrency`) for a
+   * specific business within the authorized read scope. Replaces per-field
+   * reads of the request's single admin context, so multi-business reads can
+   * resolve preferences from each row's owning business.
+   */
+  public async getBusinessPreference<K extends keyof AdminContext>(
+    businessId: string,
+    key: K,
+  ): Promise<AdminContext[K] | null> {
+    const scope = await this.getReadScope();
+    if (!scope.includes(businessId)) {
+      throw new GraphQLError('Business is outside the authorized read scope', {
+        extensions: { code: 'FORBIDDEN' },
+      });
+    }
+
+    const adminContext =
+      await this.adminContextProvider.adminContextByOwnerIdLoader.load(businessId);
+    return adminContext ? adminContext[key] : null;
+  }
+}


### PR DESCRIPTION
## Summary

Step 10 of the multi-business migration (Prompt 10: Shared Scope Helper). Adds the single reusable provider that resolvers/providers use for scope decisions, so modules don't re-implement narrowing or reach into the admin context directly.

- **New `auth/providers/scope.provider.ts`** (`@Injectable`, Operation-scoped, registered in the auth module):
  - `getReadScope(argsBusinessIds?)` — the request's authorized scope (header ∩ memberships, from the auth context) narrowed by optional args; defaults to all accessible businesses; throws `FORBIDDEN` when args fall outside the authorized scope.
  - `resolveWriteTarget(businessId)` — requires an explicit business id and validates it is one of the user's memberships; throws `BAD_USER_INPUT`/`FORBIDDEN` otherwise.
  - `getBusinessPreference(businessId, key)` — resolves a per-business preference (e.g. `defaultLocalCurrency`) within the read scope via `AdminContextProvider.getAdminContextByOwnerId`, replacing per-field single-admin-context reads.
- **Tests**: default-all, args-narrowing, out-of-scope rejection, unauthenticated; write-target valid/missing/non-member; per-business preference resolution + out-of-scope rejection (10 cases).

Stacked on step 9 (`multi-business-request-9-usercontext-hardcut`).

### First-consumer note (scope decision)
The blueprint pairs this with wiring into the **businesses** module. The only `adminContext.ownerId` use there is the business **insert** path (`reassureOwnerIdExists` fallback), which the bootstrap/seed flows depend on — changing it safely requires the DB-backed `bootstrap-client`/seed integration tests, which can't run in this sandbox (no Postgres). To avoid destabilizing bootstrap blindly, the provider is delivered and registered here, and its first real consumers are the module-migration PRs that follow (charges/reports/ledger/salaries, steps 11–14), each of which CI can validate. Reads are already scope-correct at the RLS layer (steps 7–8), so no resolver read-path change is needed for correctness.

## Test plan

- [x] `vitest run --project unit` scope provider — 10 pass
- [x] Isolated `tsc` clean on the provider; `prettier`/`eslint` clean
- [x] `AdminContextProvider` is `global` so the cross-module DI resolves

> Same environment caveats as earlier steps (no Postgres → no full server `tsc`/integration; `xlsx` CDN install).

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_