### PR TITLE
Multi-business step 11: charges migration

### DIFF
--- a/packages/server/src/modules/charges/resolvers/charges.resolver.ts
+++ b/packages/server/src/modules/charges/resolvers/charges.resolver.ts
@@ -5,6 +5,7 @@ import { EMPTY_UUID } from '../../../shared/constants.js';
 import { ChargeSortByField, ChargeTypeEnum } from '../../../shared/enums.js';
 import { errorSimplifier } from '../../../shared/errors.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { ScopeProvider } from '../../auth/providers/scope.provider.js';
 import { BusinessTripsProvider } from '../../business-trips/providers/business-trips.provider.js';
 import { isInvoice, isReceipt } from '../../documents/helpers/common.helper.js';
 import { DocumentsProvider } from '../../documents/providers/documents.provider.js';
@@ -226,10 +227,10 @@ export const chargesResolvers: ChargesModule.Resolvers &
           }),
         );
 
-        const { ownerId } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+        const readScope = await injector.get(ScopeProvider).getReadScope();
 
         const pageCharges = charges
-          .filter(charge => charge.owner_id === ownerId)
+          .filter(charge => !!charge.owner_id && readScope.includes(charge.owner_id))
           .sort((chargeA, chargeB) => {
             const dateA =
               (

--- a/packages/server/src/modules/charges/resolvers/financial-charges.resolver.ts
+++ b/packages/server/src/modules/charges/resolvers/financial-charges.resolver.ts
@@ -1,8 +1,10 @@
 import { GraphQLError } from 'graphql';
+import { type Injector } from 'graphql-modules';
 import { ChargeTypeEnum } from '../../../shared/enums.js';
 import { errorSimplifier } from '../../../shared/errors.js';
 import { dateToTimelessDateString } from '../../../shared/helpers/index.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { ScopeProvider } from '../../auth/providers/scope.provider.js';
 import { getMinDate } from '../../ledger/helpers/ledger-lock.js';
 import { generateLedgerRecordsForFinancialCharge } from '../../ledger/resolvers/ledger-generation/financial-ledger-generation.resolver.js';
 import { MiscExpensesProvider } from '../../misc-expenses/providers/misc-expenses.provider.js';
@@ -13,13 +15,41 @@ import { ChargesProvider } from '../providers/charges.provider.js';
 import type { ChargesModule } from '../types.js';
 import { commonChargeFields } from './common.js';
 
+// Validate an explicit write-target business against the caller's memberships,
+// then load that business's admin context (not the request's primary), so
+// charge generation uses the correct per-business tax configuration.
+async function getWriteTargetAdminContext(injector: Injector, ownerId: string) {
+  const target = await injector.get(ScopeProvider).resolveWriteTarget(ownerId);
+  const adminContext = await injector.get(AdminContextProvider).getAdminContextByOwnerId(target);
+  if (!adminContext) {
+    throw new GraphQLError('Admin context not found for the target business', {
+      extensions: { code: 'NOT_FOUND' },
+    });
+  }
+  return adminContext;
+}
+
 export const financialChargesResolvers: ChargesModule.Resolvers = {
   Query: {
     annualFinancialCharges: async (_, { ownerId, year }, { injector }) => {
-      const adminContext = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+      // This report is shaped around a single business's tax categories. When a
+      // business is requested explicitly, validate it is within the read scope
+      // and use its admin context; otherwise default to the request's primary.
+      let adminContext;
+      if (ownerId) {
+        const [scopedId] = await injector.get(ScopeProvider).getReadScope([ownerId]);
+        adminContext = await injector.get(AdminContextProvider).getAdminContextByOwnerId(scopedId);
+        if (!adminContext) {
+          throw new GraphQLError('Admin context not found for the requested business', {
+            extensions: { code: 'NOT_FOUND' },
+          });
+        }
+      } else {
+        adminContext = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+      }
 
       const charges = await injector.get(ChargesProvider).getChargesByFilters({
-        ownerIds: [ownerId ?? adminContext.ownerId],
+        ownerIds: [adminContext.ownerId],
         type: 'FINANCIAL',
         fromAnyDate: year,
         toAnyDate: year,
@@ -69,7 +99,7 @@ export const financialChargesResolvers: ChargesModule.Resolvers = {
         general: {
           taxCategories: { exchangeRevaluationTaxCategoryId },
         },
-      } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+      } = await getWriteTargetAdminContext(injector, ownerId);
       if (ledgerLock && date <= ledgerLock) {
         throw new GraphQLError('Cannot generate revaluation charge for locked period');
       }
@@ -98,7 +128,7 @@ export const financialChargesResolvers: ChargesModule.Resolvers = {
       const {
         ledgerLock,
         bankDeposits: { bankDepositInterestIncomeTaxCategoryId },
-      } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+      } = await getWriteTargetAdminContext(injector, ownerId);
       if (ledgerLock && date <= ledgerLock) {
         throw new GraphQLError('Cannot generate revaluation charge for locked period');
       }
@@ -130,7 +160,7 @@ export const financialChargesResolvers: ChargesModule.Resolvers = {
       const {
         ledgerLock,
         authorities: { taxExpensesTaxCategoryId },
-      } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+      } = await getWriteTargetAdminContext(injector, ownerId);
       if (ledgerLock && `${year}-12-31` <= ledgerLock) {
         throw new GraphQLError('Cannot generate revaluation charge for locked period');
       }
@@ -159,7 +189,7 @@ export const financialChargesResolvers: ChargesModule.Resolvers = {
       const {
         ledgerLock,
         depreciation: { accumulatedDepreciationTaxCategoryId },
-      } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+      } = await getWriteTargetAdminContext(injector, ownerId);
       if (ledgerLock && `${year}-12-31` <= ledgerLock) {
         throw new GraphQLError('Cannot generate revaluation charge for locked period');
       }
@@ -191,7 +221,7 @@ export const financialChargesResolvers: ChargesModule.Resolvers = {
       const {
         ledgerLock,
         salaries: { recoveryReserveTaxCategoryId },
-      } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+      } = await getWriteTargetAdminContext(injector, ownerId);
       if (ledgerLock && `${year}-12-31` <= ledgerLock) {
         throw new GraphQLError('Cannot generate revaluation charge for locked period');
       }
@@ -223,7 +253,7 @@ export const financialChargesResolvers: ChargesModule.Resolvers = {
       const {
         ledgerLock,
         salaries: { vacationReserveTaxCategoryId },
-      } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+      } = await getWriteTargetAdminContext(injector, ownerId);
       if (ledgerLock && `${year}-12-31` <= ledgerLock) {
         throw new GraphQLError('Cannot generate revaluation charge for locked period');
       }


### PR DESCRIPTION
## Summary

Step 11 of the multi-business migration (Prompt 11: Charges Migration). Migrates the charges module to explicit, membership-validated write targets and scoped reads.

- **Write mutations** (`generateRevaluationCharge`, `generateBankDepositsRevaluationCharge`, `generateTaxExpensesCharge`, `generateDepreciationCharge`, `generateRecoveryReserveCharge`, `generateVacationReserveCharge`): now validate the explicit `ownerId: UUID!` arg via `ScopeProvider.resolveWriteTarget` and load **that** business's admin context via `getAdminContextByOwnerId` (instead of the request's primary `getVerifiedAdminContext`), so per-business tax configuration is correct under multi-business.
- **Reads**: `chargesWithMissingRequiredInfo` filters to the authorized read scope (`getReadScope()`) instead of the single admin business; `annualFinancialCharges` validates an explicit `ownerId` against the read scope and uses that business's context (defaults to primary when omitted, as that report is shaped around one business's tax categories).

Stacked on step 10 (`multi-business-request-10-scope-provider`).

### Notes / deferred
- `generateBalanceCharge` has no `ownerId` arg (derives owner from the authenticated context). Adding a required `businessId` arg is a schema+client change, so it's left as-is here (authenticated business is always a membership) and flagged for a follow-up.
- Blueprint task 4 asks for multi-business read / write-authorization **integration tests** — these need Postgres (unavailable here). The underlying `ScopeProvider` is unit-tested in step 10.

## Test plan

- [x] `vitest run --project unit` charges — 504 pass (no regressions)
- [x] `financial-charges.resolver.ts` isolated `tsc` clean; `prettier`/`eslint` clean (only pre-existing `no-console` warnings)
- [ ] DB-backed integration tests / full `tsc` (pgtyped) — CI only. `charges.resolver.ts` isolated tsc shows only pre-existing missing-pgtyped-codegen errors, unrelated to this change.

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_