### PR TITLE
Multi-business step 12: reports migration

### DIFF
--- a/packages/server/src/modules/reports/resolvers/annual-revenue.resover.ts
+++ b/packages/server/src/modules/reports/resolvers/annual-revenue.resover.ts
@@ -1,8 +1,10 @@
 import { endOfYear, startOfYear } from 'date-fns';
+import { GraphQLError } from 'graphql';
 import { Currency } from '../../../shared/enums.js';
 import { dateToTimelessDateString, formatFinancialAmount } from '../../../shared/helpers/index.js';
 import { TimelessDateString } from '../../../shared/types/index.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { ScopeProvider } from '../../auth/providers/scope.provider.js';
 import { CountriesProvider } from '../../countries/providers/countries.provider.js';
 import { BusinessesProvider } from '../../financial-entities/providers/businesses.provider.js';
 import { TaxCategoriesProvider } from '../../financial-entities/providers/tax-categories.provider.js';
@@ -31,8 +33,25 @@ interface NormalizedRecord {
 export const annualRevenueResolvers: ReportsModule.Resolvers = {
   Query: {
     annualRevenueReport: async (_, { filters: { year, adminBusinessId } }, { injector }) => {
-      const adminContext = await injector.get(AdminContextProvider).getVerifiedAdminContext();
-      const ownerId = adminBusinessId ?? adminContext.ownerId;
+      // Per-business report: validate an explicitly requested business against
+      // the read scope and use its admin context; default to the primary.
+      let adminContext;
+      if (adminBusinessId) {
+        // Validates the id is within the read scope (throws otherwise), so the
+        // requested id can be used directly.
+        await injector.get(ScopeProvider).getReadScope([adminBusinessId]);
+        adminContext = await injector
+          .get(AdminContextProvider)
+          .getAdminContextByOwnerId(adminBusinessId);
+        if (!adminContext) {
+          throw new GraphQLError('Admin context not found for the requested business', {
+            extensions: { code: 'NOT_FOUND' },
+          });
+        }
+      } else {
+        adminContext = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+      }
+      const ownerId = adminContext.ownerId;
       const incomeTaxCategories = await injector
         .get(TaxCategoriesProvider)
         .taxCategoriesBySortCodeLoader.load(810);

--- a/packages/server/src/modules/reports/resolvers/shaam6111.resolver.ts
+++ b/packages/server/src/modules/reports/resolvers/shaam6111.resolver.ts
@@ -1,6 +1,7 @@
 import { GraphQLError } from 'graphql';
 import { generateReport } from '@accounter/shaam6111-generator';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { ScopeProvider } from '../../auth/providers/scope.provider.js';
 import { BusinessesProvider } from '../../financial-entities/providers/businesses.provider.js';
 import {
   convertLocalReportDataToShaam6111ReportData,
@@ -11,8 +12,17 @@ import type { ReportsModule } from '../types.js';
 export const shaam6111Resolvers: ReportsModule.Resolvers = {
   Query: {
     shaam6111: async (_, { year, businessId: requestedBusinessId }, { injector }) => {
-      const { ownerId } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
-      const businessId = requestedBusinessId ?? ownerId;
+      // Per-business report: a requested business must be within the read scope;
+      // default to the request's primary business otherwise.
+      let businessId: string;
+      if (requestedBusinessId) {
+        // Validates the id is within the read scope (throws otherwise).
+        await injector.get(ScopeProvider).getReadScope([requestedBusinessId]);
+        businessId = requestedBusinessId;
+      } else {
+        const { ownerId } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+        businessId = ownerId;
+      }
       const reportData = await getShaam6111Data(injector, businessId, year);
 
       return {


### PR DESCRIPTION
## Summary

Step 12 of the multi-business migration (Prompt 12: Reports Migration). Replaces unchecked single-business defaults in the report entry points with scope-validated business selection.

- **`annualRevenueReport`**: when `filters.adminBusinessId` is provided, validate it against the read scope (`ScopeProvider.getReadScope([id])`) and use **that** business's admin context (for `incomeToCollectTaxCategoryId` / `ownerId`); default to the request's primary otherwise. Previously `adminBusinessId ?? adminContext.ownerId` used the requested id unchecked while still reading config from the primary.
- **`shaam6111`**: an explicitly requested `businessId` must be within the read scope; default to the primary when omitted.

Both are inherently per-business reports, so explicit args **narrow within** the authorized scope (never broaden) rather than aggregate.

Stacked on step 11 (`multi-business-request-11-charges-migration`).

### Deferred (with reason)
The VAT-report currency field resolvers in `reports.resolver.ts` read `defaultLocalCurrency` from the request's single admin context. Each record carries `raw.businessId`, so the correct multi-business behavior is per-row `getBusinessPreference(raw.businessId, 'defaultLocalCurrency')` — but that needs a null-currency fallback and a per-owner memo to avoid N+1, and it touches a hot formatting path I can't exercise without a DB. I'm folding that (plus the supporting `AdminContextProvider` per-owner cache) into **step 14** (which explicitly refactors the admin-context provider), to keep this PR safe.

## Test plan

- [x] `vitest run --project unit` reports — 79 pass (5 pre-existing skips)
- [x] `prettier`/`eslint` clean on changed files
- [ ] Full `tsc` / integration — CI only (isolated tsc shows only pre-existing missing-pgtyped / unbuilt-generator cascades).

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_