### PR TITLE
Multi-business step 13: ledger migration

### DIFF
--- a/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
@@ -1,4 +1,5 @@
 import { GraphQLError } from 'graphql';
+import { type Injector } from 'graphql-modules';
 import { Repeater } from 'graphql-yoga';
 import {
   ChargeSortByField,
@@ -6,8 +7,10 @@ import {
   type ResolversTypes,
 } from '../../../__generated__/types.js';
 import { EMPTY_UUID } from '../../../shared/constants.js';
+import type { Currency } from '../../../shared/enums.js';
 import { formatFinancialAmount } from '../../../shared/helpers/index.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { ScopeProvider } from '../../auth/providers/scope.provider.js';
 import { ChargesProvider } from '../../charges/providers/charges.provider.js';
 import { accountant_statusArray } from '../../charges/types.js';
 import { FinancialEntitiesProvider } from '../../financial-entities/providers/financial-entities.provider.js';
@@ -31,6 +34,27 @@ import type {
   LedgerModule,
 } from '../types.js';
 import { commonChargeLedgerResolver } from './common.resolver.js';
+
+// Resolve a ledger record's local currency from its OWNING business, so
+// multi-business reads format each record in the right currency. Falls back to
+// the request's primary business when the per-business preference is missing.
+async function recordLocalCurrency(
+  injector: Injector,
+  ownerId: string | null | undefined,
+): Promise<Currency> {
+  if (ownerId) {
+    const currency = await injector
+      .get(ScopeProvider)
+      .getBusinessPreference(ownerId, 'defaultLocalCurrency');
+    if (currency) {
+      return currency;
+    }
+  }
+  const { defaultLocalCurrency } = await injector
+    .get(AdminContextProvider)
+    .getVerifiedAdminContext();
+  return defaultLocalCurrency;
+}
 
 export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'GeneratedLedgerRecords'> = {
   Query: {
@@ -371,29 +395,21 @@ export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'Generate
         ? null
         : formatFinancialAmount(DbLedgerRecord.credit_foreign_amount2, DbLedgerRecord.currency),
     localCurrencyDebitAmount1: async (DbLedgerRecord, _, { injector }) => {
-      const { defaultLocalCurrency } = await injector
-        .get(AdminContextProvider)
-        .getVerifiedAdminContext();
+      const defaultLocalCurrency = await recordLocalCurrency(injector, DbLedgerRecord.owner_id);
       return formatFinancialAmount(DbLedgerRecord.debit_local_amount1, defaultLocalCurrency);
     },
     localCurrencyDebitAmount2: async (DbLedgerRecord, _, { injector }) => {
-      const { defaultLocalCurrency } = await injector
-        .get(AdminContextProvider)
-        .getVerifiedAdminContext();
+      const defaultLocalCurrency = await recordLocalCurrency(injector, DbLedgerRecord.owner_id);
       return DbLedgerRecord.debit_local_amount2 == null
         ? null
         : formatFinancialAmount(DbLedgerRecord.debit_local_amount2, defaultLocalCurrency);
     },
     localCurrencyCreditAmount1: async (DbLedgerRecord, _, { injector }) => {
-      const { defaultLocalCurrency } = await injector
-        .get(AdminContextProvider)
-        .getVerifiedAdminContext();
+      const defaultLocalCurrency = await recordLocalCurrency(injector, DbLedgerRecord.owner_id);
       return formatFinancialAmount(DbLedgerRecord.credit_local_amount1, defaultLocalCurrency);
     },
     localCurrencyCreditAmount2: async (DbLedgerRecord, _, { injector }) => {
-      const { defaultLocalCurrency } = await injector
-        .get(AdminContextProvider)
-        .getVerifiedAdminContext();
+      const defaultLocalCurrency = await recordLocalCurrency(injector, DbLedgerRecord.owner_id);
       return DbLedgerRecord.credit_local_amount2 == null
         ? null
         : formatFinancialAmount(DbLedgerRecord.credit_local_amount2, defaultLocalCurrency);


### PR DESCRIPTION
## Summary

Step 13 of the multi-business migration (Prompt 13: Ledger Migration). Resolves ledger record currency from each record's owning business instead of the request's single primary.

- **`LedgerRecord` field resolvers** (`localCurrencyDebitAmount1/2`, `localCurrencyCreditAmount1/2`): now format using `recordLocalCurrency(injector, DbLedgerRecord.owner_id)`, which resolves the owning business's `defaultLocalCurrency` via `ScopeProvider.getBusinessPreference` (batched by the admin-context loader) and falls back to the request's primary currency when absent. Previously every row used the primary admin context's currency — wrong under multi-business reads.

Stacked on step 12 (`multi-business-request-12-reports-migration`).

### Scope note / deferred
The blueprint also targets ledger **entry points** (reads/writes) and the provider's internal `owner_id = $ownerId` filters. Those derive the owner from the admin context with no explicit args, and changing them safely means pgtyped query changes + (for writes) new mutation args that cascade to the client — neither validatable without a DB here. Per the blueprint's "adapt at boundaries first / keep internal helper behavior stable" guidance, this PR lands the per-record currency boundary change (the clear multi-business correctness win in this module) and defers the provider read-filter/write-target refactor to a follow-up. Reads remain tenant-safe via the RLS scope from steps 7–8.

## Test plan

- [x] `prettier`/`eslint` clean (only pre-existing `no-console` warnings)
- [x] Isolated `tsc` shows no errors tied to the change (`recordLocalCurrency`/`owner_id`/`ScopeProvider`); remaining noise is the pre-existing missing-pgtyped cascade
- [x] Ledger has only integration tests (excluded from the unit project), so no unit regressions; integration tests need Postgres → CI only

> Rebased onto the updated stack (steps 1–9 merged into `multi-business-request`, step 10 rebased on top, then steps 11/12). Picked up the rebased step-10 fix that batches per-owner admin-context lookups via a DataLoader.

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_