### PR TITLE
Multi-business step 14a: remaining modules migration

### DIFF
--- a/packages/server/src/modules/charges/resolvers/charge-suggestions/charge-suggestions.resolver.ts
+++ b/packages/server/src/modules/charges/resolvers/charge-suggestions/charge-suggestions.resolver.ts
@@ -10,6 +10,7 @@ import { UUID_REGEX } from '../../../../shared/constants.js';
 import { ChargeTypeEnum } from '../../../../shared/enums.js';
 import { errorSimplifier } from '../../../../shared/errors.js';
 import { AdminContextProvider } from '../../../admin-context/providers/admin-context.provider.js';
+import { ScopeProvider } from '../../../auth/providers/scope.provider.js';
 import { suggestionDataSchema } from '../../../financial-entities/helpers/business-suggestion-data-schema.helper.js';
 import { BusinessesProvider } from '../../../financial-entities/providers/businesses.provider.js';
 import { ChargeTagsProvider } from '../../../tags/providers/charge-tags.provider.js';
@@ -694,10 +695,17 @@ export const chargeSuggestionsResolvers: ChargesModule.Resolvers = {
         throw new GraphQLError('Business ID is required');
       }
 
-      const adminContext = await injector.get(AdminContextProvider).getVerifiedAdminContext();
-
       try {
-        const ownerId = ownerIdInput?.trim() || adminContext.ownerId;
+        // Validate an explicit owner against the read scope (throws if out of
+        // scope); otherwise default to the request's primary business.
+        const trimmedOwnerId = ownerIdInput?.trim();
+        let ownerId: string;
+        if (trimmedOwnerId) {
+          await injector.get(ScopeProvider).getReadScope([trimmedOwnerId]);
+          ownerId = trimmedOwnerId;
+        } else {
+          ownerId = (await injector.get(AdminContextProvider).getVerifiedAdminContext()).ownerId;
+        }
 
         const similarCharges = await injector
           .get(ChargesProvider)

--- a/packages/server/src/modules/green-invoice/resolvers/green-invoice.resolvers.ts
+++ b/packages/server/src/modules/green-invoice/resolvers/green-invoice.resolvers.ts
@@ -2,6 +2,7 @@ import { GraphQLError } from 'graphql';
 import type { _DOLLAR_defs_Document } from '@accounter/green-invoice-graphql';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
 import { GreenInvoiceClientProvider } from '../../app-providers/green-invoice-client.js';
+import { ScopeProvider } from '../../auth/providers/scope.provider.js';
 import { IssuedDocumentsProvider } from '../../documents/providers/issued-documents.provider.js';
 import type {
   IGetAllIssuedDocumentsResult,
@@ -48,9 +49,12 @@ export const greenInvoiceResolvers: GreenInvoiceModule.Resolvers = {
       { ownerId: inputOwnerId, singlePageLimit = true },
       { injector },
     ) => {
-      const adminContext = await injector.get(AdminContextProvider).getVerifiedAdminContext();
-
-      const ownerId = inputOwnerId ?? adminContext.ownerId;
+      // Sync targets a single business: validate an explicit target against
+      // membership; otherwise (incl. blank input) default to the primary business.
+      const trimmedOwnerId = inputOwnerId?.trim();
+      const ownerId = trimmedOwnerId
+        ? await injector.get(ScopeProvider).resolveWriteTarget(trimmedOwnerId)
+        : (await injector.get(AdminContextProvider).getVerifiedAdminContext()).ownerId;
       const greenInvoiceDocuments = await getGreenInvoiceDocuments(injector, !singlePageLimit);
 
       const issuedDocuments = await injector.get(IssuedDocumentsProvider).getAllIssuedDocuments();

--- a/packages/server/src/modules/reports/resolvers/balance-report.resolver.ts
+++ b/packages/server/src/modules/reports/resolvers/balance-report.resolver.ts
@@ -2,6 +2,7 @@ import { GraphQLError } from 'graphql';
 import { Currency } from '../../../shared/enums.js';
 import { dateToTimelessDateString, formatFinancialAmount } from '../../../shared/helpers/index.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { ScopeProvider } from '../../auth/providers/scope.provider.js';
 import { ChargesProvider } from '../../charges/providers/charges.provider.js';
 import { getFinancialAccountByTransactionId } from '../../financial-accounts/helpers/account-by-transaction.helper.js';
 import { FinancialEntitiesProvider } from '../../financial-entities/providers/financial-entities.provider.js';
@@ -11,13 +12,23 @@ import type { ReportsModule } from '../types.js';
 export const balanceReportResolver: ReportsModule.Resolvers = {
   Query: {
     transactionsForBalanceReport: async (_, { fromDate, toDate, ownerId }, { injector }) => {
-      const adminContext = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+      // Per-business report: validate an explicit owner against the read scope
+      // (throws if out of scope); blank/omitted defaults to the primary business.
+      const trimmedOwnerId = ownerId?.trim();
+      let targetOwnerId: string;
+      if (trimmedOwnerId) {
+        await injector.get(ScopeProvider).getReadScope([trimmedOwnerId]);
+        targetOwnerId = trimmedOwnerId;
+      } else {
+        targetOwnerId = (await injector.get(AdminContextProvider).getVerifiedAdminContext())
+          .ownerId;
+      }
 
       try {
         return injector.get(BalanceReportProvider).getNormalizedBalanceTransactions({
           fromDate,
           toDate,
-          ownerId: ownerId ?? adminContext.ownerId,
+          ownerId: targetOwnerId,
         });
       } catch (error) {
         const message = 'Failed to get balance transactions';

--- a/packages/server/src/modules/tags/providers/tags.provider.ts
+++ b/packages/server/src/modules/tags/providers/tags.provider.ts
@@ -109,8 +109,10 @@ export class TagsProvider {
   public async addNewTag(params: IAddNewTagParams) {
     this.clearCache();
 
-    const adminContext = await this.adminContextProvider.getVerifiedAdminContext();
-    return addNewTag.run(reassureOwnerIdExists(params, adminContext.ownerId), this.db);
+    // TODO(multi-business): accept an explicit target business once the addTag
+    // mutation exposes one; today a tag is created for the request's primary business.
+    const { ownerId } = await this.adminContextProvider.getVerifiedAdminContext();
+    return addNewTag.run(reassureOwnerIdExists(params, ownerId), this.db);
   }
 
   public async renameTag(params: IRenameTagParams) {

--- a/packages/server/src/modules/transactions/resolvers/transactions.resolver.ts
+++ b/packages/server/src/modules/transactions/resolvers/transactions.resolver.ts
@@ -3,6 +3,7 @@ import type { Resolvers } from '../../../__generated__/types.js';
 import { EMPTY_UUID } from '../../../shared/constants.js';
 import { formatCurrency } from '../../../shared/helpers/index.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { ScopeProvider } from '../../auth/providers/scope.provider.js';
 import { deleteCharges } from '../../charges/helpers/delete-charges.helper.js';
 import { ChargesProvider } from '../../charges/providers/charges.provider.js';
 import { DocumentsProvider } from '../../documents/providers/documents.provider.js';
@@ -46,12 +47,12 @@ export const transactionsResolvers: TransactionsModule.Resolvers &
       return transactionIDs;
     },
     transactionsByFinancialEntity: async (_, { financialEntityID }, { injector }) => {
-      const adminContext = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+      const ownerIDs = await injector.get(ScopeProvider).getReadScope();
       const transactions = await injector
         .get(TransactionsProvider)
         .getTransactionsByFilters({
           businessIDs: [financialEntityID],
-          ownerIDs: [adminContext.ownerId],
+          ownerIDs,
         })
         .then(res => res.map(t => t.id));
       return transactions;


### PR DESCRIPTION
## Summary

Step 14a of the multi-business migration (Prompt 14a: Remaining Modules). Removes the remaining `adminContext.ownerId` single-business fallbacks across modules the earlier steps didn't cover.

- **transactions**: `transactionsByFinancialEntity` reads now use `ScopeProvider.getReadScope()` instead of `ownerIDs: [adminContext.ownerId]`.
- **green-invoice**: `syncGreenInvoiceDocuments` validates an explicit `ownerId` via `resolveWriteTarget`, defaulting to the primary business when omitted (removes the `?? adminContext.ownerId` fallback).
- **reports / balance-report** (`transactionsForBalanceReport`) and **charges / similarChargesByBusiness**: validate an explicit owner against the read scope, defaulting to the primary.
- **tags**: `addNewTag` no longer references `adminContext.ownerId` directly (still creates for the primary business; an explicit target needs a mutation arg — `TODO` left).

### No change needed (verified)
- **contracts** provider is already `@Injectable({ scope: Scope.Operation })`, so its `adminBusinessIds`-keyed loader is per-request isolated (task 3 already satisfied).
- **charges-matcher** `document-business.helper.ts` takes `adminBusinessId` as a parameter (no direct admin-context read).

Stacked on step 14 (`multi-business-request-14-salaries-admin-context`).

### Remaining for step 15
Two `adminContext.ownerId` references remain in `financial-charges.resolver.ts` and `annual-revenue.resover.ts`, but there `adminContext` is the **validated target** business's context (from steps 11/12), not a fallback. I'll rename those to `targetAdminContext` in step 15 when adding the grep guard, so the guard returns zero.

## Test plan

- [x] `vitest run --project unit` transactions/tags/charges/reports/green-invoice — 583 pass
- [x] `prettier`/`eslint` clean (only pre-existing `no-console` warnings)
- [ ] DB-backed integration / full `tsc` — CI only

https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4KjJ3SghkYEPzWWJrtwCk)_