### PR TITLE
UX: use shadcn date inputs on Balance Charge insertion modal

### DIFF
--- a/packages/client/src/components/common/modals/balance-charge-modal.tsx
+++ b/packages/client/src/components/common/modals/balance-charge-modal.tsx
@@ -293,9 +293,9 @@ function BalanceChargeForm({ onOpenChange }: { onOpenChange: (open: boolean) => 
                             <FormControl>
                               <DatePickerInput
                                 required
-                                value={(field.value as TimelessDateString) ?? undefined}
+                                value={(field.value as TimelessDateString) || undefined}
                                 onChange={(date?: TimelessDateString | null): void => {
-                                  if (date !== field.value) field.onChange(date);
+                                  if (date !== field.value) field.onChange(date ?? undefined);
                                 }}
                                 aria-invalid={!!fieldState.error}
                               />

--- a/packages/client/src/components/common/modals/balance-charge-modal.tsx
+++ b/packages/client/src/components/common/modals/balance-charge-modal.tsx
@@ -1,23 +1,21 @@
 'use client';
 
 import { useCallback } from 'react';
-import { format } from 'date-fns';
 import { Plus, XIcon } from 'lucide-react';
 import { useFieldArray, useForm, type SubmitHandler } from 'react-hook-form';
 import { toast } from 'sonner';
 import z from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Input, Select } from '@mantine/core';
-import { DatePickerInput, DateTimePicker } from '@mantine/dates';
 import { Currency, type GenerateBalanceChargeMutationVariables } from '../../../gql/graphql.js';
-import { TIMELESS_DATE_REGEX } from '../../../helpers/index.js';
+import { TIMELESS_DATE_REGEX, type TimelessDateString } from '../../../helpers/index.js';
 import { useGenerateBalanceCharge } from '../../../hooks/use-balance-charge.js';
 import { useGetFinancialEntities } from '../../../hooks/use-get-financial-entities.js';
 import { Button } from '../../ui/button.js';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../../ui/dialog.js';
 import { Form, FormControl, FormField, FormItem, FormMessage } from '../../ui/form.js';
 import { Label } from '../../ui/label.js';
-import { CurrencyInput } from '../index.js';
+import { CurrencyInput, DatePickerInput, DateTimePickerInput } from '../index.js';
 
 export function BalanceChargeModal({
   open,
@@ -290,46 +288,36 @@ function BalanceChargeForm({ onOpenChange }: { onOpenChange: (open: boolean) => 
                           },
                         }}
                         name={`balanceRecords.${index}.invoiceDate`}
-                        render={({ field: { value, ...field } }) => {
-                          const date = value ? new Date(value) : undefined;
-                          return (
-                            <FormItem>
-                              <FormControl>
-                                <DatePickerInput
-                                  {...field}
-                                  required
-                                  onChange={(date?: Date | string | null): void => {
-                                    const newDate = date
-                                      ? typeof date === 'string'
-                                        ? date
-                                        : format(date, 'yyyy-MM-dd')
-                                      : undefined;
-                                    if (newDate !== value) field.onChange(newDate);
-                                  }}
-                                  value={date}
-                                  valueFormat="DD/MM/YYYY"
-                                />
-                              </FormControl>
-                              <FormMessage />
-                            </FormItem>
-                          );
-                        }}
+                        render={({ field, fieldState }) => (
+                          <FormItem>
+                            <FormControl>
+                              <DatePickerInput
+                                required
+                                value={(field.value as TimelessDateString) ?? undefined}
+                                onChange={(date?: TimelessDateString | null): void => {
+                                  if (date !== field.value) field.onChange(date);
+                                }}
+                                aria-invalid={!!fieldState.error}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
                       />
 
                       <FormField
                         control={control}
                         name={`balanceRecords.${index}.valueDate`}
-                        render={({ field }) => (
+                        render={({ field, fieldState }) => (
                           <FormItem>
                             <FormControl>
-                              <DateTimePicker
-                                {...field}
-                                onPointerEnterCapture={(): void => {}}
-                                onPointerLeaveCapture={(): void => {}}
+                              <DateTimePickerInput
                                 required
-                                placeholder="Value Dates"
-                                valueFormat="DD/MM/YYYY HH:mm:ss"
-                                withSeconds
+                                value={field.value ?? null}
+                                onChange={(date?: Date | null): void => {
+                                  field.onChange(date ?? undefined);
+                                }}
+                                aria-invalid={!!fieldState.error}
                               />
                             </FormControl>
                             <FormMessage />


### PR DESCRIPTION
## Summary

Replaces the legacy Mantine date inputs on the Balance Charge insertion modal with the shadcn-based, user-editable inputs already used elsewhere in the client package.

- `Invoice Date`: `@mantine/dates` `DatePickerInput` → local shadcn `DatePickerInput` (`common/inputs/date-picker-input.tsx`)
- `Value Date`: `@mantine/dates` `DateTimePicker` → local shadcn `DateTimePickerInput` (`common/inputs/date-time-picker-input.tsx`)

These shadcn inputs allow direct text editing of the date (typing `YYYY-MM-DD` / `YYYY-MM-DD HH:mm:ss`) in addition to the calendar popover, matching the pattern used in `modify-misc-expense-fields.tsx`.

The form field types are unchanged: `invoiceDate` stays a `TimelessDateString` and `valueDate` stays a `Date`, so no schema or mutation changes are needed.

Closes #3568

## Test plan

> Note: `yarn install` could not complete in the sandbox because the `xlsx` CDN (`cdn.sheetjs.com`) is blocked by the network policy, so a local build/typecheck was not run. The change mirrors the type-checked usage pattern in `modify-misc-expense-fields.tsx`.

- [ ] Open the Balance Charge modal, add an expense row
- [ ] Verify the Invoice Date field accepts typed `YYYY-MM-DD` input and the calendar popover
- [ ] Verify the Value Date field accepts typed `YYYY-MM-DD HH:mm:ss` input and the calendar + time spinners
- [ ] Submit and confirm the balance charge is generated with the expected dates

https://claude.ai/code/session_019CnQBQmq8H7a4MtmEDYBET

---
_Generated by [Claude Code](https://claude.ai/code/session_019CnQBQmq8H7a4MtmEDYBET)_