### PR TITLE
fix(scraper-app): fix Otsar HaHayal UI progress display bugs

### DIFF
--- a/packages/scraper-app/src/server/websocket.ts
+++ b/packages/scraper-app/src/server/websocket.ts
@@ -157,20 +157,20 @@ function buildTask(
           const insertedTransactions: InsertedTransactionSummary[] = [];
           const changedTransactions: ChangedTransaction[] = [];
 
-          if (acceptedIlsData.length > 0) {
-            const ilsCount = acceptedIlsData.reduce((s, d) => s + d.transactions.length, 0);
+          for (const d of acceptedIlsData) {
+            const accountId = `${d.account.branch}-${d.account.account}`;
             emit({
               type: 'task-account-txns-uploading',
               sourceId: src.id,
-              accountId: 'ils',
+              accountId,
               txnType: 'ils',
-              count: ilsCount,
+              count: d.transactions.length,
             });
-            const r = await uploadClient.uploadOtsarIls(acceptedIlsData);
+            const r = await uploadClient.uploadOtsarIls([d]);
             emit({
               type: 'task-account-txns-done',
               sourceId: src.id,
-              accountId: 'ils',
+              accountId,
               txnType: 'ils',
               inserted: r.inserted,
               skipped: r.skipped,
@@ -182,20 +182,20 @@ function buildTask(
             changedTransactions.push(...(r.changedTransactions ?? []));
           }
 
-          if (acceptedForeignData.length > 0) {
-            const foreignCount = acceptedForeignData.reduce((s, d) => s + d.transactions.length, 0);
+          for (const d of acceptedForeignData) {
+            const accountId = `${d.metadata.branch}-${d.metadata.account}`;
             emit({
               type: 'task-account-txns-uploading',
               sourceId: src.id,
-              accountId: 'foreign',
+              accountId,
               txnType: 'foreign',
-              count: foreignCount,
+              count: d.transactions.length,
             });
-            const rf = await uploadClient.uploadOtsarForeign(acceptedForeignData);
+            const rf = await uploadClient.uploadOtsarForeign([d]);
             emit({
               type: 'task-account-txns-done',
               sourceId: src.id,
-              accountId: 'foreign',
+              accountId,
               txnType: 'foreign',
               inserted: rf.inserted,
               skipped: rf.skipped,

--- a/packages/scraper-app/src/ui/components/task-row.tsx
+++ b/packages/scraper-app/src/ui/components/task-row.tsx
@@ -175,7 +175,17 @@ function AccountStepsTable({ steps }: { steps: AccountStep[] }) {
   );
 }
 
-function TaskSteps({ steps, status }: { steps: MonthStep[] | AccountStep[]; status: string }) {
+function CollapsibleSection({
+  label,
+  count,
+  status,
+  children,
+}: {
+  label: string;
+  count: number;
+  status: string;
+  children: React.ReactNode;
+}) {
   const [collapsed, setCollapsed] = useState(false);
 
   useEffect(() => {
@@ -184,9 +194,7 @@ function TaskSteps({ steps, status }: { steps: MonthStep[] | AccountStep[]; stat
     }
   }, [status]);
 
-  if (steps.length === 0) return null;
-
-  const isAccountSteps = 'accountId' in steps[0]!;
+  if (count === 0) return null;
 
   return (
     <div style={{ marginTop: 4 }}>
@@ -205,17 +213,9 @@ function TaskSteps({ steps, status }: { steps: MonthStep[] | AccountStep[]; stat
           gap: 4,
         }}
       >
-        {collapsed ? '▸' : '▾'} {isAccountSteps ? 'Accounts' : 'Months'} ({steps.length})
+        {collapsed ? '▸' : '▾'} {label} ({count})
       </button>
-      {!collapsed && (
-        <div style={{ paddingLeft: 4 }}>
-          {isAccountSteps ? (
-            <AccountStepsTable steps={steps as AccountStep[]} />
-          ) : (
-            <MonthStepsTable steps={steps as MonthStep[]} />
-          )}
-        </div>
-      )}
+      {!collapsed && <div style={{ paddingLeft: 4 }}>{children}</div>}
     </div>
   );
 }
@@ -303,8 +303,15 @@ export function TaskRow({
         )}
       </div>
 
-      {state.steps && state.steps.length > 0 && (
-        <TaskSteps steps={state.steps} status={state.status} />
+      {(state.accountSteps?.length ?? 0) > 0 && (
+        <CollapsibleSection label="Accounts" count={state.accountSteps!.length} status={state.status}>
+          <AccountStepsTable steps={state.accountSteps!} />
+        </CollapsibleSection>
+      )}
+      {(state.monthSteps?.length ?? 0) > 0 && (
+        <CollapsibleSection label="Months" count={state.monthSteps!.length} status={state.status}>
+          <MonthStepsTable steps={state.monthSteps!} />
+        </CollapsibleSection>
       )}
 
       {state.status === 'error' && expanded && (

--- a/packages/scraper-app/src/ui/lib/ws.ts
+++ b/packages/scraper-app/src/ui/lib/ws.ts
@@ -57,7 +57,8 @@ export type TaskState = {
   otpSourceId?: string;
   insertedTransactions?: InsertedTransactionSummary[];
   changedTransactions?: ChangedTransaction[];
-  steps?: MonthStep[] | AccountStep[];
+  accountSteps?: AccountStep[];
+  monthSteps?: MonthStep[];
 };
 
 export type RunStatus = 'idle' | 'running' | 'complete';
@@ -108,15 +109,6 @@ function updateAccountStep(
   return steps.map(s => (s.accountId === accountId ? { ...s, ...patch } : s));
 }
 
-function asMonthSteps(steps: MonthStep[] | AccountStep[] | undefined): MonthStep[] {
-  if (!steps || (steps.length > 0 && 'accountId' in steps[0]!)) return [];
-  return steps as MonthStep[];
-}
-
-function asAccountSteps(steps: MonthStep[] | AccountStep[] | undefined): AccountStep[] {
-  if (!steps || (steps.length > 0 && 'month' in steps[0]!)) return [];
-  return steps as AccountStep[];
-}
 
 export function useRunSocket(): UseRunSocketResult {
   const [taskStates, setTaskStates] = useState<Map<string, TaskState>>(new Map());
@@ -181,21 +173,21 @@ export function useRunSocket(): UseRunSocketResult {
           // ── Per-month progress ─────────────────────────────────────────────
           case 'task-month-fetching': {
             const state = get(msg.sourceId);
-            const monthSteps = asMonthSteps(state.steps);
+            const monthSteps = state.monthSteps ?? [];
             const [updated] = findOrCreateMonthStep(monthSteps, msg.month);
             next.set(msg.sourceId, {
               ...state,
-              steps: updateMonthStep(updated, msg.month, { phase: 'fetching' }),
+              monthSteps: updateMonthStep(updated, msg.month, { phase: 'fetching' }),
             });
             break;
           }
           case 'task-month-fetched': {
             const state = get(msg.sourceId);
-            const monthSteps = asMonthSteps(state.steps);
+            const monthSteps = state.monthSteps ?? [];
             const [updated] = findOrCreateMonthStep(monthSteps, msg.month);
             next.set(msg.sourceId, {
               ...state,
-              steps: updateMonthStep(updated, msg.month, {
+              monthSteps: updateMonthStep(updated, msg.month, {
                 phase: 'fetched',
                 transactionCount: msg.transactionCount,
               }),
@@ -204,21 +196,21 @@ export function useRunSocket(): UseRunSocketResult {
           }
           case 'task-month-error': {
             const state = get(msg.sourceId);
-            const monthSteps = asMonthSteps(state.steps);
+            const monthSteps = state.monthSteps ?? [];
             const [updated] = findOrCreateMonthStep(monthSteps, msg.month);
             next.set(msg.sourceId, {
               ...state,
-              steps: updateMonthStep(updated, msg.month, { phase: 'error', error: msg.error }),
+              monthSteps: updateMonthStep(updated, msg.month, { phase: 'error', error: msg.error }),
             });
             break;
           }
           case 'task-month-uploading': {
             const state = get(msg.sourceId);
-            const monthSteps = asMonthSteps(state.steps);
+            const monthSteps = state.monthSteps ?? [];
             const [updated] = findOrCreateMonthStep(monthSteps, msg.month);
             next.set(msg.sourceId, {
               ...state,
-              steps: updateMonthStep(updated, msg.month, {
+              monthSteps: updateMonthStep(updated, msg.month, {
                 phase: 'uploading',
                 transactionCount: msg.transactionCount,
               }),
@@ -227,11 +219,11 @@ export function useRunSocket(): UseRunSocketResult {
           }
           case 'task-month-uploaded': {
             const state = get(msg.sourceId);
-            const monthSteps = asMonthSteps(state.steps);
+            const monthSteps = state.monthSteps ?? [];
             const [updated] = findOrCreateMonthStep(monthSteps, msg.month);
             next.set(msg.sourceId, {
               ...state,
-              steps: updateMonthStep(updated, msg.month, {
+              monthSteps: updateMonthStep(updated, msg.month, {
                 phase: 'uploaded',
                 inserted: msg.inserted,
                 skipped: msg.skipped,
@@ -240,54 +232,54 @@ export function useRunSocket(): UseRunSocketResult {
             break;
           }
 
-          // ── Per-account progress (Poalim) ──────────────────────────────────
+          // ── Per-account progress (Poalim / Otsar HaHayal) ─────────────────
           case 'task-accounts-found': {
             const state = get(msg.sourceId);
-            const steps: AccountStep[] = msg.accounts.map(a => ({
+            const accountSteps: AccountStep[] = msg.accounts.map(a => ({
               accountId: `${a.branchNumber}-${a.accountNumber}`,
             }));
-            next.set(msg.sourceId, { ...state, steps });
+            next.set(msg.sourceId, { ...state, accountSteps });
             break;
           }
           case 'task-account-vault-checked': {
             const state = get(msg.sourceId);
-            const accountSteps = asAccountSteps(state.steps);
+            const accountSteps = state.accountSteps ?? [];
             const [updated] = findOrCreateAccountStep(accountSteps, msg.accountId);
             next.set(msg.sourceId, {
               ...state,
-              steps: updateAccountStep(updated, msg.accountId, { vaultStatus: msg.status }),
+              accountSteps: updateAccountStep(updated, msg.accountId, { vaultStatus: msg.status }),
             });
             break;
           }
           case 'task-account-txns-fetching': {
             const state = get(msg.sourceId);
-            const accountSteps = asAccountSteps(state.steps);
+            const accountSteps = state.accountSteps ?? [];
             const [updated, step] = findOrCreateAccountStep(accountSteps, msg.accountId);
             const txnPatch: Partial<AccountStep> = {
               [msg.txnType]: { phase: 'fetching' as const },
             };
             next.set(msg.sourceId, {
               ...state,
-              steps: updateAccountStep(updated, msg.accountId, { ...step, ...txnPatch }),
+              accountSteps: updateAccountStep(updated, msg.accountId, { ...step, ...txnPatch }),
             });
             break;
           }
           case 'task-account-txns-uploading': {
             const state = get(msg.sourceId);
-            const accountSteps = asAccountSteps(state.steps);
+            const accountSteps = state.accountSteps ?? [];
             const [updated, step] = findOrCreateAccountStep(accountSteps, msg.accountId);
             const txnPatch: Partial<AccountStep> = {
               [msg.txnType]: { phase: 'uploading' as const, count: msg.count },
             };
             next.set(msg.sourceId, {
               ...state,
-              steps: updateAccountStep(updated, msg.accountId, { ...step, ...txnPatch }),
+              accountSteps: updateAccountStep(updated, msg.accountId, { ...step, ...txnPatch }),
             });
             break;
           }
           case 'task-account-txns-done': {
             const state = get(msg.sourceId);
-            const accountSteps = asAccountSteps(state.steps);
+            const accountSteps = state.accountSteps ?? [];
             const [updated, step] = findOrCreateAccountStep(accountSteps, msg.accountId);
             const txnPatch: Partial<AccountStep> = {
               [msg.txnType]: {
@@ -298,7 +290,7 @@ export function useRunSocket(): UseRunSocketResult {
             };
             next.set(msg.sourceId, {
               ...state,
-              steps: updateAccountStep(updated, msg.accountId, { ...step, ...txnPatch }),
+              accountSteps: updateAccountStep(updated, msg.accountId, { ...step, ...txnPatch }),
             });
             break;
           }


### PR DESCRIPTION
## Summary

- **Bug 1 (credit cards override bank accounts):** `TaskState.steps` was a single union field (`MonthStep[] | AccountStep[]`). When credit card month-step events arrived after bank account steps were populated, `asMonthSteps()` returned `[]` (because the existing steps were `AccountStep[]`), then overwrote them with month steps. Fixed by splitting into two separate fields: `accountSteps?: AccountStep[]` and `monthSteps?: MonthStep[]` — they now accumulate independently.

- **Bug 2 (ILS/foreign batched as fake rows):** The Otsar HaHayal upload was sending all ILS accounts in one batch with `accountId: 'ils'` and all foreign accounts with `accountId: 'foreign'`, creating new fake rows instead of updating the existing per-account rows. Fixed by looping over each account individually and emitting the real `accountId` (`branch-account`), uploading one account at a time.

## Changes

- `ws.ts` — Split `steps` into `accountSteps` / `monthSteps`; removed the now-unnecessary `asMonthSteps` / `asAccountSteps` helpers
- `task-row.tsx` — Replaced `TaskSteps` with a generic `CollapsibleSection`; render both `accountSteps` and `monthSteps` independently so both are visible when a source has both (e.g. Otsar HaHayal)
- `websocket.ts` — Loop per-account for Otsar ILS and foreign uploads, using the real account ID in each emit

## Test plan

- [ ] Run Otsar HaHayal scrape and confirm bank account rows remain visible after credit card phase completes
- [ ] Confirm ILS/foreign progress updates appear on each account's own row (not as separate "ils"/"foreign" rows)
- [ ] Confirm credit card month rows appear in a separate collapsible "Months" section below the "Accounts" section

https://claude.ai/code/session_01HJLSNC3MQVTibXpXgohX5s

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJLSNC3MQVTibXpXgohX5s)_