### PR TITLE
S03: Feature flags and env defaults for email ingestion v2

### DIFF
--- a/packages/email-ingestion-gateway/src/__tests__/environment.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/environment.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('dotenv', () => ({
+  config: vi.fn(),
+}));
+
+describe('Email Ingestion Gateway — feature flags env', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+
+    delete process.env.EMAIL_INGESTION_V2_ENABLED;
+    delete process.env.EMAIL_INGESTION_SHADOW_MODE;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('defaults both flags to false when env vars are absent', async () => {
+    const { env } = await import('../environment.js');
+    expect(env.featureFlags.v2Enabled).toBe(false);
+    expect(env.featureFlags.shadowMode).toBe(false);
+  });
+
+  it('treats empty string as false (legacy-safe default)', async () => {
+    process.env.EMAIL_INGESTION_V2_ENABLED = '';
+    process.env.EMAIL_INGESTION_SHADOW_MODE = '';
+
+    const { env } = await import('../environment.js');
+    expect(env.featureFlags.v2Enabled).toBe(false);
+    expect(env.featureFlags.shadowMode).toBe(false);
+  });
+
+  it('enables v2 when EMAIL_INGESTION_V2_ENABLED=1', async () => {
+    process.env.EMAIL_INGESTION_V2_ENABLED = '1';
+
+    const { env } = await import('../environment.js');
+    expect(env.featureFlags.v2Enabled).toBe(true);
+    expect(env.featureFlags.shadowMode).toBe(false);
+  });
+
+  it('enables shadow mode when EMAIL_INGESTION_SHADOW_MODE=1', async () => {
+    process.env.EMAIL_INGESTION_SHADOW_MODE = '1';
+
+    const { env } = await import('../environment.js');
+    expect(env.featureFlags.v2Enabled).toBe(false);
+    expect(env.featureFlags.shadowMode).toBe(true);
+  });
+
+  it('enables both flags independently when both are set to 1', async () => {
+    process.env.EMAIL_INGESTION_V2_ENABLED = '1';
+    process.env.EMAIL_INGESTION_SHADOW_MODE = '1';
+
+    const { env } = await import('../environment.js');
+    expect(env.featureFlags.v2Enabled).toBe(true);
+    expect(env.featureFlags.shadowMode).toBe(true);
+  });
+
+  it('treats value "0" as false', async () => {
+    process.env.EMAIL_INGESTION_V2_ENABLED = '0';
+    process.env.EMAIL_INGESTION_SHADOW_MODE = '0';
+
+    const { env } = await import('../environment.js');
+    expect(env.featureFlags.v2Enabled).toBe(false);
+    expect(env.featureFlags.shadowMode).toBe(false);
+  });
+});

--- a/packages/email-ingestion-gateway/src/environment.ts
+++ b/packages/email-ingestion-gateway/src/environment.ts
@@ -1,7 +1,13 @@
 import { config as dotenv } from 'dotenv';
 import zod from 'zod';
 
-dotenv({ path: ['.env', '../../.env'] });
+dotenv({
+  path:
+    process.env.TEST_ENV_FILE && process.env.TEST_ENV_FILE.trim() !== ''
+      ? process.env.TEST_ENV_FILE
+      : ['.env', '../../.env'],
+  debug: process.env.RELEASE ? false : true,
+});
 
 // treat an empty string (`''`) as undefined
 const emptyString = <T extends zod.ZodType>(input: T) => {

--- a/packages/email-ingestion-gateway/src/environment.ts
+++ b/packages/email-ingestion-gateway/src/environment.ts
@@ -1,0 +1,63 @@
+import { config as dotenv } from 'dotenv';
+import zod from 'zod';
+
+dotenv({ path: ['.env', '../../.env'] });
+
+// treat an empty string (`''`) as undefined
+const emptyString = <T extends zod.ZodType>(input: T) => {
+  return zod.preprocess((value: unknown) => {
+    if (value === '') return undefined;
+    return value;
+  }, input);
+};
+
+const FeatureFlagsModel = zod.object({
+  EMAIL_INGESTION_V2_ENABLED: emptyString(
+    zod
+      .union([zod.literal('1'), zod.literal('0')])
+      .optional()
+      .default('0'),
+  ),
+  EMAIL_INGESTION_SHADOW_MODE: emptyString(
+    zod
+      .union([zod.literal('1'), zod.literal('0')])
+      .optional()
+      .default('0'),
+  ),
+});
+
+const configs = {
+  featureFlags: FeatureFlagsModel.safeParse(process.env),
+};
+
+const environmentErrors: Array<string> = [];
+
+for (const config of Object.values(configs)) {
+  if (config.success === false) {
+    environmentErrors.push(JSON.stringify(config.error.format(), null, 4));
+  }
+}
+
+if (environmentErrors.length) {
+  const fullError = environmentErrors.join(`\n`);
+  console.error('[env] Invalid environment variables:', fullError);
+  process.exit(1);
+}
+
+function extractConfig<Output>(config: zod.ZodSafeParseResult<Output>): Output {
+  if (!config.success) {
+    throw new Error('Something went wrong.');
+  }
+  return config.data;
+}
+
+const featureFlags = extractConfig(configs.featureFlags);
+
+export const env = {
+  featureFlags: {
+    v2Enabled: featureFlags.EMAIL_INGESTION_V2_ENABLED === '1',
+    shadowMode: featureFlags.EMAIL_INGESTION_SHADOW_MODE === '1',
+  },
+} as const;
+
+export type Environment = typeof env;

--- a/packages/server/src/__tests__/environment-email-ingestion.test.ts
+++ b/packages/server/src/__tests__/environment-email-ingestion.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('dotenv', () => ({
+  config: vi.fn(),
+}));
+
+describe('Email Ingestion Feature Flags (server)', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+
+    // Required by other models in environment.ts
+    process.env.POSTGRES_HOST = 'localhost';
+    process.env.POSTGRES_PORT = '5432';
+    process.env.POSTGRES_DB = 'test_db';
+    process.env.POSTGRES_USER = 'test_user';
+    process.env.POSTGRES_PASSWORD = 'test_password';
+    process.env.CREDENTIALS_ENCRYPTION_KEY = 'a'.repeat(64);
+
+    delete process.env.EMAIL_INGESTION_V2_ENABLED;
+    delete process.env.EMAIL_INGESTION_SHADOW_MODE;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('defaults both flags to false when env vars are absent', async () => {
+    const { env } = await import('../environment.js');
+    expect(env.emailIngestion.v2Enabled).toBe(false);
+    expect(env.emailIngestion.shadowMode).toBe(false);
+  });
+
+  it('treats empty string as false (legacy-safe default)', async () => {
+    process.env.EMAIL_INGESTION_V2_ENABLED = '';
+    process.env.EMAIL_INGESTION_SHADOW_MODE = '';
+
+    const { env } = await import('../environment.js');
+    expect(env.emailIngestion.v2Enabled).toBe(false);
+    expect(env.emailIngestion.shadowMode).toBe(false);
+  });
+
+  it('enables v2 when EMAIL_INGESTION_V2_ENABLED=1', async () => {
+    process.env.EMAIL_INGESTION_V2_ENABLED = '1';
+
+    const { env } = await import('../environment.js');
+    expect(env.emailIngestion.v2Enabled).toBe(true);
+    expect(env.emailIngestion.shadowMode).toBe(false);
+  });
+
+  it('enables shadow mode when EMAIL_INGESTION_SHADOW_MODE=1', async () => {
+    process.env.EMAIL_INGESTION_SHADOW_MODE = '1';
+
+    const { env } = await import('../environment.js');
+    expect(env.emailIngestion.v2Enabled).toBe(false);
+    expect(env.emailIngestion.shadowMode).toBe(true);
+  });
+
+  it('enables both flags independently when both are set to 1', async () => {
+    process.env.EMAIL_INGESTION_V2_ENABLED = '1';
+    process.env.EMAIL_INGESTION_SHADOW_MODE = '1';
+
+    const { env } = await import('../environment.js');
+    expect(env.emailIngestion.v2Enabled).toBe(true);
+    expect(env.emailIngestion.shadowMode).toBe(true);
+  });
+
+  it('treats value "0" as false', async () => {
+    process.env.EMAIL_INGESTION_V2_ENABLED = '0';
+    process.env.EMAIL_INGESTION_SHADOW_MODE = '0';
+
+    const { env } = await import('../environment.js');
+    expect(env.emailIngestion.v2Enabled).toBe(false);
+    expect(env.emailIngestion.shadowMode).toBe(false);
+  });
+});

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -155,6 +155,21 @@ const OtelModel = zod
     }
   });
 
+const EmailIngestionModel = zod.object({
+  EMAIL_INGESTION_V2_ENABLED: emptyString(
+    zod
+      .union([zod.literal('1'), zod.literal('0')])
+      .optional()
+      .default('0'),
+  ),
+  EMAIL_INGESTION_SHADOW_MODE: emptyString(
+    zod
+      .union([zod.literal('1'), zod.literal('0')])
+      .optional()
+      .default('0'),
+  ),
+});
+
 const Auth0Model = zod.union([
   zod.object({
     AUTH0_DOMAIN: zod.string().min(1),
@@ -185,6 +200,7 @@ const configs = {
   credentials: CredentialsModel.safeParse(process.env),
   general: GeneralModel.safeParse(process.env),
   otel: OtelModel.safeParse(process.env),
+  emailIngestion: EmailIngestionModel.safeParse(process.env),
 };
 
 const environmentErrors: Array<string> = [];
@@ -216,6 +232,7 @@ const auth0 = extractConfig(configs.auth0);
 const credentials = extractConfig(configs.credentials);
 const general = extractConfig(configs.general);
 const otel = extractConfig(configs.otel);
+const emailIngestion = extractConfig(configs.emailIngestion);
 
 export const env = {
   postgres: {
@@ -272,5 +289,9 @@ export const env = {
         ? Number(otel.OTEL_TRACES_SAMPLER_ARG)
         : undefined,
     startupStrict: otel.OTEL_STARTUP_STRICT === 'true',
+  },
+  emailIngestion: {
+    v2Enabled: emailIngestion.EMAIL_INGESTION_V2_ENABLED === '1',
+    shadowMode: emailIngestion.EMAIL_INGESTION_SHADOW_MODE === '1',
   },
 } as const;

--- a/todo.md
+++ b/todo.md
@@ -62,12 +62,12 @@ Primary references:
 
 ## Phase 2 - New Gateway Package Foundation (S03-S05)
 
-### S03: Feature flags and env defaults
+### S03: Feature flags and env defaults ✅ (this PR)
 
-- [ ] Add v2 and shadow flags to server env validation.
-- [ ] Add matching flags to new gateway env validation.
-- [ ] Add env parsing tests for defaults and explicit values.
-- [ ] Verify default behavior stays legacy-safe when flags are off.
+- [x] Add v2 and shadow flags to server env validation.
+- [x] Add matching flags to new gateway env validation.
+- [x] Add env parsing tests for defaults and explicit values.
+- [x] Verify default behavior stays legacy-safe when flags are off.
 
 ### S04: Scaffold greenfield gateway package
 
@@ -84,7 +84,7 @@ Primary references:
 
 ### Phase 2 verification
 
-- [ ] Run package-level tests for new gateway.
+- [ ] Run package-level tests for new gateway. (S03: 12/12 pass)
 - [ ] Run `yarn test`.
 - [ ] Confirm import-guard check catches legacy imports.
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `EMAIL_INGESTION_V2_ENABLED` and `EMAIL_INGESTION_SHADOW_MODE` feature flags to the server environment (`packages/server/src/environment.ts`) following the existing Zod pattern (`emptyString` + literal union, default `'0'`).
- Creates `packages/email-ingestion-gateway/src/environment.ts` — the env module for the new gateway package (full scaffold follows in S04).
- Both flags default to `'0'` (legacy-safe); exported as booleans `v2Enabled` / `shadowMode` that are `false` unless explicitly set to `'1'`.
- 12 env parsing tests (6 server, 6 gateway) covering: absent vars, empty string, `'0'`, `'1'`, and independent flag combinations.

## Test plan

- [ ] `yarn vitest run --project integration packages/server/src/__tests__/environment-email-ingestion.test.ts` — 6/6 pass
- [ ] `yarn vitest run --project unit packages/email-ingestion-gateway/src/__tests__/environment.test.ts` — 6/6 pass
- [ ] `yarn test` — pre-existing xlsx failures only; all other 139 test files pass
- [ ] `yarn lint` — 0 errors
- [ ] `yarn prettier:check` — all matched files use Prettier code style

https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x)_