### PR TITLE
S04: scaffold email-ingestion-gateway package

### DIFF
--- a/packages/email-ingestion-gateway/package.json
+++ b/packages/email-ingestion-gateway/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@accounter/email-ingestion-gateway",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "Cloudflare Email to Server ingestion gateway for multi-tenant email document ingestion",
+  "private": true,
+  "engines": {
+    "node": "26.3.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "dotenv": "17.4.2",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "25.9.2",
+    "tsx": "4.22.4",
+    "typescript": "6.0.3"
+  }
+}

--- a/packages/email-ingestion-gateway/src/__tests__/environment.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/environment.test.ts
@@ -68,3 +68,34 @@ describe('Email Ingestion Gateway — feature flags env', () => {
     expect(env.featureFlags.shadowMode).toBe(false);
   });
 });
+
+describe('Email Ingestion Gateway — general env', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.PORT;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('defaults port to 3000 when PORT is absent', async () => {
+    const { env } = await import('../environment.js');
+    expect(env.general.port).toBe(3000);
+  });
+
+  it('treats empty string PORT as default 3000', async () => {
+    process.env.PORT = '';
+    const { env } = await import('../environment.js');
+    expect(env.general.port).toBe(3000);
+  });
+
+  it('parses an explicit PORT value', async () => {
+    process.env.PORT = '4001';
+    const { env } = await import('../environment.js');
+    expect(env.general.port).toBe(4001);
+  });
+});

--- a/packages/email-ingestion-gateway/src/__tests__/server.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/server.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ServerResponse } from 'node:http';
+
+vi.mock('dotenv', () => ({ config: vi.fn() }));
+
+const { routes, sendJson } = await import('../index.js');
+
+describe('sendJson', () => {
+  it('writes status code and JSON body', () => {
+    const res = { writeHead: vi.fn(), end: vi.fn() } as unknown as ServerResponse;
+    sendJson(res, 201, { id: 'abc' });
+    expect(res.writeHead).toHaveBeenCalledWith(201, { 'Content-Type': 'application/json' });
+    expect(res.end).toHaveBeenCalledWith('{"id":"abc"}');
+  });
+});
+
+describe('GET /health', () => {
+  it('returns 200 with { status: "ok" }', () => {
+    const res = { writeHead: vi.fn(), end: vi.fn() } as unknown as ServerResponse;
+    routes.GET['/health']({} as never, res);
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
+    expect(res.end).toHaveBeenCalledWith('{"status":"ok"}');
+  });
+});
+
+describe('unknown route', () => {
+  it('is not present in the routes table', () => {
+    expect(routes.GET['/unknown']).toBeUndefined();
+    expect(routes.POST).toBeUndefined();
+  });
+});

--- a/packages/email-ingestion-gateway/src/environment.ts
+++ b/packages/email-ingestion-gateway/src/environment.ts
@@ -17,6 +17,10 @@ const emptyString = <T extends zod.ZodType>(input: T) => {
   }, input);
 };
 
+const GeneralModel = zod.object({
+  PORT: emptyString(zod.coerce.number().optional().default(3000)),
+});
+
 const FeatureFlagsModel = zod.object({
   EMAIL_INGESTION_V2_ENABLED: emptyString(
     zod
@@ -33,6 +37,7 @@ const FeatureFlagsModel = zod.object({
 });
 
 const configs = {
+  general: GeneralModel.safeParse(process.env),
   featureFlags: FeatureFlagsModel.safeParse(process.env),
 };
 
@@ -57,9 +62,13 @@ function extractConfig<Output>(config: zod.ZodSafeParseResult<Output>): Output {
   return config.data;
 }
 
+const general = extractConfig(configs.general);
 const featureFlags = extractConfig(configs.featureFlags);
 
 export const env = {
+  general: {
+    port: general.PORT,
+  },
   featureFlags: {
     v2Enabled: featureFlags.EMAIL_INGESTION_V2_ENABLED === '1',
     shadowMode: featureFlags.EMAIL_INGESTION_SHADOW_MODE === '1',

--- a/packages/email-ingestion-gateway/src/index.ts
+++ b/packages/email-ingestion-gateway/src/index.ts
@@ -1,0 +1,44 @@
+/* eslint-disable no-console */
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { env } from './environment.js';
+import type { HealthResponse, JsonObject } from './types.js';
+
+const PORT = env.general.port;
+
+export function sendJson(res: ServerResponse, statusCode: number, data: JsonObject): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+export const routes: Record<
+  string,
+  Record<string, (req: IncomingMessage, res: ServerResponse) => void>
+> = {
+  GET: {
+    '/health': (_req, res) => {
+      const body: HealthResponse = { status: 'ok' };
+      sendJson(res, 200, body);
+    },
+  },
+};
+
+export const server = createServer((req, res) => {
+  const url = new URL(req.url ?? '/', `http://localhost:${PORT}`);
+  const handler = routes[req.method ?? '']?.[url.pathname];
+  if (handler) {
+    try {
+      handler(req, res);
+    } catch (err) {
+      console.error('[gateway] Unhandled request error:', err);
+      sendJson(res, 500, { error: 'Internal server error' });
+    }
+  } else {
+    sendJson(res, 404, { error: 'Not found' });
+  }
+});
+
+if (process.env.NODE_ENV !== 'test') {
+  server.listen(PORT, () => {
+    console.log(`[email-ingestion-gateway] Listening on port ${PORT}`);
+  });
+}

--- a/packages/email-ingestion-gateway/src/index.ts
+++ b/packages/email-ingestion-gateway/src/index.ts
@@ -12,7 +12,7 @@ export function sendJson(res: ServerResponse, statusCode: number, data: JsonObje
 
 export const routes: Record<
   string,
-  Record<string, (req: IncomingMessage, res: ServerResponse) => void>
+  Record<string, (req: IncomingMessage, res: ServerResponse) => void | Promise<void>>
 > = {
   GET: {
     '/health': (_req, res) => {
@@ -22,18 +22,18 @@ export const routes: Record<
   },
 };
 
-export const server = createServer((req, res) => {
-  const url = new URL(req.url ?? '/', `http://localhost:${PORT}`);
-  const handler = routes[req.method ?? '']?.[url.pathname];
-  if (handler) {
-    try {
-      handler(req, res);
-    } catch (err) {
-      console.error('[gateway] Unhandled request error:', err);
-      sendJson(res, 500, { error: 'Internal server error' });
+export const server = createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url ?? '/', `http://localhost:${PORT}`);
+    const handler = routes[req.method ?? '']?.[url.pathname];
+    if (handler) {
+      await handler(req, res);
+    } else {
+      sendJson(res, 404, { error: 'Not found' });
     }
-  } else {
-    sendJson(res, 404, { error: 'Not found' });
+  } catch (err) {
+    console.error('[gateway] Unhandled request error:', err);
+    sendJson(res, 500, { error: 'Internal server error' });
   }
 });
 

--- a/packages/email-ingestion-gateway/src/types.ts
+++ b/packages/email-ingestion-gateway/src/types.ts
@@ -1,0 +1,7 @@
+export type { Environment } from './environment.js';
+
+export type JsonObject = Record<string, unknown>;
+
+export interface HealthResponse {
+  status: 'ok';
+}

--- a/packages/email-ingestion-gateway/tsconfig.json
+++ b/packages/email-ingestion-gateway/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "ES2022",
+    "target": "ES2022",
+    "strict": true,
+    "sourceMap": true,
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/todo.md
+++ b/todo.md
@@ -69,12 +69,12 @@ Primary references:
 - [x] Add env parsing tests for defaults and explicit values.
 - [x] Verify default behavior stays legacy-safe when flags are off.
 
-### S04: Scaffold greenfield gateway package
+### S04: Scaffold greenfield gateway package ✅ (this PR)
 
-- [ ] Create `packages/email-ingestion-gateway` package scaffold.
-- [ ] Add package scripts, tsconfig, entrypoint, and baseline types.
-- [ ] Add independent env module and health endpoint.
-- [ ] Ensure workspace build/test scripts include new package.
+- [x] Create `packages/email-ingestion-gateway` package scaffold.
+- [x] Add package scripts, tsconfig, entrypoint, and baseline types.
+- [x] Add independent env module and health endpoint.
+- [x] Ensure workspace build/test scripts include new package.
 
 ### S05: Gateway runtime baseline
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,6 +136,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@accounter/email-ingestion-gateway@workspace:packages/email-ingestion-gateway":
+  version: 0.0.0-use.local
+  resolution: "@accounter/email-ingestion-gateway@workspace:packages/email-ingestion-gateway"
+  dependencies:
+    "@types/node": "npm:25.9.2"
+    dotenv: "npm:17.4.2"
+    tsx: "npm:4.22.4"
+    typescript: "npm:6.0.3"
+    zod: "npm:4.4.3"
+  languageName: unknown
+  linkType: soft
+
 "@accounter/etana-scraper@workspace:packages/etana-scraper":
   version: 0.0.0-use.local
   resolution: "@accounter/etana-scraper@workspace:packages/etana-scraper"


### PR DESCRIPTION
## Summary

- Creates `packages/email-ingestion-gateway` as a standalone, greenfield ESM service package (no runtime sharing with `packages/gmail-listener`).
- **`package.json`** — `@accounter/email-ingestion-gateway`, `type: module`, `private: true`. Picked up automatically by the `packages/*` workspace glob; no root config changes needed.
- **`tsconfig.json`** — extends root tsconfig, compiles `src/` → `dist/`.
- **`src/environment.ts`** — extends the S03 feature-flag env with a `GeneralModel` adding `PORT` (default `3000`).
- **`src/types.ts`** — re-exports `Environment`; defines baseline `JsonObject` and `HealthResponse` types.
- **`src/index.ts`** — minimal Node `http.createServer` with an unauthenticated `GET /health` returning `{"status":"ok"}`. `server.listen` is gated on `NODE_ENV !== 'test'` so tests import safely.

## Test plan

- [ ] `yarn vitest run --project unit packages/email-ingestion-gateway/src/__tests__/` — 12/12 pass (9 env + 3 server)
- [ ] `yarn test` — 140 files pass (pre-existing xlsx failures unchanged)
- [ ] `yarn lint` — 0 errors
- [ ] `yarn prettier:check` — all matched files use Prettier code style

https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x)_