### PR TITLE
S06: canonical ingest outcomes and reason codes

### DIFF
--- a/packages/email-ingestion-gateway/src/__tests__/contracts.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/contracts.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { IngestOutcome, IngestReasonCode } from '../contracts.js';
+
+// ---------------------------------------------------------------------------
+// Completeness guards — these tests fail if a code is removed or renamed.
+// ---------------------------------------------------------------------------
+
+describe('IngestOutcome', () => {
+  it('defines all required outcome values', () => {
+    expect(IngestOutcome.INSERTED).toBe('inserted');
+    expect(IngestOutcome.DUPLICATE).toBe('duplicate');
+    expect(IngestOutcome.QUARANTINED).toBe('quarantined');
+    expect(IngestOutcome.REJECTED).toBe('rejected');
+  });
+
+  it('has exactly four outcomes', () => {
+    expect(Object.keys(IngestOutcome)).toHaveLength(4);
+  });
+
+  it('all values are non-empty strings', () => {
+    for (const value of Object.values(IngestOutcome)) {
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('IngestReasonCode', () => {
+  const REQUIRED_CODES = [
+    'UNKNOWN_ALIAS',
+    'INVALID_AUTH',
+    'REPLAY_DETECTED',
+    'GRANT_INVALID',
+    'TENANT_MISMATCH',
+    'NO_DOCUMENTS',
+    'PARSE_ERROR',
+    'OVERSIZE_MESSAGE',
+    'TIMEOUT',
+    'TRANSIENT_UPSTREAM',
+  ] as const;
+
+  it.each(REQUIRED_CODES)('defines %s', code => {
+    expect(IngestReasonCode[code]).toBe(code);
+  });
+
+  it('has exactly ten reason codes', () => {
+    expect(Object.keys(IngestReasonCode)).toHaveLength(10);
+  });
+
+  it('all keys equal their values (self-referential constants)', () => {
+    for (const [key, value] of Object.entries(IngestReasonCode)) {
+      expect(key).toBe(value);
+    }
+  });
+
+  it('all values are non-empty strings', () => {
+    for (const value of Object.values(IngestReasonCode)) {
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/email-ingestion-gateway/src/contracts.ts
+++ b/packages/email-ingestion-gateway/src/contracts.ts
@@ -1,0 +1,30 @@
+/**
+ * Canonical outcome and reason-code constants for the email-ingestion gateway.
+ *
+ * Intentionally duplicated from the server package — no runtime import between
+ * packages. Parity is enforced by the parallel test suites in each package.
+ */
+
+export const IngestOutcome = {
+  INSERTED: 'inserted',
+  DUPLICATE: 'duplicate',
+  QUARANTINED: 'quarantined',
+  REJECTED: 'rejected',
+} as const;
+
+export type IngestOutcome = (typeof IngestOutcome)[keyof typeof IngestOutcome];
+
+export const IngestReasonCode = {
+  UNKNOWN_ALIAS: 'UNKNOWN_ALIAS',
+  INVALID_AUTH: 'INVALID_AUTH',
+  REPLAY_DETECTED: 'REPLAY_DETECTED',
+  GRANT_INVALID: 'GRANT_INVALID',
+  TENANT_MISMATCH: 'TENANT_MISMATCH',
+  NO_DOCUMENTS: 'NO_DOCUMENTS',
+  PARSE_ERROR: 'PARSE_ERROR',
+  OVERSIZE_MESSAGE: 'OVERSIZE_MESSAGE',
+  TIMEOUT: 'TIMEOUT',
+  TRANSIENT_UPSTREAM: 'TRANSIENT_UPSTREAM',
+} as const;
+
+export type IngestReasonCode = (typeof IngestReasonCode)[keyof typeof IngestReasonCode];

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion.contracts.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion.contracts.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { IngestOutcome, IngestReasonCode } from '../contracts.js';
+
+// ---------------------------------------------------------------------------
+// Completeness guards — these tests fail if a code is removed or renamed.
+// ---------------------------------------------------------------------------
+
+describe('IngestOutcome', () => {
+  it('defines all required outcome values', () => {
+    expect(IngestOutcome.INSERTED).toBe('inserted');
+    expect(IngestOutcome.DUPLICATE).toBe('duplicate');
+    expect(IngestOutcome.QUARANTINED).toBe('quarantined');
+    expect(IngestOutcome.REJECTED).toBe('rejected');
+  });
+
+  it('has exactly four outcomes', () => {
+    expect(Object.keys(IngestOutcome)).toHaveLength(4);
+  });
+
+  it('all values are non-empty strings', () => {
+    for (const value of Object.values(IngestOutcome)) {
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('IngestReasonCode', () => {
+  const REQUIRED_CODES = [
+    'UNKNOWN_ALIAS',
+    'INVALID_AUTH',
+    'REPLAY_DETECTED',
+    'GRANT_INVALID',
+    'TENANT_MISMATCH',
+    'NO_DOCUMENTS',
+    'PARSE_ERROR',
+    'OVERSIZE_MESSAGE',
+    'TIMEOUT',
+    'TRANSIENT_UPSTREAM',
+  ] as const;
+
+  it.each(REQUIRED_CODES)('defines %s', code => {
+    expect(IngestReasonCode[code]).toBe(code);
+  });
+
+  it('has exactly ten reason codes', () => {
+    expect(Object.keys(IngestReasonCode)).toHaveLength(10);
+  });
+
+  it('all keys equal their values (self-referential constants)', () => {
+    for (const [key, value] of Object.entries(IngestReasonCode)) {
+      expect(key).toBe(value);
+    }
+  });
+
+  it('all values are non-empty strings', () => {
+    for (const value of Object.values(IngestReasonCode)) {
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/server/src/modules/email-ingestion/contracts.ts
+++ b/packages/server/src/modules/email-ingestion/contracts.ts
@@ -1,0 +1,30 @@
+/**
+ * Canonical outcome and reason-code constants for the email-ingestion module.
+ *
+ * These are the authoritative definitions on the server side. The gateway
+ * package holds an independent duplicate — no runtime import between them.
+ */
+
+export const IngestOutcome = {
+  INSERTED: 'inserted',
+  DUPLICATE: 'duplicate',
+  QUARANTINED: 'quarantined',
+  REJECTED: 'rejected',
+} as const;
+
+export type IngestOutcome = (typeof IngestOutcome)[keyof typeof IngestOutcome];
+
+export const IngestReasonCode = {
+  UNKNOWN_ALIAS: 'UNKNOWN_ALIAS',
+  INVALID_AUTH: 'INVALID_AUTH',
+  REPLAY_DETECTED: 'REPLAY_DETECTED',
+  GRANT_INVALID: 'GRANT_INVALID',
+  TENANT_MISMATCH: 'TENANT_MISMATCH',
+  NO_DOCUMENTS: 'NO_DOCUMENTS',
+  PARSE_ERROR: 'PARSE_ERROR',
+  OVERSIZE_MESSAGE: 'OVERSIZE_MESSAGE',
+  TIMEOUT: 'TIMEOUT',
+  TRANSIENT_UPSTREAM: 'TRANSIENT_UPSTREAM',
+} as const;
+
+export type IngestReasonCode = (typeof IngestReasonCode)[keyof typeof IngestReasonCode];

--- a/packages/server/src/modules/email-ingestion/index.ts
+++ b/packages/server/src/modules/email-ingestion/index.ts
@@ -12,3 +12,4 @@ export const emailIngestionModule = createModule({
 });
 
 export * as CommonTypes from './types.js';
+export * from './contracts.js';

--- a/todo.md
+++ b/todo.md
@@ -90,12 +90,12 @@ Primary references:
 
 ## Phase 3 - Contracts and Persistence (S06-S09)
 
-### S06: Canonical contracts and reason codes
+### S06: Canonical contracts and reason codes ✅ (this PR)
 
-- [ ] Add canonical outcomes and reason codes in server.
-- [ ] Add equivalent constants in new gateway package.
-- [ ] Ensure no runtime import from legacy package for shared constants.
-- [ ] Add tests guarding completeness and naming stability.
+- [x] Add canonical outcomes and reason codes in server.
+- [x] Add equivalent constants in new gateway package.
+- [x] Ensure no runtime import from legacy package for shared constants.
+- [x] Add tests guarding completeness and naming stability.
 
 ### S07: Alias routing migration
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `IngestOutcome` and `IngestReasonCode` as `as const` objects in both packages:
  - `packages/server/src/modules/email-ingestion/contracts.ts`
  - `packages/email-ingestion-gateway/src/contracts.ts`
- Exports contracts from the server module's `index.ts`
- Definitions are **intentionally duplicated** — no runtime import between packages, per the anti-coupling rule
- Parity is enforced by parallel completeness-guard test suites (32 tests across both packages)

## Contracts defined

**`IngestOutcome`** (4 values): `inserted`, `duplicate`, `quarantined`, `rejected`

**`IngestReasonCode`** (10 values): `UNKNOWN_ALIAS`, `INVALID_AUTH`, `REPLAY_DETECTED`, `GRANT_INVALID`, `TENANT_MISMATCH`, `NO_DOCUMENTS`, `PARSE_ERROR`, `OVERSIZE_MESSAGE`, `TIMEOUT`, `TRANSIENT_UPSTREAM`

## Test plan

- [x] TDD: failing tests written before implementation
- [x] 16 completeness-guard tests per package (32 total) — all pass
- [x] Tests enforce: all required codes present, exact count, self-referential keys, non-empty string values
- [x] `yarn test` passes (pre-existing failures in migrations/scraper-app are unrelated)
- [x] `yarn lint` — 0 errors
- [x] `yarn prettier:check` — all files clean

https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x)_