### PR TITLE
feat(client): expose financial accounts filtering in balance report

### DIFF
--- a/.changeset/balance-report-financial-accounts-filter.md
+++ b/.changeset/balance-report-financial-accounts-filter.md
@@ -1,0 +1,8 @@
+---
+"@accounter/client": patch
+---
+
+Expose financial accounts filtering in the balance report. Added a "Filter Out Financial Accounts"
+switch (default on) and an editable "Financial Accounts Businesses" list to the report filters, so
+users can include those transactions in the report and customize which businesses are treated as
+financial accounts.

--- a/packages/client/src/components/screens/reports/balance-report/balance-report-filters.tsx
+++ b/packages/client/src/components/screens/reports/balance-report/balance-report-filters.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import equal from 'deep-equal';
 import { Filter } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
@@ -13,6 +13,7 @@ import { TIMELESS_DATE_REGEX, type TimelessDateString } from '../../../../helper
 import { useGetFinancialEntities } from '../../../../hooks/use-get-financial-entities.js';
 import { useGetTags } from '../../../../hooks/use-get-tags.js';
 import { useUrlQuery } from '../../../../hooks/use-url-query.js';
+import { UserContext } from '../../../../providers/user-provider.js';
 import { ComboBox, DatePickerInput, MultiSelect, PopUpModal } from '../../../common/index.js';
 import { Button } from '../../../ui/button.js';
 import {
@@ -23,6 +24,7 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../ui/form.js';
+import { Switch } from '../../../ui/switch.js';
 
 export function encodeBalanceReportFilters(filter?: BalanceReportFilter | null): string | null {
   return encodeFilters(filter ?? null);
@@ -51,6 +53,8 @@ const balanceReportFilterSchema = z.object({
     Periods.SEMI_ANNUALLY,
     Periods.ANNUALLY,
   ]),
+  filterFinancialAccounts: z.boolean(),
+  financialAccountsBusinesses: z.array(z.string()),
   includedCounterparties: z.array(z.string()),
   excludedCounterparties: z.array(z.string()),
   includedTags: z.array(z.string()),
@@ -63,6 +67,8 @@ type BalanceReportFilterFormValues = z.infer<typeof balanceReportFilterSchema>;
 
 export type BalanceReportFilter = BalanceReportScreenQueryVariables & {
   period: Period;
+  filterFinancialAccounts: boolean;
+  financialAccountsBusinesses: string[];
   includedCounterparties: string[];
   excludedCounterparties: string[];
   includedTags: string[];
@@ -71,12 +77,18 @@ export type BalanceReportFilter = BalanceReportScreenQueryVariables & {
   excludedAccounts: string[];
 };
 
-function filterToFormValues(filter: BalanceReportFilter): BalanceReportFilterFormValues {
+function filterToFormValues(
+  filter: BalanceReportFilter,
+  defaultFinancialAccountsBusinesses: string[],
+): BalanceReportFilterFormValues {
   return {
     ownerId: filter.ownerId ?? undefined,
     fromDate: filter.fromDate,
     toDate: filter.toDate,
     period: filter.period ?? Periods.MONTHLY,
+    filterFinancialAccounts: filter.filterFinancialAccounts ?? true,
+    financialAccountsBusinesses:
+      filter.financialAccountsBusinesses ?? defaultFinancialAccountsBusinesses,
     includedCounterparties: filter.includedCounterparties ?? [],
     excludedCounterparties: filter.excludedCounterparties ?? [],
     includedTags: filter.includedTags ?? [],
@@ -97,9 +109,14 @@ function BalanceReportFiltersForm({
   setFilter,
   closeModal,
 }: BalanceReportFiltersFormProps): ReactElement {
+  const { userContext } = useContext(UserContext);
+  const defaultFinancialAccountsBusinesses = useMemo(
+    () => userContext?.context.financialAccountsBusinessesIds ?? [],
+    [userContext?.context.financialAccountsBusinessesIds],
+  );
   const form = useForm<BalanceReportFilterFormValues>({
     resolver: zodResolver(balanceReportFilterSchema),
-    defaultValues: filterToFormValues(filter),
+    defaultValues: filterToFormValues(filter, defaultFinancialAccountsBusinesses),
   });
 
   const { selectableAdminBusinesses: adminBusinesses, fetching: fetchingAdminBusinesses } =
@@ -127,6 +144,7 @@ function BalanceReportFiltersForm({
     () => includedAccounts.length > 0,
     [includedAccounts],
   );
+  const filterFinancialAccounts = form.watch('filterFinancialAccounts');
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
@@ -204,6 +222,43 @@ function BalanceReportFiltersForm({
                     value={field.value}
                     placeholder="Select period"
                     formPart
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="filterFinancialAccounts"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Filter Out Financial Accounts</FormLabel>
+                <FormControl>
+                  <div className="flex h-9 items-center">
+                    <Switch checked={field.value} onCheckedChange={field.onChange} />
+                  </div>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="financialAccountsBusinesses"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Financial Accounts Businesses</FormLabel>
+                <FormControl>
+                  <MultiSelect
+                    asChild
+                    options={financialEntities}
+                    onValueChange={field.onChange}
+                    defaultValue={field.value ?? []}
+                    value={field.value ?? []}
+                    placeholder="Scroll to see all options"
+                    variant="default"
+                    disabled={financialEntitiesFetching || !filterFinancialAccounts}
                   />
                 </FormControl>
                 <FormMessage />

--- a/packages/client/src/components/screens/reports/balance-report/balance-report-filters.tsx
+++ b/packages/client/src/components/screens/reports/balance-report/balance-report-filters.tsx
@@ -68,7 +68,7 @@ type BalanceReportFilterFormValues = z.infer<typeof balanceReportFilterSchema>;
 export type BalanceReportFilter = BalanceReportScreenQueryVariables & {
   period: Period;
   filterFinancialAccounts: boolean;
-  financialAccountsBusinesses: string[];
+  financialAccountsBusinesses?: string[];
   includedCounterparties: string[];
   excludedCounterparties: string[];
   includedTags: string[];

--- a/packages/client/src/components/screens/reports/balance-report/index.tsx
+++ b/packages/client/src/components/screens/reports/balance-report/index.tsx
@@ -161,7 +161,7 @@ export const BalanceReport = (): ReactElement => {
       period: Periods.MONTHLY,
       fromDate: format(sub(new Date(), { years: 1 }), 'yyyy-MM-dd') as TimelessDateString,
       filterFinancialAccounts: true,
-      financialAccountsBusinesses: userContext?.context.financialAccountsBusinessesIds ?? [],
+      financialAccountsBusinesses: userContext?.context.financialAccountsBusinessesIds,
       includedCounterparties: [],
       excludedCounterparties: [],
       includedTags: [],

--- a/packages/client/src/components/screens/reports/balance-report/index.tsx
+++ b/packages/client/src/components/screens/reports/balance-report/index.tsx
@@ -160,6 +160,8 @@ export const BalanceReport = (): ReactElement => {
       toDate: format(new Date(), 'yyyy-MM-dd') as TimelessDateString,
       period: Periods.MONTHLY,
       fromDate: format(sub(new Date(), { years: 1 }), 'yyyy-MM-dd') as TimelessDateString,
+      filterFinancialAccounts: true,
+      financialAccountsBusinesses: userContext?.context.financialAccountsBusinessesIds ?? [],
       includedCounterparties: [],
       excludedCounterparties: [],
       includedTags: [],
@@ -176,7 +178,11 @@ export const BalanceReport = (): ReactElement => {
       }
     }
     return defaultFilters;
-  }, [userContext?.context.adminBusinessId, get]);
+  }, [
+    userContext?.context.adminBusinessId,
+    userContext?.context.financialAccountsBusinessesIds,
+    get,
+  ]);
   const [filter, setFilter] = useState<BalanceReportFilter>(initialFilters);
   const [extendedPeriod, setExtendedPeriod] = useState<string | undefined>(undefined);
   const [visibleSets, setVisibleSets] = useState<string[]>(Object.keys(chartConfig));
@@ -221,6 +227,12 @@ export const BalanceReport = (): ReactElement => {
 
   const periods = useMemo((): PeriodInfo[] => {
     if (!data?.transactionsForBalanceReport) return [];
+    // when enabled, filter out internal transactions to the configured financial accounts businesses
+    const shouldFilterFinancialAccounts = filter.filterFinancialAccounts !== false;
+    const financialAccountsBusinesses =
+      filter.financialAccountsBusinesses ??
+      userContext?.context.financialAccountsBusinessesIds ??
+      [];
     const periods = new Map<string, PeriodInfo>();
     data.transactionsForBalanceReport.map(txn => {
       // filter by counterparty
@@ -230,8 +242,9 @@ export const BalanceReport = (): ReactElement => {
           return;
         }
         if (
+          shouldFilterFinancialAccounts &&
           !txn.isFee &&
-          userContext?.context.financialAccountsBusinessesIds?.includes(txn.counterparty.id)
+          financialAccountsBusinesses.includes(txn.counterparty.id)
         ) {
           // filter out internal transactions
           return;
@@ -242,8 +255,9 @@ export const BalanceReport = (): ReactElement => {
         }
       } else if (txn.counterparty?.id) {
         if (
+          shouldFilterFinancialAccounts &&
           !txn.isFee &&
-          userContext?.context.financialAccountsBusinessesIds?.includes(txn.counterparty.id)
+          financialAccountsBusinesses.includes(txn.counterparty.id)
         ) {
           // filter out internal transactions
           return;
@@ -340,6 +354,8 @@ export const BalanceReport = (): ReactElement => {
   }, [
     data,
     filter.period,
+    filter.filterFinancialAccounts,
+    filter.financialAccountsBusinesses,
     filter.includedCounterparties,
     filter.excludedCounterparties,
     filter.includedAccounts,


### PR DESCRIPTION
## What & why

Closes #3494.

Previously, transactions whose counterparty is one of the user's *financial accounts businesses* were **hard-coded filtered out** of the balance report (treated as internal transfers). There was no way to see them or to change which businesses are treated this way.

This PR surfaces that behavior in the report filters:

- **`Filter Out Financial Accounts` switch** (default **on**, preserving current behavior). When switched off, transactions to/from financial accounts businesses are reflected in the report.
- **`Financial Accounts Businesses` multi-select** — pre-populated with the user's default list (`userContext.financialAccountsBusinessesIds`), letting the user customize which businesses are treated as financial accounts for the report. Disabled when the switch is off.

## Changes

- `balance-report-filters.tsx`
  - Added `filterFinancialAccounts: boolean` and `financialAccountsBusinesses: string[]` to the filter schema/type.
  - Added the switch and businesses multi-select to the filter form. The list defaults to the user context's financial accounts businesses.
- `index.tsx`
  - Initialized the new filter fields (switch on, list from user context).
  - Replaced the hard-coded `userContext.financialAccountsBusinessesIds` check in the period aggregation with the configurable `filterFinancialAccounts` flag and `financialAccountsBusinesses` list (falling back to the context list for filters loaded from older URLs).

## Backward compatibility

- Default behavior is unchanged: the switch defaults to on and the list defaults to the existing context value.
- Filters persisted in older URLs (lacking the new fields) are handled defensively: `filterFinancialAccounts` is treated as `true` and the businesses list falls back to the user context value.

## Notes

`yarn lint` / typecheck could not be run in this environment — `yarn install` is blocked by the network policy (the `xlsx` package CDN `cdn.sheetjs.com` returns 403). The changes are scoped to two client files and follow existing patterns in the same components.

https://claude.ai/code/session_0151eBH3XbimiPgiYHTLUsWK

---
_Generated by [Claude Code](https://claude.ai/code/session_0151eBH3XbimiPgiYHTLUsWK)_