### PR TITLE
S12: strict grant validation and atomic consume-once

### DIFF
--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-grant-validation.provider.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-grant-validation.provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EmailIngestionControlProvider } from '../providers/email-ingestion-control.provider.js';
 import { IngestReasonCode } from '../contracts.js';
 
@@ -51,10 +51,16 @@ function makeProvider(
 // ---------------------------------------------------------------------------
 
 describe('EmailIngestionControlProvider.validateAndConsumeGrant', () => {
-  it('returns valid=true and grant data on successful consume', async () => {
+  beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
+  });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns valid=true and grant data on successful consume', async () => {
     const { provider } = makeProvider();
     const result = await provider.validateAndConsumeGrant(baseInput);
 
@@ -62,8 +68,6 @@ describe('EmailIngestionControlProvider.validateAndConsumeGrant', () => {
       valid: true,
       grant: expect.objectContaining({ jti: 'jti-uuid', tenantId: 'tenant-uuid', action: 'ingest' }),
     });
-
-    vi.useRealTimers();
   });
 
   it('returns GRANT_INVALID when jti is not found', async () => {
@@ -74,84 +78,56 @@ describe('EmailIngestionControlProvider.validateAndConsumeGrant', () => {
   });
 
   it('returns GRANT_INVALID when grant is already consumed', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-
     const consumed = { ...baseGrant, consumed_at: new Date(NOW.getTime() - 60_000) };
     const { provider } = makeProvider([consumed], []);
     const result = await provider.validateAndConsumeGrant(baseInput);
 
     expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
-    vi.useRealTimers();
   });
 
   it('returns GRANT_INVALID when grant is expired', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-
     const expired = { ...baseGrant, expires_at: PAST };
     const { provider } = makeProvider([expired], []);
     const result = await provider.validateAndConsumeGrant(baseInput);
 
     expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
-    vi.useRealTimers();
   });
 
   it('returns TENANT_MISMATCH when owner_id does not match tenantId', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-
     const { provider } = makeProvider();
     const result = await provider.validateAndConsumeGrant({ ...baseInput, tenantId: 'other-tenant' });
 
     expect(result).toEqual({ valid: false, reason: IngestReasonCode.TENANT_MISMATCH });
-    vi.useRealTimers();
   });
 
   it('returns GRANT_INVALID when message_id does not match', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-
     const { provider } = makeProvider();
     const result = await provider.validateAndConsumeGrant({ ...baseInput, messageId: 'wrong-msg' });
 
     expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
-    vi.useRealTimers();
   });
 
   it('returns GRANT_INVALID when raw_message_hash does not match', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-
     const { provider } = makeProvider();
     const result = await provider.validateAndConsumeGrant({ ...baseInput, rawMessageHash: 'wrong-hash' });
 
     expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
-    vi.useRealTimers();
   });
 
   it('returns GRANT_INVALID when action is not ingest', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-
     const wrongAction = { ...baseGrant, action: 'other' };
     const { provider } = makeProvider([wrongAction], []);
     const result = await provider.validateAndConsumeGrant(baseInput);
 
     expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
-    vi.useRealTimers();
   });
 
   it('returns GRANT_INVALID when consume UPDATE returns no rows (race condition)', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-
     // grant lookup succeeds but consume returns 0 rows (another request consumed it first)
     const { provider } = makeProvider([baseGrant], []);
     const result = await provider.validateAndConsumeGrant(baseInput);
 
     expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
-    vi.useRealTimers();
   });
 
   it('does not call consume when validation fails', async () => {

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-grant-validation.provider.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-grant-validation.provider.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EmailIngestionControlProvider } from '../providers/email-ingestion-control.provider.js';
+import { IngestReasonCode } from '../contracts.js';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+const NOW = new Date('2026-06-11T12:00:00.000Z');
+const FUTURE = new Date(NOW.getTime() + 5 * 60 * 1000); // +5 min
+const PAST = new Date(NOW.getTime() - 1); // 1 ms ago — expired
+
+const baseGrant = {
+  id: 'row-uuid',
+  jti: 'jti-uuid',
+  owner_id: 'tenant-uuid',
+  message_id: 'msg-abc-123',
+  raw_message_hash: 'sha256-abc',
+  action: 'ingest',
+  expires_at: FUTURE,
+  consumed_at: null as Date | null,
+};
+
+const baseInput = {
+  jti: 'jti-uuid',
+  tenantId: 'tenant-uuid',
+  messageId: 'msg-abc-123',
+  rawMessageHash: 'sha256-abc',
+};
+
+function makeProvider(
+  grantRows: typeof baseGrant[] = [baseGrant],
+  consumeRows: { id: string }[] = [{ id: 'row-uuid' }],
+) {
+  const queryFn = vi
+    .fn()
+    // First call: getGrantByJti
+    .mockResolvedValueOnce({ rows: grantRows, rowCount: grantRows.length })
+    // Second call: consumeGrantByJti
+    .mockResolvedValueOnce({ rows: consumeRows, rowCount: consumeRows.length });
+
+  const pool = { query: queryFn };
+  return {
+    provider: new EmailIngestionControlProvider({ pool } as never),
+    queryFn,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// validateAndConsumeGrant
+// ---------------------------------------------------------------------------
+
+describe('EmailIngestionControlProvider.validateAndConsumeGrant', () => {
+  it('returns valid=true and grant data on successful consume', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { provider } = makeProvider();
+    const result = await provider.validateAndConsumeGrant(baseInput);
+
+    expect(result).toMatchObject({
+      valid: true,
+      grant: expect.objectContaining({ jti: 'jti-uuid', tenantId: 'tenant-uuid', action: 'ingest' }),
+    });
+
+    vi.useRealTimers();
+  });
+
+  it('returns GRANT_INVALID when jti is not found', async () => {
+    const { provider } = makeProvider([], []);
+    const result = await provider.validateAndConsumeGrant(baseInput);
+
+    expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
+  });
+
+  it('returns GRANT_INVALID when grant is already consumed', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const consumed = { ...baseGrant, consumed_at: new Date(NOW.getTime() - 60_000) };
+    const { provider } = makeProvider([consumed], []);
+    const result = await provider.validateAndConsumeGrant(baseInput);
+
+    expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
+    vi.useRealTimers();
+  });
+
+  it('returns GRANT_INVALID when grant is expired', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const expired = { ...baseGrant, expires_at: PAST };
+    const { provider } = makeProvider([expired], []);
+    const result = await provider.validateAndConsumeGrant(baseInput);
+
+    expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
+    vi.useRealTimers();
+  });
+
+  it('returns TENANT_MISMATCH when owner_id does not match tenantId', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { provider } = makeProvider();
+    const result = await provider.validateAndConsumeGrant({ ...baseInput, tenantId: 'other-tenant' });
+
+    expect(result).toEqual({ valid: false, reason: IngestReasonCode.TENANT_MISMATCH });
+    vi.useRealTimers();
+  });
+
+  it('returns GRANT_INVALID when message_id does not match', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { provider } = makeProvider();
+    const result = await provider.validateAndConsumeGrant({ ...baseInput, messageId: 'wrong-msg' });
+
+    expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
+    vi.useRealTimers();
+  });
+
+  it('returns GRANT_INVALID when raw_message_hash does not match', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const { provider } = makeProvider();
+    const result = await provider.validateAndConsumeGrant({ ...baseInput, rawMessageHash: 'wrong-hash' });
+
+    expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
+    vi.useRealTimers();
+  });
+
+  it('returns GRANT_INVALID when action is not ingest', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const wrongAction = { ...baseGrant, action: 'other' };
+    const { provider } = makeProvider([wrongAction], []);
+    const result = await provider.validateAndConsumeGrant(baseInput);
+
+    expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
+    vi.useRealTimers();
+  });
+
+  it('returns GRANT_INVALID when consume UPDATE returns no rows (race condition)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    // grant lookup succeeds but consume returns 0 rows (another request consumed it first)
+    const { provider } = makeProvider([baseGrant], []);
+    const result = await provider.validateAndConsumeGrant(baseInput);
+
+    expect(result).toEqual({ valid: false, reason: IngestReasonCode.GRANT_INVALID });
+    vi.useRealTimers();
+  });
+
+  it('does not call consume when validation fails', async () => {
+    const { provider, queryFn } = makeProvider([], []);
+    await provider.validateAndConsumeGrant(baseInput);
+
+    // only one DB call (the lookup) — no consume attempt
+    expect(queryFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/server/src/modules/email-ingestion/providers/email-ingestion-control.provider.ts
+++ b/packages/server/src/modules/email-ingestion/providers/email-ingestion-control.provider.ts
@@ -3,7 +3,12 @@ import { Injectable, Scope } from 'graphql-modules';
 import { sql } from '@pgtyped/runtime';
 import { DBProvider } from '../../app-providers/db.provider.js';
 import { IngestReasonCode } from '../contracts.js';
-import type { IGetAliasByAliasQuery, IInsertIngestGrantQuery } from '../types.js';
+import type {
+  IConsumeGrantByJtiQuery,
+  IGetAliasByAliasQuery,
+  IGetGrantByJtiQuery,
+  IInsertIngestGrantQuery,
+} from '../types.js';
 
 // ---------------------------------------------------------------------------
 // Queries
@@ -22,6 +27,21 @@ const insertIngestGrant = sql<IInsertIngestGrantQuery>`
     (jti, owner_id, message_id, raw_message_hash, action, expires_at)
   VALUES ($jti, $ownerId, $messageId, $rawMessageHash, $action, $expiresAt)
   RETURNING id, jti, owner_id, action, expires_at
+`;
+
+const getGrantByJti = sql<IGetGrantByJtiQuery>`
+  SELECT id, jti, owner_id, message_id, raw_message_hash, action, expires_at, consumed_at
+    FROM accounter_schema.email_ingestion_grants
+   WHERE jti = $jti
+   LIMIT 1
+`;
+
+const consumeGrantByJti = sql<IConsumeGrantByJtiQuery>`
+  UPDATE accounter_schema.email_ingestion_grants
+     SET consumed_at = NOW()
+   WHERE jti = $jti
+     AND consumed_at IS NULL
+  RETURNING id
 `;
 
 // ---------------------------------------------------------------------------
@@ -50,6 +70,27 @@ export type IssueGrantInput = {
   expiresAt: Date;
   correlationId?: string;
 };
+
+export type ValidateGrantInput = {
+  jti: string;
+  tenantId: string;
+  messageId: string;
+  rawMessageHash: string;
+};
+
+export type ValidatedGrant = {
+  jti: string;
+  tenantId: string;
+  action: string;
+  expiresAt: Date;
+};
+
+export type GrantValidationResult =
+  | { valid: true; grant: ValidatedGrant }
+  | {
+      valid: false;
+      reason: typeof IngestReasonCode.GRANT_INVALID | typeof IngestReasonCode.TENANT_MISMATCH;
+    };
 
 // ---------------------------------------------------------------------------
 // Provider
@@ -108,6 +149,65 @@ export class EmailIngestionControlProvider {
       expiresAt: row.expires_at,
       decisionId,
       auditId,
+    };
+  }
+
+  /**
+   * Validate a presented grant against the stored record and atomically consume it.
+   * Checks: existence, expiry, consumed state, action scope, tenant binding, and message binding.
+   * The consume UPDATE (SET consumed_at = NOW() WHERE consumed_at IS NULL) is atomic —
+   * if a concurrent request consumed the grant first the UPDATE returns 0 rows and
+   * the method returns GRANT_INVALID, preventing double-use.
+   * Uses raw pool for the same reason as resolveAlias: no tenant session is active yet.
+   */
+  async validateAndConsumeGrant(input: ValidateGrantInput): Promise<GrantValidationResult> {
+    const rows = await getGrantByJti.run({ jti: input.jti }, this.dbProvider.pool);
+
+    if (rows.length === 0) {
+      return { valid: false, reason: IngestReasonCode.GRANT_INVALID };
+    }
+
+    const grant = rows[0];
+
+    if (grant.consumed_at !== null) {
+      return { valid: false, reason: IngestReasonCode.GRANT_INVALID };
+    }
+
+    if (grant.expires_at <= new Date()) {
+      return { valid: false, reason: IngestReasonCode.GRANT_INVALID };
+    }
+
+    if (grant.action !== 'ingest') {
+      return { valid: false, reason: IngestReasonCode.GRANT_INVALID };
+    }
+
+    if (grant.owner_id !== input.tenantId) {
+      return { valid: false, reason: IngestReasonCode.TENANT_MISMATCH };
+    }
+
+    if (grant.message_id !== input.messageId) {
+      return { valid: false, reason: IngestReasonCode.GRANT_INVALID };
+    }
+
+    if (grant.raw_message_hash !== input.rawMessageHash) {
+      return { valid: false, reason: IngestReasonCode.GRANT_INVALID };
+    }
+
+    // Atomic consume-once: if this returns 0 rows a concurrent request beat us to it.
+    const consumed = await consumeGrantByJti.run({ jti: input.jti }, this.dbProvider.pool);
+
+    if (consumed.length === 0) {
+      return { valid: false, reason: IngestReasonCode.GRANT_INVALID };
+    }
+
+    return {
+      valid: true,
+      grant: {
+        jti: grant.jti,
+        tenantId: grant.owner_id,
+        action: grant.action,
+        expiresAt: grant.expires_at,
+      },
     };
   }
 }

--- a/todo.md
+++ b/todo.md
@@ -148,11 +148,11 @@ Primary references:
 - [x] Add resolver success/auth-failure tests.
 - [x] Run GraphQL codegen.
 
-### S12: Grant validation and single-use consume
+### S12: Grant validation and single-use consume ✅ (this PR)
 
-- [ ] Implement strict validation: scope, tenant, message binding, expiry, unconsumed.
-- [ ] Implement atomic consume-once behavior.
-- [ ] Add negative tests for reused/expired/mismatched grant behavior.
+- [x] Implement strict validation: scope, tenant, message binding, expiry, unconsumed.
+- [x] Implement atomic consume-once behavior.
+- [x] Add negative tests for reused/expired/mismatched grant behavior.
 
 ### S13: Idempotency and dedup
 


### PR DESCRIPTION
## Summary

- Adds `validateAndConsumeGrant(input: ValidateGrantInput): Promise<GrantValidationResult>` to `EmailIngestionControlProvider`
- Validates all six invariants before consuming: grant existence, expiry, unconsumed state, action scope (`'ingest'`), tenant binding (`owner_id === tenantId`), message ID, and raw message hash
- Atomic consume-once via `UPDATE...SET consumed_at = NOW() WHERE jti = $jti AND consumed_at IS NULL RETURNING id` — if a concurrent request consumed first, 0 rows returns `GRANT_INVALID`
- Two new pgtyped queries at module level: `getGrantByJti` (SELECT all validation fields) and `consumeGrantByJti` (atomic UPDATE)
- Exports `ValidateGrantInput`, `ValidatedGrant`, `GrantValidationResult` for use by the ingest resolver (S14)

## Test plan

- [x] TDD: tests written first (all 10 failed with `validateAndConsumeGrant is not a function`), then implementation made them pass
- [x] Negative paths covered: not found, already consumed, expired, wrong action, tenant mismatch, message ID mismatch, hash mismatch, race condition (consume returns 0 rows)
- [x] Happy path: returns `{ valid: true, grant: { jti, tenantId, action, expiresAt } }`
- [x] Invariant test: no consume DB call made when pre-consume validation fails
- [x] `yarn test` — 1893 tests pass, same 4 pre-existing failures unrelated to this change
- [x] Prettier applied to all changed files

https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x)_