### PR TITLE
S13.5: Gateway control-plane service credential auth path

### DIFF
--- a/docs/multi-tenant-gmail-listener/prompt-plan.md
+++ b/docs/multi-tenant-gmail-listener/prompt-plan.md
@@ -105,19 +105,18 @@ Chunk check:
 12. S12: Implement grant validation + single-use consume provider logic.
 13. S13: Implement idempotency + dedup in ingest flow.
 14. S13.5: Implement Gateway control-plane service credential and auth path.
-15. S13.6: Harden server data-plane provider boundaries (operation scope, TenantAwareDBClient,
-   and explicit raw DB bootstrap boundary).
+15. S13.6: Harden server data-plane provider boundaries (operation scope, TenantAwareDBClient, and
+    explicit raw DB bootstrap boundary).
 16. S14: Implement ingest GraphQL operation, replace legacy-style active ingest path, and
-   reason-code mapping.
+    reason-code mapping.
 17. S15: Implement gateway Cloudflare authenticity verifier.
 18. S16: Implement gateway webhook endpoint and payload validation.
 19. S17: Implement gateway extraction pipeline with limits (duplicate/adapt, do not import legacy
     code).
 20. S18: Implement gateway server client and control->new-ingest orchestration.
-21. S19: Add observability, shadow mode, live-path integration, and adversarial integration
-   suites.
+21. S19: Add observability, shadow mode, live-path integration, and adversarial integration suites.
 22. S20: Add Cloudflare setup runbook, final wiring review, DB-boundary audit, and release
-   checklist.
+    checklist.
 
 ---
 

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -155,6 +155,10 @@ const OtelModel = zod
     }
   });
 
+const GatewayControlPlaneModel = zod.object({
+  GATEWAY_CP_TOKEN: emptyString(zod.string().optional()),
+});
+
 const EmailIngestionModel = zod.object({
   EMAIL_INGESTION_V2_ENABLED: emptyString(
     zod
@@ -201,6 +205,7 @@ const configs = {
   general: GeneralModel.safeParse(process.env),
   otel: OtelModel.safeParse(process.env),
   emailIngestion: EmailIngestionModel.safeParse(process.env),
+  gatewayControlPlane: GatewayControlPlaneModel.safeParse(process.env),
 };
 
 const environmentErrors: Array<string> = [];
@@ -233,6 +238,7 @@ const credentials = extractConfig(configs.credentials);
 const general = extractConfig(configs.general);
 const otel = extractConfig(configs.otel);
 const emailIngestion = extractConfig(configs.emailIngestion);
+const gatewayControlPlane = extractConfig(configs.gatewayControlPlane);
 
 export const env = {
   postgres: {
@@ -293,5 +299,8 @@ export const env = {
   emailIngestion: {
     v2Enabled: emailIngestion.EMAIL_INGESTION_V2_ENABLED === '1',
     shadowMode: emailIngestion.EMAIL_INGESTION_SHADOW_MODE === '1',
+  },
+  gatewayControlPlane: {
+    token: gatewayControlPlane.GATEWAY_CP_TOKEN,
   },
 } as const;

--- a/packages/server/src/modules/auth/providers/__tests__/gateway-control-plane-auth.test.ts
+++ b/packages/server/src/modules/auth/providers/__tests__/gateway-control-plane-auth.test.ts
@@ -88,6 +88,8 @@ describe('AuthContextProvider gateway control-plane auth', () => {
       mockDb as never,
     );
 
-    await expect(provider.getAuthContext()).resolves.not.toThrow();
+    const context = await provider.getAuthContext();
+    expect(context?.authType).toBe('gatewayControlPlane');
+    expect(context?.user?.roleId).toBe('gateway_control_plane');
   });
 });

--- a/packages/server/src/modules/auth/providers/__tests__/gateway-control-plane-auth.test.ts
+++ b/packages/server/src/modules/auth/providers/__tests__/gateway-control-plane-auth.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import type { Environment } from '../../../../shared/types/index.js';
+import { AuthContextProvider } from '../auth-context.provider.js';
+
+const VALID_TOKEN = 'test-gateway-cp-token-abc123';
+
+const envWithToken = {
+  gatewayControlPlane: { token: VALID_TOKEN },
+} as unknown as Environment;
+
+const envWithoutToken = {
+  gatewayControlPlane: { token: undefined },
+} as unknown as Environment;
+
+describe('AuthContextProvider gateway control-plane auth', () => {
+  it('valid gateway CP token returns gatewayControlPlane authType', async () => {
+    const provider = new AuthContextProvider(
+      envWithToken,
+      { authType: 'gatewayControlPlane', token: VALID_TOKEN },
+      {} as never,
+    );
+
+    const context = await provider.getAuthContext();
+
+    expect(context?.authType).toBe('gatewayControlPlane');
+    expect(context?.user?.roleId).toBe('gateway_control_plane');
+  });
+
+  it('gateway CP context has no real tenant businessId', async () => {
+    const provider = new AuthContextProvider(
+      envWithToken,
+      { authType: 'gatewayControlPlane', token: VALID_TOKEN },
+      {} as never,
+    );
+
+    const context = await provider.getAuthContext();
+
+    expect(context?.tenant.businessId).toBe('');
+    expect(context?.memberships).toBeUndefined();
+  });
+
+  it('invalid gateway CP token returns null', async () => {
+    const provider = new AuthContextProvider(
+      envWithToken,
+      { authType: 'gatewayControlPlane', token: 'wrong-token' },
+      {} as never,
+    );
+
+    const context = await provider.getAuthContext();
+
+    expect(context).toBeNull();
+  });
+
+  it('empty gateway CP token returns null', async () => {
+    const provider = new AuthContextProvider(
+      envWithToken,
+      { authType: 'gatewayControlPlane', token: '' },
+      {} as never,
+    );
+
+    const context = await provider.getAuthContext();
+
+    expect(context).toBeNull();
+  });
+
+  it('missing GATEWAY_CP_TOKEN env config returns null', async () => {
+    const provider = new AuthContextProvider(
+      envWithoutToken,
+      { authType: 'gatewayControlPlane', token: VALID_TOKEN },
+      {} as never,
+    );
+
+    const context = await provider.getAuthContext();
+
+    expect(context).toBeNull();
+  });
+
+  it('does not make DB queries for CP token validation', async () => {
+    const mockDb = {
+      query: () => {
+        throw new Error('DB must not be called for gateway CP auth');
+      },
+    };
+
+    const provider = new AuthContextProvider(
+      envWithToken,
+      { authType: 'gatewayControlPlane', token: VALID_TOKEN },
+      mockDb as never,
+    );
+
+    await expect(provider.getAuthContext()).resolves.not.toThrow();
+  });
+});

--- a/packages/server/src/modules/auth/providers/auth-context.provider.ts
+++ b/packages/server/src/modules/auth/providers/auth-context.provider.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import { GraphQLError } from 'graphql';
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
@@ -161,6 +161,11 @@ export class AuthContextProvider {
       return this.handlingAuth;
     }
 
+    if (this.rawAuth.authType === 'gatewayControlPlane') {
+      this.handlingAuth = this.handleGatewayControlPlaneAuth();
+      return this.handlingAuth;
+    }
+
     return null;
   }
 
@@ -309,6 +314,54 @@ export class AuthContextProvider {
       // exactly that one business.
       memberships: [{ businessId: apiKey.business_id, roleId: apiKey.role_id }],
     };
+  }
+
+  private async handleGatewayControlPlaneAuth(): Promise<AuthContext | null> {
+    const token = this.rawAuth.token;
+    if (!token) {
+      this.handlingAuth = null;
+      this.cachedContext = null;
+      return null;
+    }
+
+    const expectedToken = this.env.gatewayControlPlane?.token;
+    if (!expectedToken) {
+      this.handlingAuth = null;
+      this.cachedContext = null;
+      return null;
+    }
+
+    // Timing-safe comparison: hash both values to ensure equal-length buffers
+    // and prevent token-length leakage.
+    const tokenHash = createHash('sha256').update(token).digest();
+    const expectedHash = createHash('sha256').update(expectedToken).digest();
+    if (!timingSafeEqual(tokenHash, expectedHash)) {
+      this.handlingAuth = null;
+      this.cachedContext = null;
+      return null;
+    }
+
+    const context: AuthContext = {
+      authType: 'gatewayControlPlane',
+      token,
+      user: {
+        userId: 'gateway-control-plane',
+        auth0UserId: null,
+        email: '',
+        roleId: 'gateway_control_plane',
+        permissions: [],
+        emailVerified: false,
+        permissionsVersion: 0,
+      },
+      // Empty businessId: no real tenant context for the control-plane identity.
+      // TenantAwareDBClient will fail if called with this context, enforcing that
+      // control-plane operations only use the raw DBProvider pool.
+      tenant: { businessId: '' },
+    };
+
+    this.cachedContext = context;
+    this.handlingAuth = null;
+    return context;
   }
 
   private async handleJwtAuth(): Promise<AuthContext | null> {

--- a/packages/server/src/modules/auth/providers/auth-context.provider.ts
+++ b/packages/server/src/modules/auth/providers/auth-context.provider.ts
@@ -317,6 +317,12 @@ export class AuthContextProvider {
   }
 
   private async handleGatewayControlPlaneAuth(): Promise<AuthContext | null> {
+    // Yield to the microtask queue so getAuthContext can assign this.handlingAuth
+    // before any early-return path clears it. Without this, the function runs
+    // synchronously (no await), clearing this.handlingAuth before the caller's
+    // assignment, which then overwrites null with the resolved promise.
+    await Promise.resolve();
+
     const token = this.rawAuth.token;
     if (!token) {
       this.handlingAuth = null;
@@ -326,6 +332,10 @@ export class AuthContextProvider {
 
     const expectedToken = this.env.gatewayControlPlane?.token;
     if (!expectedToken) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'AuthContext: GATEWAY_CP_TOKEN is not configured; rejecting gateway control-plane auth attempt',
+      );
       this.handlingAuth = null;
       this.cachedContext = null;
       return null;

--- a/packages/server/src/modules/email-ingestion/__tests__/gateway-control-plane-access.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/gateway-control-plane-access.test.ts
@@ -1,0 +1,130 @@
+import { createYoga } from 'graphql-yoga';
+import { useSchema } from '@envelop/core';
+import { useGraphQLModules } from '@envelop/graphql-modules';
+import { createApplication, createModule, gql, Scope } from 'graphql-modules';
+import { describe, expect, it } from 'vitest';
+import { AuthContextProvider } from '../../auth/providers/auth-context.provider.js';
+import { authDirectiveTransformer } from '../../auth/directives/auth-directives.js';
+
+/**
+ * Role isolation tests for the gateway control-plane identity.
+ *
+ * Verifies that:
+ * - gateway_control_plane role can call operations protected by @requiresRole(role: "gateway_control_plane")
+ * - gmail_listener role cannot call operations protected by @requiresRole(role: "gateway_control_plane")
+ * - gateway_control_plane role cannot call operations protected by @requiresRole(role: "gmail_listener")
+ */
+
+function makeYoga(roleId: string | null) {
+  const testModule = createModule({
+    id: 'gcp-access-test',
+    typeDefs: [
+      gql`
+        directive @requiresAuth on FIELD_DEFINITION
+        directive @requiresRole(role: String!) on FIELD_DEFINITION
+
+        type Query {
+          noop: String
+        }
+
+        type Mutation {
+          " Mirrors requestIngestControl: requires gateway_control_plane role "
+          requestIngestControl: String! @requiresAuth @requiresRole(role: "gateway_control_plane")
+          " Mirrors insertEmailDocuments: requires gmail_listener role "
+          insertEmailDocuments: String! @requiresAuth @requiresRole(role: "gmail_listener")
+        }
+      `,
+    ],
+    resolvers: {
+      Query: { noop: () => null },
+      Mutation: {
+        requestIngestControl: () => 'control-ok',
+        insertEmailDocuments: () => 'ingest-ok',
+      },
+    },
+    providers: [
+      {
+        provide: AuthContextProvider,
+        useFactory: () => ({
+          getAuthContext: async () => {
+            if (!roleId) return null;
+            return {
+              authType: roleId === 'gateway_control_plane' ? 'gatewayControlPlane' : 'apiKey',
+              user: { roleId },
+              tenant: { businessId: '' },
+            };
+          },
+        }),
+        scope: Scope.Operation,
+      },
+    ],
+  });
+
+  const application = createApplication({ modules: [testModule] });
+  const transformedSchema = authDirectiveTransformer(application.schema);
+
+  return createYoga({
+    maskedErrors: false,
+    plugins: [useGraphQLModules(application), useSchema(transformedSchema)],
+    context: () => ({
+      injector: {
+        get: (token: unknown) => {
+          if (token !== AuthContextProvider) return undefined;
+          return {
+            getAuthContext: async () => {
+              if (!roleId) return null;
+              return {
+                authType: roleId === 'gateway_control_plane' ? 'gatewayControlPlane' : 'apiKey',
+                user: { roleId },
+                tenant: { businessId: '' },
+              };
+            },
+          };
+        },
+      },
+    }),
+  });
+}
+
+async function execute(yoga: ReturnType<typeof makeYoga>, query: string) {
+  const response = await yoga.fetch('http://localhost:4000/graphql', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ query }),
+  });
+  return response.json();
+}
+
+describe('gateway_control_plane role isolation', () => {
+  it('gateway_control_plane can call requestIngestControl', async () => {
+    const yoga = makeYoga('gateway_control_plane');
+    const result = await execute(yoga, 'mutation { requestIngestControl }');
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ requestIngestControl: 'control-ok' });
+  });
+
+  it('gmail_listener cannot call requestIngestControl (FORBIDDEN)', async () => {
+    const yoga = makeYoga('gmail_listener');
+    const result = await execute(yoga, 'mutation { requestIngestControl }');
+
+    expect(result.data).toBeNull();
+    expect(result.errors?.[0]?.extensions?.code).toBe('FORBIDDEN');
+  });
+
+  it('gateway_control_plane cannot call insertEmailDocuments (FORBIDDEN)', async () => {
+    const yoga = makeYoga('gateway_control_plane');
+    const result = await execute(yoga, 'mutation { insertEmailDocuments }');
+
+    expect(result.data).toBeNull();
+    expect(result.errors?.[0]?.extensions?.code).toBe('FORBIDDEN');
+  });
+
+  it('unauthenticated request is rejected (UNAUTHENTICATED)', async () => {
+    const yoga = makeYoga(null);
+    const result = await execute(yoga, 'mutation { requestIngestControl }');
+
+    expect(result.data).toBeNull();
+    expect(result.errors?.[0]?.extensions?.code).toBe('UNAUTHENTICATED');
+  });
+});

--- a/packages/server/src/modules/email-ingestion/typeDefs/email-ingestion.graphql.ts
+++ b/packages/server/src/modules/email-ingestion/typeDefs/email-ingestion.graphql.ts
@@ -18,7 +18,7 @@ export default gql`
     " Request a short-lived ingest control grant for a verified incoming message "
     requestIngestControl(input: IngestControlInput!): IngestControlResult!
       @requiresAuth
-      @requiresRole(role: "gmail_listener")
+      @requiresRole(role: "gateway_control_plane")
   }
 
   " Input for requesting a short-lived ingest control grant "

--- a/packages/server/src/plugins/auth-plugin.ts
+++ b/packages/server/src/plugins/auth-plugin.ts
@@ -6,7 +6,7 @@ import type { BusinessScopeParseResult } from '../shared/types/auth.js';
 import { BUSINESS_SCOPE_HEADER, parseBusinessScopeHeader } from './business-scope-header.js';
 
 export interface RawAuth {
-  authType: 'jwt' | 'apiKey' | 'devBypass' | null;
+  authType: 'jwt' | 'apiKey' | 'devBypass' | 'gatewayControlPlane' | null;
   token: string | null;
   /**
    * Parsed `X-Business-Scope` header, present only when the header was sent.
@@ -45,6 +45,7 @@ export const authPlugin = (): Plugin<{ rawAuth: RawAuth }> => {
       const devAuthHeader = request.headers.get('x-dev-auth');
       const authHeader = request.headers.get('authorization');
       const apiKeyHeader = request.headers.get('x-api-key');
+      const gatewayCpTokenHeader = request.headers.get('x-gateway-cp-token');
 
       // Parse the requested read scope once. Attach it only when the header was
       // actually sent, so requests without it keep the original rawAuth shape.
@@ -82,6 +83,20 @@ export const authPlugin = (): Plugin<{ rawAuth: RawAuth }> => {
               };
             }
           }
+        }
+      }
+
+      // Gateway control-plane service identity (no tenant context)
+      if (gatewayCpTokenHeader) {
+        const token = gatewayCpTokenHeader.trim();
+        if (token.length > 0) {
+          return {
+            rawAuth: {
+              authType: 'gatewayControlPlane',
+              token,
+              ...scopeFields,
+            },
+          };
         }
       }
 

--- a/packages/server/src/shared/types/auth.ts
+++ b/packages/server/src/shared/types/auth.ts
@@ -1,4 +1,4 @@
-export type AuthType = 'jwt' | 'apiKey' | 'system' | 'devBypass';
+export type AuthType = 'jwt' | 'apiKey' | 'system' | 'devBypass' | 'gatewayControlPlane';
 
 export interface AuthUser {
   userId: string;

--- a/todo.md
+++ b/todo.md
@@ -161,6 +161,16 @@ Primary references:
 - [x] Persist dedup decisions for auditability.
 - [x] Add tests for duplicate handling and cross-tenant isolation.
 
+### S13.5: Gateway control-plane service credential ✅ (this PR)
+
+- [x] Add `'gatewayControlPlane'` to `AuthType` and `RawAuth.authType`.
+- [x] Extend auth plugin to extract `X-Gateway-CP-Token` header.
+- [x] Add `GATEWAY_CP_TOKEN` optional env var with timing-safe validation.
+- [x] Implement `handleGatewayControlPlaneAuth()` in `AuthContextProvider`: no DB, no tenant, `roleId: 'gateway_control_plane'`.
+- [x] Update `requestIngestControl` to require `@requiresRole(role: "gateway_control_plane")`.
+- [x] Add TDD tests: valid/invalid token, missing env, no DB calls.
+- [x] Add role isolation tests: gateway_control_plane can call control op, gmail_listener cannot, gateway_control_plane cannot call ingest op.
+
 ### S14: Ingest GraphQL operation
 
 - [ ] Add ingest operation typeDefs and resolver under email-ingestion module.

--- a/todo.md
+++ b/todo.md
@@ -166,10 +166,12 @@ Primary references:
 - [x] Add `'gatewayControlPlane'` to `AuthType` and `RawAuth.authType`.
 - [x] Extend auth plugin to extract `X-Gateway-CP-Token` header.
 - [x] Add `GATEWAY_CP_TOKEN` optional env var with timing-safe validation.
-- [x] Implement `handleGatewayControlPlaneAuth()` in `AuthContextProvider`: no DB, no tenant, `roleId: 'gateway_control_plane'`.
+- [x] Implement `handleGatewayControlPlaneAuth()` in `AuthContextProvider`: no DB, no tenant,
+      `roleId: 'gateway_control_plane'`.
 - [x] Update `requestIngestControl` to require `@requiresRole(role: "gateway_control_plane")`.
 - [x] Add TDD tests: valid/invalid token, missing env, no DB calls.
-- [x] Add role isolation tests: gateway_control_plane can call control op, gmail_listener cannot, gateway_control_plane cannot call ingest op.
+- [x] Add role isolation tests: gateway_control_plane can call control op, gmail_listener cannot,
+      gateway_control_plane cannot call ingest op.
 
 ### S14: Ingest GraphQL operation
 


### PR DESCRIPTION
## Summary

- Introduces a dedicated `gatewayControlPlane` auth type so `requestIngestControl` no longer depends on tenant-scoped `gmail_listener` API keys
- Adds `X-Gateway-CP-Token` header extraction in the auth plugin, validated timing-safely against `GATEWAY_CP_TOKEN` env var
- `handleGatewayControlPlaneAuth()` returns a context with `roleId: 'gateway_control_plane'` and no real tenant (`businessId: ''`), ensuring `TenantAwareDBClient` cannot be reached from control-plane identity
- Changes `requestIngestControl` mutation from `@requiresRole(role: "gmail_listener")` → `@requiresRole(role: "gateway_control_plane")`

## Test plan

- [x] Auth provider unit tests: valid token → correct context, invalid token → null, missing env → null, no DB calls made
- [x] Role isolation tests: `gateway_control_plane` can call `requestIngestControl`; `gmail_listener` cannot (FORBIDDEN); `gateway_control_plane` cannot call `insertEmailDocuments` (FORBIDDEN)
- [x] `yarn test` — 1918 tests pass

https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x)_