### PR TITLE
feat(auth): add schema for business user & invitation management

### DIFF
--- a/packages/server/src/modules/auth/typeDefs/auth.graphql.ts
+++ b/packages/server/src/modules/auth/typeDefs/auth.graphql.ts
@@ -11,7 +11,7 @@ export default gql`
   extend type Query {
     listApiKeys: [ApiKey!]! @requiresRole(role: "business_owner")
     listBusinessUsers: [BusinessUser!]! @requiresRole(role: "business_owner")
-    listInvitations: [InvitationPayload!]! @requiresRole(role: "business_owner")
+    listInvitations: [Invitation!]! @requiresRole(role: "business_owner")
   }
 
   extend type Mutation {
@@ -25,13 +25,21 @@ export default gql`
     revokeInvitation(id: ID!): Boolean! @requiresRole(role: "business_owner")
   }
 
-  " Invitation payload returned after creating an invitation "
+  " Invitation payload returned after creating an invitation (includes the one-time token) "
   type InvitationPayload {
     id: ID!
     email: String!
     roleId: String!
     expiresAt: DateTime!
     token: String!
+  }
+
+  " Stored invitation state, as listed for management (never exposes the one-time token) "
+  type Invitation {
+    id: ID!
+    email: String!
+    roleId: String!
+    expiresAt: DateTime!
   }
 
   " Result payload returned after accepting an invitation "

--- a/packages/server/src/modules/auth/typeDefs/auth.graphql.ts
+++ b/packages/server/src/modules/auth/typeDefs/auth.graphql.ts
@@ -10,6 +10,8 @@ export default gql`
 
   extend type Query {
     listApiKeys: [ApiKey!]! @requiresRole(role: "business_owner")
+    listBusinessUsers: [BusinessUser!]! @requiresRole(role: "business_owner")
+    listInvitations: [InvitationPayload!]! @requiresRole(role: "business_owner")
   }
 
   extend type Mutation {
@@ -19,6 +21,8 @@ export default gql`
     generateApiKey(name: String!, roleId: String!): GenerateApiKeyPayload!
       @requiresRole(role: "business_owner")
     revokeApiKey(id: ID!): Boolean! @requiresRole(role: "business_owner")
+    removeBusinessUser(userId: ID!): Boolean! @requiresRole(role: "business_owner")
+    revokeInvitation(id: ID!): Boolean! @requiresRole(role: "business_owner")
   }
 
   " Invitation payload returned after creating an invitation "
@@ -49,6 +53,15 @@ export default gql`
     name: String!
     roleId: String!
     lastUsedAt: DateTime
+    createdAt: DateTime!
+  }
+
+  " Business user member of a tenant "
+  type BusinessUser {
+    id: ID!
+    email: String!
+    name: String
+    roleId: String!
     createdAt: DateTime!
   }
 `;


### PR DESCRIPTION
## Summary

First step toward the new **Auth Management** dashboard for business admins. This extends the auth GraphQL schema to support viewing users, listing existing invitations, and removing users/invitations.

Ref: `docs/auth-management-flows-completion/spec.md`

## Changes

In `packages/server/src/modules/auth/typeDefs/auth.graphql.ts`:

- **New type** `BusinessUser`:
  - `id: ID!`, `email: String!`, `name: String`, `roleId: String!`, `createdAt: DateTime!`
- **New queries** (both `@requiresRole(role: "business_owner")`):
  - `listBusinessUsers: [BusinessUser!]!`
  - `listInvitations: [InvitationPayload!]!`
- **New mutations** (both `@requiresRole(role: "business_owner")`):
  - `removeBusinessUser(userId: ID!): Boolean!`
  - `revokeInvitation(id: ID!): Boolean!`

This is schema-only — no resolver/provider implementation yet (that's a follow-up step per the spec).

## Verification

- `yarn generate` (GraphQL codegen) completed successfully and regenerated the backend resolver types and frontend operation types. The generated `auth/__generated__/types.ts` includes `BusinessUser`, `listBusinessUsers`, `listInvitations`, `removeBusinessUser`, and `revokeInvitation`.
- Note: the SQL codegen half of `yarn generate` and the full server build require a running Postgres/Docker, which isn't available in this environment; the only failures observed are the pre-existing pgtyped types that need a DB — none relate to this schema change.

Generated files (`__generated__/`, `gql/`, `schema.graphql`) are git-ignored and not part of this commit.

https://claude.ai/code/session_01WngYxNYKtRn9SYKD3fjcs8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WngYxNYKtRn9SYKD3fjcs8)_