### PR TITLE
Extract RLS test helpers and add read-side visibility tests

### DIFF
--- a/.changeset/tidy-trees-attack.md
+++ b/.changeset/tidy-trees-attack.md
@@ -1,0 +1,5 @@
+---
+'@accounter/server': patch
+---
+
+Refactors Row-Level Security (RLS) testing infrastructure by extracting shared role-management utilities into a reusable helper module, and adds comprehensive integration tests for the read-side (USING clause) of the tenant_isolation policy.

--- a/packages/server/src/__tests__/helpers/rls-role.ts
+++ b/packages/server/src/__tests__/helpers/rls-role.ts
@@ -1,0 +1,103 @@
+import type { Pool, PoolClient } from 'pg';
+
+/**
+ * Shared utilities for exercising Row-Level Security (RLS) in integration tests.
+ *
+ * The test pool connects as `postgres`, a superuser with BYPASSRLS, so any query
+ * run as postgres bypasses RLS regardless of `FORCE ROW LEVEL SECURITY`. To make
+ * Postgres actually evaluate the `tenant_isolation` policies (USING for reads,
+ * WITH CHECK for writes) a test must run the queries-under-test as a non-superuser
+ * role. These helpers create that role and confine the privilege drop to a
+ * SAVEPOINT so the surrounding test transaction stays usable.
+ *
+ * This is the same boundary the tenant-bound providers rely on at runtime, so
+ * future tenant-scoped providers can reuse it rather than re-deriving the
+ * role-switch mechanics.
+ */
+
+const SCHEMA = 'accounter_schema';
+
+/**
+ * Per-process unique role name. Avoids collisions when Vitest runs test files in
+ * parallel workers (each worker is a separate process).
+ */
+export const RLS_TEST_ROLE = `rls_test_user_${process.pid}`;
+
+/** A table privilege grant: e.g. `{ table: 'sort_codes', privileges: 'INSERT, SELECT' }`. */
+export interface RlsRoleGrant {
+  /** Unqualified table name (schema prefix is added automatically). */
+  table: string;
+  /** Comma-separated SQL privileges, e.g. `'SELECT'` or `'INSERT, SELECT'`. */
+  privileges: string;
+}
+
+export interface RlsRoleOptions {
+  /** Table privileges to grant the role for the queries under test. */
+  grants?: RlsRoleGrant[];
+}
+
+/**
+ * Idempotently create the per-process non-superuser RLS role and grant it schema
+ * usage plus any requested table privileges.
+ *
+ * `CREATE ROLE` / `GRANT` are not meant to be rolled back per-test, so this runs
+ * on its own connection outside any test transaction. Call from `beforeAll` and
+ * pair with {@link dropRlsRole} in `afterAll`.
+ */
+export async function ensureRlsRole(pool: Pool, options: RlsRoleOptions = {}): Promise<void> {
+  const client = await pool.connect();
+  try {
+    // CREATE ROLE is not transactional — guard against re-create across workers.
+    await client.query(
+      `DO $$ BEGIN
+         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${RLS_TEST_ROLE}') THEN
+           CREATE ROLE ${RLS_TEST_ROLE} LOGIN PASSWORD 'unused';
+         END IF;
+       END $$`,
+    );
+    await client.query(`GRANT USAGE ON SCHEMA ${SCHEMA} TO ${RLS_TEST_ROLE}`);
+    for (const { table, privileges } of options.grants ?? []) {
+      await client.query(`GRANT ${privileges} ON ${SCHEMA}.${table} TO ${RLS_TEST_ROLE}`);
+    }
+  } finally {
+    client.release();
+  }
+}
+
+/** Revoke grants and drop the per-process RLS role. Mirror of {@link ensureRlsRole}. */
+export async function dropRlsRole(pool: Pool, options: RlsRoleOptions = {}): Promise<void> {
+  const client = await pool.connect();
+  try {
+    for (const { table, privileges } of options.grants ?? []) {
+      await client.query(`REVOKE ${privileges} ON ${SCHEMA}.${table} FROM ${RLS_TEST_ROLE}`);
+    }
+    await client.query(`REVOKE USAGE ON SCHEMA ${SCHEMA} FROM ${RLS_TEST_ROLE}`);
+    await client.query(`DROP ROLE IF EXISTS ${RLS_TEST_ROLE}`);
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Run `fn` with the connection's role dropped to the non-superuser RLS role, so
+ * Postgres evaluates the RLS policies. The role switch is confined to a SAVEPOINT:
+ * on success the role is reset and the savepoint released; on any error the
+ * savepoint is rolled back (which also restores the original role) and the error
+ * is rethrown for the caller to interpret (e.g. `42501` = WITH CHECK rejection).
+ *
+ * Set the relevant `app.*` session variables BEFORE calling this — as superuser,
+ * before privileges are dropped.
+ */
+export async function runAsRlsRole<T>(client: PoolClient, fn: () => Promise<T>): Promise<T> {
+  await client.query(`SAVEPOINT rls_role`);
+  try {
+    await client.query(`SET LOCAL ROLE ${RLS_TEST_ROLE}`);
+    const result = await fn();
+    await client.query(`RESET ROLE`);
+    await client.query(`RELEASE SAVEPOINT rls_role`);
+    return result;
+  } catch (err) {
+    await client.query(`ROLLBACK TO SAVEPOINT rls_role`);
+    throw err;
+  }
+}

--- a/packages/server/src/__tests__/helpers/rls-role.ts
+++ b/packages/server/src/__tests__/helpers/rls-role.ts
@@ -18,10 +18,11 @@ import type { Pool, PoolClient } from 'pg';
 const SCHEMA = 'accounter_schema';
 
 /**
- * Per-process unique role name. Avoids collisions when Vitest runs test files in
- * parallel workers (each worker is a separate process).
+ * Unique role name per worker. `process.pid` alone is not enough: in Vitest's
+ * thread pool, parallel workers share one process (and thus one pid), so a random
+ * suffix is appended to avoid role-name collisions across concurrent test files.
  */
-export const RLS_TEST_ROLE = `rls_test_user_${process.pid}`;
+export const RLS_TEST_ROLE = `rls_test_user_${process.pid}_${Math.random().toString(36).slice(2, 10)}`;
 
 /** A table privilege grant: e.g. `{ table: 'sort_codes', privileges: 'INSERT, SELECT' }`. */
 export interface RlsRoleGrant {
@@ -64,15 +65,27 @@ export async function ensureRlsRole(pool: Pool, options: RlsRoleOptions = {}): P
   }
 }
 
-/** Revoke grants and drop the per-process RLS role. Mirror of {@link ensureRlsRole}. */
-export async function dropRlsRole(pool: Pool, options: RlsRoleOptions = {}): Promise<void> {
+/**
+ * Drop the RLS role. Mirror of {@link ensureRlsRole}.
+ *
+ * A bare `DROP ROLE` would fail while the role still holds the schema/table grants
+ * from ensureRlsRole — Postgres tracks them in pg_shdepend and refuses to drop a
+ * role other objects depend on. So we first `DROP OWNED BY`, which revokes every
+ * privilege granted to the role in the current database, then drop the role. The
+ * whole thing is guarded on role existence so a failed setup (role never created)
+ * surfaces the real error instead of a "role does not exist" during teardown.
+ */
+export async function dropRlsRole(pool: Pool): Promise<void> {
   const client = await pool.connect();
   try {
-    for (const { table, privileges } of options.grants ?? []) {
-      await client.query(`REVOKE ${privileges} ON ${SCHEMA}.${table} FROM ${RLS_TEST_ROLE}`);
-    }
-    await client.query(`REVOKE USAGE ON SCHEMA ${SCHEMA} FROM ${RLS_TEST_ROLE}`);
-    await client.query(`DROP ROLE IF EXISTS ${RLS_TEST_ROLE}`);
+    await client.query(
+      `DO $$ BEGIN
+         IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${RLS_TEST_ROLE}') THEN
+           EXECUTE 'DROP OWNED BY ${RLS_TEST_ROLE}';
+           EXECUTE 'DROP ROLE ${RLS_TEST_ROLE}';
+         END IF;
+       END $$`,
+    );
   } finally {
     client.release();
   }

--- a/packages/server/src/__tests__/rls-multi-business.integration.test.ts
+++ b/packages/server/src/__tests__/rls-multi-business.integration.test.ts
@@ -8,9 +8,12 @@ import { TestDatabase } from './helpers/db-setup.js';
  * - tenant_isolation policies read via the scope array (USING) while writes
  *   stay pinned to the single business (WITH CHECK).
  *
- * Note: the test DB connects as a superuser, which bypasses RLS row filtering,
- * so this asserts the helper behavior and the policy definitions (via
- * pg_policies) rather than cross-connection row visibility.
+ * This file asserts the helper behavior and the policy definitions (via
+ * pg_policies). The actual row filtering is exercised under a non-superuser role
+ * in rls-read-visibility.integration.test.ts (USING / reads) and
+ * rls-write-target.integration.test.ts (WITH CHECK / writes) — the test DB
+ * connects as a superuser (BYPASSRLS), so those tests drop to a non-privileged
+ * role to make Postgres evaluate the policies.
  */
 describe('multi-business RLS scope', () => {
   let db: TestDatabase;

--- a/packages/server/src/__tests__/rls-read-visibility.integration.test.ts
+++ b/packages/server/src/__tests__/rls-read-visibility.integration.test.ts
@@ -92,6 +92,7 @@ describe('RLS read visibility: get_current_business_scope controls row filtering
   });
 
   afterAll(async () => {
+    if (!pool) return;
     const teardown = await pool.connect();
     try {
       await teardown.query('SET row_security = off');
@@ -112,7 +113,7 @@ describe('RLS read visibility: get_current_business_scope controls row filtering
     } finally {
       teardown.release();
     }
-    await dropRlsRole(pool, { grants: GRANTS });
+    await dropRlsRole(pool);
     // Pool managed by global vitest setup — do not close here.
   });
 

--- a/packages/server/src/__tests__/rls-read-visibility.integration.test.ts
+++ b/packages/server/src/__tests__/rls-read-visibility.integration.test.ts
@@ -1,0 +1,163 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import type { Pool, PoolClient } from 'pg';
+import { TestDatabase } from './helpers/db-setup.js';
+import { dropRlsRole, ensureRlsRole, runAsRlsRole } from './helpers/rls-role.js';
+
+/**
+ * Integration tests for the read side of RLS — the `USING` clause of the
+ * `tenant_isolation` policy: `owner_id = ANY(get_current_business_scope())`.
+ *
+ * Companion to rls-write-target.integration.test.ts, which covers the write side
+ * (`WITH CHECK`). Together they prove the policy is actually enforced at the DB
+ * level, not merely defined — the test pool connects as postgres (BYPASSRLS), so
+ * each SELECT-under-test runs under a non-superuser role (see helpers/rls-role.ts)
+ * to make Postgres evaluate the policy and filter rows by the active read scope.
+ */
+
+// Two tenant businesses, distinct from the write-target fixtures so the two
+// files can run against the same DB without interfering.
+const A = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+const B = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee';
+
+// High, file-local key range to avoid colliding with other tests' sort_codes.
+const KEY_A = 910_001;
+const KEY_B = 910_002;
+
+const GRANTS = [{ table: 'sort_codes', privileges: 'SELECT' }];
+
+/** Read the sort_code keys visible under the current RLS context as the RLS role. */
+async function visibleKeys(client: PoolClient): Promise<number[]> {
+  return runAsRlsRole(client, async () => {
+    const res = await client.query<{ key: number }>(
+      `SELECT key FROM accounter_schema.sort_codes
+       WHERE owner_id IN ($1, $2)
+       ORDER BY key`,
+      [A, B],
+    );
+    return res.rows.map(r => Number(r.key));
+  });
+}
+
+describe('RLS read visibility: get_current_business_scope controls row filtering', () => {
+  let db: TestDatabase;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    db = new TestDatabase();
+    pool = await db.connect();
+
+    await ensureRlsRole(pool, { grants: GRANTS });
+
+    const setup = await pool.connect();
+    try {
+      // Fixture businesses A and B as self-owned entities, plus one sort_code
+      // owned by each. Committed so they persist across rolled-back per-test txns.
+      await setup.query('BEGIN');
+      for (const id of [A, B]) {
+        await setup.query(`SELECT set_config('app.current_business_id', $1, true)`, [id]);
+        await setup.query(
+          `INSERT INTO accounter_schema.financial_entities (id, name, type, owner_id)
+           VALUES ($1, $2, $3, NULL)
+           ON CONFLICT (id) DO NOTHING`,
+          [id, id, 'business'],
+        );
+        await setup.query(
+          `INSERT INTO accounter_schema.businesses (id, country, owner_id)
+           VALUES ($1, $2, $1)
+           ON CONFLICT (id) DO NOTHING`,
+          [id, 'ISR'],
+        );
+        await setup.query(
+          `UPDATE accounter_schema.financial_entities SET owner_id = $1 WHERE id = $1`,
+          [id],
+        );
+      }
+      await setup.query(
+        `INSERT INTO accounter_schema.sort_codes (key, name, owner_id)
+         VALUES ($1, 'rls-read-a', $2), ($3, 'rls-read-b', $4)
+         ON CONFLICT (key, owner_id) DO NOTHING`,
+        [KEY_A, A, KEY_B, B],
+      );
+      await setup.query('COMMIT');
+    } catch (e) {
+      try {
+        await setup.query('ROLLBACK');
+      } catch {
+        /* ignore */
+      }
+      throw e;
+    } finally {
+      setup.release();
+    }
+  });
+
+  afterAll(async () => {
+    const teardown = await pool.connect();
+    try {
+      await teardown.query('SET row_security = off');
+      await teardown.query(
+        `DELETE FROM accounter_schema.sort_codes WHERE owner_id IN ($1, $2)`,
+        [A, B],
+      );
+      await teardown.query(
+        `UPDATE accounter_schema.financial_entities SET owner_id = NULL WHERE id IN ($1, $2)`,
+        [A, B],
+      );
+      await teardown.query(`DELETE FROM accounter_schema.businesses WHERE id IN ($1, $2)`, [A, B]);
+      await teardown.query(`DELETE FROM accounter_schema.financial_entities WHERE id IN ($1, $2)`, [
+        A,
+        B,
+      ]);
+      await teardown.query('RESET row_security');
+    } finally {
+      teardown.release();
+    }
+    await dropRlsRole(pool, { grants: GRANTS });
+    // Pool managed by global vitest setup — do not close here.
+  });
+
+  test('scope {A} sees only A’s rows, hiding B', async () => {
+    await db.withTransaction(async client => {
+      await client.query(
+        `SELECT set_config('app.current_business_id', $1, true),
+                set_config('app.current_business_scope', $2, true)`,
+        [A, `{${A}}`],
+      );
+      expect(await visibleKeys(client)).toEqual([KEY_A]);
+    });
+  });
+
+  test('scope {B} sees only B’s rows, hiding A', async () => {
+    await db.withTransaction(async client => {
+      await client.query(
+        `SELECT set_config('app.current_business_id', $1, true),
+                set_config('app.current_business_scope', $2, true)`,
+        [B, `{${B}}`],
+      );
+      expect(await visibleKeys(client)).toEqual([KEY_B]);
+    });
+  });
+
+  test('scope {A,B} sees both tenants’ rows (multi-business read scope)', async () => {
+    await db.withTransaction(async client => {
+      await client.query(
+        `SELECT set_config('app.current_business_id', $1, true),
+                set_config('app.current_business_scope', $2, true)`,
+        [A, `{${A},${B}}`],
+      );
+      expect(await visibleKeys(client)).toEqual([KEY_A, KEY_B]);
+    });
+  });
+
+  test('empty scope falls back to the single business context, hiding B', async () => {
+    await db.withTransaction(async client => {
+      // Scope unset → get_current_business_scope() returns [current_business_id].
+      await client.query(
+        `SELECT set_config('app.current_business_id', $1, true),
+                set_config('app.current_business_scope', '', true)`,
+        [A],
+      );
+      expect(await visibleKeys(client)).toEqual([KEY_A]);
+    });
+  });
+});

--- a/packages/server/src/__tests__/rls-write-target.integration.test.ts
+++ b/packages/server/src/__tests__/rls-write-target.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import type { Pool, PoolClient } from 'pg';
 import { TestDatabase } from './helpers/db-setup.js';
+import { dropRlsRole, ensureRlsRole, runAsRlsRole } from './helpers/rls-role.js';
 
 /**
  * Integration tests for the X-Business-Scope write-target logic.
@@ -23,13 +24,12 @@ const A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
 const B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
 const C = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
 
-// Temporary non-superuser role used to test RLS enforcement.
-// The test pool connects as postgres (BYPASSRLS), so inserts as postgres always
-// bypass RLS regardless of FORCE ROW LEVEL SECURITY. We SET LOCAL ROLE to this
+// The non-superuser role used to test RLS enforcement (see helpers/rls-role.ts):
+// the test pool connects as postgres (BYPASSRLS), so inserts as postgres always
+// bypass RLS regardless of FORCE ROW LEVEL SECURITY. runAsRlsRole drops to a
 // non-privileged role for the inserts-under-test so Postgres actually evaluates
 // the WITH CHECK policy.
-// Per-process unique name avoids collisions when Vitest runs files in parallel workers.
-const RLS_TEST_ROLE = `rls_test_user_${process.pid}`;
+const SORT_CODES_GRANTS = [{ table: 'sort_codes', privileges: 'INSERT, SELECT' }];
 
 /**
  * Mirrors the write-target and read-scope derivation from:
@@ -87,21 +87,17 @@ async function attemptInsert(
   );
 
   // Drop to a non-superuser role so Postgres actually evaluates the RLS
-  // WITH CHECK policy. The pool connects as postgres which has BYPASSRLS;
-  // SET LOCAL ROLE confines the privilege drop to this savepoint scope.
-  await client.query(`SAVEPOINT rls_check`);
+  // WITH CHECK policy (the pool connects as postgres, which has BYPASSRLS).
   try {
-    await client.query(`SET LOCAL ROLE ${RLS_TEST_ROLE}`);
-    const result = await client.query(
-      `INSERT INTO accounter_schema.sort_codes (key, name, owner_id)
-       VALUES ($1, 'rls-test', $2)`,
-      [key, targetOwnerId],
-    );
-    await client.query(`RESET ROLE`);
-    await client.query(`RELEASE SAVEPOINT rls_check`);
-    return (result.rowCount ?? 0) > 0;
+    return await runAsRlsRole(client, async () => {
+      const result = await client.query(
+        `INSERT INTO accounter_schema.sort_codes (key, name, owner_id)
+         VALUES ($1, 'rls-test', $2)`,
+        [key, targetOwnerId],
+      );
+      return (result.rowCount ?? 0) > 0;
+    });
   } catch (err) {
-    await client.query(`ROLLBACK TO SAVEPOINT rls_check`);
     // 42501 = insufficient_privilege — the expected RLS WITH CHECK rejection.
     // Rethrow anything else so unexpected errors (bad SQL, missing table, etc.)
     // surface as real test failures rather than silent false negatives.
@@ -192,21 +188,12 @@ describe('RLS write-target: X-Business-Scope header controls insert target', () 
     db = new TestDatabase();
     pool = await db.connect();
 
+    // Create the non-superuser role for RLS enforcement and grant it the
+    // table + schema privileges needed for the INSERT under test.
+    await ensureRlsRole(pool, { grants: SORT_CODES_GRANTS });
+
     const setup = await pool.connect();
     try {
-      // Create a temporary non-superuser role for RLS enforcement testing.
-      // Must be done outside a transaction (CREATE ROLE is not transactional).
-      await setup.query(
-        `DO $$ BEGIN
-           IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${RLS_TEST_ROLE}') THEN
-             CREATE ROLE ${RLS_TEST_ROLE} LOGIN PASSWORD 'unused';
-           END IF;
-         END $$`,
-      );
-      // Grant table + schema privileges needed for the INSERT under test.
-      await setup.query(`GRANT USAGE ON SCHEMA accounter_schema TO ${RLS_TEST_ROLE}`);
-      await setup.query(`GRANT INSERT, SELECT ON accounter_schema.sort_codes TO ${RLS_TEST_ROLE}`);
-
       // Create fixture businesses A, B, C as self-owned entities.
       // Committed so they persist across all per-test rolled-back transactions.
       await setup.query('BEGIN');
@@ -261,12 +248,10 @@ describe('RLS write-target: X-Business-Scope header controls insert target', () 
         [A, B, C],
       );
       await teardown.query('RESET row_security');
-      await teardown.query(`REVOKE INSERT, SELECT ON accounter_schema.sort_codes FROM ${RLS_TEST_ROLE}`);
-      await teardown.query(`REVOKE USAGE ON SCHEMA accounter_schema FROM ${RLS_TEST_ROLE}`);
-      await teardown.query(`DROP ROLE IF EXISTS ${RLS_TEST_ROLE}`);
     } finally {
       teardown.release();
     }
+    await dropRlsRole(pool, { grants: SORT_CODES_GRANTS });
     // Pool managed by global vitest setup — do not close here.
   });
 

--- a/packages/server/src/__tests__/rls-write-target.integration.test.ts
+++ b/packages/server/src/__tests__/rls-write-target.integration.test.ts
@@ -226,6 +226,7 @@ describe('RLS write-target: X-Business-Scope header controls insert target', () 
   });
 
   afterAll(async () => {
+    if (!pool) return;
     const teardown = await pool.connect();
     try {
       await teardown.query('SET row_security = off');
@@ -251,7 +252,7 @@ describe('RLS write-target: X-Business-Scope header controls insert target', () 
     } finally {
       teardown.release();
     }
-    await dropRlsRole(pool, { grants: SORT_CODES_GRANTS });
+    await dropRlsRole(pool);
     // Pool managed by global vitest setup — do not close here.
   });
 


### PR DESCRIPTION
## Summary

Refactors Row-Level Security (RLS) testing infrastructure by extracting shared role-management utilities into a reusable helper module, and adds comprehensive integration tests for the read-side (`USING` clause) of the `tenant_isolation` policy.

## Key Changes

- **New file: `packages/server/src/__tests__/helpers/rls-role.ts`**
  - Extracted RLS role lifecycle management (`ensureRlsRole`, `dropRlsRole`) from `rls-write-target.integration.test.ts`
  - Added `runAsRlsRole` helper to safely drop privileges to a non-superuser role within a SAVEPOINT, enabling Postgres to evaluate RLS policies
  - Provides per-process unique role naming to avoid collisions in parallel test workers
  - Includes comprehensive JSDoc explaining the boundary between superuser (BYPASSRLS) and non-superuser contexts

- **New file: `packages/server/src/__tests__/rls-read-visibility.integration.test.ts`**
  - Integration tests for the read-side of RLS (`USING` clause: `owner_id = ANY(get_current_business_scope())`)
  - Tests four scenarios: single-business scope, multi-business scope, and fallback behavior when scope is unset
  - Verifies that `get_current_business_scope()` correctly filters visible rows based on the active read scope
  - Companion to `rls-write-target.integration.test.ts` (which covers the write side / `WITH CHECK`)

- **Modified: `packages/server/src/__tests__/rls-write-target.integration.test.ts`**
  - Refactored to use extracted helpers from `rls-role.ts`
  - Simplified `attemptInsert` function by delegating role-switching logic to `runAsRlsRole`
  - Moved role creation/teardown to use `ensureRlsRole` and `dropRlsRole`
  - Improved code clarity with reduced boilerplate

- **Modified: `packages/server/src/__tests__/rls-multi-business.integration.test.ts`**
  - Updated documentation to clarify that actual row filtering is tested in the new read/write-specific test files
  - Notes that this file asserts helper behavior and policy definitions, while the new files exercise filtering under non-superuser roles

## Implementation Details

- The RLS test role is created once per process (using `process.pid` for uniqueness) in `beforeAll` and dropped in `afterAll`, avoiding transactional issues with `CREATE ROLE`
- `runAsRlsRole` uses a SAVEPOINT to confine the privilege drop, allowing the surrounding test transaction to remain usable
- Both read and write tests now use the same role-switching boundary, establishing a pattern for future tenant-scoped providers
- Tests use distinct UUID ranges (A/B for reads, A/B/C for writes) to avoid fixture collisions when running against the same database

https://claude.ai/code/session_017u3pRVj2ckiszjr8Qm3np2