### PR TITLE
S15: Gateway Cloudflare authenticity verifier

### DIFF
--- a/packages/email-ingestion-gateway/src/__tests__/verifier.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/verifier.test.ts
@@ -83,6 +83,17 @@ describe('CloudflareAuthenticityVerifier', () => {
       );
       expect(result).toEqual({ valid: false, reason: IngestReasonCode.INVALID_AUTH });
     });
+
+    it('rejects a signature with trailing garbage after valid hex (strict length check)', async () => {
+      const valid = buildSignature(SECRET, FIXED_NOW, RAW_BODY);
+      const result = await verifier.verify(makeInput({ signature: valid + 'zz' }));
+      expect(result).toEqual({ valid: false, reason: IngestReasonCode.INVALID_AUTH });
+    });
+
+    it('rejects a signature that is valid hex but shorter than 64 chars', async () => {
+      const result = await verifier.verify(makeInput({ signature: 'deadbeef' }));
+      expect(result).toEqual({ valid: false, reason: IngestReasonCode.INVALID_AUTH });
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -264,6 +275,17 @@ describe('MemoryNonceStore', () => {
     const store = new MemoryNonceStore(() => fakeTime);
     await store.checkAndStore('n1', 300); // expires at 1_000_300
     fakeTime = 1_000_299; // 1 second before expiry
+    expect(await store.checkAndStore('n1', 300)).toBe(false);
+  });
+
+  it('re-accepts a nonce after it expires and is evicted from the queue', async () => {
+    let fakeTime = 1_000_000;
+    const store = new MemoryNonceStore(() => fakeTime);
+    await store.checkAndStore('n1', 10); // expires at 1_000_010
+    fakeTime = 1_000_011;
+    await store.checkAndStore('n1', 300); // re-accepted; expires at 1_001_311
+    fakeTime = 1_000_012;
+    // n1 is live again — must be rejected
     expect(await store.checkAndStore('n1', 300)).toBe(false);
   });
 });

--- a/packages/email-ingestion-gateway/src/__tests__/verifier.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/verifier.test.ts
@@ -1,0 +1,269 @@
+import { createHmac } from 'node:crypto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { IngestReasonCode } from '../contracts.js';
+import {
+  CloudflareAuthenticityVerifier,
+  MemoryNonceStore,
+  type AuthenticityInput,
+  type VerifierConfig,
+} from '../verifier.js';
+
+// Fixed wall-clock value for fully deterministic tests
+const FIXED_NOW = 1_700_000_000;
+
+const SECRET = 'test-webhook-secret-32-chars-long';
+const ALLOWED_IP = '198.41.128.1';
+const RAW_BODY = Buffer.from('{"event":"email","alias":"acme@example.com"}');
+
+function buildSignature(secret: string, timestampSeconds: number, rawBody: Buffer): string {
+  const prefix = Buffer.from(`${timestampSeconds}.`);
+  return createHmac('sha256', secret).update(Buffer.concat([prefix, rawBody])).digest('hex');
+}
+
+function makeConfig(overrides: Partial<VerifierConfig> = {}): VerifierConfig {
+  return {
+    webhookSecret: SECRET,
+    ipAllowlist: [ALLOWED_IP],
+    currentTimeSeconds: () => FIXED_NOW,
+    ...overrides,
+  };
+}
+
+function makeInput(overrides: Partial<AuthenticityInput> = {}): AuthenticityInput {
+  return {
+    rawBody: RAW_BODY,
+    signature: buildSignature(SECRET, FIXED_NOW, RAW_BODY),
+    timestampSeconds: FIXED_NOW,
+    nonce: 'unique-nonce-abc123',
+    sourceIp: ALLOWED_IP,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CloudflareAuthenticityVerifier
+// ---------------------------------------------------------------------------
+
+describe('CloudflareAuthenticityVerifier', () => {
+  let nonceStore: MemoryNonceStore;
+  let verifier: CloudflareAuthenticityVerifier;
+
+  beforeEach(() => {
+    nonceStore = new MemoryNonceStore(() => FIXED_NOW);
+    verifier = new CloudflareAuthenticityVerifier(makeConfig(), nonceStore);
+  });
+
+  it('accepts a fully valid request', async () => {
+    expect(await verifier.verify(makeInput())).toEqual({ valid: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // Signature validation
+  // -------------------------------------------------------------------------
+
+  describe('signature validation', () => {
+    it('rejects a tampered signature', async () => {
+      const result = await verifier.verify(makeInput({ signature: 'deadbeef'.repeat(8) }));
+      expect(result).toEqual({ valid: false, reason: IngestReasonCode.INVALID_AUTH });
+    });
+
+    it('rejects an empty signature', async () => {
+      const result = await verifier.verify(makeInput({ signature: '' }));
+      expect(result).toEqual({ valid: false, reason: IngestReasonCode.INVALID_AUTH });
+    });
+
+    it('rejects when the body is tampered after signing', async () => {
+      const result = await verifier.verify(makeInput({ rawBody: Buffer.from('tampered-body') }));
+      expect(result).toEqual({ valid: false, reason: IngestReasonCode.INVALID_AUTH });
+    });
+
+    it('rejects a signature computed with the wrong secret', async () => {
+      const result = await verifier.verify(
+        makeInput({ signature: buildSignature('wrong-secret', FIXED_NOW, RAW_BODY) }),
+      );
+      expect(result).toEqual({ valid: false, reason: IngestReasonCode.INVALID_AUTH });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // IP allowlist
+  // -------------------------------------------------------------------------
+
+  describe('IP allowlist', () => {
+    it('rejects a source IP not in the allowlist', async () => {
+      const result = await verifier.verify(makeInput({ sourceIp: '1.2.3.4' }));
+      expect(result).toEqual({ valid: false, reason: IngestReasonCode.INVALID_AUTH });
+    });
+
+    it('accepts any IP when the allowlist is empty (allowlist disabled)', async () => {
+      const openVerifier = new CloudflareAuthenticityVerifier(
+        makeConfig({ ipAllowlist: [] }),
+        nonceStore,
+      );
+      const result = await openVerifier.verify(makeInput({ sourceIp: '9.9.9.9' }));
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('accepts a source IP that matches a CIDR block', async () => {
+      const cidrVerifier = new CloudflareAuthenticityVerifier(
+        makeConfig({ ipAllowlist: ['198.41.128.0/20'] }),
+        nonceStore,
+      );
+      // 198.41.135.5 is within 198.41.128.0–198.41.143.255
+      const result = await cidrVerifier.verify(makeInput({ sourceIp: '198.41.135.5' }));
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('rejects a source IP outside the CIDR block', async () => {
+      const cidrVerifier = new CloudflareAuthenticityVerifier(
+        makeConfig({ ipAllowlist: ['198.41.128.0/20'] }),
+        nonceStore,
+      );
+      // 198.41.144.1 is beyond 198.41.143.255
+      const result = await cidrVerifier.verify(makeInput({ sourceIp: '198.41.144.1' }));
+      expect(result).toEqual({ valid: false, reason: IngestReasonCode.INVALID_AUTH });
+    });
+
+    it('accepts a source IP matching one of multiple allowlist entries', async () => {
+      const multiVerifier = new CloudflareAuthenticityVerifier(
+        makeConfig({ ipAllowlist: ['10.0.0.1', '198.41.128.0/20', '172.16.0.0/12'] }),
+        nonceStore,
+      );
+      // 172.16.5.10 is within 172.16.0.0–172.31.255.255
+      const result = await multiVerifier.verify(makeInput({ sourceIp: '172.16.5.10' }));
+      expect(result).toEqual({ valid: true });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Timestamp window
+  // -------------------------------------------------------------------------
+
+  describe('timestamp window', () => {
+    it('rejects a request with a stale timestamp (1 second past tolerance)', async () => {
+      const staleTs = FIXED_NOW - 301;
+      const result = await verifier.verify(
+        makeInput({
+          timestampSeconds: staleTs,
+          signature: buildSignature(SECRET, staleTs, RAW_BODY),
+        }),
+      );
+      expect(result).toEqual({ valid: false, reason: IngestReasonCode.INVALID_AUTH });
+    });
+
+    it('rejects a request with a future timestamp (1 second past tolerance)', async () => {
+      const futureTs = FIXED_NOW + 301;
+      const result = await verifier.verify(
+        makeInput({
+          timestampSeconds: futureTs,
+          signature: buildSignature(SECRET, futureTs, RAW_BODY),
+        }),
+      );
+      expect(result).toEqual({ valid: false, reason: IngestReasonCode.INVALID_AUTH });
+    });
+
+    it('accepts a request exactly at the past tolerance boundary (inclusive)', async () => {
+      const boundaryTs = FIXED_NOW - 300;
+      const result = await verifier.verify(
+        makeInput({
+          timestampSeconds: boundaryTs,
+          signature: buildSignature(SECRET, boundaryTs, RAW_BODY),
+        }),
+      );
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('accepts a request exactly at the future tolerance boundary (inclusive)', async () => {
+      const boundaryTs = FIXED_NOW + 300;
+      const result = await verifier.verify(
+        makeInput({
+          timestampSeconds: boundaryTs,
+          signature: buildSignature(SECRET, boundaryTs, RAW_BODY),
+        }),
+      );
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('respects a custom timestamp tolerance', async () => {
+      const strictVerifier = new CloudflareAuthenticityVerifier(
+        makeConfig({ timestampToleranceSeconds: 60 }),
+        nonceStore,
+      );
+      const slightlyOldTs = FIXED_NOW - 90;
+      const result = await strictVerifier.verify(
+        makeInput({
+          timestampSeconds: slightlyOldTs,
+          signature: buildSignature(SECRET, slightlyOldTs, RAW_BODY),
+        }),
+      );
+      expect(result).toEqual({ valid: false, reason: IngestReasonCode.INVALID_AUTH });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Nonce replay protection
+  // -------------------------------------------------------------------------
+
+  describe('nonce replay protection', () => {
+    it('rejects a replayed nonce on a second valid request', async () => {
+      await verifier.verify(makeInput({ nonce: 'replay-nonce-xyz' }));
+      const result = await verifier.verify(makeInput({ nonce: 'replay-nonce-xyz' }));
+      expect(result).toEqual({ valid: false, reason: IngestReasonCode.REPLAY_DETECTED });
+    });
+
+    it('accepts different nonces on consecutive valid requests', async () => {
+      const first = await verifier.verify(makeInput({ nonce: 'nonce-aaa' }));
+      const second = await verifier.verify(makeInput({ nonce: 'nonce-bbb' }));
+      expect(first).toEqual({ valid: true });
+      expect(second).toEqual({ valid: true });
+    });
+
+    it('does not consume the nonce when the signature is invalid', async () => {
+      // Bad signature → verification fails before touching the nonce store
+      await verifier.verify(makeInput({ signature: 'badsig', nonce: 'precious-nonce' }));
+      // Same nonce with a valid signature must now succeed (nonce was never stored)
+      const result = await verifier.verify(makeInput({ nonce: 'precious-nonce' }));
+      expect(result).toEqual({ valid: true });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MemoryNonceStore
+// ---------------------------------------------------------------------------
+
+describe('MemoryNonceStore', () => {
+  it('returns true the first time a nonce is stored', async () => {
+    const store = new MemoryNonceStore();
+    expect(await store.checkAndStore('n1', 300)).toBe(true);
+  });
+
+  it('returns false when the same nonce is submitted again', async () => {
+    const store = new MemoryNonceStore();
+    await store.checkAndStore('n1', 300);
+    expect(await store.checkAndStore('n1', 300)).toBe(false);
+  });
+
+  it('accepts independent nonces independently', async () => {
+    const store = new MemoryNonceStore();
+    expect(await store.checkAndStore('n1', 300)).toBe(true);
+    expect(await store.checkAndStore('n2', 300)).toBe(true);
+    expect(await store.checkAndStore('n3', 300)).toBe(true);
+  });
+
+  it('evicts expired nonces and accepts them again', async () => {
+    let fakeTime = 1_000_000;
+    const store = new MemoryNonceStore(() => fakeTime);
+    await store.checkAndStore('n1', 10); // expires at 1_000_010
+    fakeTime = 1_000_011; // advance past expiry
+    expect(await store.checkAndStore('n1', 300)).toBe(true);
+  });
+
+  it('does not evict a nonce before its TTL expires', async () => {
+    let fakeTime = 1_000_000;
+    const store = new MemoryNonceStore(() => fakeTime);
+    await store.checkAndStore('n1', 300); // expires at 1_000_300
+    fakeTime = 1_000_299; // 1 second before expiry
+    expect(await store.checkAndStore('n1', 300)).toBe(false);
+  });
+});

--- a/packages/email-ingestion-gateway/src/verifier.ts
+++ b/packages/email-ingestion-gateway/src/verifier.ts
@@ -1,0 +1,173 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { IngestReasonCode } from './contracts.js';
+
+export interface VerifierConfig {
+  /** HMAC-SHA256 shared secret used to validate request signatures */
+  webhookSecret: string;
+  /** Allowed source IPs or IPv4 CIDR blocks — empty list disables the IP check */
+  ipAllowlist: string[];
+  /** Maximum age (and future skew) of a request timestamp in seconds (default: 300) */
+  timestampToleranceSeconds?: number;
+  /** How long to retain seen nonces for replay detection in seconds (default: 600) */
+  nonceRetentionSeconds?: number;
+  /** Current time provider — injectable for deterministic tests (default: wall clock) */
+  currentTimeSeconds?: () => number;
+}
+
+export interface AuthenticityInput {
+  /** Raw request body bytes */
+  rawBody: Buffer | Uint8Array;
+  /** Hex-encoded HMAC-SHA256 of `${timestampSeconds}.${rawBody}` */
+  signature: string;
+  /** Unix timestamp in seconds, extracted from the request header */
+  timestampSeconds: number;
+  /** Unique per-request nonce for replay detection */
+  nonce: string;
+  /** Source IP address of the incoming request */
+  sourceIp: string;
+}
+
+export type AuthenticityVerdict = { valid: true } | { valid: false; reason: IngestReasonCode };
+
+export interface NonceStore {
+  /** Stores the nonce and returns true; returns false if already present (replay) */
+  checkAndStore(nonce: string, expirySeconds: number): Promise<boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory nonce store with TTL eviction
+// ---------------------------------------------------------------------------
+
+export class MemoryNonceStore implements NonceStore {
+  private readonly seen = new Map<string, number>();
+  private readonly clock: () => number;
+
+  constructor(currentTimeSeconds?: () => number) {
+    this.clock = currentTimeSeconds ?? (() => Math.floor(Date.now() / 1000));
+  }
+
+  async checkAndStore(nonce: string, expirySeconds: number): Promise<boolean> {
+    const now = this.clock();
+    // Evict expired entries on each call to bound memory usage
+    for (const [key, exp] of this.seen) {
+      if (exp < now) this.seen.delete(key);
+    }
+    if (this.seen.has(nonce)) return false;
+    this.seen.set(nonce, now + expirySeconds);
+    return true;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cloudflare authenticity verifier
+// ---------------------------------------------------------------------------
+
+export class CloudflareAuthenticityVerifier {
+  private readonly secret: string;
+  private readonly ipAllowlist: string[];
+  private readonly toleranceSeconds: number;
+  private readonly retentionSeconds: number;
+  private readonly clock: () => number;
+  private readonly nonceStore: NonceStore;
+
+  constructor(config: VerifierConfig, nonceStore?: NonceStore) {
+    this.secret = config.webhookSecret;
+    this.ipAllowlist = config.ipAllowlist;
+    this.toleranceSeconds = config.timestampToleranceSeconds ?? 300;
+    this.retentionSeconds = config.nonceRetentionSeconds ?? 600;
+    this.clock = config.currentTimeSeconds ?? (() => Math.floor(Date.now() / 1000));
+    this.nonceStore = nonceStore ?? new MemoryNonceStore(config.currentTimeSeconds);
+  }
+
+  async verify(input: AuthenticityInput): Promise<AuthenticityVerdict> {
+    // 1. IP allowlist — cheap fail-fast; defense-in-depth, never sole trust signal
+    if (this.ipAllowlist.length > 0 && !this.checkIpAllowlist(input.sourceIp)) {
+      return { valid: false, reason: IngestReasonCode.INVALID_AUTH };
+    }
+
+    // 2. Timestamp window — reject stale or far-future requests
+    if (!this.checkTimestampWindow(input.timestampSeconds)) {
+      return { valid: false, reason: IngestReasonCode.INVALID_AUTH };
+    }
+
+    // 3. HMAC-SHA256 signature — primary authenticity control
+    if (!this.verifySignature(input.rawBody, input.timestampSeconds, input.signature)) {
+      return { valid: false, reason: IngestReasonCode.INVALID_AUTH };
+    }
+
+    // 4. Nonce replay — only reached after signature is verified to prevent store pollution
+    if (!(await this.nonceStore.checkAndStore(input.nonce, this.retentionSeconds))) {
+      return { valid: false, reason: IngestReasonCode.REPLAY_DETECTED };
+    }
+
+    return { valid: true };
+  }
+
+  private verifySignature(
+    rawBody: Buffer | Uint8Array,
+    timestampSeconds: number,
+    signature: string,
+  ): boolean {
+    if (!signature) return false;
+
+    const prefix = Buffer.from(`${timestampSeconds}.`);
+    const body = Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody);
+    const payload = Buffer.concat([prefix, body]);
+    const expected = createHmac('sha256', this.secret).update(payload).digest('hex');
+
+    try {
+      const expBuf = Buffer.from(expected, 'hex');
+      const gotBuf = Buffer.from(signature, 'hex');
+      // timingSafeEqual requires equal lengths; check first to avoid throwing
+      if (expBuf.length !== gotBuf.length) return false;
+      return timingSafeEqual(expBuf, gotBuf);
+    } catch {
+      return false;
+    }
+  }
+
+  private checkIpAllowlist(ip: string): boolean {
+    return this.ipAllowlist.some(entry => matchesCidrOrIp(ip, entry));
+  }
+
+  private checkTimestampWindow(timestampSeconds: number): boolean {
+    return Math.abs(this.clock() - timestampSeconds) <= this.toleranceSeconds;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// IPv4 CIDR / exact-IP matching helpers
+// ---------------------------------------------------------------------------
+
+function matchesCidrOrIp(ip: string, entry: string): boolean {
+  return entry.includes('/') ? matchesIpv4Cidr(ip, entry) : ip === entry;
+}
+
+function matchesIpv4Cidr(ip: string, cidr: string): boolean {
+  const slashIdx = cidr.lastIndexOf('/');
+  const network = cidr.slice(0, slashIdx);
+  const prefixLen = parseInt(cidr.slice(slashIdx + 1), 10);
+  if (isNaN(prefixLen) || prefixLen < 0 || prefixLen > 32) return false;
+  if (prefixLen === 0) return true;
+
+  const ipNum = ipv4ToNumber(ip);
+  const networkNum = ipv4ToNumber(network);
+  if (ipNum === null || networkNum === null) return false;
+
+  // Zero the host bits using arithmetic to avoid JS 32-bit signed overflow in bitwise ops.
+  // For /24: shift=8, factor=256 — dividing and flooring drops the last octet, then multiply restores.
+  const factor = 2 ** (32 - prefixLen);
+  return Math.floor(ipNum / factor) === Math.floor(networkNum / factor);
+}
+
+function ipv4ToNumber(ip: string): number | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  let result = 0;
+  for (const part of parts) {
+    const n = parseInt(part, 10);
+    if (isNaN(n) || n < 0 || n > 255) return null;
+    result = result * 256 + n;
+  }
+  return result;
+}

--- a/packages/email-ingestion-gateway/src/verifier.ts
+++ b/packages/email-ingestion-gateway/src/verifier.ts
@@ -40,6 +40,8 @@ export interface NonceStore {
 
 export class MemoryNonceStore implements NonceStore {
   private readonly seen = new Map<string, number>();
+  // Insertion-ordered queue for O(1) amortized expiry without full-map scans
+  private readonly expiryQueue: { nonce: string; expiresAt: number }[] = [];
   private readonly clock: () => number;
 
   constructor(currentTimeSeconds?: () => number) {
@@ -48,12 +50,17 @@ export class MemoryNonceStore implements NonceStore {
 
   async checkAndStore(nonce: string, expirySeconds: number): Promise<boolean> {
     const now = this.clock();
-    // Evict expired entries on each call to bound memory usage
-    for (const [key, exp] of this.seen) {
-      if (exp < now) this.seen.delete(key);
+    // Evict from the front of the queue (entries are in chronological order)
+    while (this.expiryQueue.length > 0 && (this.expiryQueue[0]?.expiresAt ?? 0) < now) {
+      const expired = this.expiryQueue.shift();
+      if (expired && this.seen.get(expired.nonce) === expired.expiresAt) {
+        this.seen.delete(expired.nonce);
+      }
     }
     if (this.seen.has(nonce)) return false;
-    this.seen.set(nonce, now + expirySeconds);
+    const expiresAt = now + expirySeconds;
+    this.seen.set(nonce, expiresAt);
+    this.expiryQueue.push({ nonce, expiresAt });
     return true;
   }
 }
@@ -108,7 +115,7 @@ export class CloudflareAuthenticityVerifier {
     timestampSeconds: number,
     signature: string,
   ): boolean {
-    if (!signature) return false;
+    if (!signature || !/^[0-9a-fA-F]{64}$/.test(signature)) return false;
 
     const prefix = Buffer.from(`${timestampSeconds}.`);
     const body = Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody);
@@ -146,8 +153,10 @@ function matchesCidrOrIp(ip: string, entry: string): boolean {
 function matchesIpv4Cidr(ip: string, cidr: string): boolean {
   const slashIdx = cidr.lastIndexOf('/');
   const network = cidr.slice(0, slashIdx);
-  const prefixLen = parseInt(cidr.slice(slashIdx + 1), 10);
-  if (isNaN(prefixLen) || prefixLen < 0 || prefixLen > 32) return false;
+  const prefixStr = cidr.slice(slashIdx + 1);
+  if (!/^\d+$/.test(prefixStr)) return false;
+  const prefixLen = parseInt(prefixStr, 10);
+  if (prefixLen > 32) return false;
   if (prefixLen === 0) return true;
 
   const ipNum = ipv4ToNumber(ip);
@@ -165,8 +174,10 @@ function ipv4ToNumber(ip: string): number | null {
   if (parts.length !== 4) return null;
   let result = 0;
   for (const part of parts) {
+    // Reject trailing non-digits, leading zeros (octal ambiguity), and empty strings
+    if (!/^(0|[1-9]\d*)$/.test(part)) return null;
     const n = parseInt(part, 10);
-    if (isNaN(n) || n < 0 || n > 255) return null;
+    if (n > 255) return null;
     result = result * 256 + n;
   }
   return result;

--- a/todo.md
+++ b/todo.md
@@ -222,12 +222,12 @@ Primary references:
 
 ## Phase 5 - New Gateway Implementation (S15-S18)
 
-### S15: Cloudflare authenticity verifier
+### S15: Cloudflare authenticity verifier ✅ (this PR)
 
-- [ ] Add signature/mTLS authenticity checks in new gateway package.
-- [ ] Add IP allowlist check as defense-in-depth.
-- [ ] Add timestamp window and nonce replay checks.
-- [ ] Add tests for valid/invalid/stale/replayed requests.
+- [x] Add signature/mTLS authenticity checks in new gateway package.
+- [x] Add IP allowlist check as defense-in-depth.
+- [x] Add timestamp window and nonce replay checks.
+- [x] Add tests for valid/invalid/stale/replayed requests.
 
 ### S16: Webhook endpoint
 


### PR DESCRIPTION
## Summary

- Adds `CloudflareAuthenticityVerifier` in `packages/email-ingestion-gateway` — orchestrates HMAC-SHA256 signature verification, IPv4 CIDR IP allowlist, timestamp window, and nonce replay protection
- Adds `MemoryNonceStore` with TTL-based eviction and an injectable clock for deterministic tests
- IPv4 CIDR matching uses arithmetic (avoids JS 32-bit signed-overflow in bitwise ops)
- 23 TDD unit tests covering: valid request, tampered signature, wrong secret, tampered body, empty signature, IP not in allowlist, CIDR matching, empty allowlist (disabled), stale/future timestamps, boundary timestamps, custom tolerance, nonce replay, independent nonces, nonce not stored on invalid signature

## Design decisions

**Check order** — IP (cheap fail-fast) → timestamp → signature (primary auth) → nonce. Nonce is stored only after signature is verified to prevent nonce-store pollution by unauthenticated callers.

**IP cannot override signature** — Both checks must pass; the IP check can only cause early rejection, never bypass the signature check.

**Empty allowlist = disabled** — Allows deploying without an IP allowlist for dev/test environments; production should always set `ipAllowlist`.

**No imports from `packages/gmail-listener`** — Verifier logic is greenfield in the gateway package per the anti-coupling constraint.

## Test plan

- [x] `yarn test --project unit packages/email-ingestion-gateway/src/__tests__/verifier.test.ts` — 23/23 pass
- [x] `yarn test --project unit` — no new failures (pre-existing DB-dependent failures unchanged)
- [x] `yarn prettier:check` — all matched files use Prettier code style

https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x)_