### PR TITLE
S17: Gateway MIME extraction pipeline (duplicate/adapt, no sharing)

### DIFF
--- a/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
@@ -4,6 +4,7 @@ import { IngestReasonCode } from '../contracts.js';
 import {
   MAX_ATTACHMENT_COUNT,
   MAX_EXTRACTED_BYTES,
+  MAX_MIME_DEPTH,
   MAX_RAW_MIME_BYTES,
   extractFromMime,
   type ExtractedDocument,
@@ -380,3 +381,101 @@ describe('extractFromMime — senderEvidence', () => {
 });
 
 import { beforeAll } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Limit constants (depth)
+// ---------------------------------------------------------------------------
+
+describe('exported limit constants — MAX_MIME_DEPTH', () => {
+  it('MAX_MIME_DEPTH is 10', () => {
+    expect(MAX_MIME_DEPTH).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security: deeply nested multipart → PARSE_ERROR (stack overflow guard)
+// ---------------------------------------------------------------------------
+
+describe('extractFromMime — deeply nested multipart', () => {
+  function buildNestedMultipart(depth: number): string {
+    if (depth === 0) {
+      return [
+        'Content-Type: text/plain',
+        '',
+        'leaf',
+      ].join('\r\n');
+    }
+    const boundary = `NEST${depth}`;
+    const inner = buildNestedMultipart(depth - 1);
+    return [
+      `Content-Type: multipart/mixed; boundary="${boundary}"`,
+      '',
+      `--${boundary}`,
+      inner,
+      `--${boundary}--`,
+    ].join('\r\n');
+  }
+
+  it('returns PARSE_ERROR for MIME nesting deeper than MAX_MIME_DEPTH', () => {
+    // Build a message nested deeper than the limit
+    const nested = buildNestedMultipart(MAX_MIME_DEPTH + 2);
+    const raw = Buffer.from(
+      ['From: attacker@evil.com', '', nested].join('\r\n'),
+      'utf8',
+    );
+    const result = extractFromMime(raw);
+    // Either PARSE_ERROR (throws) or NO_DOCUMENTS (no docs at max depth) — never success
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect([IngestReasonCode.PARSE_ERROR, IngestReasonCode.NO_DOCUMENTS]).toContain(
+        result.reason,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security: boundary string appearing inside base64 body is not a false delimiter
+// ---------------------------------------------------------------------------
+
+describe('extractFromMime — boundary collision in body', () => {
+  it('does not treat boundary string inside base64 content as a real boundary', () => {
+    // Craft a PDF whose base64 encoding contains the boundary string embedded
+    // in the middle of a line (not preceded by a newline). The parser should
+    // ignore it and successfully decode the attachment.
+    const boundary = 'COLLISION';
+    // Small PDF whose content doesn't accidentally contain --COLLISION at line start
+    const pdf = fakePdf(64);
+    const b64 = pdf.toString('base64');
+    // The base64 encoding of a small buffer won't naturally contain the boundary,
+    // but we verify that even with a crafted preamble text part that contains the
+    // boundary string, the attachment still decodes correctly.
+    const mime = Buffer.from(
+      [
+        'From: sender@example.com',
+        `Content-Type: multipart/mixed; boundary="${boundary}"`,
+        '',
+        `--${boundary}`,
+        'Content-Type: text/plain',
+        '',
+        // The boundary string appears mid-line here — should NOT split
+        `Text with --${boundary} in the middle of a line`,
+        `--${boundary}`,
+        'Content-Type: application/pdf',
+        `Content-Disposition: attachment; filename="doc.pdf"`,
+        'Content-Transfer-Encoding: base64',
+        '',
+        b64,
+        `--${boundary}--`,
+      ].join('\r\n'),
+      'utf8',
+    );
+
+    const result = extractFromMime(mime);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]?.content).toEqual(pdf);
+    }
+  });
+});

--- a/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
@@ -1,0 +1,382 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { IngestReasonCode } from '../contracts.js';
+import {
+  MAX_ATTACHMENT_COUNT,
+  MAX_EXTRACTED_BYTES,
+  MAX_RAW_MIME_BYTES,
+  extractFromMime,
+  type ExtractedDocument,
+  type SenderEvidence,
+} from '../mime-extractor.js';
+
+vi.mock('dotenv', () => ({ config: vi.fn() }));
+
+// ---------------------------------------------------------------------------
+// MIME helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal plain-text MIME message */
+function makeTextMime(from: string, subject: string, body = 'hello'): Buffer {
+  return Buffer.from(
+    [
+      `From: ${from}`,
+      `To: invoices@example.com`,
+      `Subject: ${subject}`,
+      `MIME-Version: 1.0`,
+      `Content-Type: text/plain; charset=utf-8`,
+      `Content-Transfer-Encoding: 7bit`,
+      ``,
+      body,
+    ].join('\r\n'),
+    'utf8',
+  );
+}
+
+/**
+ * Build a multipart/mixed MIME with one base64-encoded attachment.
+ * `content` should be the raw bytes of the attachment.
+ */
+function makeMultipartMime(opts: {
+  from?: string;
+  replyTo?: string;
+  originalFrom?: string;
+  originalSender?: string;
+  attachments?: Array<{ filename: string; mimeType: string; content: Buffer }>;
+}): Buffer {
+  const boundary = 'TESTBOUNDARY001';
+  const headers = [
+    `From: ${opts.from ?? 'sender@example.com'}`,
+    `To: invoices@example.com`,
+    `Subject: Test`,
+    `MIME-Version: 1.0`,
+    `Content-Type: multipart/mixed; boundary="${boundary}"`,
+  ];
+  if (opts.replyTo) headers.push(`Reply-To: ${opts.replyTo}`);
+  if (opts.originalFrom) headers.push(`X-Original-From: ${opts.originalFrom}`);
+  if (opts.originalSender) headers.push(`X-Original-Sender: ${opts.originalSender}`);
+
+  const parts: string[] = [];
+  parts.push(
+    [
+      `Content-Type: text/plain`,
+      `Content-Transfer-Encoding: 7bit`,
+      ``,
+      `See attached.`,
+    ].join('\r\n'),
+  );
+
+  for (const att of opts.attachments ?? []) {
+    parts.push(
+      [
+        `Content-Type: ${att.mimeType}`,
+        `Content-Disposition: attachment; filename="${att.filename}"`,
+        `Content-Transfer-Encoding: base64`,
+        ``,
+        att.content.toString('base64'),
+      ].join('\r\n'),
+    );
+  }
+
+  const body = [
+    `--${boundary}`,
+    parts.join(`\r\n--${boundary}\r\n`),
+    `--${boundary}--`,
+  ].join('\r\n');
+
+  return Buffer.from([...headers, '', body].join('\r\n'), 'utf8');
+}
+
+/** Build a small fake PDF buffer */
+function fakePdf(sizeBytes = 512): Buffer {
+  const buf = Buffer.alloc(sizeBytes);
+  buf.write('%PDF-1.4 fake', 0, 'ascii');
+  return buf;
+}
+
+/** Build a small fake PNG buffer */
+function fakePng(sizeBytes = 256): Buffer {
+  const buf = Buffer.alloc(sizeBytes);
+  // PNG magic bytes
+  buf[0] = 0x89;
+  buf[1] = 0x50;
+  buf[2] = 0x4e;
+  buf[3] = 0x47;
+  return buf;
+}
+
+import { vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Limit constants
+// ---------------------------------------------------------------------------
+
+describe('exported limit constants', () => {
+  it('MAX_RAW_MIME_BYTES is 25 MB', () => {
+    expect(MAX_RAW_MIME_BYTES).toBe(25 * 1024 * 1024);
+  });
+  it('MAX_ATTACHMENT_COUNT is 10', () => {
+    expect(MAX_ATTACHMENT_COUNT).toBe(10);
+  });
+  it('MAX_EXTRACTED_BYTES is 20 MB', () => {
+    expect(MAX_EXTRACTED_BYTES).toBe(20 * 1024 * 1024);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OVERSIZE_MESSAGE — raw MIME size
+// ---------------------------------------------------------------------------
+
+describe('extractFromMime — OVERSIZE_MESSAGE', () => {
+  it('returns OVERSIZE_MESSAGE when raw MIME exceeds 25 MB', () => {
+    const big = Buffer.alloc(MAX_RAW_MIME_BYTES + 1);
+    const result = extractFromMime(big);
+    expect(result).toEqual({ success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE });
+  });
+
+  it('does NOT reject a message at exactly 25 MB', () => {
+    // A buffer of exactly MAX size should not trigger the oversize check
+    // (even if it's invalid MIME it will fail differently)
+    const exact = Buffer.alloc(MAX_RAW_MIME_BYTES);
+    const result = extractFromMime(exact);
+    // Either PARSE_ERROR or NO_DOCUMENTS — not OVERSIZE_MESSAGE
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.reason).not.toBe(IngestReasonCode.OVERSIZE_MESSAGE);
+    }
+  });
+
+  it('returns OVERSIZE_MESSAGE when attachment count exceeds 10', () => {
+    const attachments = Array.from({ length: MAX_ATTACHMENT_COUNT + 1 }, (_, i) => ({
+      filename: `doc${i}.pdf`,
+      mimeType: 'application/pdf',
+      content: fakePdf(100),
+    }));
+    const mime = makeMultipartMime({ attachments });
+    const result = extractFromMime(mime);
+    expect(result).toEqual({ success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE });
+  });
+
+  it('returns OVERSIZE_MESSAGE when total extracted bytes exceed 20 MB', () => {
+    // One attachment that is just over 20 MB
+    const big = Buffer.alloc(MAX_EXTRACTED_BYTES + 1);
+    const mime = makeMultipartMime({
+      attachments: [{ filename: 'big.pdf', mimeType: 'application/pdf', content: big }],
+    });
+    const result = extractFromMime(mime);
+    expect(result).toEqual({ success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PARSE_ERROR
+// ---------------------------------------------------------------------------
+
+describe('extractFromMime — PARSE_ERROR', () => {
+  it('returns PARSE_ERROR for completely empty buffer', () => {
+    const result = extractFromMime(Buffer.alloc(0));
+    expect(result).toEqual({ success: false, reason: IngestReasonCode.PARSE_ERROR });
+  });
+
+  it('returns PARSE_ERROR for random binary data with no MIME structure', () => {
+    const noise = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+    const result = extractFromMime(noise);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NO_DOCUMENTS
+// ---------------------------------------------------------------------------
+
+describe('extractFromMime — NO_DOCUMENTS', () => {
+  it('returns NO_DOCUMENTS for a plain-text-only message', () => {
+    const mime = makeTextMime('sender@example.com', 'Hello');
+    const result = extractFromMime(mime);
+    expect(result).toEqual({ success: false, reason: IngestReasonCode.NO_DOCUMENTS });
+  });
+
+  it('returns NO_DOCUMENTS for multipart/mixed with no document attachments', () => {
+    // Has a text attachment, not a PDF/image
+    const mime = makeMultipartMime({
+      attachments: [
+        { filename: 'notes.txt', mimeType: 'text/plain', content: Buffer.from('notes') },
+      ],
+    });
+    const result = extractFromMime(mime);
+    expect(result).toEqual({ success: false, reason: IngestReasonCode.NO_DOCUMENTS });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success path — documents
+// ---------------------------------------------------------------------------
+
+describe('extractFromMime — success: PDF attachment', () => {
+  const pdfBytes = fakePdf(1024);
+  let mime: Buffer;
+
+  beforeAll(() => {
+    mime = makeMultipartMime({
+      from: 'vendor@biz.com',
+      attachments: [{ filename: 'invoice.pdf', mimeType: 'application/pdf', content: pdfBytes }],
+    });
+  });
+
+  it('returns success: true', () => {
+    const result = extractFromMime(mime);
+    expect(result.success).toBe(true);
+  });
+
+  it('includes one document', () => {
+    const result = extractFromMime(mime) as { success: true; documents: ExtractedDocument[] };
+    expect(result.documents).toHaveLength(1);
+  });
+
+  it('document has correct filename and mimeType', () => {
+    const result = extractFromMime(mime) as { success: true; documents: ExtractedDocument[] };
+    expect(result.documents[0]?.filename).toBe('invoice.pdf');
+    expect(result.documents[0]?.mimeType).toBe('application/pdf');
+  });
+
+  it('document size matches original bytes', () => {
+    const result = extractFromMime(mime) as { success: true; documents: ExtractedDocument[] };
+    expect(result.documents[0]?.size).toBe(pdfBytes.length);
+  });
+
+  it('document sha256 matches crypto hash of original bytes', () => {
+    const result = extractFromMime(mime) as { success: true; documents: ExtractedDocument[] };
+    const expected = createHash('sha256').update(pdfBytes).digest('hex');
+    expect(result.documents[0]?.sha256).toBe(expected);
+  });
+
+  it('document content matches original bytes', () => {
+    const result = extractFromMime(mime) as { success: true; documents: ExtractedDocument[] };
+    expect(result.documents[0]?.content).toEqual(pdfBytes);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success path — image attachment
+// ---------------------------------------------------------------------------
+
+describe('extractFromMime — success: image attachment', () => {
+  it('extracts image/png attachment', () => {
+    const png = fakePng(512);
+    const mime = makeMultipartMime({
+      attachments: [{ filename: 'receipt.png', mimeType: 'image/png', content: png }],
+    });
+    const result = extractFromMime(mime);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.documents[0]?.mimeType).toBe('image/png');
+      expect(result.documents[0]?.size).toBe(png.length);
+    }
+  });
+
+  it('extracts image/jpeg attachment', () => {
+    const jpg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, ...Buffer.alloc(100)]);
+    const mime = makeMultipartMime({
+      attachments: [{ filename: 'scan.jpg', mimeType: 'image/jpeg', content: jpg }],
+    });
+    const result = extractFromMime(mime);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success path — application/octet-stream with .pdf filename
+// ---------------------------------------------------------------------------
+
+describe('extractFromMime — octet-stream with .pdf filename', () => {
+  it('treats application/octet-stream with .pdf filename as PDF', () => {
+    const pdf = fakePdf(256);
+    const mime = makeMultipartMime({
+      attachments: [
+        {
+          filename: 'document.pdf',
+          mimeType: 'application/octet-stream',
+          content: pdf,
+        },
+      ],
+    });
+    const result = extractFromMime(mime);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.documents[0]?.mimeType).toBe('application/pdf');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple attachments
+// ---------------------------------------------------------------------------
+
+describe('extractFromMime — multiple attachments', () => {
+  it('returns all document attachments up to the limit', () => {
+    const attachments = Array.from({ length: MAX_ATTACHMENT_COUNT }, (_, i) => ({
+      filename: `doc${i}.pdf`,
+      mimeType: 'application/pdf',
+      content: fakePdf(64),
+    }));
+    const mime = makeMultipartMime({ attachments });
+    const result = extractFromMime(mime);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.documents).toHaveLength(MAX_ATTACHMENT_COUNT);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sender evidence
+// ---------------------------------------------------------------------------
+
+describe('extractFromMime — senderEvidence', () => {
+  it('captures From header', () => {
+    const mime = makeMultipartMime({
+      from: 'Alice <alice@vendor.com>',
+      attachments: [{ filename: 'a.pdf', mimeType: 'application/pdf', content: fakePdf() }],
+    });
+    const result = extractFromMime(mime) as { success: true; senderEvidence: SenderEvidence };
+    expect(result.senderEvidence.from).toBe('Alice <alice@vendor.com>');
+  });
+
+  it('captures Reply-To header', () => {
+    const mime = makeMultipartMime({
+      replyTo: 'billing@vendor.com',
+      attachments: [{ filename: 'a.pdf', mimeType: 'application/pdf', content: fakePdf() }],
+    });
+    const result = extractFromMime(mime) as { success: true; senderEvidence: SenderEvidence };
+    expect(result.senderEvidence.replyTo).toBe('billing@vendor.com');
+  });
+
+  it('captures X-Original-From header', () => {
+    const mime = makeMultipartMime({
+      originalFrom: 'original@sender.com',
+      attachments: [{ filename: 'a.pdf', mimeType: 'application/pdf', content: fakePdf() }],
+    });
+    const result = extractFromMime(mime) as { success: true; senderEvidence: SenderEvidence };
+    expect(result.senderEvidence.originalFrom).toBe('original@sender.com');
+  });
+
+  it('captures X-Original-Sender header (fallback when X-Original-From absent)', () => {
+    const mime = makeMultipartMime({
+      originalSender: 'orig-sender@vendor.com',
+      attachments: [{ filename: 'a.pdf', mimeType: 'application/pdf', content: fakePdf() }],
+    });
+    const result = extractFromMime(mime) as { success: true; senderEvidence: SenderEvidence };
+    expect(result.senderEvidence.originalFrom).toBe('orig-sender@vendor.com');
+  });
+
+  it('returns undefined for absent optional headers', () => {
+    const mime = makeMultipartMime({
+      attachments: [{ filename: 'a.pdf', mimeType: 'application/pdf', content: fakePdf() }],
+    });
+    const result = extractFromMime(mime) as { success: true; senderEvidence: SenderEvidence };
+    expect(result.senderEvidence.replyTo).toBeUndefined();
+    expect(result.senderEvidence.originalFrom).toBeUndefined();
+  });
+});
+
+import { beforeAll } from 'vitest';

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -4,6 +4,7 @@ import { IngestReasonCode } from './contracts.js';
 export const MAX_RAW_MIME_BYTES = 25 * 1024 * 1024; // 25 MB
 export const MAX_ATTACHMENT_COUNT = 10;
 export const MAX_EXTRACTED_BYTES = 20 * 1024 * 1024; // 20 MB
+export const MAX_MIME_DEPTH = 10;
 
 export interface ExtractedDocument {
   filename: string | undefined;
@@ -153,7 +154,9 @@ function getMediaType(contentType: string): string {
 }
 
 function getParam(contentType: string, param: string): string | undefined {
-  const re = new RegExp(`${param}=(?:"([^"]+)"|([^\\s;]+))`, 'i');
+  // Require the param name to be preceded by ';', whitespace, or start-of-string
+  // to avoid matching suffixes (e.g. "x-boundary" when looking for "boundary").
+  const re = new RegExp(`(?:^|[\\s;])${param}=(?:"([^"]+)"|([^\\s;]+))`, 'i');
   const m = contentType.match(re);
   return m?.[1] ?? m?.[2];
 }
@@ -179,9 +182,8 @@ function getFilename(headers: Headers): string | undefined {
 function decodeBody(body: Buffer, encoding: string | undefined): Buffer {
   const enc = (encoding ?? '7bit').trim().toLowerCase();
   if (enc === 'base64') {
-    // Strip whitespace before decoding (base64 lines have CRLF)
-    const cleaned = body.toString('latin1').replace(/\s+/g, '');
-    return Buffer.from(cleaned, 'base64');
+    // Buffer.from(..., 'base64') already ignores all whitespace, including CRLF line endings.
+    return Buffer.from(body.toString('ascii'), 'base64');
   }
   if (enc === 'quoted-printable') {
     return decodeQuotedPrintable(body.toString('latin1'));
@@ -243,8 +245,22 @@ function splitMultipartParts(body: Buffer, boundary: string): Buffer[] {
   const closing = Buffer.from(`--${boundary}--`);
   const parts: Buffer[] = [];
 
+  // RFC 2046 §5.1.1: each boundary must be preceded by a CRLF (or be at
+  // position 0). Without this check, boundary strings that appear inside
+  // base64 content could be incorrectly treated as delimiters.
+  const findBoundary = (start: number): number => {
+    let s = start;
+    while (s < body.length) {
+      const idx = body.indexOf(delim, s);
+      if (idx < 0) return -1;
+      if (idx === 0 || body[idx - 1] === 0x0a) return idx;
+      s = idx + 1;
+    }
+    return -1;
+  };
+
   // Find the first boundary
-  let pos = bufferIndexOf(body, delim, 0);
+  let pos = findBoundary(0);
   if (pos < 0) return parts;
 
   while (pos < body.length) {
@@ -264,7 +280,7 @@ function splitMultipartParts(body: Buffer, boundary: string): Buffer[] {
     if (body[partStart] === 0x0a) partStart++;
 
     // Find the next boundary occurrence
-    const nextDelim = bufferIndexOf(body, delim, partStart);
+    const nextDelim = findBoundary(partStart);
 
     let partEnd: number;
     if (nextDelim < 0) {
@@ -291,7 +307,11 @@ function splitMultipartParts(body: Buffer, boundary: string): Buffer[] {
 // Recursive MIME part parser
 // ---------------------------------------------------------------------------
 
-function parseMimePart(raw: Buffer): ParsedPart {
+function parseMimePart(raw: Buffer, depth = 0): ParsedPart {
+  if (depth > MAX_MIME_DEPTH) {
+    throw new Error('Max MIME nesting depth exceeded');
+  }
+
   const { headerText, body } = splitHeaderBody(raw);
   const headers = parseHeaders(headerText);
 
@@ -306,7 +326,7 @@ function parseMimePart(raw: Buffer): ParsedPart {
 
     const subParts = splitMultipartParts(body, boundary);
     for (const part of subParts) {
-      const sub = parseMimePart(part);
+      const sub = parseMimePart(part, depth + 1);
       documents.push(...sub.documents);
     }
   } else if (isDocumentPart(headers)) {

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -1,0 +1,341 @@
+import { createHash } from 'node:crypto';
+import { IngestReasonCode } from './contracts.js';
+
+export const MAX_RAW_MIME_BYTES = 25 * 1024 * 1024; // 25 MB
+export const MAX_ATTACHMENT_COUNT = 10;
+export const MAX_EXTRACTED_BYTES = 20 * 1024 * 1024; // 20 MB
+
+export interface ExtractedDocument {
+  filename: string | undefined;
+  mimeType: string;
+  content: Buffer;
+  size: number;
+  sha256: string;
+}
+
+export interface SenderEvidence {
+  from: string | undefined;
+  replyTo: string | undefined;
+  /** X-Original-From or X-Original-Sender */
+  originalFrom: string | undefined;
+  /** X-Forwarded-To or Envelope-To */
+  forwardedTo: string | undefined;
+}
+
+export type ExtractionFailureReason =
+  | typeof IngestReasonCode.NO_DOCUMENTS
+  | typeof IngestReasonCode.PARSE_ERROR
+  | typeof IngestReasonCode.OVERSIZE_MESSAGE;
+
+export type ExtractionResult =
+  | { success: true; senderEvidence: SenderEvidence; documents: ExtractedDocument[] }
+  | { success: false; reason: ExtractionFailureReason };
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+export function extractFromMime(rawMime: Buffer): ExtractionResult {
+  if (rawMime.length === 0) {
+    return { success: false, reason: IngestReasonCode.PARSE_ERROR };
+  }
+
+  if (rawMime.length > MAX_RAW_MIME_BYTES) {
+    return { success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE };
+  }
+
+  try {
+    const { headers, documents } = parseMimePart(rawMime);
+
+    if (documents.length > MAX_ATTACHMENT_COUNT) {
+      return { success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE };
+    }
+
+    const totalBytes = documents.reduce((sum, d) => sum + d.size, 0);
+    if (totalBytes > MAX_EXTRACTED_BYTES) {
+      return { success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE };
+    }
+
+    if (documents.length === 0) {
+      return { success: false, reason: IngestReasonCode.NO_DOCUMENTS };
+    }
+
+    return { success: true, senderEvidence: buildSenderEvidence(headers), documents };
+  } catch {
+    return { success: false, reason: IngestReasonCode.PARSE_ERROR };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MIME header types
+// ---------------------------------------------------------------------------
+
+type Headers = Map<string, string>;
+
+interface ParsedPart {
+  headers: Headers;
+  documents: ExtractedDocument[];
+}
+
+// ---------------------------------------------------------------------------
+// Low-level buffer utilities
+// ---------------------------------------------------------------------------
+
+/** Find index of a byte pattern in a Buffer. Returns -1 if not found. */
+function bufferIndexOf(haystack: Buffer, needle: Buffer, start = 0): number {
+  return haystack.indexOf(needle, start);
+}
+
+/**
+ * Split a raw MIME part buffer into header text and body buffer.
+ * Handles both CRLF and bare-LF line endings.
+ */
+function splitHeaderBody(raw: Buffer): { headerText: string; body: Buffer } {
+  const CRLFCRLF = Buffer.from('\r\n\r\n');
+  const LFLF = Buffer.from('\n\n');
+
+  const ci = bufferIndexOf(raw, CRLFCRLF);
+  const li = bufferIndexOf(raw, LFLF);
+
+  let splitAt: number;
+  let offset: number;
+
+  if (ci >= 0 && (li < 0 || ci <= li)) {
+    splitAt = ci;
+    offset = 4;
+  } else if (li >= 0) {
+    splitAt = li;
+    offset = 2;
+  } else {
+    // No body separator — treat whole buffer as headers with empty body
+    return { headerText: raw.toString('latin1'), body: Buffer.alloc(0) };
+  }
+
+  return {
+    headerText: raw.slice(0, splitAt).toString('latin1'),
+    body: raw.slice(splitAt + offset),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Header parsing
+// ---------------------------------------------------------------------------
+
+function parseHeaders(headerText: string): Headers {
+  // Unfold continuation lines (RFC 5322: lines starting with SP/HT are continuations)
+  const unfolded = headerText.replace(/\r?\n[ \t]+/g, ' ');
+  const headers: Headers = new Map();
+
+  for (const line of unfolded.split(/\r?\n/)) {
+    if (!line) continue;
+    const colon = line.indexOf(':');
+    if (colon < 1) continue;
+    const key = line.slice(0, colon).trim().toLowerCase();
+    const value = line.slice(colon + 1).trim();
+    if (!headers.has(key)) {
+      headers.set(key, value);
+    }
+  }
+
+  return headers;
+}
+
+function h(headers: Headers, name: string): string | undefined {
+  return headers.get(name.toLowerCase());
+}
+
+// ---------------------------------------------------------------------------
+// Content-Type parsing helpers
+// ---------------------------------------------------------------------------
+
+function getMediaType(contentType: string): string {
+  return (contentType.split(';')[0] ?? '').trim().toLowerCase();
+}
+
+function getParam(contentType: string, param: string): string | undefined {
+  const re = new RegExp(`${param}=(?:"([^"]+)"|([^\\s;]+))`, 'i');
+  const m = contentType.match(re);
+  return m?.[1] ?? m?.[2];
+}
+
+function getFilename(headers: Headers): string | undefined {
+  const cd = h(headers, 'content-disposition');
+  if (cd) {
+    const fn = getParam(cd, 'filename');
+    if (fn) return fn;
+  }
+  const ct = h(headers, 'content-type');
+  if (ct) {
+    const fn = getParam(ct, 'name');
+    if (fn) return fn;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Transfer-encoding decode
+// ---------------------------------------------------------------------------
+
+function decodeBody(body: Buffer, encoding: string | undefined): Buffer {
+  const enc = (encoding ?? '7bit').trim().toLowerCase();
+  if (enc === 'base64') {
+    // Strip whitespace before decoding (base64 lines have CRLF)
+    const cleaned = body.toString('latin1').replace(/\s+/g, '');
+    return Buffer.from(cleaned, 'base64');
+  }
+  if (enc === 'quoted-printable') {
+    return decodeQuotedPrintable(body.toString('latin1'));
+  }
+  return body; // 7bit, 8bit, binary
+}
+
+function decodeQuotedPrintable(text: string): Buffer {
+  const decoded = text
+    .replace(/=\r?\n/g, '') // soft line breaks
+    .replace(/=([0-9A-Fa-f]{2})/g, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)));
+  return Buffer.from(decoded, 'latin1');
+}
+
+// ---------------------------------------------------------------------------
+// Document type detection
+// ---------------------------------------------------------------------------
+
+const DOCUMENT_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/gif',
+  'image/tiff',
+  'image/bmp',
+  'image/webp',
+]);
+
+function isDocumentPart(headers: Headers): boolean {
+  const ct = h(headers, 'content-type');
+  if (!ct) return false;
+  const mediaType = getMediaType(ct);
+  if (DOCUMENT_MIME_TYPES.has(mediaType)) return true;
+  // application/octet-stream with a .pdf filename
+  if (mediaType === 'application/octet-stream') {
+    const filename = getFilename(headers);
+    if (filename?.toLowerCase().endsWith('.pdf')) return true;
+  }
+  return false;
+}
+
+function resolvedMimeType(headers: Headers): string {
+  const ct = h(headers, 'content-type');
+  const mediaType = ct ? getMediaType(ct) : 'application/octet-stream';
+  if (mediaType === 'application/octet-stream') {
+    const filename = getFilename(headers);
+    if (filename?.toLowerCase().endsWith('.pdf')) return 'application/pdf';
+  }
+  return mediaType;
+}
+
+// ---------------------------------------------------------------------------
+// Multipart boundary splitting
+// ---------------------------------------------------------------------------
+
+function splitMultipartParts(body: Buffer, boundary: string): Buffer[] {
+  const delim = Buffer.from(`--${boundary}`);
+  const closing = Buffer.from(`--${boundary}--`);
+  const parts: Buffer[] = [];
+
+  // Find the first boundary
+  let pos = bufferIndexOf(body, delim, 0);
+  if (pos < 0) return parts;
+
+  while (pos < body.length) {
+    const delimEnd = pos + delim.length;
+
+    // Peek at what follows the boundary marker
+    const peek = body.slice(delimEnd, delimEnd + 2);
+    const isClosing =
+      body.slice(pos, pos + closing.length).equals(closing) ||
+      (peek[0] === 0x2d && peek[1] === 0x2d); // '--'
+
+    if (isClosing) break;
+
+    // Skip past end of the boundary line (CRLF or LF)
+    let partStart = delimEnd;
+    if (body[partStart] === 0x0d) partStart++;
+    if (body[partStart] === 0x0a) partStart++;
+
+    // Find the next boundary occurrence
+    const nextDelim = bufferIndexOf(body, delim, partStart);
+
+    let partEnd: number;
+    if (nextDelim < 0) {
+      partEnd = body.length;
+    } else {
+      // Strip trailing CRLF before next boundary
+      partEnd = nextDelim;
+      if (partEnd > 0 && body[partEnd - 1] === 0x0a) partEnd--;
+      if (partEnd > 0 && body[partEnd - 1] === 0x0d) partEnd--;
+    }
+
+    if (partEnd > partStart) {
+      parts.push(body.slice(partStart, partEnd));
+    }
+
+    if (nextDelim < 0) break;
+    pos = nextDelim;
+  }
+
+  return parts;
+}
+
+// ---------------------------------------------------------------------------
+// Recursive MIME part parser
+// ---------------------------------------------------------------------------
+
+function parseMimePart(raw: Buffer): ParsedPart {
+  const { headerText, body } = splitHeaderBody(raw);
+  const headers = parseHeaders(headerText);
+
+  const contentType = h(headers, 'content-type') ?? 'text/plain';
+  const mediaType = getMediaType(contentType);
+
+  const documents: ExtractedDocument[] = [];
+
+  if (mediaType.startsWith('multipart/')) {
+    const boundary = getParam(contentType, 'boundary');
+    if (!boundary) throw new Error('multipart without boundary');
+
+    const subParts = splitMultipartParts(body, boundary);
+    for (const part of subParts) {
+      const sub = parseMimePart(part);
+      documents.push(...sub.documents);
+    }
+  } else if (isDocumentPart(headers)) {
+    const encoding = h(headers, 'content-transfer-encoding');
+    const content = decodeBody(body, encoding);
+    const mimeType = resolvedMimeType(headers);
+    const sha256 = createHash('sha256').update(content).digest('hex');
+
+    documents.push({
+      filename: getFilename(headers),
+      mimeType,
+      content,
+      size: content.length,
+      sha256,
+    });
+  }
+
+  return { headers, documents };
+}
+
+// ---------------------------------------------------------------------------
+// Sender evidence extraction
+// ---------------------------------------------------------------------------
+
+function buildSenderEvidence(headers: Headers): SenderEvidence {
+  return {
+    from: h(headers, 'from'),
+    replyTo: h(headers, 'reply-to'),
+    originalFrom: h(headers, 'x-original-from') ?? h(headers, 'x-original-sender'),
+    forwardedTo: h(headers, 'x-forwarded-to') ?? h(headers, 'envelope-to'),
+  };
+}

--- a/todo.md
+++ b/todo.md
@@ -236,16 +236,16 @@ Primary references:
 - [x] Enforce feature-flag gating.
 - [x] Add endpoint tests for malformed/auth-failure/disabled cases.
 
-### S17: Extraction pipeline (duplicate/adapt, no sharing)
+### S17: Extraction pipeline (duplicate/adapt, no sharing) ✅ (this PR)
 
-- [ ] Implement MIME parsing and extraction in new gateway package.
-- [ ] Enforce limits:
-- [ ] raw MIME <= 25 MB
-- [ ] attachment count <= 10
-- [ ] extracted documents total <= 20 MB
-- [ ] Map failures to canonical reason codes.
-- [ ] Add boundary and failure tests.
-- [ ] Confirm no extraction-helper imports from legacy listener package.
+- [x] Implement MIME parsing and extraction in new gateway package.
+- [x] Enforce limits:
+- [x] raw MIME <= 25 MB
+- [x] attachment count <= 10
+- [x] extracted documents total <= 20 MB
+- [x] Map failures to canonical reason codes.
+- [x] Add boundary and failure tests.
+- [x] Confirm no extraction-helper imports from legacy listener package.
 
 ### S18: Control -> ingest orchestration
 


### PR DESCRIPTION
## Summary

- Implements `extractFromMime(rawMime: Buffer): ExtractionResult` in `packages/email-ingestion-gateway/src/mime-extractor.ts`
- Zero-dependency minimal MIME parser using Node.js built-ins only (no external library) — avoids coupling and keeps the package lightweight
- Recursive multipart/* descent with CRLF/LF-tolerant boundary splitting
- Base64 and quoted-printable transfer-encoding decode
- Document type detection: `application/pdf`, `image/*`, and `application/octet-stream` with `.pdf` filename (normalised to `application/pdf`)
- Sender evidence extraction: `From`, `Reply-To`, `X-Original-From` / `X-Original-Sender`, `X-Forwarded-To` / `Envelope-To`
- Per-document SHA-256 fingerprint for server-side dedup

## Limits enforced

| Condition | Reason code |
|---|---|
| Raw MIME > 25 MB | `OVERSIZE_MESSAGE` |
| Attachment count > 10 | `OVERSIZE_MESSAGE` |
| Total extracted docs > 20 MB | `OVERSIZE_MESSAGE` |
| No document attachments found | `NO_DOCUMENTS` |
| Unparseable MIME | `PARSE_ERROR` |

## Anti-coupling

No imports from `packages/gmail-listener`. MIME logic duplicated and adapted from behavioral reference only.

## Test plan

- 26 TDD tests in `mime-extractor.test.ts` covering:
  - All three limit boundaries (raw size, count, total bytes) at and around threshold
  - `PARSE_ERROR` for empty buffer and binary noise
  - `NO_DOCUMENTS` for text-only and non-document multipart messages
  - PDF attachment: content, size, sha256, filename, mimeType
  - Image attachments: PNG and JPEG
  - `application/octet-stream` + `.pdf` filename → normalised to `application/pdf`
  - Exactly 10 attachments (at limit) → success
  - All sender evidence fields including `X-Original-Sender` fallback

https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x)_