### PR TITLE
feat(client): scaffold Auth Management page and navigation

### DIFF
--- a/packages/client/src/components/admin-settings/auth-management/index.tsx
+++ b/packages/client/src/components/admin-settings/auth-management/index.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from 'react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs.js';
+
+export function AuthManagement(): ReactElement {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <h1 className="text-2xl font-semibold">Access Management</h1>
+      <Tabs defaultValue="api-keys" className="w-full">
+        <TabsList>
+          <TabsTrigger value="api-keys">API Keys</TabsTrigger>
+          <TabsTrigger value="invitations">Invitations</TabsTrigger>
+          <TabsTrigger value="users">Users</TabsTrigger>
+        </TabsList>
+        <TabsContent value="api-keys">
+          <p className="text-sm text-muted-foreground">API keys management coming soon.</p>
+        </TabsContent>
+        <TabsContent value="invitations">
+          <p className="text-sm text-muted-foreground">Invitations management coming soon.</p>
+        </TabsContent>
+        <TabsContent value="users">
+          <p className="text-sm text-muted-foreground">Users management coming soon.</p>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/packages/client/src/components/admin-settings/auth-management/index.tsx
+++ b/packages/client/src/components/admin-settings/auth-management/index.tsx
@@ -1,7 +1,21 @@
-import type { ReactElement } from 'react';
+import { useContext, type ReactElement } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs.js';
+import { UserContext } from '@/providers/index.js';
+import { ROUTES } from '@/router/routes.js';
 
 export function AuthManagement(): ReactElement {
+  const { businessId } = useParams<{ businessId: string }>();
+  const { userContext } = useContext(UserContext);
+  const adminBusinessId = userContext?.context.adminBusinessId;
+
+  // Access Management is admin-only and scoped to the admin's own business.
+  // The backend independently enforces business_owner authorization, but we
+  // also guard the route client-side to avoid rendering it for other users.
+  if (!adminBusinessId || adminBusinessId !== businessId) {
+    return <Navigate to={ROUTES.HOME} replace />;
+  }
+
   return (
     <div className="flex flex-col gap-4 p-4">
       <h1 className="text-2xl font-semibold">Access Management</h1>

--- a/packages/client/src/components/layout/user-nav.tsx
+++ b/packages/client/src/components/layout/user-nav.tsx
@@ -1,5 +1,5 @@
 import { useContext, useState, type JSX } from 'react';
-import { CircleCheckBig, FileDown, Shield, User2Icon } from 'lucide-react';
+import { CircleCheckBig, FileDown, KeyRound, Shield, User2Icon } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { useCornJobs } from '../../hooks/use-corn-jobs.js';
@@ -116,17 +116,25 @@ export function UserNav(): JSX.Element | null {
             </>
           )}
           {userContext?.context.adminBusinessId && (
-            <DropdownMenuItem asChild>
-              <Link
-                to={{
-                  pathname: ROUTES.BUSINESSES.DETAIL(userContext.context.adminBusinessId),
-                  search: '?tab=admin',
-                }}
-              >
-                <Shield className="size-4" />
-                <span className="hidden sm:inline">Admin Configurations</span>
-              </Link>
-            </DropdownMenuItem>
+            <>
+              <DropdownMenuItem asChild>
+                <Link
+                  to={{
+                    pathname: ROUTES.BUSINESSES.DETAIL(userContext.context.adminBusinessId),
+                    search: '?tab=admin',
+                  }}
+                >
+                  <Shield className="size-4" />
+                  <span className="hidden sm:inline">Admin Configurations</span>
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link to={ROUTES.BUSINESSES.AUTH_MANAGEMENT(userContext.context.adminBusinessId)}>
+                  <KeyRound className="size-4" />
+                  <span className="hidden sm:inline">Access Management</span>
+                </Link>
+              </DropdownMenuItem>
+            </>
           )}
           <DropdownMenuItem>
             <Button variant="ghost" onClick={() => setBalanceChargeModalOpen(true)}>

--- a/packages/client/src/router/config.tsx
+++ b/packages/client/src/router/config.tsx
@@ -53,6 +53,11 @@ const ContractsScreen = lazy(() =>
     default: m.ContractsScreen,
   })),
 );
+const AuthManagement = lazy(() =>
+  import('../components/admin-settings/auth-management/index.js').then(m => ({
+    default: m.AuthManagement,
+  })),
+);
 
 // Business Trips
 const BusinessTrips = lazy(() =>
@@ -336,6 +341,14 @@ export const routes: RouteObject[] = [
                 handle: {
                   title: 'Business Ledger',
                   breadcrumb: 'Ledger',
+                },
+              },
+              {
+                path: ':businessId/auth-management',
+                element: withSuspense(AuthManagement),
+                handle: {
+                  title: 'Access Management',
+                  breadcrumb: 'Access Management',
                 },
               },
               {

--- a/packages/client/src/router/routes.ts
+++ b/packages/client/src/router/routes.ts
@@ -87,6 +87,7 @@ export const ROUTES = {
     CONTRACTS: '/businesses/contracts',
     DETAIL: (businessId: string) => `/businesses/${businessId}`,
     DETAIL_LEDGER: (businessId: string) => `/businesses/${businessId}/ledger`,
+    AUTH_MANAGEMENT: (businessId: string) => `/businesses/${businessId}/auth-management`,
   },
 
   BUSINESS_TRIPS: {


### PR DESCRIPTION
## Summary

Frontend plumbing for the **Access Management** page (the UI that will host the API-keys / invitations / users backends from #3700 and #3709). This PR is scaffolding only — the tabs render text placeholders; wiring them to GraphQL comes next.

## Changes

1. **New placeholder component** — `packages/client/src/components/admin-settings/auth-management/index.tsx`. Renders a layout container with an **"Access Management"** title and a shadcn `Tabs` with three triggers — **API Keys**, **Invitations**, **Users** — each `TabsContent` showing a "coming soon" text placeholder.
2. **Route helper** — `routes.ts`: added `BUSINESSES.AUTH_MANAGEMENT(businessId) => /businesses/${businessId}/auth-management`.
3. **Routing** — `config.tsx`: lazily imports the page and maps `:businessId/auth-management` as a child of the `businesses` section, so it sits inside `ProtectedRoute → DashboardLayoutRoute` (where `adminBusinessId` is guaranteed). Uses the standard `withSuspense` + `handle` title/breadcrumb pattern.
4. **Navigation** — `user-nav.tsx`: added an **"Access Management"** `DropdownMenuItem` directly below "Admin Configurations", linking to `ROUTES.BUSINESSES.AUTH_MANAGEMENT(userContext.context.adminBusinessId)`. Both items are kept inside the existing `adminBusinessId` guard so the id is always defined; used a `KeyRound` icon to match the surrounding lucide-icon style.

## Verification
- `yarn eslint` on all four files: **0 problems**.
- `tsc --noEmit` on `@accounter/client`: **passes** (no type errors).
- Prettier-clean.

https://claude.ai/code/session_01WngYxNYKtRn9SYKD3fjcs8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WngYxNYKtRn9SYKD3fjcs8)_