### PR TITLE
feat(client): implement API Keys tab in Auth Management

### DIFF
--- a/packages/client/src/components/admin-settings/auth-management/api-keys-tab.tsx
+++ b/packages/client/src/components/admin-settings/auth-management/api-keys-tab.tsx
@@ -1,0 +1,296 @@
+import { useCallback, useState, type ReactElement } from 'react';
+import { Copy, KeyRound, Loader2, ShieldAlert, Trash2 } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { useQuery } from 'urql';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.js';
+import { Button } from '@/components/ui/button.js';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog.js';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form.js';
+import { Input } from '@/components/ui/input.js';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select.js';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table.js';
+import { ListApiKeysDocument, type ListApiKeysQuery } from '@/gql/graphql.js';
+import { writeToClipboard } from '@/helpers/clipboard.js';
+import { useGenerateApiKey } from '@/hooks/use-generate-api-key.js';
+import { useRevokeApiKey } from '@/hooks/use-revoke-api-key.js';
+import { ConfirmationModal } from '../../common/index.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  query ListApiKeys {
+    listApiKeys {
+      id
+      name
+      roleId
+      lastUsedAt
+      createdAt
+    }
+  }
+`;
+
+// API keys may only be issued for automated roles (mirrors the server allow-list).
+const API_KEY_ROLES = [
+  { value: 'scraper', label: 'Scraper' },
+  { value: 'gmail_listener', label: 'Gmail Listener' },
+] as const;
+
+const formSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  roleId: z.enum(['scraper', 'gmail_listener']),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+type ApiKeyRow = ListApiKeysQuery['listApiKeys'][number];
+
+export function ApiKeysTab(): ReactElement {
+  const [{ data, fetching, error }, reexecuteQuery] = useQuery({ query: ListApiKeysDocument });
+  const { revokeApiKey, fetching: revoking } = useRevokeApiKey();
+
+  const refetch = useCallback(
+    () => reexecuteQuery({ requestPolicy: 'network-only' }),
+    [reexecuteQuery],
+  );
+
+  const handleRevoke = useCallback(
+    async (id: string) => {
+      const result = await revokeApiKey(id);
+      if (result) {
+        refetch();
+      }
+    },
+    [revokeApiKey, refetch],
+  );
+
+  const apiKeys = data?.listApiKeys ?? [];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-medium">API Keys</h2>
+          <p className="text-sm text-muted-foreground">
+            Programmatic access keys for automated roles.
+          </p>
+        </div>
+        <GenerateApiKeyDialog onCreated={refetch} />
+      </div>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Failed to load API keys</AlertTitle>
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      ) : fetching ? (
+        <div className="flex justify-center p-8">
+          <Loader2 className="h-8 w-8 animate-spin" />
+        </div>
+      ) : apiKeys.length === 0 ? (
+        <p className="p-6 text-center text-sm text-muted-foreground">No API keys yet.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Last Used</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {apiKeys.map((key: ApiKeyRow) => (
+              <TableRow key={key.id}>
+                <TableCell className="font-medium">{key.name}</TableCell>
+                <TableCell>{key.roleId}</TableCell>
+                <TableCell>
+                  {key.lastUsedAt ? new Date(key.lastUsedAt).toLocaleString() : 'Never'}
+                </TableCell>
+                <TableCell>{new Date(key.createdAt).toLocaleDateString()}</TableCell>
+                <TableCell className="text-right">
+                  <ConfirmationModal
+                    onConfirm={() => handleRevoke(key.id)}
+                    title={`Revoke "${key.name}"? This cannot be undone and any client using it will lose access.`}
+                  >
+                    <Button variant="destructive" size="sm" disabled={revoking}>
+                      <Trash2 className="size-4" />
+                      Revoke
+                    </Button>
+                  </ConfirmationModal>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}
+
+function GenerateApiKeyDialog({ onCreated }: { onCreated: () => void }): ReactElement {
+  const [open, setOpen] = useState(false);
+  const [generatedKey, setGeneratedKey] = useState<string | null>(null);
+  const { generateApiKey, fetching } = useGenerateApiKey();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { name: '', roleId: 'scraper' },
+  });
+
+  const onSubmit = useCallback(
+    async (values: FormValues) => {
+      const result = await generateApiKey(values);
+      if (result?.apiKey) {
+        setGeneratedKey(result.apiKey);
+        onCreated();
+      }
+    },
+    [generateApiKey, onCreated],
+  );
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      if (!next) {
+        // Clear the one-time token and form once the dialog closes.
+        setGeneratedKey(null);
+        form.reset();
+      }
+    },
+    [form],
+  );
+
+  const handleCopy = useCallback(() => {
+    if (generatedKey) {
+      writeToClipboard(generatedKey);
+      toast.success('Copied', { description: 'API key copied to clipboard' });
+    }
+  }, [generatedKey]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button>
+          <KeyRound className="size-4" />
+          Generate New Key
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        {generatedKey ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>API Key Created</DialogTitle>
+              <DialogDescription>Copy your key now — it will not be shown again.</DialogDescription>
+            </DialogHeader>
+            <Alert variant="destructive">
+              <ShieldAlert className="size-4" />
+              <AlertTitle>Save this key immediately</AlertTitle>
+              <AlertDescription>
+                For security, the plaintext key is shown only once and cannot be retrieved later.
+              </AlertDescription>
+            </Alert>
+            <div className="flex items-center gap-2">
+              <Input readOnly value={generatedKey} className="font-mono text-xs" />
+              <Button type="button" variant="outline" size="icon" onClick={handleCopy}>
+                <Copy className="size-4" />
+                <span className="sr-only">Copy API key</span>
+              </Button>
+            </div>
+            <DialogFooter>
+              <Button type="button" onClick={() => handleOpenChange(false)}>
+                Done
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Generate New API Key</DialogTitle>
+              <DialogDescription>
+                Create a key for programmatic access. Choose a descriptive name and a role.
+              </DialogDescription>
+            </DialogHeader>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Name</FormLabel>
+                      <FormControl>
+                        <Input placeholder="e.g. Production Scraper" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="roleId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Role</FormLabel>
+                      <Select onValueChange={field.onChange} value={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select a role" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {API_KEY_ROLES.map(role => (
+                            <SelectItem key={role.value} value={role.value}>
+                              {role.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <DialogFooter>
+                  <Button type="submit" disabled={fetching}>
+                    {fetching && <Loader2 className="size-4 animate-spin" />}
+                    Generate
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/admin-settings/auth-management/api-keys-tab.tsx
+++ b/packages/client/src/components/admin-settings/auth-management/api-keys-tab.tsx
@@ -66,7 +66,7 @@ const API_KEY_ROLES = [
 ] as const;
 
 const formSchema = z.object({
-  name: z.string().min(1, 'Name is required'),
+  name: z.string().trim().min(1, 'Name is required'),
   roleId: z.enum(['scraper', 'gmail_listener']),
 });
 
@@ -133,7 +133,9 @@ export function ApiKeysTab(): ReactElement {
             {apiKeys.map((key: ApiKeyRow) => (
               <TableRow key={key.id}>
                 <TableCell className="font-medium">{key.name}</TableCell>
-                <TableCell>{key.roleId}</TableCell>
+                <TableCell>
+                  {API_KEY_ROLES.find(role => role.value === key.roleId)?.label ?? key.roleId}
+                </TableCell>
                 <TableCell>
                   {key.lastUsedAt ? new Date(key.lastUsedAt).toLocaleString() : 'Never'}
                 </TableCell>
@@ -206,7 +208,20 @@ function GenerateApiKeyDialog({ onCreated }: { onCreated: () => void }): ReactEl
           Generate New Key
         </Button>
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent
+        // While the one-time token is visible, block outside-click / Escape
+        // dismissal so it cannot be lost accidentally before being copied.
+        onPointerDownOutside={event => {
+          if (generatedKey) {
+            event.preventDefault();
+          }
+        }}
+        onEscapeKeyDown={event => {
+          if (generatedKey) {
+            event.preventDefault();
+          }
+        }}
+      >
         {generatedKey ? (
           <>
             <DialogHeader>

--- a/packages/client/src/components/admin-settings/auth-management/index.tsx
+++ b/packages/client/src/components/admin-settings/auth-management/index.tsx
@@ -3,6 +3,7 @@ import { Navigate, useParams } from 'react-router-dom';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs.js';
 import { UserContext } from '@/providers/index.js';
 import { ROUTES } from '@/router/routes.js';
+import { ApiKeysTab } from './api-keys-tab.js';
 
 export function AuthManagement(): ReactElement {
   const { businessId } = useParams<{ businessId: string }>();
@@ -26,7 +27,7 @@ export function AuthManagement(): ReactElement {
           <TabsTrigger value="users">Users</TabsTrigger>
         </TabsList>
         <TabsContent value="api-keys">
-          <p className="text-sm text-muted-foreground">API keys management coming soon.</p>
+          <ApiKeysTab />
         </TabsContent>
         <TabsContent value="invitations">
           <p className="text-sm text-muted-foreground">Invitations management coming soon.</p>

--- a/packages/client/src/hooks/use-generate-api-key.ts
+++ b/packages/client/src/hooks/use-generate-api-key.ts
@@ -1,0 +1,72 @@
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { useMutation, type CombinedError } from 'urql';
+import { GenerateApiKeyDocument, type GenerateApiKeyMutation } from '../gql/graphql.js';
+import { handleCommonErrors } from '../helpers/error-handling.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  mutation GenerateApiKey($name: String!, $roleId: String!) {
+    generateApiKey(name: $name, roleId: $roleId) {
+      apiKey
+      record {
+        id
+        name
+        roleId
+        lastUsedAt
+        createdAt
+      }
+    }
+  }
+`;
+
+type UseGenerateApiKey = {
+  fetching: boolean;
+  error: CombinedError | undefined;
+  generateApiKey: (input: {
+    name: string;
+    roleId: string;
+  }) => Promise<GenerateApiKeyMutation['generateApiKey'] | void>;
+};
+
+const NOTIFICATION_ID = 'generateApiKey';
+
+export const useGenerateApiKey = (): UseGenerateApiKey => {
+  const [{ fetching, error }, mutate] = useMutation(GenerateApiKeyDocument);
+  const generateApiKey = useCallback(
+    async ({ name, roleId }: { name: string; roleId: string }) => {
+      const message = 'Error generating API key';
+      const notificationId = NOTIFICATION_ID;
+      toast.loading('Generating API key', {
+        id: notificationId,
+      });
+      try {
+        const result = await mutate({ name, roleId });
+        const data = handleCommonErrors(result, message, notificationId);
+        if (data) {
+          toast.success('Success', {
+            id: notificationId,
+            description: 'API key generated successfully',
+          });
+          return data.generateApiKey;
+        }
+      } catch (e) {
+        console.error(message, e);
+        toast.error('Error', {
+          id: notificationId,
+          description: message,
+          duration: 10_000,
+          closeButton: true,
+        });
+      }
+      return void 0;
+    },
+    [mutate],
+  );
+
+  return {
+    fetching,
+    error,
+    generateApiKey,
+  };
+};

--- a/packages/client/src/hooks/use-revoke-api-key.ts
+++ b/packages/client/src/hooks/use-revoke-api-key.ts
@@ -32,11 +32,19 @@ export const useRevokeApiKey = (): UseRevokeApiKey => {
         const result = await mutate({ id });
         const data = handleCommonErrors(result, message, notificationId);
         if (data) {
-          toast.success('Success', {
+          if (data.revokeApiKey) {
+            toast.success('Success', {
+              id: notificationId,
+              description: 'API key revoked successfully',
+            });
+            return true;
+          }
+          // No GraphQL error, but the key was not revoked (already revoked or not found).
+          toast.error('Error', {
             id: notificationId,
-            description: 'API key revoked successfully',
+            description: 'Failed to revoke API key. It may have already been revoked.',
           });
-          return data.revokeApiKey;
+          return false;
         }
       } catch (e) {
         console.error(message, e);

--- a/packages/client/src/hooks/use-revoke-api-key.ts
+++ b/packages/client/src/hooks/use-revoke-api-key.ts
@@ -1,0 +1,60 @@
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { useMutation, type CombinedError } from 'urql';
+import { RevokeApiKeyDocument, type RevokeApiKeyMutation } from '../gql/graphql.js';
+import { handleCommonErrors } from '../helpers/error-handling.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  mutation RevokeApiKey($id: ID!) {
+    revokeApiKey(id: $id)
+  }
+`;
+
+type UseRevokeApiKey = {
+  fetching: boolean;
+  error: CombinedError | undefined;
+  revokeApiKey: (id: string) => Promise<RevokeApiKeyMutation['revokeApiKey'] | void>;
+};
+
+const NOTIFICATION_ID = 'revokeApiKey';
+
+export const useRevokeApiKey = (): UseRevokeApiKey => {
+  const [{ fetching, error }, mutate] = useMutation(RevokeApiKeyDocument);
+  const revokeApiKey = useCallback(
+    async (id: string) => {
+      const message = 'Error revoking API key';
+      const notificationId = NOTIFICATION_ID;
+      toast.loading('Revoking API key', {
+        id: notificationId,
+      });
+      try {
+        const result = await mutate({ id });
+        const data = handleCommonErrors(result, message, notificationId);
+        if (data) {
+          toast.success('Success', {
+            id: notificationId,
+            description: 'API key revoked successfully',
+          });
+          return data.revokeApiKey;
+        }
+      } catch (e) {
+        console.error(message, e);
+        toast.error('Error', {
+          id: notificationId,
+          description: message,
+          duration: 10_000,
+          closeButton: true,
+        });
+      }
+      return void 0;
+    },
+    [mutate],
+  );
+
+  return {
+    fetching,
+    error,
+    revokeApiKey,
+  };
+};


### PR DESCRIPTION
## Summary

Implements the first tab of the **Access Management** page — **API Keys** — wiring the `listApiKeys` / `generateApiKey` / `revokeApiKey` backend (from #3700's schema) to a real UI.

## Changes

### GraphQL hooks & query
- `hooks/use-generate-api-key.ts` — `GenerateApiKey($name, $roleId)` mutation hook (returns `{ apiKey, record }`).
- `hooks/use-revoke-api-key.ts` — `RevokeApiKey($id)` mutation hook.
- Both follow the established convention: `useMutation` + `handleCommonErrors` + sonner toasts (loading → success/error); components consume a simplified `{ fetching, error, <action> }`.
- `ListApiKeys` query declared inline (magic-comment) in the tab component, consumed via `useQuery`.

### `ApiKeysTab` component
- **Data table** of keys: Name, Role, Last Used, Created, Actions.
- **Revoke** per row — wrapped in the existing `ConfirmationModal` (irreversible action) and refetches the list with `requestPolicy: 'network-only'` on success to update the urql cache.
- **Generate New Key** button opens a shadcn `Dialog` with a `react-hook-form` + `zod` form requiring `name` and `roleId`. The role select is restricted to the API-key roles (`scraper`, `gmail_listener`) — mirroring the server's `ALLOWED_API_KEY_ROLES` allow-list, so submissions can't be rejected for an invalid role.
- **One-time token reveal**: on success the dialog swaps to a view showing the plaintext key in a read-only field with a **Copy** button (via the existing `writeToClipboard` helper) and a destructive `Alert` warning to save it immediately, since it can't be retrieved again. The token is cleared from state when the dialog closes.

### Wiring
- Replaced the API Keys placeholder in `auth-management/index.tsx` with `<ApiKeysTab />`.

## Verification
- `yarn generate:graphql` produces the new typed documents.
- `yarn eslint` on all four files: 0 errors (2 `no-console` warnings that match the existing `use-accept-invitation.ts` hook pattern).
- `tsc --noEmit` on `@accounter/client`: passes.
- Prettier-clean.

## Notes / judgment calls
- **Role options are a static list** mirroring the server allow-list rather than a dynamic query — there's no `roles` query in the schema, and the allow-list (`scraper`, `gmail_listener`) is small and stable. If you'd prefer it sourced dynamically, that's a quick follow-up.
- **Revoke confirmation** isn't strictly in the task ("a Revoke button that calls revokeApiKey") but revoking is irreversible, so I used the codebase-standard `ConfirmationModal`. Easy to drop to a direct call if you prefer.

https://claude.ai/code/session_01WngYxNYKtRn9SYKD3fjcs8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WngYxNYKtRn9SYKD3fjcs8)_