### PR TITLE
fix(email-ingestion): address Gemini review on gateway ingestion path

### DIFF
--- a/docs/multi-tenant-gmail-listener/cloudflare-setup-runbook.md
+++ b/docs/multi-tenant-gmail-listener/cloudflare-setup-runbook.md
@@ -40,6 +40,10 @@ export default {
       false,
       ['sign']
     )
+    // Sign the raw MIME bytes — the gateway verifies the signature over the
+    // exact body it receives, parses the MIME, and extracts attachments. The
+    // gateway also computes the SHA-256 content hash itself, so the worker only
+    // forwards the message and its routing metadata (no hash is sent).
     const prefix = new TextEncoder().encode(timestamp + '.')
     const payload = new Uint8Array(prefix.length + rawBytes.length)
     payload.set(prefix, 0)
@@ -49,30 +53,22 @@ export default {
       .map(b => b.toString(16).padStart(2, '0'))
       .join('')
 
-    // Compute SHA-256 of the raw MIME bytes
-    const hashBytes = await crypto.subtle.digest('SHA-256', rawBytes)
-    const rawMessageHash = Array.from(new Uint8Array(hashBytes))
-      .map(b => b.toString(16).padStart(2, '0'))
-      .join('')
-
-    const body = JSON.stringify({
-      recipientAlias: message.to,
-      messageId: message.headers.get('message-id') ?? nonce,
-      rawMessageHash,
-      receivedAt: new Date().toISOString(),
-      correlationId: nonce
-    })
-
     try {
       const res = await fetch(`${env.GATEWAY_URL}/webhook`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
+          'Content-Type': 'message/rfc822',
           'x-cf-timestamp': String(timestamp),
           'x-cf-signature': signature,
-          'x-cf-nonce': nonce
+          'x-cf-nonce': nonce,
+          // Routing metadata — the body itself is the raw MIME message.
+          'x-cf-recipient': message.to,
+          'x-cf-message-id': message.headers.get('message-id') ?? nonce,
+          'x-cf-received-at': new Date().toISOString(),
+          'x-correlation-id': nonce
         },
-        body
+        // Send the raw MIME bytes as the request body.
+        body: rawBytes
       })
       if (!res.ok) {
         throw new Error('Gateway returned status ' + res.status)
@@ -285,21 +281,23 @@ sign() {
     | awk '{print $2}'
 }
 
+# The body is the raw MIME message; routing metadata travels in headers.
+MIME=$(printf 'From: sender@example.com\r\nTo: %s\r\nSubject: Test\r\nContent-Type: text/plain\r\n\r\nhello\r\n' "$ALIAS")
+
 send() {
-  local ts nonce body sig
+  local ts nonce sig
   ts=$(date +%s)
   nonce=$(uuidgen | tr '[:upper:]' '[:lower:]')
-  body=$(printf '{"recipientAlias":"%s","messageId":"%s","rawMessageHash":"%s"}' \
-    "$ALIAS" "msg-$nonce" \
-    "$(printf 'fake-body' | openssl dgst -sha256 -hex | awk '{print $2}')")
-  sig=$(sign "$ts" "$body")
+  sig=$(sign "$ts" "$MIME")
   curl -s -w '\nHTTP %{http_code}\n' \
     -X POST "$GATEWAY_URL/webhook" \
-    -H "Content-Type: application/json" \
+    -H "Content-Type: message/rfc822" \
     -H "x-cf-timestamp: $ts" \
     -H "x-cf-signature: $sig" \
     -H "x-cf-nonce: $nonce" \
-    -d "$body"
+    -H "x-cf-recipient: $ALIAS" \
+    -H "x-cf-message-id: msg-$nonce" \
+    --data-binary "$MIME"
 }
 ```
 
@@ -315,14 +313,15 @@ send
 ```bash
 ts=$(date +%s)
 nonce=$(uuidgen | tr '[:upper:]' '[:lower:]')
-body='{"recipientAlias":"test@mail.example.com","messageId":"m1","rawMessageHash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}'
 curl -s -w '\nHTTP %{http_code}\n' \
   -X POST "$GATEWAY_URL/webhook" \
-  -H "Content-Type: application/json" \
+  -H "Content-Type: message/rfc822" \
   -H "x-cf-timestamp: $ts" \
   -H "x-cf-signature: 0000000000000000000000000000000000000000000000000000000000000000" \
   -H "x-cf-nonce: $nonce" \
-  -d "$body"
+  -H "x-cf-recipient: test@mail.example.com" \
+  -H "x-cf-message-id: m1" \
+  --data-binary "$MIME"
 # Expected: HTTP 401, body contains {"error":"Unauthorized"}
 ```
 

--- a/packages/email-ingestion-gateway/src/__tests__/integration.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/integration.test.ts
@@ -5,7 +5,7 @@
  * mocked server HTTP responses) to prove that security invariants hold end-to-end.
  */
 import { PassThrough } from 'node:stream';
-import { createHmac } from 'node:crypto';
+import { createHash, createHmac } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { IngestReasonCode } from '../contracts.js';
@@ -45,6 +45,10 @@ function makeReq(
     'x-cf-timestamp': timestamp,
     'x-cf-signature': sig,
     'x-cf-nonce': nonce,
+    // Routing metadata travels in headers; the body is the raw MIME message.
+    'x-cf-recipient': 'invoices@acme.example.com',
+    'x-cf-message-id': '<msg001@mail.example.com>',
+    'x-correlation-id': 'e2e-corr-001',
     ...overrides,
   };
   for (const [k, v] of Object.entries(overrides)) {
@@ -76,12 +80,18 @@ function makeRes() {
   };
 }
 
-const VALID_PAYLOAD = JSON.stringify({
-  recipientAlias: 'invoices@acme.example.com',
-  messageId: '<msg001@mail.example.com>',
-  rawMessageHash: 'a'.repeat(64),
-  correlationId: 'e2e-corr-001',
-});
+// The request body is the raw MIME message; routing metadata is sent in headers
+// (see makeReq). This minimal message has no attachments, which is fine for these
+// orchestration-focused tests — the mocked serverClient controls the outcome.
+const VALID_PAYLOAD = [
+  'From: sender@example.com',
+  'To: invoices@acme.example.com',
+  'Subject: Invoice',
+  'MIME-Version: 1.0',
+  'Content-Type: text/plain; charset=utf-8',
+  '',
+  'See attached.',
+].join('\r\n');
 
 const GRANT = {
   id: 'grant-001',
@@ -155,6 +165,54 @@ describe('integration — happy path', () => {
     const b = getBody();
     expect(b).toMatchObject({ status: 'accepted', outcome: 'INSERTED' });
     expect((b as { correlationId: string }).correlationId).toBe('e2e-corr-001');
+  });
+
+  it('extracts a PDF attachment from the raw MIME body and forwards it to ingest', async () => {
+    // Build a multipart MIME with a single base64-encoded PDF attachment.
+    const pdf = Buffer.from('%PDF-1.4 fake invoice body');
+    const boundary = 'MIMEBOUNDARY01';
+    const mime = [
+      'From: vendor@example.com',
+      'To: invoices@acme.example.com',
+      'Subject: Invoice',
+      'MIME-Version: 1.0',
+      `Content-Type: multipart/mixed; boundary="${boundary}"`,
+      '',
+      `--${boundary}`,
+      'Content-Type: text/plain',
+      '',
+      'See attached.',
+      `--${boundary}`,
+      'Content-Type: application/pdf',
+      'Content-Disposition: attachment; filename="invoice.pdf"',
+      'Content-Transfer-Encoding: base64',
+      '',
+      pdf.toString('base64'),
+      `--${boundary}--`,
+    ].join('\r\n');
+
+    const serverClient = makeServerClient(CONTROL_SUCCESS);
+    const handler = createWebhookHandler({
+      verifier,
+      featureFlags: { v2Enabled: true, shadowMode: false },
+      serverClient,
+    });
+    const { res, getStatus } = makeRes();
+    await handler(makeReq(mime), res);
+
+    expect(getStatus()).toBe(202);
+    expect(serverClient.requestIngest).toHaveBeenCalledOnce();
+    const ingestArg = serverClient.requestIngest.mock.calls[0][0];
+    // The gateway computes the hash over the signed raw MIME body.
+    expect(ingestArg.rawMessageHash).toBe(createHash('sha256').update(mime).digest('hex'));
+    expect(ingestArg.extractedDocuments).toEqual([
+      {
+        hash: createHash('sha256').update(pdf).digest('hex'),
+        sizeBytes: pdf.length,
+        mimeType: 'application/pdf',
+        filename: 'invoice.pdf',
+      },
+    ]);
   });
 
   it('returns 202 with DUPLICATE outcome for repeated delivery', async () => {
@@ -242,6 +300,8 @@ describe('integration — invalid auth', () => {
         'x-cf-timestamp': String(NOW_SECONDS),
         'x-cf-signature': sign(VALID_PAYLOAD, WEBHOOK_SECRET, NOW_SECONDS),
         'x-cf-nonce': nonce, // same nonce = replay
+        'x-cf-recipient': 'invoices@acme.example.com',
+        'x-cf-message-id': '<msg001@mail.example.com>',
       },
       method: 'POST',
       socket: { remoteAddress: '127.0.0.1' },

--- a/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
@@ -478,4 +478,54 @@ describe('extractFromMime — boundary collision in body', () => {
       expect(result.documents[0]?.content).toEqual(pdf);
     }
   });
+
+  it('does not mistake a nested boundary that the outer boundary is a prefix of', () => {
+    // Outer boundary `BND` is a prefix of the inner boundary `BND-1`. A naive
+    // `indexOf("--BND")` matches inside `--BND-1`, so the outer parser would
+    // split parts at the inner boundary and drop the attachment. The delimiter
+    // must be followed by whitespace/CRLF or `--` to count as a real boundary.
+    const outer = 'BND';
+    const inner = 'BND-1';
+    const pdf = fakePdf(64);
+    const b64 = pdf.toString('base64');
+
+    const innerPart = [
+      `Content-Type: multipart/related; boundary="${inner}"`,
+      '',
+      `--${inner}`,
+      'Content-Type: application/pdf',
+      `Content-Disposition: attachment; filename="doc.pdf"`,
+      'Content-Transfer-Encoding: base64',
+      '',
+      b64,
+      `--${inner}--`,
+    ].join('\r\n');
+
+    const mime = Buffer.from(
+      [
+        'From: sender@example.com',
+        'To: invoices@example.com',
+        'Subject: Prefix collision',
+        'MIME-Version: 1.0',
+        `Content-Type: multipart/mixed; boundary="${outer}"`,
+        '',
+        `--${outer}`,
+        'Content-Type: text/plain',
+        '',
+        'See attached.',
+        `--${outer}`,
+        innerPart,
+        `--${outer}--`,
+      ].join('\r\n'),
+      'utf8',
+    );
+
+    const result = extractFromMime(mime);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]?.content).toEqual(pdf);
+      expect(result.documents[0]?.filename).toBe('doc.pdf');
+    }
+  });
 });

--- a/packages/email-ingestion-gateway/src/__tests__/webhook.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/webhook.test.ts
@@ -15,11 +15,17 @@ vi.spyOn(console, 'error').mockImplementation(() => {});
 
 const VALID_TIMESTAMP = String(1_700_000_000);
 
-const VALID_BODY = JSON.stringify({
-  recipientAlias: 'invoices@acme.example.com',
-  messageId: '<abc123@mail.example.com>',
-  rawMessageHash: 'a'.repeat(64),
-});
+// The request body is now the raw MIME message; routing metadata (recipient
+// alias, message id) travels in headers.
+const VALID_BODY = [
+  'From: sender@example.com',
+  'To: invoices@acme.example.com',
+  'Subject: Test',
+  'MIME-Version: 1.0',
+  'Content-Type: text/plain; charset=utf-8',
+  '',
+  'See attached.',
+].join('\r\n');
 
 function makeVerifier(verdict: AuthenticityVerdict = { valid: true }) {
   return {
@@ -38,6 +44,8 @@ function makeReq(
     'x-cf-timestamp': VALID_TIMESTAMP,
     'x-cf-signature': 'a'.repeat(64),
     'x-cf-nonce': 'unique-nonce-abc',
+    'x-cf-recipient': 'invoices@acme.example.com',
+    'x-cf-message-id': '<abc123@mail.example.com>',
   };
   for (const [k, v] of Object.entries(headerOverrides)) {
     if (v === undefined) {
@@ -164,39 +172,31 @@ describe('POST /webhook — createWebhookHandler', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Body validation
+  // Metadata header validation
   // -------------------------------------------------------------------------
 
-  it('returns 400 when body is not valid JSON', async () => {
+  it('returns 400 when x-cf-recipient is missing', async () => {
     const { res, getStatus, getBody } = makeRes();
-    await handler(makeReq('not-json'), res);
+    await handler(makeReq(VALID_BODY, { 'x-cf-recipient': undefined }), res);
     expect(getStatus()).toBe(400);
     expect(getBody()).toMatchObject({ error: 'Bad request' });
   });
 
-  it('returns 400 when recipientAlias is missing', async () => {
-    const body = JSON.stringify({ messageId: '<id@x>', rawMessageHash: 'a'.repeat(64) });
+  it('returns 400 when x-cf-message-id is missing', async () => {
     const { res, getStatus } = makeRes();
-    await handler(makeReq(body), res);
+    await handler(makeReq(VALID_BODY, { 'x-cf-message-id': undefined }), res);
     expect(getStatus()).toBe(400);
   });
 
-  it('returns 400 when messageId is missing', async () => {
-    const body = JSON.stringify({ recipientAlias: 'a@b.com', rawMessageHash: 'a'.repeat(64) });
-    const { res, getStatus } = makeRes();
-    await handler(makeReq(body), res);
-    expect(getStatus()).toBe(400);
-  });
-
-  it('returns 400 when rawMessageHash is not a 64-char hex string', async () => {
-    const body = JSON.stringify({
-      recipientAlias: 'a@b.com',
-      messageId: '<id@x>',
-      rawMessageHash: 'tooshort',
+  it('does not call the verifier when a metadata header is missing', async () => {
+    const mockVerifier = makeVerifier({ valid: true });
+    const h = createWebhookHandler({
+      verifier: mockVerifier,
+      featureFlags: { v2Enabled: true, shadowMode: false },
     });
-    const { res, getStatus } = makeRes();
-    await handler(makeReq(body), res);
-    expect(getStatus()).toBe(400);
+    const { res } = makeRes();
+    await h(makeReq(VALID_BODY, { 'x-cf-recipient': undefined }), res);
+    expect(mockVerifier.verify).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------------
@@ -213,10 +213,9 @@ describe('POST /webhook — createWebhookHandler', () => {
     expect((body as { correlationId: string }).correlationId.length).toBeGreaterThan(0);
   });
 
-  it('uses the correlationId from the request body when present', async () => {
-    const body = JSON.stringify({ ...JSON.parse(VALID_BODY), correlationId: 'client-corr-id' });
+  it('uses the correlationId from the x-correlation-id header when present', async () => {
     const { res, getStatus, getBody } = makeRes();
-    await handler(makeReq(body), res);
+    await handler(makeReq(VALID_BODY, { 'x-correlation-id': 'client-corr-id' }), res);
     expect(getStatus()).toBe(202);
     expect((getBody() as { correlationId: string }).correlationId).toBe('client-corr-id');
   });
@@ -256,6 +255,8 @@ describe('POST /webhook — createWebhookHandler', () => {
         'x-cf-timestamp': VALID_TIMESTAMP,
         'x-cf-signature': 'a'.repeat(64),
         'x-cf-nonce': 'unique-nonce-abc',
+        'x-cf-recipient': 'invoices@acme.example.com',
+        'x-cf-message-id': '<abc123@mail.example.com>',
       },
       method: 'POST',
       socket: { remoteAddress: '127.0.0.1' },
@@ -296,6 +297,8 @@ describe('POST /webhook — createWebhookHandler', () => {
         'x-cf-timestamp': VALID_TIMESTAMP,
         'x-cf-signature': 'a'.repeat(64),
         'x-cf-nonce': 'unique-nonce-abc',
+        'x-cf-recipient': 'invoices@acme.example.com',
+        'x-cf-message-id': '<abc123@mail.example.com>',
       },
       method: 'POST',
       socket: { remoteAddress: '::ffff:192.168.1.1' },

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -248,12 +248,31 @@ function splitMultipartParts(body: Buffer, boundary: string): Buffer[] {
   // RFC 2046 §5.1.1: each boundary must be preceded by a CRLF (or be at
   // position 0). Without this check, boundary strings that appear inside
   // base64 content could be incorrectly treated as delimiters.
+  //
+  // The delimiter must also be *followed* only by optional linear whitespace
+  // and a line break, or by `--` (a closing boundary). Without this check a
+  // boundary that is a prefix of a longer boundary (e.g. `foo` vs `foo-1` in
+  // nested multiparts) would match the longer boundary too, splitting parts at
+  // the wrong place and dropping attachments.
   const findBoundary = (start: number): number => {
     let s = start;
     while (s < body.length) {
       const idx = body.indexOf(delim, s);
       if (idx < 0) return -1;
-      if (idx === 0 || body[idx - 1] === 0x0a) return idx;
+      if (idx === 0 || body[idx - 1] === 0x0a) {
+        let p = idx + delim.length;
+        while (p < body.length && (body[p] === 0x20 || body[p] === 0x09)) {
+          p++;
+        }
+        if (
+          p >= body.length ||
+          body[p] === 0x0d ||
+          body[p] === 0x0a ||
+          (body[p] === 0x2d && body[p + 1] === 0x2d)
+        ) {
+          return idx;
+        }
+      }
       s = idx + 1;
     }
     return -1;

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -268,7 +268,7 @@ function splitMultipartParts(body: Buffer, boundary: string): Buffer[] {
           p >= body.length ||
           body[p] === 0x0d ||
           body[p] === 0x0a ||
-          (body[p] === 0x2d && body[p + 1] === 0x2d)
+          (p + 1 < body.length && body[p] === 0x2d && body[p + 1] === 0x2d)
         ) {
           return idx;
         }

--- a/packages/email-ingestion-gateway/src/webhook.ts
+++ b/packages/email-ingestion-gateway/src/webhook.ts
@@ -1,26 +1,26 @@
+import { createHash } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import zod from 'zod';
 import { generateCorrelationId, log } from './logger.js';
+import { extractFromMime, MAX_RAW_MIME_BYTES } from './mime-extractor.js';
 import { orchestrate, type OrchestratorDeps } from './orchestrator.js';
+import type { IngestDocumentInput } from './server-client.js';
 import type { AuthenticityInput, CloudflareAuthenticityVerifier } from './verifier.js';
 
-const MAX_BODY_BYTES = 1_048_576; // 1 MiB
+// Inbound requests carry the raw MIME message as their body, so the cap matches
+// the MIME extractor's own raw-size limit. The extractor still enforces the
+// limit precisely (returning OVERSIZE_MESSAGE); this guards the read buffer.
+const MAX_BODY_BYTES = MAX_RAW_MIME_BYTES;
 
 class PayloadTooLargeError extends Error {
   override name = 'PayloadTooLargeError';
 }
 
-const WebhookBodySchema = zod.object({
-  recipientAlias: zod.string().min(1),
-  messageId: zod.string().min(1),
-  rawMessageHash: zod
-    .string()
-    .regex(/^[0-9a-fA-F]{64}$/, 'must be a 64-character SHA-256 hex string'),
-  receivedAt: zod.string().optional(),
-  correlationId: zod.string().optional(),
-});
-
-export type WebhookBody = zod.infer<typeof WebhookBodySchema>;
+/** Header carrying the recipient alias the email was addressed to. */
+const RECIPIENT_HEADER = 'x-cf-recipient';
+/** Header carrying the upstream message identifier. */
+const MESSAGE_ID_HEADER = 'x-cf-message-id';
+/** Header carrying the original received-at timestamp (ISO-8601, optional). */
+const RECEIVED_AT_HEADER = 'x-cf-received-at';
 
 export interface WebhookDeps {
   verifier: Pick<CloudflareAuthenticityVerifier, 'verify'>;
@@ -75,6 +75,19 @@ export function createWebhookHandler(deps: WebhookDeps) {
 
     const timestampSeconds = parseInt(timestampStr, 10);
 
+    // Message metadata travels in headers (the body is the raw MIME message).
+    const recipientAlias = (req.headers[RECIPIENT_HEADER] as string | undefined)?.trim();
+    const messageId = (req.headers[MESSAGE_ID_HEADER] as string | undefined)?.trim();
+    const receivedAt = (req.headers[RECEIVED_AT_HEADER] as string | undefined)?.trim() || undefined;
+
+    if (!recipientAlias || !messageId) {
+      writeJson(res, 400, {
+        error: 'Bad request',
+        details: `Missing required headers: ${RECIPIENT_HEADER}, ${MESSAGE_ID_HEADER}`,
+      });
+      return;
+    }
+
     // 3. Read raw body — needed before calling the verifier (signature covers the body)
     let rawBody: Buffer;
     try {
@@ -112,33 +125,38 @@ export function createWebhookHandler(deps: WebhookDeps) {
       return;
     }
 
-    // 5. Parse and structurally validate JSON body
-    let parsedBody: unknown;
-    try {
-      parsedBody = JSON.parse(rawBody.toString('utf8'));
-    } catch {
-      writeJson(res, 400, { error: 'Bad request', details: 'Body must be valid JSON' });
-      return;
-    }
+    const effectiveCorrelationId = reqCorrelationId;
 
-    const bodyResult = WebhookBodySchema.safeParse(parsedBody);
-    if (!bodyResult.success) {
-      writeJson(res, 400, {
-        error: 'Bad request',
-        details: bodyResult.error.issues
-          .map(i => (i.path.length > 0 ? `${i.path.join('.')}: ${i.message}` : i.message))
-          .join('; '),
-      });
-      return;
-    }
+    // 5. Compute the authoritative content hash and extract candidate documents
+    // from the raw MIME body. The gateway — not the upstream worker — owns the
+    // hash so the server can trust a value derived from the signed payload.
+    const rawMessageHash = createHash('sha256').update(rawBody).digest('hex');
+    const extraction = extractFromMime(rawBody);
 
-    const body = bodyResult.data;
-    const effectiveCorrelationId = body.correlationId ?? reqCorrelationId;
+    let extractedDocuments: IngestDocumentInput[] = [];
+    if (extraction.success) {
+      extractedDocuments = extraction.documents.map(doc => ({
+        hash: doc.sha256,
+        sizeBytes: doc.size,
+        mimeType: doc.mimeType,
+        filename: doc.filename,
+      }));
+    } else {
+      // Extraction failed (no documents, parse error, or oversize). Proceed to
+      // orchestration so the server records an auditable quarantine outcome;
+      // the empty document list drives the NO_DOCUMENTS quarantine path.
+      log(
+        'warn',
+        'webhook: MIME extraction yielded no documents',
+        { reason: extraction.reason },
+        effectiveCorrelationId,
+      );
+    }
 
     log(
       'info',
       'webhook accepted',
-      { recipientAlias: body.recipientAlias, messageId: body.messageId },
+      { recipientAlias, messageId, documentCount: extractedDocuments.length },
       effectiveCorrelationId,
     );
 
@@ -155,12 +173,12 @@ export function createWebhookHandler(deps: WebhookDeps) {
     }
 
     const orchestrateInput = {
-      recipientAlias: body.recipientAlias,
-      messageId: body.messageId,
-      rawMessageHash: body.rawMessageHash,
+      recipientAlias,
+      messageId,
+      rawMessageHash,
       correlationId: effectiveCorrelationId,
-      receivedAt: body.receivedAt,
-      extractedDocuments: [],
+      receivedAt,
+      extractedDocuments,
     };
 
     if (featureFlags.shadowMode) {

--- a/packages/email-ingestion-gateway/src/webhook.ts
+++ b/packages/email-ingestion-gateway/src/webhook.ts
@@ -22,6 +22,15 @@ const MESSAGE_ID_HEADER = 'x-cf-message-id';
 /** Header carrying the original received-at timestamp (ISO-8601, optional). */
 const RECEIVED_AT_HEADER = 'x-cf-received-at';
 
+/**
+ * Safely read a single header value. `IncomingHttpHeaders` values may be
+ * `string[]` (duplicated headers, HTTP/2), so we never assume a bare string —
+ * calling string methods on an array would crash the request handler.
+ */
+function getSingleHeader(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
 export interface WebhookDeps {
   verifier: Pick<CloudflareAuthenticityVerifier, 'verify'>;
   featureFlags: { v2Enabled: boolean; shadowMode: boolean };
@@ -48,14 +57,14 @@ export function createWebhookHandler(deps: WebhookDeps) {
       (typeof res.getHeader === 'function'
         ? (res.getHeader('X-Correlation-Id') as string | undefined)
         : undefined) ??
-      (req.headers['x-correlation-id'] as string | undefined) ??
+      getSingleHeader(req.headers['x-correlation-id']) ??
       generateCorrelationId();
     res.setHeader('X-Correlation-Id', reqCorrelationId);
 
     // 2. Validate required authenticity headers before reading the body (cheap, fail-fast)
-    const timestampStr = req.headers['x-cf-timestamp'] as string | undefined;
-    const signature = req.headers['x-cf-signature'] as string | undefined;
-    const nonce = req.headers['x-cf-nonce'] as string | undefined;
+    const timestampStr = getSingleHeader(req.headers['x-cf-timestamp']);
+    const signature = getSingleHeader(req.headers['x-cf-signature']);
+    const nonce = getSingleHeader(req.headers['x-cf-nonce']);
 
     if (!timestampStr || !signature || !nonce) {
       writeJson(res, 400, {
@@ -76,9 +85,9 @@ export function createWebhookHandler(deps: WebhookDeps) {
     const timestampSeconds = parseInt(timestampStr, 10);
 
     // Message metadata travels in headers (the body is the raw MIME message).
-    const recipientAlias = (req.headers[RECIPIENT_HEADER] as string | undefined)?.trim();
-    const messageId = (req.headers[MESSAGE_ID_HEADER] as string | undefined)?.trim();
-    const receivedAt = (req.headers[RECEIVED_AT_HEADER] as string | undefined)?.trim() || undefined;
+    const recipientAlias = getSingleHeader(req.headers[RECIPIENT_HEADER])?.trim();
+    const messageId = getSingleHeader(req.headers[MESSAGE_ID_HEADER])?.trim();
+    const receivedAt = getSingleHeader(req.headers[RECEIVED_AT_HEADER])?.trim() || undefined;
 
     if (!recipientAlias || !messageId) {
       writeJson(res, 400, {
@@ -103,8 +112,8 @@ export function createWebhookHandler(deps: WebhookDeps) {
 
     // 4. Authenticity verification: IP allowlist + timestamp window + HMAC + nonce replay
     let sourceIp =
-      (req.headers['cf-connecting-ip'] as string | undefined)?.trim() ??
-      (req.headers['x-forwarded-for'] as string | undefined)?.split(',')[0]?.trim() ??
+      getSingleHeader(req.headers['cf-connecting-ip'])?.trim() ??
+      getSingleHeader(req.headers['x-forwarded-for'])?.split(',')[0]?.trim() ??
       req.socket?.remoteAddress ??
       '';
     if (sourceIp.startsWith('::ffff:')) {

--- a/packages/migrations/src/__tests__/rls-all-tables.test.ts
+++ b/packages/migrations/src/__tests__/rls-all-tables.test.ts
@@ -37,7 +37,7 @@ describe('RLS All Tables Migration', () => {
     testPool = await createPool(testConnectionString, {
         statementTimeout: 60000,
     });
-  });
+  }, 30_000);
 
   afterAll(async () => {
     if (testPool) {
@@ -61,7 +61,7 @@ describe('RLS All Tables Migration', () => {
 
   it('should apply all migrations successfully', async () => {
     await runPGMigrations({ slonik: testPool });
-    
+
     // Check that the specific RLS migration was recorded
     const migrationResult = await testPool.query(sql.unsafe`
       SELECT 1
@@ -69,10 +69,10 @@ describe('RLS All Tables Migration', () => {
       WHERE name LIKE '%enable-rls-all-tables%'
       LIMIT 1
     `);
-    
+
     // Ensure that at least one matching migration entry exists
     expect(migrationResult.rowCount).toBe(1);
-  });
+  }, 120_000);
 
   it('should enforce RLS on key tables (isolation test)', async () => {
     // Test logic:
@@ -252,7 +252,7 @@ describe('RLS All Tables Migration', () => {
             }
           } finally {
             await connection.query(sql.unsafe`RESET ROLE`);
-          } 
+          }
         });
     } finally {
         const roleStillExists = await testPool.oneFirst(
@@ -263,5 +263,5 @@ describe('RLS All Tables Migration', () => {
           await testPool.query(sql.unsafe`DROP ROLE ${sql.identifier([TEST_ROLE_NAME])}`);
         }
     }
-  });
+  }, 30_000);
 });

--- a/packages/migrations/src/actions/2026-06-10T13-00-00.add-email-ingestion-quarantine.ts
+++ b/packages/migrations/src/actions/2026-06-10T13-00-00.add-email-ingestion-quarantine.ts
@@ -29,19 +29,23 @@ export default {
 
     ALTER TABLE accounter_schema.email_ingestion_quarantine ENABLE ROW LEVEL SECURITY;
 
-    -- Quarantine rows are owned by the tenant they were attributed to (when
-    -- known).  tenant_candidate is nullable because alias resolution may have
-    -- failed, but RLS still applies: rows with a non-null tenant_candidate are
-    -- only accessible to that tenant.
+    -- Quarantine rows are owned by the tenant they were attributed to.
+    -- tenant_candidate is nullable because alias resolution may have failed,
+    -- but a normal tenant session must NEVER see another tenant's quarantined
+    -- mail — including orphaned rows (tenant_candidate IS NULL) that could
+    -- contain content addressed to a different tenant. The policy therefore
+    -- only grants a tenant access to rows that resolved to its own business id.
+    -- Orphaned rows (tenant_candidate IS NULL) are intentionally invisible to
+    -- every tenant session and are triaged exclusively through ops tooling that
+    -- bypasses RLS (the gateway ingest path writes via the raw, RLS-bypassing
+    -- pool, so this restriction does not affect quarantine inserts).
     CREATE POLICY tenant_isolation ON accounter_schema.email_ingestion_quarantine
       FOR ALL
       USING (
-        tenant_candidate IS NULL
-        OR tenant_candidate = accounter_schema.get_current_business_id()
+        tenant_candidate = accounter_schema.get_current_business_id()
       )
       WITH CHECK (
-        tenant_candidate IS NULL
-        OR tenant_candidate = accounter_schema.get_current_business_id()
+        tenant_candidate = accounter_schema.get_current_business_id()
       );
 
     ALTER TABLE accounter_schema.email_ingestion_quarantine FORCE ROW LEVEL SECURITY;


### PR DESCRIPTION
Resolves the three open Gemini findings on PR #3651:

- Critical signature/MIME mismatch: the Cloudflare Worker signed the raw MIME bytes but POSTed only JSON metadata, so HMAC verification always failed; webhook.ts also hardcoded extractedDocuments to [] and never parsed the message, quarantining every email as NO_DOCUMENTS. The gateway now receives the raw MIME as the request body (routing metadata moves to x-cf-* headers), verifies the signature over the signed payload, computes the authoritative content hash itself, runs the MIME extractor, and forwards the extracted documents to ingest — matching the architecture plan. The worker example and smoke-test scripts in the runbook are updated to the new contract.

- Quarantine RLS leak: the tenant_isolation policy allowed tenant_candidate IS NULL rows to be read/updated/deleted by every tenant, exposing orphaned (unresolved-alias) quarantine records. The policy now scopes access to the tenant's own business id only; orphaned rows are triaged via the RLS-bypassing ops path.

- Multipart boundary prefix collision: findBoundary now requires the delimiter to be followed by optional LWSP + CRLF or `--`, so a parent boundary that is a prefix of a nested boundary no longer splits parts at the wrong place and drops attachments.

Adds regression tests for the prefix-collision case and an end-to-end test proving the gateway extracts a PDF attachment and forwards it to ingest.


Claude-Session: https://claude.ai/code/session_01WWuGaViNMgmAGbGGjZWqdm