### PR TITLE
feat(client): implement Invitations tab in Auth Management

### DIFF
--- a/packages/client/src/components/admin-settings/auth-management/index.tsx
+++ b/packages/client/src/components/admin-settings/auth-management/index.tsx
@@ -4,6 +4,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs.j
 import { UserContext } from '@/providers/index.js';
 import { ROUTES } from '@/router/routes.js';
 import { ApiKeysTab } from './api-keys-tab.js';
+import { InvitationsTab } from './invitations-tab.js';
 
 export function AuthManagement(): ReactElement {
   const { businessId } = useParams<{ businessId: string }>();
@@ -30,7 +31,7 @@ export function AuthManagement(): ReactElement {
           <ApiKeysTab />
         </TabsContent>
         <TabsContent value="invitations">
-          <p className="text-sm text-muted-foreground">Invitations management coming soon.</p>
+          <InvitationsTab />
         </TabsContent>
         <TabsContent value="users">
           <p className="text-sm text-muted-foreground">Users management coming soon.</p>

--- a/packages/client/src/components/admin-settings/auth-management/invitations-tab.tsx
+++ b/packages/client/src/components/admin-settings/auth-management/invitations-tab.tsx
@@ -98,7 +98,11 @@ export function InvitationsTab(): ReactElement {
   const handleRevoke = useCallback(
     async (id: string) => {
       const result = await revokeInvitation(id);
-      if (result) {
+      // Refetch on success and on a `false` result alike: a `false` means the
+      // invitation is no longer pending server-side (already revoked / not
+      // found), so the stale row should be dropped. `undefined` is a thrown
+      // error, where we leave the list untouched.
+      if (result !== undefined) {
         refetch();
       }
     },

--- a/packages/client/src/components/admin-settings/auth-management/invitations-tab.tsx
+++ b/packages/client/src/components/admin-settings/auth-management/invitations-tab.tsx
@@ -1,0 +1,267 @@
+import { useCallback, useState, type ReactElement } from 'react';
+import { Loader2, Trash2, UserPlus } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { useQuery } from 'urql';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.js';
+import { Badge } from '@/components/ui/badge.js';
+import { Button } from '@/components/ui/button.js';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog.js';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form.js';
+import { Input } from '@/components/ui/input.js';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select.js';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table.js';
+import { ListInvitationsDocument, type ListInvitationsQuery } from '@/gql/graphql.js';
+import { useCreateInvitation } from '@/hooks/use-create-invitation.js';
+import { useRevokeInvitation } from '@/hooks/use-revoke-invitation.js';
+import { ConfirmationModal } from '../../common/index.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  query ListInvitations {
+    listInvitations {
+      id
+      email
+      roleId
+      expiresAt
+    }
+  }
+`;
+
+// Friendly labels for any role that may appear on an invitation.
+const ROLE_LABELS: Record<string, string> = {
+  business_owner: 'Business Owner',
+  accountant: 'Accountant',
+  employee: 'Employee',
+  scraper: 'Scraper',
+  gmail_listener: 'Gmail Listener',
+};
+
+// Roles that make sense to assign to an invited human user.
+const INVITABLE_ROLES = [
+  { value: 'business_owner', label: ROLE_LABELS.business_owner },
+  { value: 'accountant', label: ROLE_LABELS.accountant },
+  { value: 'employee', label: ROLE_LABELS.employee },
+] as const;
+
+const roleLabel = (roleId: string): string => ROLE_LABELS[roleId] ?? roleId;
+
+const formSchema = z.object({
+  email: z.email('Please enter a valid email address'),
+  roleId: z.enum(['business_owner', 'accountant', 'employee']),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+type InvitationRow = ListInvitationsQuery['listInvitations'][number];
+
+export function InvitationsTab(): ReactElement {
+  const [{ data, fetching, error }, reexecuteQuery] = useQuery({
+    query: ListInvitationsDocument,
+  });
+  const { revokeInvitation, fetching: revoking } = useRevokeInvitation();
+
+  const refetch = useCallback(
+    () => reexecuteQuery({ requestPolicy: 'network-only' }),
+    [reexecuteQuery],
+  );
+
+  const handleRevoke = useCallback(
+    async (id: string) => {
+      const result = await revokeInvitation(id);
+      if (result) {
+        refetch();
+      }
+    },
+    [revokeInvitation, refetch],
+  );
+
+  const invitations = data?.listInvitations ?? [];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-medium">Invitations</h2>
+          <p className="text-sm text-muted-foreground">
+            Pending invitations to join this business.
+          </p>
+        </div>
+        <InviteUserDialog onInvited={refetch} />
+      </div>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Failed to load invitations</AlertTitle>
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      ) : fetching ? (
+        <div className="flex justify-center p-8">
+          <Loader2 className="h-8 w-8 animate-spin" />
+        </div>
+      ) : invitations.length === 0 ? (
+        <p className="p-6 text-center text-sm text-muted-foreground">No pending invitations.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Email</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Expires</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {invitations.map((invitation: InvitationRow) => (
+              <TableRow key={invitation.id}>
+                <TableCell className="font-medium">{invitation.email}</TableCell>
+                <TableCell>
+                  <Badge variant="secondary">{roleLabel(invitation.roleId)}</Badge>
+                </TableCell>
+                <TableCell>{new Date(invitation.expiresAt).toLocaleDateString()}</TableCell>
+                <TableCell className="text-right">
+                  <ConfirmationModal
+                    onConfirm={() => handleRevoke(invitation.id)}
+                    title={`Revoke the invitation for "${invitation.email}"? They will no longer be able to accept it.`}
+                  >
+                    <Button variant="destructive" size="sm" disabled={revoking}>
+                      <Trash2 className="size-4" />
+                      Revoke
+                    </Button>
+                  </ConfirmationModal>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}
+
+function InviteUserDialog({ onInvited }: { onInvited: () => void }): ReactElement {
+  const [open, setOpen] = useState(false);
+  const { createInvitation, fetching } = useCreateInvitation();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { email: '', roleId: 'employee' },
+  });
+
+  const onSubmit = useCallback(
+    async (values: FormValues) => {
+      const result = await createInvitation(values);
+      if (result) {
+        onInvited();
+        setOpen(false);
+        form.reset();
+      }
+    },
+    [createInvitation, onInvited, form],
+  );
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      if (!next) {
+        form.reset();
+      }
+    },
+    [form],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button>
+          <UserPlus className="size-4" />
+          Invite User
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Invite User</DialogTitle>
+          <DialogDescription>
+            Send an invitation to join this business with the selected role.
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-4">
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input type="email" placeholder="user@example.com" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="roleId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a role" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {INVITABLE_ROLES.map(role => (
+                        <SelectItem key={role.value} value={role.value}>
+                          {role.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="submit" disabled={fetching}>
+                {fetching && <Loader2 className="size-4 animate-spin" />}
+                Send Invitation
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/hooks/use-create-invitation.ts
+++ b/packages/client/src/hooks/use-create-invitation.ts
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { useMutation, type CombinedError } from 'urql';
+import { CreateInvitationDocument, type CreateInvitationMutation } from '../gql/graphql.js';
+import { handleCommonErrors } from '../helpers/error-handling.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  mutation CreateInvitation($email: String!, $roleId: String!) {
+    createInvitation(email: $email, roleId: $roleId) {
+      id
+      email
+      roleId
+      expiresAt
+    }
+  }
+`;
+
+type UseCreateInvitation = {
+  fetching: boolean;
+  error: CombinedError | undefined;
+  createInvitation: (input: {
+    email: string;
+    roleId: string;
+  }) => Promise<CreateInvitationMutation['createInvitation'] | void>;
+};
+
+const NOTIFICATION_ID = 'createInvitation';
+
+export const useCreateInvitation = (): UseCreateInvitation => {
+  const [{ fetching, error }, mutate] = useMutation(CreateInvitationDocument);
+  const createInvitation = useCallback(
+    async ({ email, roleId }: { email: string; roleId: string }) => {
+      const message = 'Error creating invitation';
+      const notificationId = NOTIFICATION_ID;
+      toast.loading('Creating invitation', {
+        id: notificationId,
+      });
+      try {
+        const result = await mutate({ email, roleId });
+        const data = handleCommonErrors(result, message, notificationId);
+        if (data) {
+          toast.success('Success', {
+            id: notificationId,
+            description: 'Invitation sent successfully',
+          });
+          return data.createInvitation;
+        }
+      } catch (e) {
+        console.error(message, e);
+        // Surface the specific server message (e.g. "An active invitation already
+        // exists for this user") so the user understands why it failed.
+        toast.error('Error', {
+          id: notificationId,
+          description: e instanceof Error ? e.message : message,
+          duration: 10_000,
+          closeButton: true,
+        });
+      }
+      return void 0;
+    },
+    [mutate],
+  );
+
+  return {
+    fetching,
+    error,
+    createInvitation,
+  };
+};

--- a/packages/client/src/hooks/use-revoke-invitation.ts
+++ b/packages/client/src/hooks/use-revoke-invitation.ts
@@ -1,0 +1,68 @@
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { useMutation, type CombinedError } from 'urql';
+import { RevokeInvitationDocument, type RevokeInvitationMutation } from '../gql/graphql.js';
+import { handleCommonErrors } from '../helpers/error-handling.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  mutation RevokeInvitation($id: ID!) {
+    revokeInvitation(id: $id)
+  }
+`;
+
+type UseRevokeInvitation = {
+  fetching: boolean;
+  error: CombinedError | undefined;
+  revokeInvitation: (id: string) => Promise<RevokeInvitationMutation['revokeInvitation'] | void>;
+};
+
+const NOTIFICATION_ID = 'revokeInvitation';
+
+export const useRevokeInvitation = (): UseRevokeInvitation => {
+  const [{ fetching, error }, mutate] = useMutation(RevokeInvitationDocument);
+  const revokeInvitation = useCallback(
+    async (id: string) => {
+      const message = 'Error revoking invitation';
+      const notificationId = NOTIFICATION_ID;
+      toast.loading('Revoking invitation', {
+        id: notificationId,
+      });
+      try {
+        const result = await mutate({ id });
+        const data = handleCommonErrors(result, message, notificationId);
+        if (data) {
+          if (data.revokeInvitation) {
+            toast.success('Success', {
+              id: notificationId,
+              description: 'Invitation revoked successfully',
+            });
+            return true;
+          }
+          // No GraphQL error, but nothing was revoked (already revoked or not found).
+          toast.error('Error', {
+            id: notificationId,
+            description: 'Failed to revoke invitation. It may have already been revoked.',
+          });
+          return false;
+        }
+      } catch (e) {
+        console.error(message, e);
+        toast.error('Error', {
+          id: notificationId,
+          description: message,
+          duration: 10_000,
+          closeButton: true,
+        });
+      }
+      return void 0;
+    },
+    [mutate],
+  );
+
+  return {
+    fetching,
+    error,
+    revokeInvitation,
+  };
+};


### PR DESCRIPTION
## Summary

Implements the **Invitations** tab of the Access Management page, wiring the `listInvitations` / `createInvitation` / `revokeInvitation` backend (merged in #3709) to a real UI. Mirrors the structure of the API Keys tab (#3722).

## Changes

### GraphQL hooks & query
- `hooks/use-create-invitation.ts` — `CreateInvitation($email, $roleId)` mutation hook.
- `hooks/use-revoke-invitation.ts` — `RevokeInvitation($id)` mutation hook.
- `ListInvitations` query declared inline (magic-comment), consumed via `useQuery`.
- Both hooks follow the established `useMutation` + `handleCommonErrors` + sonner-toast convention; components consume a simplified `{ fetching, error, <action> }`.

### `InvitationsTab` component
- **Data table** of pending invitations: Email, Role, Expires, Actions.
- **Roles mapped to friendly labels** via a `ROLE_LABELS` map (e.g. `business_owner` → "Business Owner"), rendered as a `Badge`; falls back to the raw id for unknown roles.
- **Expiration date** rendered with `toLocaleDateString()`.
- **Revoke** per row — wrapped in the existing `ConfirmationModal`, refetching the list (`requestPolicy: 'network-only'`) on success to update the urql cache.
- **Invite User** button opens a shadcn `Dialog` with a `react-hook-form` + `zod` form: a Zod-validated `email` and a `roleId` select (human roles: business owner / accountant / employee). On success it closes, resets, and refetches.

### Graceful error handling (item 5)
The `createInvitation` hook surfaces the **specific server error** in the error toast — so e.g. inviting an already-invited address shows "An active invitation already exists for this user" rather than a generic message. `revokeInvitation` also distinguishes a backend `false` (already revoked / not found) from a real success, matching the pattern adopted in the API Keys PR review.

### Wiring
- Replaced the Invitations placeholder in `auth-management/index.tsx` with `<InvitationsTab />`.

## Verification
- `yarn generate:graphql` produces the new typed documents.
- `yarn eslint`: 0 errors (2 `no-console` warnings matching the existing hook pattern).
- `tsc --noEmit` on `@accounter/client`: passes.
- Prettier-clean.

## Notes / judgment calls
- **Invite role options** are the human-assignable roles (`business_owner`, `accountant`, `employee`); the automated `scraper` / `gmail_listener` roles are intentionally excluded from the invite form (they belong to API keys), though the display map still labels them in case they ever appear.
- **One-time token not surfaced.** `createInvitation` returns a `token` in its payload, but the task didn't ask to display it (unlike API keys), so the dialog just confirms success. Easy to add an "invite link" reveal as a follow-up if you'd like.
- I dropped an experimental "(expired)" row indicator: computing `Date.now()` in render trips the repo's `react-hooks/purity` rule, and the lint-clean workarounds were disproportionate for an embellishment beyond the task's "display expiration dates" requirement.

https://claude.ai/code/session_01WngYxNYKtRn9SYKD3fjcs8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WngYxNYKtRn9SYKD3fjcs8)_