### PR TITLE
feat(client): implement Users tab in Auth Management

### DIFF
--- a/packages/client/src/components/admin-settings/auth-management/business-users-tab.tsx
+++ b/packages/client/src/components/admin-settings/auth-management/business-users-tab.tsx
@@ -99,7 +99,7 @@ export function BusinessUsersTab(): ReactElement {
             {users.map((user: BusinessUserRow) => (
               <TableRow key={user.id}>
                 <TableCell className="font-medium">
-                  {user.name ?? <span className="text-muted-foreground">—</span>}
+                  {user.name?.trim() || <span className="text-muted-foreground">—</span>}
                 </TableCell>
                 <TableCell>{user.email}</TableCell>
                 <TableCell>
@@ -108,7 +108,7 @@ export function BusinessUsersTab(): ReactElement {
                 <TableCell className="text-right">
                   <ConfirmationModal
                     onConfirm={() => handleRemove(user.id)}
-                    title={`Remove ${user.name ?? user.email} from this business? They will lose access immediately.`}
+                    title={`Remove ${user.name?.trim() ? `${user.name.trim()} (${user.email})` : user.email} from this business? They will lose access immediately.`}
                   >
                     <Button variant="destructive" size="sm" disabled={removing}>
                       <Trash2 className="size-4" />

--- a/packages/client/src/components/admin-settings/auth-management/business-users-tab.tsx
+++ b/packages/client/src/components/admin-settings/auth-management/business-users-tab.tsx
@@ -1,0 +1,159 @@
+import { useCallback, type ReactElement } from 'react';
+import { Trash2 } from 'lucide-react';
+import { useQuery } from 'urql';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert.js';
+import { Badge } from '@/components/ui/badge.js';
+import { Button } from '@/components/ui/button.js';
+import { Skeleton } from '@/components/ui/skeleton.js';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table.js';
+import { ListBusinessUsersDocument, type ListBusinessUsersQuery } from '@/gql/graphql.js';
+import { useRemoveBusinessUser } from '@/hooks/use-remove-business-user.js';
+import { ConfirmationModal } from '../../common/index.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  query ListBusinessUsers {
+    listBusinessUsers {
+      id
+      email
+      name
+      roleId
+      createdAt
+    }
+  }
+`;
+
+// Friendly labels for any role a business user may hold.
+const ROLE_LABELS: Record<string, string> = {
+  business_owner: 'Business Owner',
+  accountant: 'Accountant',
+  employee: 'Employee',
+  scraper: 'Scraper',
+  gmail_listener: 'Gmail Listener',
+};
+
+const roleLabel = (roleId: string): string => ROLE_LABELS[roleId] ?? roleId;
+
+type BusinessUserRow = ListBusinessUsersQuery['listBusinessUsers'][number];
+
+export function BusinessUsersTab(): ReactElement {
+  const [{ data, fetching, error }, reexecuteQuery] = useQuery({
+    query: ListBusinessUsersDocument,
+  });
+  const { removeBusinessUser, fetching: removing } = useRemoveBusinessUser();
+
+  const refetch = useCallback(
+    () => reexecuteQuery({ requestPolicy: 'network-only' }),
+    [reexecuteQuery],
+  );
+
+  const handleRemove = useCallback(
+    async (userId: string) => {
+      const result = await removeBusinessUser(userId);
+      // Refetch on success and on a `false` result alike: `false` means the user
+      // is no longer a member server-side, so the stale row should be dropped.
+      // `undefined` is a thrown error, where we leave the list untouched.
+      if (result !== undefined) {
+        refetch();
+      }
+    },
+    [removeBusinessUser, refetch],
+  );
+
+  const users = data?.listBusinessUsers ?? [];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2 className="text-lg font-medium">Users</h2>
+        <p className="text-sm text-muted-foreground">People with access to this business.</p>
+      </div>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Failed to load users</AlertTitle>
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      ) : fetching ? (
+        <BusinessUsersTableSkeleton />
+      ) : users.length === 0 ? (
+        <p className="p-6 text-center text-sm text-muted-foreground">No users found.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map((user: BusinessUserRow) => (
+              <TableRow key={user.id}>
+                <TableCell className="font-medium">
+                  {user.name ?? <span className="text-muted-foreground">—</span>}
+                </TableCell>
+                <TableCell>{user.email}</TableCell>
+                <TableCell>
+                  <Badge variant="secondary">{roleLabel(user.roleId)}</Badge>
+                </TableCell>
+                <TableCell className="text-right">
+                  <ConfirmationModal
+                    onConfirm={() => handleRemove(user.id)}
+                    title={`Remove ${user.name ?? user.email} from this business? They will lose access immediately.`}
+                  >
+                    <Button variant="destructive" size="sm" disabled={removing}>
+                      <Trash2 className="size-4" />
+                      Remove User
+                    </Button>
+                  </ConfirmationModal>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}
+
+function BusinessUsersTableSkeleton(): ReactElement {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead>Role</TableHead>
+          <TableHead className="text-right">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {Array.from({ length: 4 }).map((_, index) => (
+          <TableRow key={index}>
+            <TableCell>
+              <Skeleton className="h-4 w-32" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-4 w-48" />
+            </TableCell>
+            <TableCell>
+              <Skeleton className="h-6 w-24" />
+            </TableCell>
+            <TableCell className="text-right">
+              <Skeleton className="ml-auto h-8 w-28" />
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/packages/client/src/components/admin-settings/auth-management/index.tsx
+++ b/packages/client/src/components/admin-settings/auth-management/index.tsx
@@ -4,6 +4,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs.j
 import { UserContext } from '@/providers/index.js';
 import { ROUTES } from '@/router/routes.js';
 import { ApiKeysTab } from './api-keys-tab.js';
+import { BusinessUsersTab } from './business-users-tab.js';
 import { InvitationsTab } from './invitations-tab.js';
 
 export function AuthManagement(): ReactElement {
@@ -34,7 +35,7 @@ export function AuthManagement(): ReactElement {
           <InvitationsTab />
         </TabsContent>
         <TabsContent value="users">
-          <p className="text-sm text-muted-foreground">Users management coming soon.</p>
+          <BusinessUsersTab />
         </TabsContent>
       </Tabs>
     </div>

--- a/packages/client/src/hooks/use-remove-business-user.ts
+++ b/packages/client/src/hooks/use-remove-business-user.ts
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { useMutation, type CombinedError } from 'urql';
+import { RemoveBusinessUserDocument, type RemoveBusinessUserMutation } from '../gql/graphql.js';
+import { handleCommonErrors } from '../helpers/error-handling.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  mutation RemoveBusinessUser($userId: ID!) {
+    removeBusinessUser(userId: $userId)
+  }
+`;
+
+type UseRemoveBusinessUser = {
+  fetching: boolean;
+  error: CombinedError | undefined;
+  removeBusinessUser: (
+    userId: string,
+  ) => Promise<RemoveBusinessUserMutation['removeBusinessUser'] | void>;
+};
+
+const NOTIFICATION_ID = 'removeBusinessUser';
+
+export const useRemoveBusinessUser = (): UseRemoveBusinessUser => {
+  const [{ fetching, error }, mutate] = useMutation(RemoveBusinessUserDocument);
+  const removeBusinessUser = useCallback(
+    async (userId: string) => {
+      const message = 'Error removing user';
+      const notificationId = NOTIFICATION_ID;
+      toast.loading('Removing user', {
+        id: notificationId,
+      });
+      try {
+        const result = await mutate({ userId });
+        const data = handleCommonErrors(result, message, notificationId);
+        if (data) {
+          if (data.removeBusinessUser) {
+            toast.success('Success', {
+              id: notificationId,
+              description: 'User removed successfully',
+            });
+            return true;
+          }
+          // No GraphQL error, but nothing was removed (already removed or not found).
+          toast.error('Error', {
+            id: notificationId,
+            description: 'Failed to remove user. They may have already been removed.',
+          });
+          return false;
+        }
+      } catch (e) {
+        console.error(message, e);
+        toast.error('Error', {
+          id: notificationId,
+          description: message,
+          duration: 10_000,
+          closeButton: true,
+        });
+      }
+      return void 0;
+    },
+    [mutate],
+  );
+
+  return {
+    fetching,
+    error,
+    removeBusinessUser,
+  };
+};


### PR DESCRIPTION
## Summary

Implements the final **Users** tab of the Access Management page, wiring the `listBusinessUsers` / `removeBusinessUser` backend (merged in #3700) to the UI and completing the feature. Mirrors the structure of the API Keys (#3722) and Invitations (#3725) tabs.

## Changes

### GraphQL hook & query
- `hooks/use-remove-business-user.ts` — `RemoveBusinessUser($userId)` mutation hook (toast + `handleCommonErrors` convention; distinguishes a backend `false` result — already removed / not found — from success).
- `ListBusinessUsers` query declared inline (magic-comment), consumed via `useQuery`.

### `BusinessUsersTab` component
- **Data table** showing each user's **name**, **email**, and **role** (mapped to a friendly `Badge` label via `ROLE_LABELS`, falling back to the raw id). Null names render as a muted "—".
- **Remove User** per row → wrapped in the existing `ConfirmationModal` ("Are you sure?"-style prompt naming the user), and refetches the list (`requestPolicy: 'network-only'`) on success / `false`, matching the Invitations-tab behavior.
- **Strong fallbacks (item 5):**
  - Loading → a **table skeleton** (header + placeholder `Skeleton` rows) rather than a bare spinner.
  - Empty → **"No users found."**
  - Error → destructive `Alert`.

### Wiring (item 6)
- Replaced the Users placeholder in `auth-management/index.tsx` with `<BusinessUsersTab />`. All three tabs are now live, completing the flow: **user-nav "Access Management" → `/businesses/:businessId/auth-management` (ProtectedRoute + admin guard) → Tabs → API Keys / Invitations / Users**.

## Verification
- `yarn generate:graphql` produces the new typed documents.
- `yarn eslint` (hook + whole `auth-management/` dir): 0 errors (1 `no-console` warning matching the existing hook pattern).
- `tsc --noEmit` on `@accounter/client`: passes.
- `yarn test`: **all 19 client test files pass (177 tests)**. The 4 failing files in the full run are pre-existing `xlsx`/`node-xlsx` CommonJS-interop failures in the `scraper-app` / `modern-poalim-scraper` packages — unrelated to this change (no client files involved).
- Prettier-clean; no orphaned imports.

## Notes
- **Self-removal:** the server already guards against an owner removing themselves (`CANNOT_REMOVE_SELF`), which surfaces gracefully via the error toast. I did not also disable the current user's own row, since `UserContext` doesn't expose the local `business_users` id to match against reliably — happy to add a client-side guard if you'd prefer.
- `ROLE_LABELS` is defined locally here, consistent with the Invitations tab. If you'd like, a small follow-up could extract a shared role-label helper used by both tabs.

https://claude.ai/code/session_01WngYxNYKtRn9SYKD3fjcs8

---
_Generated by [Claude Code](https://claude.ai/code/session_01WngYxNYKtRn9SYKD3fjcs8)_