### PR TITLE
Workstream A: recognize issuing business in v2 email-ingestion control step

### DIFF
--- a/.changeset/email-ingestion-business-recognition.md
+++ b/.changeset/email-ingestion-business-recognition.md
@@ -1,0 +1,10 @@
+---
+'@accounter/server': patch
+---
+
+Recognize the issuing business in the v2 email-ingestion control step: the `requestIngestControl`
+flow now resolves the provider business from gateway-supplied sender evidence under the tenant's RLS
+context, loads its email-listener config, and binds the recognized business into the ingest grant
+(new nullable `email_ingestion_grants.business_id` column) so downstream stages can attribute
+documents without trusting gateway input. Adds `IngestControlInput.senderEvidence` and
+`IngestControlDecision.businessEmailConfig` to the schema.

--- a/docs/multi-tenant-gmail-listener/business-recognition-plan.md
+++ b/docs/multi-tenant-gmail-listener/business-recognition-plan.md
@@ -25,8 +25,8 @@ server resolver `packages/server/src/modules/email-ingestion/resolvers/email-ing
 
 The new v2 Cloudflare → Gateway → Server flow (PR #3651) **does not** carry this behavior:
 
-- Tenant resolution is by **recipient alias** (`email_ingestion_alias_routing`), which identifies the
-  Accounter **tenant the mail was sent to** — not the **sending provider business**.
+- Tenant resolution is by **recipient alias** (`email_ingestion_alias_routing`), which identifies
+  the Accounter **tenant the mail was sent to** — not the **sending provider business**.
 - Document extraction is a fixed, tenant-agnostic MIME allowlist (`mime-extractor.ts`); no
   `suggestion_data` is consulted.
 - There is no body→PDF conversion, no internal-link fetching, no per-business attachment filtering.
@@ -35,7 +35,7 @@ The new v2 Cloudflare → Gateway → Server flow (PR #3651) **does not** carry 
   (`email-ingestion-ingest.provider.ts`, "Document storage is deferred").
 
 This is a real parity gap. Provider emails differ, so **the treatment must be selected after the
-provider (business) is recognized.** Recognizing the business is therefore a *requirement*, not an
+provider (business) is recognized.** Recognizing the business is therefore a _requirement_, not an
 optimization.
 
 ## Goal
@@ -53,15 +53,15 @@ HTML→PDF rendering — force a three-stage split. It happens to match the alre
 unimplemented) contract in `data-flow.md` ("control response → policy/profile metadata"; "ingest
 request → sender_evidence … issuer candidate").
 
-| Stage                     | Where                                          | Why                                                                                                            |
-| ------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Stage                       | Where                                                    | Why                                                                                                                                            |
+| --------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | **1. Business recognition** | **Server, in the control step** (`requestIngestControl`) | Tenant is already resolved here; it has DB access to `suggestion_data`. Bind the recognized `businessId` into the grant and return its config. |
-| **2. Treatment**          | **Gateway**, after control, driven by returned config | Only the gateway holds the raw MIME body; it is the network-facing tier for link-fetch + HTML→PDF rendering.   |
-| **3. Persistence**        | **Server, in the ingest step** (`ingestEmail`) | Documents inserted under the `businessId` bound in the grant — never trusted from gateway input.               |
+| **2. Treatment**            | **Gateway**, after control, driven by returned config    | Only the gateway holds the raw MIME body; it is the network-facing tier for link-fetch + HTML→PDF rendering.                                   |
+| **3. Persistence**          | **Server, in the ingest step** (`ingestEmail`)           | Documents inserted under the `businessId` bound in the grant — never trusted from gateway input.                                               |
 
 **Trust anchor:** the recognized `businessId` is written into the grant row at control time and read
-back from the consumed grant at ingest time. The gateway never *asserts* which business a document
-belongs to — it only *triggers* recognition by supplying sender evidence. This preserves the v2 rule
+back from the consumed grant at ingest time. The gateway never _asserts_ which business a document
+belongs to — it only _triggers_ recognition by supplying sender evidence. This preserves the v2 rule
 that a control-plane gateway cannot attribute documents to an arbitrary business/tenant.
 
 ### Sequence (target)
@@ -99,20 +99,21 @@ Cloudflare ──raw MIME──▶ Gateway
    the legacy `getIssuerEmail` logic (`gmail-service.ts` ~404-435): the invoice-provider skip-list
    (`notify@morning.co`, `c@sumit.co.il`, `ap@the-guild.dev`), the self-issued skip
    (`SOFTWARE PRODUCTS GUILDA LTD`), and the `originalFrom → from → replyTo` fallback chain. Input =
-   sender evidence + body-derived `mailto:` candidates from the gateway; output = the email passed to
-   the business lookup.
+   sender evidence + body-derived `mailto:` candidates from the gateway; output = the email passed
+   to the business lookup.
 3. **No-match path:** return `businessId: null` with empty config → the gateway applies the legacy
    default (render body as PDF). Preserves the `!businessId` branch in `gmail-service.ts`.
 4. Update the `requestIngestControl` resolver to accept sender evidence and return the config block.
 
 ## Workstream B — Gateway: enrich extraction & sender evidence
 
-1. **`mime-extractor.ts`:** additionally capture the email **body** (prefer `text/html`, fall back to
-   `text/plain` — port `getEmailBody`) and scan it for `From: <mailto:…>` candidates. Extend
-   `SenderEvidence` / `ExtractionResult` to carry the body and the candidate issuer emails. (Today it
-   extracts only header-based `from`/`replyTo`/`originalFrom`/`forwardedTo` and discards the body.)
-   The retained body is **required** downstream for both body→PDF and internal-link fetching, so the
-   parse step must keep it and must **not** emit a `NO_DOCUMENTS` verdict (see Quarantine timing).
+1. **`mime-extractor.ts`:** additionally capture the email **body** (prefer `text/html`, fall back
+   to `text/plain` — port `getEmailBody`) and scan it for `From: <mailto:…>` candidates. Extend
+   `SenderEvidence` / `ExtractionResult` to carry the body and the candidate issuer emails. (Today
+   it extracts only header-based `from`/`replyTo`/`originalFrom`/`forwardedTo` and discards the
+   body.) The retained body is **required** downstream for both body→PDF and internal-link fetching,
+   so the parse step must keep it and must **not** emit a `NO_DOCUMENTS` verdict (see Quarantine
+   timing).
 2. **`orchestrator.ts` (Step 1):** thread sender evidence into the `requestControl` call.
 
 ## Workstream C — Gateway: the treatment step (new modules)
@@ -122,24 +123,24 @@ duplicate and adapt). After control returns config, build the final document set
 
 1. **Attachment filter** — keep attachments whose type is in `config.attachments` (port
    `gmail-service.ts` ~467-483, including the `octet-stream`+`.pdf` normalization).
-2. **`html-to-pdf.ts`** — if `businessId` is null **or** `config.emailBody === true`, render the body
-   → PDF via **bundled Chromium/Playwright** (port `convertHtmlToPdf`, including the `inline-css`
-   step). Reuse a single shared browser instance across requests to bound memory.
-3. **`link-fetcher.ts`** — some provider emails carry the document only as a **URL in the body**, not
-   as an attachment; `config.internalEmailLinks` names which link to follow. This is therefore a
-   *post-recognition treatment artifact*, never a MIME-extraction artifact (a hyperlink is not a MIME
-   part, and you can't know which link to fetch until recognition returns `internalEmailLinks`). For
-   each pattern, scan the **retained body** for a matching `<a href>`, fetch it, and convert to a
-   PDF/document (port `getLinkFromBody` + `innerLinkDocumentFetcher`). These are public vendor
-   "download your invoice" links (legacy fetches them unauthenticated), so egress belongs in the
-   gateway. **Harden the SSRF surface:** keep the host+path allowlist match, and add
-   private-IP/redirect blocking, a content-type allowlist, and size caps.
-4. Assemble the final document set, **then** decide emptiness (see Quarantine timing) and call ingest
-   (Step 2).
+2. **`html-to-pdf.ts`** — if `businessId` is null **or** `config.emailBody === true`, render the
+   body → PDF via **bundled Chromium/Playwright** (port `convertHtmlToPdf`, including the
+   `inline-css` step). Reuse a single shared browser instance across requests to bound memory.
+3. **`link-fetcher.ts`** — some provider emails carry the document only as a **URL in the body**,
+   not as an attachment; `config.internalEmailLinks` names which link to follow. This is therefore a
+   _post-recognition treatment artifact_, never a MIME-extraction artifact (a hyperlink is not a
+   MIME part, and you can't know which link to fetch until recognition returns
+   `internalEmailLinks`). For each pattern, scan the **retained body** for a matching `<a href>`,
+   fetch it, and convert to a PDF/document (port `getLinkFromBody` + `innerLinkDocumentFetcher`).
+   These are public vendor "download your invoice" links (legacy fetches them unauthenticated), so
+   egress belongs in the gateway. **Harden the SSRF surface:** keep the host+path allowlist match,
+   and add private-IP/redirect blocking, a content-type allowlist, and size caps.
+4. Assemble the final document set, **then** decide emptiness (see Quarantine timing) and call
+   ingest (Step 2).
 
 ## Workstream D — Document bytes transport & persistence
 
-The **central open gap:** v2 moves no bytes today, and treatment *creates* new bytes (body-PDF,
+The **central open gap:** v2 moves no bytes today, and treatment _creates_ new bytes (body-PDF,
 link-fetched PDFs) that exist only in the gateway. Transport options (**resolved → Option B**):
 
 - **Option A (recommended): gateway uploads to blob storage, passes refs.** The gateway uploads each
@@ -153,10 +154,10 @@ link-fetched PDFs) that exist only in the gateway. Transport options (**resolved
   of the `insertEmailDocuments` logic and the cleanest trust model (the gateway never touches
   storage), but heavy payloads through the CP-token path.
 
-Then **replace the ingest `TODO`** (`email-ingestion-ingest.provider.ts`): read `businessId` from the
-consumed grant, and under `withTenantContext` generate a charge (`ChargesProvider.generateCharge`)
-and insert documents (`DocumentsProvider.insertDocuments`) linked to it — mirroring the existing
-`insertEmailDocuments` resolver, including the dedup-by-hash skip.
+Then **replace the ingest `TODO`** (`email-ingestion-ingest.provider.ts`): read `businessId` from
+the consumed grant, and under `withTenantContext` generate a charge
+(`ChargesProvider.generateCharge`) and insert documents (`DocumentsProvider.insertDocuments`) linked
+to it — mirroring the existing `insertEmailDocuments` resolver, including the dedup-by-hash skip.
 
 ## Workstream E — DB & GraphQL contract changes
 
@@ -165,8 +166,8 @@ and insert documents (`DocumentsProvider.insertDocuments`) linked to it — mirr
   test.
 - **typeDefs** (`email-ingestion.graphql.ts`): `IngestControlInput` gains `senderEvidence`;
   `IngestControlDecision` gains a `businessEmailConfig`/`profile` block (`businessId`, `emailBody`,
-  `attachments`, `internalEmailLinks`); the `IngestEmailInput` document entries gain the content
-  ref / inline field. **Do not** add a client-settable `businessId` to the ingest input.
+  `attachments`, `internalEmailLinks`); the `IngestEmailInput` document entries gain the content ref
+  / inline field. **Do not** add a client-settable `businessId` to the ingest input.
 - **Regenerate:** `yarn generate` (server types) + the gateway's `gql/` from `mutations.ts`.
 - Update the gateway `server-client.ts` `ControlInput` / `ControlDecision` / `IngestInput` types and
   the mutation documents.
@@ -174,23 +175,24 @@ and insert documents (`DocumentsProvider.insertDocuments`) linked to it — mirr
 ## Cross-cutting concerns
 
 - **Quarantine timing (`NO_DOCUMENTS`):** the verdict must move from MIME-extraction time to
-  *post-treatment* time. An email whose only document is behind a URL (or **is** the body) has zero
+  _post-treatment_ time. An email whose only document is behind a URL (or **is** the body) has zero
   MIME attachment parts and would be wrongly dropped if `extractFromMime` still returned
   `NO_DOCUMENTS` (as it does today at `mime-extractor.ts:60-62`). Legacy only declared "no relevant
   documents" after attachments + body→PDF + link-fetch (`gmail-service.ts:505`). So the pre-control
-  parse must stop emitting the verdict; the gateway decides emptiness after treatment, and the server
-  ingest keeps a zero-document quarantine as a backstop.
-- **Grant TTL vs. treatment time:** the grant clock starts at control, but treatment (Chromium render
-  + multiple link fetches) runs *before* ingest. The 5-minute TTL must comfortably cover that, or
-  recognition should be split from grant issuance. (Risk.)
+  parse must stop emitting the verdict; the gateway decides emptiness after treatment, and the
+  server ingest keeps a zero-document quarantine as a backstop.
+- **Grant TTL vs. treatment time:** the grant clock starts at control, but treatment (Chromium
+  render
+  - multiple link fetches) runs _before_ ingest. The 5-minute TTL must comfortably cover that, or
+    recognition should be split from grant issuance. (Risk.)
 - **Derived-document dedup:** `idempotencyKey = rawMessageHash` is stable (good). But body-PDF /
   link-fetched bytes may not be byte-stable (e.g., PDF timestamps), which would break per-document
   hash dedup. Define a deterministic content hash, or dedup derived documents on their source (body
   hash / link URL).
-- **Parity tests** (`architecture-plan.md`: "parity enforced by tests"): run representative fixtures —
-  attachment-only, body-as-PDF provider, internal-link provider, unrecognized sender,
-  provider-skip-list cases — through both the legacy and v2 paths and compare the resulting documents
-  and charges. Keep shadow mode until parity holds.
+- **Parity tests** (`architecture-plan.md`: "parity enforced by tests"): run representative fixtures
+  — attachment-only, body-as-PDF provider, internal-link provider, unrecognized sender,
+  provider-skip-list cases — through both the legacy and v2 paths and compare the resulting
+  documents and charges. Keep shadow mode until parity holds.
 - **Docs:** update `data-flow.md` and `architecture-plan.md` to show recognition-in-control and
   treatment-in-gateway.
 
@@ -200,16 +202,16 @@ All resolved.
 
 1. **Bytes transport → Option B (inline → server).** The gateway base64-encodes each final document
    into the ingest mutation; the server uploads via the existing `getDocumentFromFile`, reusing the
-   `insertEmailDocuments` path. Chosen for trust-model simplicity — the gateway never touches storage.
-   Payload size is bounded by the existing MIME caps.
+   `insertEmailDocuments` path. Chosen for trust-model simplicity — the gateway never touches
+   storage. Payload size is bounded by the existing MIME caps.
 2. **HTML→PDF runtime → bundled Chromium (Playwright) in the gateway.** The `/webhook` path (parse +
    orchestrate + treatment) runs in the Node HTTP service (`index.ts`, `node:http`), not the
    Cloudflare Worker (`worker.ts` is only the Email forwarder), so a headless browser is viable.
    Chosen to match the legacy `convertHtmlToPdf` output for the test-enforced parity requirement —
    provider invoice emails are CSS-heavy, and a lighter renderer would risk fidelity/parity
-   regressions. Cost: a larger gateway image + render-time CPU/memory; mitigate with a shared browser
-   instance and the existing size caps. (A separate render service was rejected as unnecessary
-   operational overhead.)
+   regressions. Cost: a larger gateway image + render-time CPU/memory; mitigate with a shared
+   browser instance and the existing size caps. (A separate render service was rejected as
+   unnecessary operational overhead.)
 3. **Issuer detection → split: gateway extracts candidates, server selects.** The gateway parses the
    body for `From: <mailto:…>` candidates and forwards them alongside the header-based sender
    evidence; the server owns the selection policy (skip-lists, `originalFrom → from → replyTo`

--- a/packages/migrations/src/__tests__/email-ingestion-grant-business-id.test.ts
+++ b/packages/migrations/src/__tests__/email-ingestion-grant-business-id.test.ts
@@ -1,0 +1,61 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import migration from '../actions/2026-06-22T10-00-00.add-email-ingestion-grant-business-id.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function captureSql(strings: TemplateStringsArray): unknown {
+  return strings.join('');
+}
+
+function getMigrationSql(): string {
+  const result = migration.run({
+    sql: captureSql as Parameters<typeof migration.run>[0]['sql'],
+    connection: null as never,
+  });
+  return result as unknown as string;
+}
+
+// ---------------------------------------------------------------------------
+// Module structure
+// ---------------------------------------------------------------------------
+
+describe('migration module structure', () => {
+  it('exports the correct name', () => {
+    expect(migration.name).toBe('2026-06-22T10-00-00.add-email-ingestion-grant-business-id.sql');
+  });
+
+  it('exports a run function', () => {
+    expect(typeof migration.run).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema validation
+// ---------------------------------------------------------------------------
+
+describe('grant business_id DDL', () => {
+  let ddl: string;
+
+  beforeAll(() => {
+    ddl = getMigrationSql();
+  });
+
+  it('alters the email_ingestion_grants table', () => {
+    expect(ddl).toMatch(/ALTER TABLE/i);
+    expect(ddl).toMatch(/email_ingestion_grants/);
+  });
+
+  it('adds a nullable business_id column idempotently', () => {
+    expect(ddl).toMatch(/ADD COLUMN IF NOT EXISTS\s+business_id\s+UUID/i);
+    // Nullable: no NOT NULL on the column definition.
+    const columnLine = ddl.match(/business_id[^\n;]+/i)?.[0] ?? '';
+    expect(columnLine).not.toMatch(/NOT NULL/i);
+  });
+
+  it('references businesses with ON DELETE SET NULL (grants survive business deletion)', () => {
+    expect(ddl).toMatch(/REFERENCES\s+accounter_schema\.businesses\(id\)/i);
+    expect(ddl).toMatch(/ON DELETE SET NULL/i);
+  });
+});

--- a/packages/migrations/src/actions/2026-06-22T10-00-00.add-email-ingestion-grant-business-id.ts
+++ b/packages/migrations/src/actions/2026-06-22T10-00-00.add-email-ingestion-grant-business-id.ts
@@ -1,0 +1,16 @@
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+export default {
+  name: '2026-06-22T10-00-00.add-email-ingestion-grant-business-id.sql',
+  run: ({ sql }) => sql`
+    -- Bind the recognized issuing business to the ingest grant. The control step
+    -- resolves the provider business (via suggestion_data.emails) under the
+    -- tenant's RLS context and records it here so the ingest step can attribute
+    -- documents to it without trusting gateway-supplied input. NULL means no
+    -- business was recognized, in which case the gateway applies default
+    -- treatment (e.g. the email body as a document).
+    ALTER TABLE accounter_schema.email_ingestion_grants
+      ADD COLUMN IF NOT EXISTS business_id UUID
+        REFERENCES accounter_schema.businesses(id) ON DELETE SET NULL;
+  `,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -189,6 +189,7 @@ import migration_2026_06_10T11_00_00_add_email_ingestion_grants from './actions/
 import migration_2026_06_10T12_00_00_add_email_ingestion_replay_nonces from './actions/2026-06-10T12-00-00.add-email-ingestion-replay-nonces.js';
 import migration_2026_06_10T13_00_00_add_email_ingestion_quarantine from './actions/2026-06-10T13-00-00.add-email-ingestion-quarantine.js';
 import migration_2026_06_11T10_00_00_add_email_ingestion_idempotency from './actions/2026-06-11T10-00-00.add-email-ingestion-idempotency.js';
+import migration_2026_06_22T10_00_00_add_email_ingestion_grant_business_id from './actions/2026-06-22T10-00-00.add-email-ingestion-grant-business-id.js';
 import { runMigrations } from './pg-migrator.js';
 
 export const MIGRATIONS = [
@@ -382,6 +383,7 @@ export const MIGRATIONS = [
   migration_2026_06_10T12_00_00_add_email_ingestion_replay_nonces,
   migration_2026_06_10T13_00_00_add_email_ingestion_quarantine,
   migration_2026_06_11T10_00_00_add_email_ingestion_idempotency,
+  migration_2026_06_22T10_00_00_add_email_ingestion_grant_business_id,
 ] as const;
 
 export const LATEST_MIGRATION_NAME = MIGRATIONS[MIGRATIONS.length - 1]?.name;

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-control.provider.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-control.provider.test.ts
@@ -172,4 +172,116 @@ describe('EmailIngestionControlProvider.issueGrant', () => {
     expect(params).toContain('tenant-uuid-1');
     expect(params).toContain('msg-abc-123');
   });
+
+  it('persists the recognized business_id when provided', async () => {
+    await provider.issueGrant({ ...grantInput, businessId: 'biz-uuid-9' });
+    const query = mockDb.pool.query as ReturnType<typeof vi.fn>;
+    const insertCall = query.mock.calls.find(
+      ([sql]) =>
+        typeof sql === 'string' && /insert.*email_ingestion_grants/s.test(sql.toLowerCase()),
+    ) as [string, unknown[]] | undefined;
+    expect(insertCall).toBeDefined();
+    expect(insertCall![1]).toContain('biz-uuid-9');
+  });
+
+  it('persists null business_id when none was recognized', async () => {
+    await provider.issueGrant(grantInput);
+    const query = mockDb.pool.query as ReturnType<typeof vi.fn>;
+    const insertCall = query.mock.calls.find(
+      ([sql]) =>
+        typeof sql === 'string' && /insert.*email_ingestion_grants/s.test(sql.toLowerCase()),
+    ) as [string, unknown[]] | undefined;
+    expect(insertCall).toBeDefined();
+    expect(insertCall![1]).toContain(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recognizeBusiness
+// ---------------------------------------------------------------------------
+
+describe('EmailIngestionControlProvider.recognizeBusiness', () => {
+  it('returns the businessId and emailListener config for a matched business', async () => {
+    const db = makeDbProvider(sql => {
+      if (/from\s+accounter_schema\.businesses/.test(sql.toLowerCase())) {
+        return {
+          rows: [
+            {
+              id: 'biz-1',
+              suggestion_data: {
+                emails: ['vendor@acme.com'],
+                emailListener: {
+                  emailBody: true,
+                  attachments: ['PDF'],
+                  internalEmailLinks: ['https://acme.com/inv'],
+                },
+              },
+            },
+          ],
+          rowCount: 1,
+        };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const provider = new EmailIngestionControlProvider(db);
+    const result = await provider.recognizeBusiness('tenant-1', 'vendor@acme.com');
+
+    expect(result.businessId).toBe('biz-1');
+    expect(result.config).toEqual({
+      emailBody: true,
+      attachments: ['PDF'],
+      internalEmailLinks: ['https://acme.com/inv'],
+    });
+  });
+
+  it('returns null businessId and empty config when no business matches', async () => {
+    const db = makeDbProvider(() => ({ rows: [], rowCount: 0 }));
+    const provider = new EmailIngestionControlProvider(db);
+    const result = await provider.recognizeBusiness('tenant-1', 'nobody@nowhere.com');
+
+    expect(result.businessId).toBeNull();
+    expect(result.config).toEqual({});
+  });
+
+  it('short-circuits without touching the DB when no issuer email is given', async () => {
+    const query = vi.fn();
+    const connect = vi.fn();
+    const db = { pool: { query, connect } } as unknown as DBProvider;
+    const provider = new EmailIngestionControlProvider(db);
+    const result = await provider.recognizeBusiness('tenant-1', null);
+
+    expect(result).toEqual({ businessId: null, config: {} });
+    expect(query).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it('returns the businessId but empty config when suggestion_data is invalid', async () => {
+    const db = makeDbProvider(sql => {
+      if (/from\s+accounter_schema\.businesses/.test(sql.toLowerCase())) {
+        return { rows: [{ id: 'biz-2', suggestion_data: { unexpected: 'shape' } }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const provider = new EmailIngestionControlProvider(db);
+    const result = await provider.recognizeBusiness('tenant-1', 'vendor@acme.com');
+
+    expect(result.businessId).toBe('biz-2');
+    expect(result.config).toEqual({});
+  });
+
+  it('pins the lookup to the tenant RLS context (set_config with the tenant id)', async () => {
+    const db = makeDbProvider(() => ({
+      rows: [{ id: 'biz-3', suggestion_data: null }],
+      rowCount: 1,
+    }));
+    const provider = new EmailIngestionControlProvider(db);
+    await provider.recognizeBusiness('tenant-xyz', 'vendor@acme.com');
+
+    const query = db.pool.query as ReturnType<typeof vi.fn>;
+    const setConfigCall = query.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('set_config'),
+    ) as [string, unknown[]] | undefined;
+    expect(setConfigCall).toBeDefined();
+    expect(setConfigCall![1]).toContain('tenant-xyz');
+  });
 });

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-control.resolver.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-control.resolver.test.ts
@@ -32,6 +32,7 @@ const mockGrant = {
 function makeInjector(overrides: Partial<EmailIngestionControlProvider> = {}): Injector {
   const controlProvider: Partial<EmailIngestionControlProvider> = {
     resolveAlias: vi.fn().mockResolvedValue({ found: true, tenantId: 'tenant-uuid-1' }),
+    recognizeBusiness: vi.fn().mockResolvedValue({ businessId: null, config: {} }),
     issueGrant: vi.fn().mockResolvedValue(mockGrant),
     ...overrides,
   };
@@ -145,5 +146,61 @@ describe('Mutation.requestIngestControl', () => {
     const callArg = issueGrant.mock.calls[0][0];
     expect(callArg.correlationId).toBe('corr-999');
     expect(callArg.messageId).toBe(baseInput.messageId);
+  });
+
+  it('selects the issuer from senderEvidence and returns the business config', async () => {
+    const recognizeBusiness = vi.fn().mockResolvedValue({
+      businessId: 'biz-1',
+      config: {
+        emailBody: true,
+        attachments: ['PDF'],
+        internalEmailLinks: ['https://acme.com/inv'],
+      },
+    });
+    const injector = makeInjector({ recognizeBusiness });
+
+    const result = await resolver(
+      {} as never,
+      { input: { ...baseInput, senderEvidence: { from: 'vendor@acme.com' } } },
+      { injector } as never,
+      {} as never,
+    );
+
+    expect(recognizeBusiness).toHaveBeenCalledWith('tenant-uuid-1', 'vendor@acme.com');
+    expect(result).toMatchObject({
+      businessEmailConfig: {
+        businessId: 'biz-1',
+        emailBody: true,
+        attachments: ['PDF'],
+        internalEmailLinks: ['https://acme.com/inv'],
+      },
+    });
+  });
+
+  it('returns null businessEmailConfig when no business is recognized', async () => {
+    const injector = makeInjector();
+    const result = await resolver(
+      {} as never,
+      { input: baseInput },
+      { injector } as never,
+      {} as never,
+    );
+
+    expect((result as { businessEmailConfig: unknown }).businessEmailConfig).toBeNull();
+  });
+
+  it('binds the recognized businessId into the issued grant', async () => {
+    const issueGrant = vi.fn().mockResolvedValue(mockGrant);
+    const recognizeBusiness = vi.fn().mockResolvedValue({ businessId: 'biz-7', config: {} });
+    const injector = makeInjector({ issueGrant, recognizeBusiness });
+
+    await resolver(
+      {} as never,
+      { input: { ...baseInput, senderEvidence: { from: 'vendor@acme.com' } } },
+      { injector } as never,
+      {} as never,
+    );
+
+    expect(issueGrant.mock.calls[0][0].businessId).toBe('biz-7');
   });
 });

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-issuer.helper.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-issuer.helper.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { selectIssuerEmail } from '../helpers/email-ingestion-issuer.helper.js';
+
+describe('selectIssuerEmail', () => {
+  it('returns null for missing evidence', () => {
+    expect(selectIssuerEmail(undefined)).toBeNull();
+    expect(selectIssuerEmail(null)).toBeNull();
+    expect(selectIssuerEmail({})).toBeNull();
+  });
+
+  it('prefers a non-provider body candidate over headers', () => {
+    expect(
+      selectIssuerEmail({
+        from: 'forwarder@gmail.com',
+        replyTo: 'reply@x.com',
+        issuerCandidates: ['vendor@acme.com'],
+      }),
+    ).toBe('vendor@acme.com');
+  });
+
+  it('skips a provider body candidate when a Reply-To exists', () => {
+    expect(
+      selectIssuerEmail({
+        from: 'vendor@acme.com',
+        replyTo: 'reply@x.com',
+        issuerCandidates: ['notify@morning.co'],
+      }),
+    ).toBe('vendor@acme.com');
+  });
+
+  it('keeps a provider body candidate when there is no Reply-To', () => {
+    expect(
+      selectIssuerEmail({
+        from: 'forwarder@gmail.com',
+        issuerCandidates: ['notify@morning.co'],
+      }),
+    ).toBe('notify@morning.co');
+  });
+
+  it('returns the first non-provider candidate, scanning in order', () => {
+    expect(
+      selectIssuerEmail({
+        replyTo: 'reply@x.com',
+        issuerCandidates: ['c@sumit.co.il', 'real-issuer@vendor.com'],
+      }),
+    ).toBe('real-issuer@vendor.com');
+  });
+
+  it('falls back to originalFrom before from', () => {
+    expect(
+      selectIssuerEmail({
+        from: 'forwarder@gmail.com',
+        originalFrom: 'vendor@acme.com',
+      }),
+    ).toBe('vendor@acme.com');
+  });
+
+  it('falls back to Reply-To when from is a known provider', () => {
+    expect(
+      selectIssuerEmail({
+        from: 'notify@morning.co',
+        replyTo: 'reply@x.com',
+      }),
+    ).toBe('reply@x.com');
+  });
+
+  it('falls back to from when nothing else is usable', () => {
+    expect(selectIssuerEmail({ from: 'notify@morning.co' })).toBe('notify@morning.co');
+  });
+
+  it('extracts the bare address from a "Name <addr>" form', () => {
+    expect(selectIssuerEmail({ from: 'Acme Billing <billing@acme.com>' })).toBe('billing@acme.com');
+  });
+
+  it('ignores empty/null candidates', () => {
+    expect(
+      selectIssuerEmail({
+        from: 'vendor@acme.com',
+        issuerCandidates: [null, '', '   '],
+      }),
+    ).toBe('vendor@acme.com');
+  });
+});

--- a/packages/server/src/modules/email-ingestion/helpers/email-ingestion-issuer.helper.ts
+++ b/packages/server/src/modules/email-ingestion/helpers/email-ingestion-issuer.helper.ts
@@ -1,0 +1,94 @@
+/**
+ * Server-side issuer-selection policy, ported from the legacy gmail-listener
+ * `getIssuerEmail`.
+ *
+ * In the v2 split (see docs/multi-tenant-gmail-listener/business-recognition-plan.md,
+ * Workstream A) the gateway parses the MIME message and forwards candidate sender
+ * addresses — header-derived (`from`, `replyTo`, …) plus any `From: <mailto:…>`
+ * links found in the body — as sender evidence. The selection policy that decides
+ * *which* address identifies the issuing business stays here, next to the
+ * `suggestion_data.emails` lookup it feeds, as the single DB-adjacent source of
+ * truth.
+ */
+
+export interface SenderEvidence {
+  /** From header address. */
+  from?: string | null;
+  /** Reply-To header address. */
+  replyTo?: string | null;
+  /** X-Original-From / X-Original-Sender address. */
+  originalFrom?: string | null;
+  /** X-Forwarded-To / Envelope-To address. */
+  forwardedTo?: string | null;
+  /** Addresses parsed from `From: <mailto:…>` lines in the body, in document order. */
+  issuerCandidates?: ReadonlyArray<string | null> | null;
+}
+
+// Invoice-issuing intermediaries: when the real issuer is reachable elsewhere we
+// prefer it over these forwarding addresses.
+// TODO(workstream-follow-up): this hard-coded list is a holdover from the
+// single-tenant listener and should become per-tenant configuration.
+const INVOICE_ISSUING_PROVIDER_EMAILS = new Set([
+  'notify@morning.co',
+  'c@sumit.co.il',
+  'ap@the-guild.dev',
+]);
+
+/** Extract the bare address from a `Name <addr>` form, otherwise return as-is. */
+function extractEmailAddress(raw: string): string {
+  const match = raw.match(/<([^>]+)>/);
+  return (match?.[1] ?? raw).trim();
+}
+
+function normalize(value: string | null | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const email = extractEmailAddress(value);
+  return email.length > 0 ? email : undefined;
+}
+
+function isKnownProvider(email: string): boolean {
+  return INVOICE_ISSUING_PROVIDER_EMAILS.has(email.toLowerCase());
+}
+
+/**
+ * Pick the issuer email used for business recognition, or `null` if none can be
+ * determined. Mirrors the legacy precedence:
+ *
+ *   1. the first body `mailto:` candidate that is either not a known provider,
+ *      or — when there is no Reply-To — the first candidate regardless;
+ *   2. else the first of `originalFrom` / `from` that is not a known provider;
+ *   3. else `replyTo`;
+ *   4. else `from`.
+ */
+export function selectIssuerEmail(evidence: SenderEvidence | null | undefined): string | null {
+  if (!evidence) {
+    return null;
+  }
+
+  const replyTo = normalize(evidence.replyTo);
+
+  for (const candidate of evidence.issuerCandidates ?? []) {
+    const email = normalize(candidate);
+    if (!email) {
+      continue;
+    }
+    if (!isKnownProvider(email) || !replyTo) {
+      return email;
+    }
+  }
+
+  const sender = [normalize(evidence.originalFrom), normalize(evidence.from)].find(
+    email => email !== undefined && !isKnownProvider(email),
+  );
+  if (sender) {
+    return sender;
+  }
+
+  if (replyTo) {
+    return replyTo;
+  }
+
+  return normalize(evidence.from) ?? null;
+}

--- a/packages/server/src/modules/email-ingestion/providers/email-ingestion-control.provider.ts
+++ b/packages/server/src/modules/email-ingestion/providers/email-ingestion-control.provider.ts
@@ -3,8 +3,8 @@ import { Injectable, Scope } from 'graphql-modules';
 import { sql } from '@pgtyped/runtime';
 import { DBProvider } from '../../app-providers/db.provider.js';
 import {
-  type EmailListenerConfig,
   suggestionDataSchema,
+  type EmailListenerConfig,
 } from '../../financial-entities/helpers/business-suggestion-data-schema.helper.js';
 import { IngestReasonCode } from '../contracts.js';
 import { withTenantContext } from '../helpers/email-ingestion-tenant-context.helper.js';

--- a/packages/server/src/modules/email-ingestion/providers/email-ingestion-control.provider.ts
+++ b/packages/server/src/modules/email-ingestion/providers/email-ingestion-control.provider.ts
@@ -2,13 +2,16 @@ import { randomUUID } from 'node:crypto';
 import { Injectable, Scope } from 'graphql-modules';
 import { sql } from '@pgtyped/runtime';
 import { DBProvider } from '../../app-providers/db.provider.js';
+import {
+  type EmailListenerConfig,
+  suggestionDataSchema,
+} from '../../financial-entities/helpers/business-suggestion-data-schema.helper.js';
 import { IngestReasonCode } from '../contracts.js';
 import { withTenantContext } from '../helpers/email-ingestion-tenant-context.helper.js';
 import type {
   IConsumeGrantByJtiQuery,
   IGetAliasByAliasQuery,
   IGetGrantByJtiQuery,
-  IInsertIngestGrantQuery,
 } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -23,11 +26,49 @@ const getAliasByAlias = sql<IGetAliasByAliasQuery>`
    LIMIT 1
 `;
 
-const insertIngestGrant = sql<IInsertIngestGrantQuery>`
+// Inline query type (cf. the ingest provider) so the grant insert does not
+// depend on a regenerated pgtyped type when the business_id column is added.
+interface IInsertGrantQuery {
+  params: {
+    jti: string;
+    ownerId: string;
+    messageId: string;
+    rawMessageHash: string;
+    action: string;
+    expiresAt: Date;
+    businessId: string | null;
+  };
+  result: {
+    id: string;
+    jti: string;
+    owner_id: string;
+    action: string;
+    expires_at: Date;
+    business_id: string | null;
+  };
+}
+
+const insertIngestGrant = sql<IInsertGrantQuery>`
   INSERT INTO accounter_schema.email_ingestion_grants
-    (jti, owner_id, message_id, raw_message_hash, action, expires_at)
-  VALUES ($jti, $ownerId, $messageId, $rawMessageHash, $action, $expiresAt)
-  RETURNING id, jti, owner_id, action, expires_at
+    (jti, owner_id, message_id, raw_message_hash, action, expires_at, business_id)
+  VALUES ($jti, $ownerId, $messageId, $rawMessageHash, $action, $expiresAt, $businessId)
+  RETURNING id, jti, owner_id, action, expires_at, business_id
+`;
+
+interface IGetBusinessByEmailForIngestQuery {
+  params: { email: string };
+  result: { id: string; suggestion_data: unknown };
+}
+
+// Resolve the issuing business by a sender email listed in its
+// suggestion_data.emails. Mirrors BusinessesProvider.getBusinessByEmail, but
+// runs on a tenant-pinned client (the control plane has no auth session), so
+// businesses RLS scopes the match to the resolved tenant.
+const getBusinessByEmail = sql<IGetBusinessByEmailForIngestQuery>`
+  SELECT id, suggestion_data
+    FROM accounter_schema.businesses
+   WHERE suggestion_data->'emails' ? $email::text
+   LIMIT 1
 `;
 
 const getGrantByJti = sql<IGetGrantByJtiQuery>`
@@ -70,6 +111,15 @@ export type IssueGrantInput = {
   rawMessageHash: string;
   expiresAt: Date;
   correlationId?: string;
+  /** Recognized issuing business, bound into the grant for the ingest step. */
+  businessId?: string | null;
+};
+
+export type BusinessRecognitionResult = {
+  /** The recognized issuing business, or null when no business matched. */
+  businessId: string | null;
+  /** The business's email-processing config (empty when unrecognized). */
+  config: EmailListenerConfig;
 };
 
 export type ValidateGrantInput = {
@@ -134,11 +184,19 @@ export class EmailIngestionControlProvider {
     const decisionId = randomUUID();
     const auditId = randomUUID();
 
-    const { tenantId, messageId, rawMessageHash, expiresAt } = input;
+    const { tenantId, messageId, rawMessageHash, expiresAt, businessId } = input;
 
     const rows = await withTenantContext(this.dbProvider.pool, tenantId, client =>
       insertIngestGrant.run(
-        { jti, ownerId: tenantId, messageId, rawMessageHash, action: 'ingest', expiresAt },
+        {
+          jti,
+          ownerId: tenantId,
+          messageId,
+          rawMessageHash,
+          action: 'ingest',
+          expiresAt,
+          businessId: businessId ?? null,
+        },
         client,
       ),
     );
@@ -155,6 +213,46 @@ export class EmailIngestionControlProvider {
       decisionId,
       auditId,
     };
+  }
+
+  /**
+   * Recognize the issuing business behind an incoming email and load its
+   * email-processing config. Runs on a client pinned to the resolved tenant so
+   * the businesses RLS policy scopes the lookup to that tenant; returns a null
+   * businessId (and empty config) when no email evidence is available or no
+   * business matches, in which case the gateway applies default treatment.
+   */
+  async recognizeBusiness(
+    tenantId: string,
+    issuerEmail: string | null,
+  ): Promise<BusinessRecognitionResult> {
+    if (!issuerEmail) {
+      return { businessId: null, config: {} };
+    }
+
+    return withTenantContext(this.dbProvider.pool, tenantId, async client => {
+      const rows = await getBusinessByEmail.run({ email: issuerEmail }, client);
+      if (rows.length === 0) {
+        return { businessId: null, config: {} };
+      }
+
+      const business = rows[0];
+      let config: EmailListenerConfig = {};
+      if (business.suggestion_data) {
+        const parsed = suggestionDataSchema.safeParse(business.suggestion_data);
+        if (parsed.success) {
+          if (parsed.data.emailListener) {
+            config = parsed.data.emailListener;
+          }
+        } else {
+          console.error(
+            `Invalid suggestion_data schema for business [${business.id}]: ${JSON.stringify(parsed.error.issues)}`,
+          );
+        }
+      }
+
+      return { businessId: business.id, config };
+    });
   }
 
   /**

--- a/packages/server/src/modules/email-ingestion/resolvers/email-ingestion-control.resolver.ts
+++ b/packages/server/src/modules/email-ingestion/resolvers/email-ingestion-control.resolver.ts
@@ -1,5 +1,6 @@
 import { GraphQLError } from 'graphql';
 import type { MutationResolvers } from '../../../__generated__/types.js';
+import { selectIssuerEmail } from '../helpers/email-ingestion-issuer.helper.js';
 import { EmailIngestionControlProvider } from '../providers/email-ingestion-control.provider.js';
 
 const GRANT_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -21,6 +22,14 @@ const requestIngestControl: MutationResolvers['requestIngestControl'] = async (
       };
     }
 
+    // Recognize the issuing business from sender evidence, then bind it into the
+    // grant so the ingest step can attribute documents without trusting input.
+    const issuerEmail = selectIssuerEmail(input.senderEvidence ?? undefined);
+    const { businessId, config } = await control.recognizeBusiness(
+      aliasResult.tenantId,
+      issuerEmail,
+    );
+
     const expiresAt = new Date(Date.now() + GRANT_TTL_MS);
     const grant = await control.issueGrant({
       tenantId: aliasResult.tenantId,
@@ -28,6 +37,7 @@ const requestIngestControl: MutationResolvers['requestIngestControl'] = async (
       rawMessageHash: input.rawMessageHash,
       expiresAt,
       correlationId: input.correlationId ?? undefined,
+      businessId,
     });
 
     return {
@@ -43,6 +53,15 @@ const requestIngestControl: MutationResolvers['requestIngestControl'] = async (
         action: grant.action,
         expiresAt: grant.expiresAt.toISOString(),
       },
+      // null signals "no business recognized" → gateway applies default treatment.
+      businessEmailConfig: businessId
+        ? {
+            businessId,
+            internalEmailLinks: config.internalEmailLinks ?? null,
+            emailBody: config.emailBody ?? null,
+            attachments: config.attachments ?? null,
+          }
+        : null,
     };
   } catch (err) {
     throw new GraphQLError('Failed to process ingest control request', {

--- a/packages/server/src/modules/email-ingestion/typeDefs/email-ingestion.graphql.ts
+++ b/packages/server/src/modules/email-ingestion/typeDefs/email-ingestion.graphql.ts
@@ -53,6 +53,22 @@ export default gql`
     receivedAt: String
     " Optional correlation ID for distributed tracing "
     correlationId: String
+    " Sender evidence used to recognize the issuing business (issuer-selection runs server-side) "
+    senderEvidence: SenderEvidenceInput
+  }
+
+  " Candidate sender addresses extracted by the gateway, used for business recognition "
+  input SenderEvidenceInput {
+    " From header address "
+    from: String
+    " Reply-To header address "
+    replyTo: String
+    " X-Original-From / X-Original-Sender address "
+    originalFrom: String
+    " X-Forwarded-To / Envelope-To address "
+    forwardedTo: String
+    " Addresses parsed from `From: <mailto:…>` lines in the body, in document order "
+    issuerCandidates: [String!]
   }
 
   " Short-lived single-use ingest grant "
@@ -71,6 +87,8 @@ export default gql`
     decisionId: String!
     auditId: String!
     grant: IngestGrant!
+    " The recognized issuing business and its email-processing config; null when no business matched "
+    businessEmailConfig: BusinessEmailConfig
   }
 
   " Result of a requestIngestControl mutation: either a decision with a grant or an error "

--- a/packages/server/src/modules/email-ingestion/typeDefs/email-ingestion.graphql.ts
+++ b/packages/server/src/modules/email-ingestion/typeDefs/email-ingestion.graphql.ts
@@ -67,7 +67,7 @@ export default gql`
     originalFrom: String
     " X-Forwarded-To / Envelope-To address "
     forwardedTo: String
-    " Addresses parsed from `From: <mailto:…>` lines in the body, in document order "
+    " Sender addresses parsed from mailto links in the email body, in document order "
     issuerCandidates: [String!]
   }
 


### PR DESCRIPTION
## What

Implements **Workstream A** of the [business-recognition plan](https://github.com/Urigo/accounter-fullstack/blob/claude/magical-maxwell-az7rgc/docs/multi-tenant-gmail-listener/business-recognition-plan.md): server-side recognition of the issuing provider business in the v2 ingest **control step**, binding the recognized business into the grant so later stages can attribute documents without trusting gateway-supplied input.

Targets `claude/magical-maxwell-az7rgc` (the plan-doc branch / PR #3743) so this stacks on top of it.

## Changes

- **Migration** — adds a nullable `business_id` (FK → `businesses`, `ON DELETE SET NULL`) to `email_ingestion_grants`. Registered in `run-pg-migrations.ts`.
- **Control provider** (`EmailIngestionControlProvider`)
  - `recognizeBusiness(tenantId, issuerEmail)` — resolves the business via `suggestion_data->'emails'` under the tenant's RLS context (`withTenantContext`, raw pool — the control plane has no auth session), then parses its `emailListener` config with the shared `suggestionDataSchema`. Returns `{ businessId: null, config: {} }` when there's no evidence or no match.
  - `issueGrant(...)` now persists the recognized `businessId` into the grant.
  - The grant insert uses an inline pgtyped type (mirroring the ingest provider) so it doesn't depend on a regenerated SQL type for the new column.
- **Issuer-selection helper** (`selectIssuerEmail`) — ports the legacy `getIssuerEmail` precedence (provider skip-list, body `mailto:` candidates, `originalFrom → from → replyTo` fallback). Lives server-side as the single DB-adjacent source of truth; fed by gateway sender evidence.
- **typeDefs** — `IngestControlInput.senderEvidence` (+ `SenderEvidenceInput`); `IngestControlDecision.businessEmailConfig` (reuses the existing `BusinessEmailConfig`; **null = no business recognized → gateway applies default treatment**).
- **Resolver** — selects the issuer, recognizes the business, binds it into the grant, and returns `businessEmailConfig`.
- **Tests** — unit tests for the helper, provider (`recognizeBusiness` + grant `business_id` persistence), resolver, and the migration DDL.

## Trust model

The recognized `business_id` travels in the grant row, never in gateway-supplied input — preserving the rule that a control-plane gateway can't attribute documents to an arbitrary business.

## Deferred (later workstreams)

- **B/C** — gateway sender-evidence extraction (body + `mailto:` candidates) and the treatment step (attachment filter, body→PDF, internal-link fetch).
- **D** — ingest-time document persistence under the grant's `business_id` (replacing the ingest `TODO`).

## Validation note

Dependencies couldn't be installed in the authoring environment (network policy blocks the sheetjs CDN), so codegen/lint/tests were **not** run locally — relying on CI. Two things CI will exercise that I couldn't: GraphQL + pgtyped codegen against the new typeDefs/SQL, and the unit tests. I'm watching CI and will fix any failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNHHjHfq9G4snq7U42hcjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNHHjHfq9G4snq7U42hcjj)_