### PR TITLE
Workstream B: capture body + sender evidence in the email-ingestion gateway

### DIFF
--- a/.changeset/email-ingestion-gateway-sender-evidence.md
+++ b/.changeset/email-ingestion-gateway-sender-evidence.md
@@ -1,0 +1,9 @@
+---
+'@accounter/email-ingestion-gateway': patch
+---
+
+Gateway: capture the email body and issuer (`From: <mailto:…>`) candidates during MIME extraction,
+and forward sender evidence to the control endpoint so the server can recognize the issuing business
+(Workstream B). Attachment-less emails are no longer treated as an extraction failure — the body may
+still yield a document during treatment, so emptiness is decided later with the server ingest as the
+backstop.

--- a/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
@@ -34,6 +34,23 @@ function makeTextMime(from: string, subject: string, body = 'hello'): Buffer {
   );
 }
 
+/** Build a single text/html MIME message with the given HTML body. */
+function makeHtmlMime(html: string, from = 'forwarder@gmail.com'): Buffer {
+  return Buffer.from(
+    [
+      `From: ${from}`,
+      `To: invoices@example.com`,
+      `Subject: Fwd: Invoice`,
+      `MIME-Version: 1.0`,
+      `Content-Type: text/html; charset=utf-8`,
+      `Content-Transfer-Encoding: 7bit`,
+      ``,
+      html,
+    ].join('\r\n'),
+    'utf8',
+  );
+}
+
 /**
  * Build a multipart/mixed MIME with one base64-encoded attachment.
  * `content` should be the raw bytes of the attachment.
@@ -135,13 +152,10 @@ describe('extractFromMime — OVERSIZE_MESSAGE', () => {
     expect(result).toEqual({ success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE });
   });
 
-  it('does NOT reject a message at exactly 25 MB', () => {
-    // A buffer of exactly MAX size should not trigger the oversize check
-    // (even if it's invalid MIME it will fail differently)
+  it('does NOT reject a message at exactly 25 MB as oversize', () => {
+    // A buffer of exactly MAX size must not trigger the oversize check.
     const exact = Buffer.alloc(MAX_RAW_MIME_BYTES);
     const result = extractFromMime(exact);
-    // Either PARSE_ERROR or NO_DOCUMENTS — not OVERSIZE_MESSAGE
-    expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.reason).not.toBe(IngestReasonCode.OVERSIZE_MESSAGE);
     }
@@ -187,17 +201,22 @@ describe('extractFromMime — PARSE_ERROR', () => {
 });
 
 // ---------------------------------------------------------------------------
-// NO_DOCUMENTS
+// Attachment-less messages — no longer an extraction failure
 // ---------------------------------------------------------------------------
 
-describe('extractFromMime — NO_DOCUMENTS', () => {
-  it('returns NO_DOCUMENTS for a plain-text-only message', () => {
-    const mime = makeTextMime('sender@example.com', 'Hello');
+describe('extractFromMime — attachment-less messages', () => {
+  it('succeeds with empty documents for a plain-text-only message', () => {
+    const mime = makeTextMime('sender@example.com', 'Hello', 'just some text');
     const result = extractFromMime(mime);
-    expect(result).toEqual({ success: false, reason: IngestReasonCode.NO_DOCUMENTS });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.documents).toHaveLength(0);
+      expect(result.body).toContain('just some text');
+      expect(result.senderEvidence.from).toBe('sender@example.com');
+    }
   });
 
-  it('returns NO_DOCUMENTS for multipart/mixed with no document attachments', () => {
+  it('succeeds with empty documents for multipart with no document attachments', () => {
     // Has a text attachment, not a PDF/image
     const mime = makeMultipartMime({
       attachments: [
@@ -205,7 +224,10 @@ describe('extractFromMime — NO_DOCUMENTS', () => {
       ],
     });
     const result = extractFromMime(mime);
-    expect(result).toEqual({ success: false, reason: IngestReasonCode.NO_DOCUMENTS });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.documents).toHaveLength(0);
+    }
   });
 });
 
@@ -424,12 +446,10 @@ describe('extractFromMime — deeply nested multipart', () => {
       'utf8',
     );
     const result = extractFromMime(raw);
-    // Either PARSE_ERROR (throws) or NO_DOCUMENTS (no docs at max depth) — never success
+    // Exceeding the nesting limit throws → PARSE_ERROR (never success).
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect([IngestReasonCode.PARSE_ERROR, IngestReasonCode.NO_DOCUMENTS]).toContain(
-        result.reason,
-      );
+      expect(result.reason).toBe(IngestReasonCode.PARSE_ERROR);
     }
   });
 });
@@ -526,6 +546,67 @@ describe('extractFromMime — boundary collision in body', () => {
       expect(result.documents).toHaveLength(1);
       expect(result.documents[0]?.content).toEqual(pdf);
       expect(result.documents[0]?.filename).toBe('doc.pdf');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Body capture & issuer candidates
+// ---------------------------------------------------------------------------
+
+describe('extractFromMime — body capture & issuer candidates', () => {
+  it('captures the HTML body of a text/html message', () => {
+    const result = extractFromMime(makeHtmlMime('<p>hello body world</p>'));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.body).toContain('hello body world');
+    }
+  });
+
+  it('prefers the HTML body over text/plain in multipart/alternative', () => {
+    const boundary = 'ALT001';
+    const mime = Buffer.from(
+      [
+        'From: sender@example.com',
+        'To: invoices@example.com',
+        'MIME-Version: 1.0',
+        `Content-Type: multipart/alternative; boundary="${boundary}"`,
+        '',
+        `--${boundary}`,
+        'Content-Type: text/plain; charset=utf-8',
+        '',
+        'plain version',
+        `--${boundary}`,
+        'Content-Type: text/html; charset=utf-8',
+        '',
+        '<p>html version</p>',
+        `--${boundary}--`,
+      ].join('\r\n'),
+      'utf8',
+    );
+    const result = extractFromMime(mime);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.body).toContain('html version');
+      expect(result.body).not.toContain('plain version');
+    }
+  });
+
+  it('extracts (and URL-decodes) issuer mailto candidates from "From:" links in the body', () => {
+    const html =
+      '<div>From: Real Vendor &lt;<a href="mailto:real%40vendor.com">real@vendor.com</a>&gt;</div>';
+    const result = extractFromMime(makeHtmlMime(html));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.senderEvidence.issuerCandidates).toContain('real@vendor.com');
+    }
+  });
+
+  it('returns no issuer candidates when the body has no From: mailto link', () => {
+    const result = extractFromMime(makeHtmlMime('<p>no contact links here</p>'));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.senderEvidence.issuerCandidates).toEqual([]);
     }
   });
 });

--- a/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
@@ -609,4 +609,35 @@ describe('extractFromMime — body capture & issuer candidates', () => {
       expect(result.senderEvidence.issuerCandidates).toEqual([]);
     }
   });
+
+  it('matches issuer candidates across a newline-wrapped From: line', () => {
+    const html = 'From: Real Vendor\r\n<a href="mailto:wrapped@vendor.com">link</a>';
+    const result = extractFromMime(makeHtmlMime(html));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.senderEvidence.issuerCandidates).toContain('wrapped@vendor.com');
+    }
+  });
+
+  it('decodes a non-UTF-8 (windows-1255) text body via its declared charset', () => {
+    const header = Buffer.from(
+      [
+        'From: sender@example.com',
+        'To: invoices@example.com',
+        'MIME-Version: 1.0',
+        'Content-Type: text/plain; charset=windows-1255',
+        'Content-Transfer-Encoding: 8bit',
+        '',
+        '',
+      ].join('\r\n'),
+      'ascii',
+    );
+    // 0xE0 0xE1 0xE2 = אבג in windows-1255
+    const mime = Buffer.concat([header, Buffer.from([0xe0, 0xe1, 0xe2])]);
+    const result = extractFromMime(mime);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.body).toBe('אבג');
+    }
+  });
 });

--- a/packages/email-ingestion-gateway/src/__tests__/orchestrator.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/orchestrator.test.ts
@@ -355,6 +355,19 @@ describe('orchestrate — end-to-end flow verification', () => {
     expect(ingestArg.extractedDocuments).toEqual(docs);
   });
 
+  it('passes senderEvidence to control for business recognition', async () => {
+    const senderEvidence = {
+      from: 'forwarder@gmail.com',
+      replyTo: 'reply@vendor.com',
+      issuerCandidates: ['real@vendor.com'],
+    };
+    const deps = makeDeps(CONTROL_SUCCESS);
+    await orchestrate({ ...BASE_INPUT, senderEvidence }, deps);
+    const controlArg = (deps.serverClient.requestControl as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(controlArg.senderEvidence).toEqual(senderEvidence);
+  });
+
   it('returns idempotent duplicate outcome on repeated delivery', async () => {
     // Simulates Cloudflare delivering the same email twice.
     // Second delivery with same messageId returns DUPLICATE from server.

--- a/packages/email-ingestion-gateway/src/__tests__/server-client.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/server-client.test.ts
@@ -193,6 +193,22 @@ describe('ServerClient.requestControl — success', () => {
     const body = JSON.parse(opts.body as string) as { variables: { input: ControlInput } };
     expect(body.variables.input.correlationId).toBe('corr-abc');
   });
+
+  it('sends senderEvidence in the request body when provided', async () => {
+    const fetchFn = makeFetch([{ body: CONTROL_SUCCESS_RESPONSE }]);
+    const client = makeClient(fetchFn);
+    await client.requestControl({
+      ...CONTROL_INPUT,
+      senderEvidence: { from: 'forwarder@gmail.com', issuerCandidates: ['real@vendor.com'] },
+    });
+
+    const [, opts] = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(opts.body as string) as { variables: { input: ControlInput } };
+    expect(body.variables.input.senderEvidence).toEqual({
+      from: 'forwarder@gmail.com',
+      issuerCandidates: ['real@vendor.com'],
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/email-ingestion-gateway/src/__tests__/webhook.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/webhook.test.ts
@@ -245,6 +245,66 @@ describe('POST /webhook — createWebhookHandler', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Sender evidence forwarding (business recognition)
+  // -------------------------------------------------------------------------
+
+  it('forwards extracted senderEvidence to the control endpoint (even with no attachments)', async () => {
+    const requestControl = vi.fn().mockResolvedValue({
+      success: true,
+      decision: {
+        id: 'd1',
+        tenantId: 't1',
+        decisionId: 'dec1',
+        auditId: 'a1',
+        grant: {
+          id: 'g1',
+          jti: 'jti-1',
+          tenantId: 't1',
+          action: 'ingest',
+          expiresAt: '2099-01-01T00:00:00Z',
+        },
+      },
+    });
+    const serverClient = {
+      requestControl,
+      requestIngest: vi.fn().mockResolvedValue({
+        success: true,
+        outcome: 'QUARANTINED',
+        ingestId: null,
+        existingIngestId: null,
+        auditId: 'a2',
+        reasonCode: 'NO_DOCUMENTS',
+      }),
+    };
+    const h = createWebhookHandler({
+      verifier: makeVerifier({ valid: true }),
+      featureFlags: { v2Enabled: true, shadowMode: false },
+      serverClient,
+    });
+    const body = [
+      'From: Forwarder <forwarder@gmail.com>',
+      'To: invoices@acme.example.com',
+      'Reply-To: reply@vendor.com',
+      'MIME-Version: 1.0',
+      'Content-Type: text/plain; charset=utf-8',
+      '',
+      'no attachments here',
+    ].join('\r\n');
+
+    const { res, getStatus } = makeRes();
+    await h(makeReq(body), res);
+
+    expect(getStatus()).toBe(202);
+    expect(requestControl).toHaveBeenCalledOnce();
+    const controlArg = requestControl.mock.calls[0][0] as { senderEvidence?: Record<string, unknown> };
+    expect(controlArg.senderEvidence).toMatchObject({
+      from: 'Forwarder <forwarder@gmail.com>',
+      replyTo: 'reply@vendor.com',
+      issuerCandidates: [],
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Body read errors
   // -------------------------------------------------------------------------
 

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -21,15 +21,30 @@ export interface SenderEvidence {
   originalFrom: string | undefined;
   /** X-Forwarded-To or Envelope-To */
   forwardedTo: string | undefined;
+  /**
+   * Addresses parsed from `From: <mailto:…>` links in the (HTML) body, in
+   * document order. The server applies the issuer-selection policy over these
+   * plus the header fields.
+   */
+  issuerCandidates: string[];
 }
 
+// NO_DOCUMENTS is intentionally not an extraction failure: an email with no
+// attachment may still yield a document during gateway treatment (body→PDF,
+// internal-link fetch). Emptiness is decided after treatment, with the server
+// ingest as the final backstop.
 export type ExtractionFailureReason =
-  | typeof IngestReasonCode.NO_DOCUMENTS
   | typeof IngestReasonCode.PARSE_ERROR
   | typeof IngestReasonCode.OVERSIZE_MESSAGE;
 
 export type ExtractionResult =
-  | { success: true; senderEvidence: SenderEvidence; documents: ExtractedDocument[] }
+  | {
+      success: true;
+      senderEvidence: SenderEvidence;
+      /** Decoded email body (HTML preferred, else plain text), for downstream treatment. */
+      body: string;
+      documents: ExtractedDocument[];
+    }
   | { success: false; reason: ExtractionFailureReason };
 
 // ---------------------------------------------------------------------------
@@ -46,7 +61,7 @@ export function extractFromMime(rawMime: Buffer): ExtractionResult {
   }
 
   try {
-    const { headers, documents } = parseMimePart(rawMime);
+    const { headers, documents, textParts } = parseMimePart(rawMime);
 
     if (documents.length > MAX_ATTACHMENT_COUNT) {
       return { success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE };
@@ -57,11 +72,14 @@ export function extractFromMime(rawMime: Buffer): ExtractionResult {
       return { success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE };
     }
 
-    if (documents.length === 0) {
-      return { success: false, reason: IngestReasonCode.NO_DOCUMENTS };
-    }
+    const body = pickBody(textParts);
 
-    return { success: true, senderEvidence: buildSenderEvidence(headers), documents };
+    return {
+      success: true,
+      senderEvidence: buildSenderEvidence(headers, body),
+      body,
+      documents,
+    };
   } catch {
     return { success: false, reason: IngestReasonCode.PARSE_ERROR };
   }
@@ -73,9 +91,16 @@ export function extractFromMime(rawMime: Buffer): ExtractionResult {
 
 type Headers = Map<string, string>;
 
+interface TextPart {
+  mediaType: string;
+  content: string;
+}
+
 interface ParsedPart {
   headers: Headers;
   documents: ExtractedDocument[];
+  /** Inline text/html and text/plain parts, for body extraction. */
+  textParts: TextPart[];
 }
 
 // ---------------------------------------------------------------------------
@@ -338,6 +363,7 @@ function parseMimePart(raw: Buffer, depth = 0): ParsedPart {
   const mediaType = getMediaType(contentType);
 
   const documents: ExtractedDocument[] = [];
+  const textParts: TextPart[] = [];
 
   if (mediaType.startsWith('multipart/')) {
     const boundary = getParam(contentType, 'boundary');
@@ -347,6 +373,7 @@ function parseMimePart(raw: Buffer, depth = 0): ParsedPart {
     for (const part of subParts) {
       const sub = parseMimePart(part, depth + 1);
       documents.push(...sub.documents);
+      textParts.push(...sub.textParts);
     }
   } else if (isDocumentPart(headers)) {
     const encoding = h(headers, 'content-transfer-encoding');
@@ -361,20 +388,59 @@ function parseMimePart(raw: Buffer, depth = 0): ParsedPart {
       size: content.length,
       sha256,
     });
+  } else if (mediaType === 'text/html' || mediaType === 'text/plain') {
+    // Inline body part — skip text/* sent as a downloadable attachment.
+    const disposition = h(headers, 'content-disposition');
+    if (!disposition || !disposition.trim().toLowerCase().startsWith('attachment')) {
+      const encoding = h(headers, 'content-transfer-encoding');
+      textParts.push({ mediaType, content: decodeBody(body, encoding).toString('utf8') });
+    }
   }
 
-  return { headers, documents };
+  return { headers, documents, textParts };
 }
 
 // ---------------------------------------------------------------------------
 // Sender evidence extraction
 // ---------------------------------------------------------------------------
 
-function buildSenderEvidence(headers: Headers): SenderEvidence {
+/** Prefer the HTML body (richer, carries mailto links); fall back to plain text. */
+function pickBody(textParts: TextPart[]): string {
+  return (
+    textParts.find(p => p.mediaType === 'text/html')?.content ??
+    textParts.find(p => p.mediaType === 'text/plain')?.content ??
+    ''
+  );
+}
+
+// Forwarded emails often carry the real sender as a `From: <a href="mailto:…">`
+// line in the body. Collect those addresses (decoded), in document order, for
+// the server's issuer-selection policy.
+const ISSUER_MAILTO_RE = /From:.*?<a\s+href="mailto:([^"]+)"/i;
+
+function extractIssuerCandidates(body: string): string[] {
+  const candidates: string[] = [];
+  for (const rawLine of body.split('\n')) {
+    const match = rawLine.trim().match(ISSUER_MAILTO_RE);
+    if (match?.[1]) {
+      let email = match[1];
+      try {
+        email = decodeURIComponent(email);
+      } catch {
+        // keep the raw value if it is not valid percent-encoding
+      }
+      candidates.push(email);
+    }
+  }
+  return candidates;
+}
+
+function buildSenderEvidence(headers: Headers, body: string): SenderEvidence {
   return {
     from: h(headers, 'from'),
     replyTo: h(headers, 'reply-to'),
     originalFrom: h(headers, 'x-original-from') ?? h(headers, 'x-original-sender'),
     forwardedTo: h(headers, 'x-forwarded-to') ?? h(headers, 'envelope-to'),
+    issuerCandidates: extractIssuerCandidates(body),
   };
 }

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -393,7 +393,17 @@ function parseMimePart(raw: Buffer, depth = 0): ParsedPart {
     const disposition = h(headers, 'content-disposition');
     if (!disposition || !disposition.trim().toLowerCase().startsWith('attachment')) {
       const encoding = h(headers, 'content-transfer-encoding');
-      textParts.push({ mediaType, content: decodeBody(body, encoding).toString('utf8') });
+      const decoded = decodeBody(body, encoding);
+      // Decode using the part's declared charset (e.g. windows-1255 for Hebrew),
+      // falling back to UTF-8 for unknown/unsupported labels.
+      const charset = getParam(contentType, 'charset') ?? 'utf-8';
+      let content: string;
+      try {
+        content = new TextDecoder(charset).decode(decoded);
+      } catch {
+        content = decoded.toString('utf8');
+      }
+      textParts.push({ mediaType, content });
     }
   }
 
@@ -413,24 +423,24 @@ function pickBody(textParts: TextPart[]): string {
   );
 }
 
-// Forwarded emails often carry the real sender as a `From: <a href="mailto:…">`
-// line in the body. Collect those addresses (decoded), in document order, for
-// the server's issuer-selection policy.
-const ISSUER_MAILTO_RE = /From:.*?<a\s+href="mailto:([^"]+)"/i;
+// Forwarded emails often carry the real sender as a `From: … <a href="mailto:…">`
+// span in the body. Collect those addresses (decoded), in document order, for
+// the server's issuer-selection policy. The bounded lazy quantifier keeps the
+// match span small: it tolerates a newline-wrapped `From:` line, avoids matching
+// an unrelated mailto far down a minified single-line body, and bounds regex
+// backtracking on very large bodies.
+const ISSUER_MAILTO_RE = /From:[\s\S]{0,250}?<a\s+href="mailto:([^"]+)"/gi;
 
 function extractIssuerCandidates(body: string): string[] {
   const candidates: string[] = [];
-  for (const rawLine of body.split('\n')) {
-    const match = rawLine.trim().match(ISSUER_MAILTO_RE);
-    if (match?.[1]) {
-      let email = match[1];
-      try {
-        email = decodeURIComponent(email);
-      } catch {
-        // keep the raw value if it is not valid percent-encoding
-      }
-      candidates.push(email);
+  for (const match of body.matchAll(ISSUER_MAILTO_RE)) {
+    let email = match[1];
+    try {
+      email = decodeURIComponent(email);
+    } catch {
+      // keep the raw value if it is not valid percent-encoding
     }
+    candidates.push(email);
   }
   return candidates;
 }

--- a/packages/email-ingestion-gateway/src/orchestrator.ts
+++ b/packages/email-ingestion-gateway/src/orchestrator.ts
@@ -1,6 +1,7 @@
 import { log } from './logger.js';
 import type {
   ControlInput,
+  ControlSenderEvidence,
   IngestDocumentInput,
   IngestInput,
   ServerClient,
@@ -17,6 +18,8 @@ export interface OrchestrateInput {
   correlationId: string;
   receivedAt?: string;
   extractedDocuments: IngestDocumentInput[];
+  /** Sender evidence forwarded to the control endpoint for business recognition. */
+  senderEvidence?: ControlSenderEvidence;
 }
 
 export type OrchestrateResult =
@@ -54,6 +57,7 @@ export async function orchestrate(
     rawMessageHash: input.rawMessageHash,
     receivedAt: input.receivedAt,
     correlationId,
+    senderEvidence: input.senderEvidence,
   };
 
   log('info', 'orchestrate:control:start', { recipientAlias: input.recipientAlias }, correlationId);

--- a/packages/email-ingestion-gateway/src/server-client.ts
+++ b/packages/email-ingestion-gateway/src/server-client.ts
@@ -21,12 +21,22 @@ export const INGEST_MAX_RETRIES = 1;
 // Domain types (public API)
 // ---------------------------------------------------------------------------
 
+/** Candidate sender addresses for server-side issuer/business recognition. */
+export interface ControlSenderEvidence {
+  from?: string;
+  replyTo?: string;
+  originalFrom?: string;
+  forwardedTo?: string;
+  issuerCandidates?: string[];
+}
+
 export interface ControlInput {
   recipientAlias: string;
   messageId: string;
   rawMessageHash: string;
   receivedAt?: string;
   correlationId?: string;
+  senderEvidence?: ControlSenderEvidence;
 }
 
 export interface GrantData {

--- a/packages/email-ingestion-gateway/src/webhook.ts
+++ b/packages/email-ingestion-gateway/src/webhook.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import { generateCorrelationId, log } from './logger.js';
 import { extractFromMime, MAX_RAW_MIME_BYTES } from './mime-extractor.js';
 import { orchestrate, type OrchestratorDeps } from './orchestrator.js';
-import type { IngestDocumentInput } from './server-client.js';
+import type { ControlSenderEvidence, IngestDocumentInput } from './server-client.js';
 import type { AuthenticityInput, CloudflareAuthenticityVerifier } from './verifier.js';
 
 // Inbound requests carry the raw MIME message as their body, so the cap matches
@@ -143,6 +143,7 @@ export function createWebhookHandler(deps: WebhookDeps) {
     const extraction = extractFromMime(rawBody);
 
     let extractedDocuments: IngestDocumentInput[] = [];
+    let senderEvidence: ControlSenderEvidence | undefined;
     if (extraction.success) {
       extractedDocuments = extraction.documents.map(doc => ({
         hash: doc.sha256,
@@ -150,13 +151,18 @@ export function createWebhookHandler(deps: WebhookDeps) {
         mimeType: doc.mimeType,
         filename: doc.filename,
       }));
+      // Forward sender evidence so the server can recognize the issuing business.
+      // Present even when there are no attachments (the body may still yield a
+      // document during treatment).
+      senderEvidence = extraction.senderEvidence;
     } else {
-      // Extraction failed (no documents, parse error, or oversize). Proceed to
-      // orchestration so the server records an auditable quarantine outcome;
-      // the empty document list drives the NO_DOCUMENTS quarantine path.
+      // Extraction failed (parse error or oversize). Proceed to orchestration so
+      // the server records an auditable quarantine outcome; the empty document
+      // list drives the server-side NO_DOCUMENTS quarantine. No trustworthy
+      // sender evidence is available in this case.
       log(
         'warn',
-        'webhook: MIME extraction yielded no documents',
+        'webhook: MIME extraction failed',
         { reason: extraction.reason },
         effectiveCorrelationId,
       );
@@ -188,6 +194,7 @@ export function createWebhookHandler(deps: WebhookDeps) {
       correlationId: effectiveCorrelationId,
       receivedAt,
       extractedDocuments,
+      senderEvidence,
     };
 
     if (featureFlags.shadowMode) {


### PR DESCRIPTION
## What

Implements **Workstream B** of the [business-recognition plan](https://github.com/Urigo/accounter-fullstack/blob/claude/magical-maxwell-az7rgc/docs/multi-tenant-gmail-listener/business-recognition-plan.md): the gateway now enriches MIME extraction with the email **body** and **issuer candidates**, and forwards **sender evidence** to the control endpoint so the server (Workstream A) can recognize the issuing business.

Stacks on Workstream A — targets `claude/magical-maxwell-az7rgc`.

## Changes

- **`mime-extractor.ts`**
  - Captures the email **body** (HTML preferred, plain-text fallback) from inline text parts, and parses `From: <mailto:…>` **issuer candidates** out of it. Both are exposed on the extraction result (`senderEvidence.issuerCandidates`, `body`).
  - **`NO_DOCUMENTS` is no longer an extraction failure.** An attachment-less email now *succeeds* with empty documents so sender evidence is still produced (the body may yield a document during Workstream C treatment). Emptiness is decided post-treatment, with the server ingest as the backstop (`ExtractionFailureReason` is now just `PARSE_ERROR | OVERSIZE_MESSAGE`).
- **`webhook.ts`** — forwards the extracted `senderEvidence` into orchestration (present even when there are no attachments).
- **`orchestrator.ts` + `server-client.ts`** — thread `senderEvidence` into the `requestControl` call (`ControlInput.senderEvidence` / `ControlSenderEvidence`). The control mutation already takes the whole `$input`, so no operation-document change was needed — codegen picks up the `senderEvidence` field added to `IngestControlInput` in Workstream A.
- **Tests** — body capture, HTML-over-plain preference, issuer-candidate parsing (+ URL-decoding), attachment-less success, and sender-evidence propagation through webhook → orchestrate → control; updated the former `NO_DOCUMENTS` extractor assertions.

## Notable design point

Removing the extractor's `NO_DOCUMENTS` short-circuit is what enables recognition for **body-only / link-only** emails: sender evidence only existed on the success branch, so those emails must succeed (with empty docs) to carry it forward. The webhook already proceeded to orchestration on the old failure path, so the server-side quarantine behavior is unchanged.

## Deferred (Workstream C)

Gateway **treatment** — attachment filtering, body→PDF rendering (bundled Chromium), and internal-link document fetching — which consumes the captured `body` and the `businessEmailConfig` returned by control.

## Validation note

As with Workstream A, deps can't be installed in the authoring environment (network policy blocks the sheetjs CDN), so the gateway's vitest + GraphQL codegen were **not** run locally — relying on CI. Prettier was verified locally against the repo's real config. I'm watching CI and will fix any failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNHHjHfq9G4snq7U42hcjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNHHjHfq9G4snq7U42hcjj)_