### PR TITLE
Workstream C: recognized-business treatment step in the email-ingestion gateway

### DIFF
--- a/.changeset/email-ingestion-gateway-treatment.md
+++ b/.changeset/email-ingestion-gateway-treatment.md
@@ -1,0 +1,15 @@
+---
+'@accounter/email-ingestion-gateway': minor
+---
+
+Gateway treatment step (Workstream C): after the server recognizes the issuing business, the gateway
+now assembles the final document set from the returned `businessEmailConfig` — filtering attachments
+by the allowed types, rendering the email body to a PDF (bundled Chromium via Playwright) when no
+business is recognized or `emailBody` is enabled, and fetching documents from configured
+`internalEmailLinks` in the body (SSRF-hardened: host/path allowlist, private-IP/redirect blocking,
+content-type allowlist, size caps). Orchestration runs treatment between control and ingest, so the
+document set (and emptiness) is decided post-recognition.
+
+Note: the gateway runtime must provide a Chromium binary (e.g. `playwright install --with-deps
+chromium`). Document bytes are still transported as metadata only — inline byte transport and
+server-side persistence land in Workstream D.

--- a/packages/email-ingestion-gateway/package.json
+++ b/packages/email-ingestion-gateway/package.json
@@ -25,9 +25,12 @@
   "dependencies": {
     "dotenv": "17.4.2",
     "graphql-request": "7.4.0",
+    "inline-css": "4.0.3",
+    "playwright": "1.61.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@types/inline-css": "3.0.4",
     "@types/node": "25.9.2",
     "tsx": "4.22.4",
     "typescript": "6.0.3",

--- a/packages/email-ingestion-gateway/src/__tests__/integration.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/integration.test.ts
@@ -109,8 +109,14 @@ const CONTROL_SUCCESS: ControlResult = {
     decisionId: 'decision-001',
     auditId: 'audit-ctrl-001',
     grant: GRANT,
+    businessEmailConfig: null,
   },
 };
+
+// Treatment passthrough: forward raw attachments unchanged so these
+// orchestration-focused tests never launch Chromium / hit the network.
+const passthroughTreatment = () =>
+  vi.fn(async (input: { attachments: unknown[] }) => input.attachments);
 
 function makeServerClient(
   controlResult: ControlResult,
@@ -158,6 +164,7 @@ describe('integration — happy path', () => {
       verifier,
       featureFlags: { v2Enabled: true, shadowMode: false },
       serverClient,
+      applyTreatment: passthroughTreatment(),
     });
     const { res, getStatus, getBody } = makeRes();
     await handler(makeReq(VALID_PAYLOAD), res);
@@ -196,6 +203,7 @@ describe('integration — happy path', () => {
       verifier,
       featureFlags: { v2Enabled: true, shadowMode: false },
       serverClient,
+      applyTreatment: passthroughTreatment(),
     });
     const { res, getStatus } = makeRes();
     await handler(makeReq(mime), res);
@@ -228,6 +236,7 @@ describe('integration — happy path', () => {
       verifier,
       featureFlags: { v2Enabled: true, shadowMode: false },
       serverClient,
+      applyTreatment: passthroughTreatment(),
     });
     const { res, getStatus, getBody } = makeRes();
     await handler(makeReq(VALID_PAYLOAD), res);
@@ -248,6 +257,7 @@ describe('integration — happy path', () => {
       verifier,
       featureFlags: { v2Enabled: true, shadowMode: false },
       serverClient,
+      applyTreatment: passthroughTreatment(),
     });
     const { res, getStatus, getBody } = makeRes();
     await handler(makeReq(VALID_PAYLOAD), res);
@@ -268,6 +278,7 @@ describe('integration — invalid auth', () => {
       verifier,
       featureFlags: { v2Enabled: true, shadowMode: false },
       serverClient,
+      applyTreatment: passthroughTreatment(),
     });
     const { res, getStatus, getBody } = makeRes();
     // Use wrong secret so HMAC check fails
@@ -284,6 +295,7 @@ describe('integration — invalid auth', () => {
       verifier,
       featureFlags: { v2Enabled: true, shadowMode: false },
       serverClient,
+      applyTreatment: passthroughTreatment(),
     });
     // First request passes
     const req1 = makeReq(VALID_PAYLOAD);
@@ -329,6 +341,7 @@ describe('integration — unknown alias', () => {
       verifier: makeVerifier(),
       featureFlags: { v2Enabled: true, shadowMode: false },
       serverClient,
+      applyTreatment: passthroughTreatment(),
     });
     const { res, getStatus, getBody } = makeRes();
     await handler(makeReq(VALID_PAYLOAD), res);
@@ -354,6 +367,7 @@ describe('integration — grant reuse', () => {
       verifier: makeVerifier(),
       featureFlags: { v2Enabled: true, shadowMode: false },
       serverClient,
+      applyTreatment: passthroughTreatment(),
     });
     const { res, getStatus, getBody } = makeRes();
     await handler(makeReq(VALID_PAYLOAD), res);
@@ -381,6 +395,7 @@ describe('integration — cross-tenant insertion prevention', () => {
       verifier: makeVerifier(),
       featureFlags: { v2Enabled: true, shadowMode: false },
       serverClient,
+      applyTreatment: passthroughTreatment(),
     });
     const { res, getStatus, getBody } = makeRes();
     await handler(makeReq(VALID_PAYLOAD), res);

--- a/packages/email-ingestion-gateway/src/__tests__/link-fetcher.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/link-fetcher.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { getLinkFromBody, isBlockedHost } from '../link-fetcher.js';
+
+describe('getLinkFromBody', () => {
+  it('returns the first href matching the configured host + path prefix', () => {
+    const body =
+      '<a href="https://vendor.com/other">x</a> <a href="https://vendor.com/invoices/123">y</a>';
+    expect(getLinkFromBody(body, 'https://vendor.com/invoices')).toBe(
+      'https://vendor.com/invoices/123',
+    );
+  });
+
+  it('matches an exact path', () => {
+    const body = '<a href="https://vendor.com/download">d</a>';
+    expect(getLinkFromBody(body, 'https://vendor.com/download')).toBe(
+      'https://vendor.com/download',
+    );
+  });
+
+  it('returns null when no href matches the host', () => {
+    const body = '<a href="https://evil.com/invoices/1">x</a>';
+    expect(getLinkFromBody(body, 'https://vendor.com/invoices')).toBeNull();
+  });
+
+  it('does not match a different path that merely shares a prefix string', () => {
+    const body = '<a href="https://vendor.com/invoices-evil/1">x</a>';
+    expect(getLinkFromBody(body, 'https://vendor.com/invoices')).toBeNull();
+  });
+
+  it('returns null for an invalid configured URL', () => {
+    expect(getLinkFromBody('<a href="https://vendor.com/x">x</a>', 'not a url')).toBeNull();
+  });
+
+  it('returns null when the body has no links', () => {
+    expect(getLinkFromBody('no links here', 'https://vendor.com/x')).toBeNull();
+  });
+});
+
+describe('isBlockedHost (SSRF defense)', () => {
+  it('blocks loopback hosts', () => {
+    expect(isBlockedHost('localhost')).toBe(true);
+    expect(isBlockedHost('127.0.0.1')).toBe(true);
+    expect(isBlockedHost('::1')).toBe(true);
+  });
+
+  it('blocks private IPv4 ranges', () => {
+    expect(isBlockedHost('10.0.0.5')).toBe(true);
+    expect(isBlockedHost('192.168.1.1')).toBe(true);
+    expect(isBlockedHost('172.16.0.1')).toBe(true);
+    expect(isBlockedHost('172.31.255.255')).toBe(true);
+    expect(isBlockedHost('169.254.1.1')).toBe(true);
+  });
+
+  it('blocks .local / .internal / .localhost suffixes', () => {
+    expect(isBlockedHost('foo.internal')).toBe(true);
+    expect(isBlockedHost('printer.local')).toBe(true);
+    expect(isBlockedHost('api.localhost')).toBe(true);
+  });
+
+  it('allows public hosts and public IPs', () => {
+    expect(isBlockedHost('vendor.com')).toBe(false);
+    expect(isBlockedHost('8.8.8.8')).toBe(false);
+    expect(isBlockedHost('172.32.0.1')).toBe(false); // outside the 172.16–31 private range
+  });
+});

--- a/packages/email-ingestion-gateway/src/__tests__/link-fetcher.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/link-fetcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getLinkFromBody, isBlockedHost } from '../link-fetcher.js';
+import { getLinkFromBody, isBlockedHost, isBlockedIp } from '../link-fetcher.js';
 
 describe('getLinkFromBody', () => {
   it('returns the first href matching the configured host + path prefix', () => {
@@ -61,5 +61,25 @@ describe('isBlockedHost (SSRF defense)', () => {
     expect(isBlockedHost('vendor.com')).toBe(false);
     expect(isBlockedHost('8.8.8.8')).toBe(false);
     expect(isBlockedHost('172.32.0.1')).toBe(false); // outside the 172.16–31 private range
+  });
+});
+
+describe('isBlockedIp (resolved-address check)', () => {
+  it('blocks private / loopback / link-local IPv4 and IPv6', () => {
+    expect(isBlockedIp('127.0.0.1')).toBe(true);
+    expect(isBlockedIp('10.1.2.3')).toBe(true);
+    expect(isBlockedIp('169.254.169.254')).toBe(true); // cloud metadata endpoint
+    expect(isBlockedIp('::1')).toBe(true);
+    expect(isBlockedIp('fd00::1')).toBe(true);
+  });
+
+  it('blocks IPv4-mapped IPv6 forms of private addresses', () => {
+    expect(isBlockedIp('::ffff:127.0.0.1')).toBe(true);
+    expect(isBlockedIp('::ffff:10.0.0.1')).toBe(true);
+  });
+
+  it('allows public addresses', () => {
+    expect(isBlockedIp('8.8.8.8')).toBe(false);
+    expect(isBlockedIp('::ffff:8.8.8.8')).toBe(false);
   });
 });

--- a/packages/email-ingestion-gateway/src/__tests__/orchestrator.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/orchestrator.test.ts
@@ -17,7 +17,8 @@ const BASE_INPUT: OrchestrateInput = {
   rawMessageHash: 'a'.repeat(64),
   correlationId: 'corr-test-001',
   receivedAt: '2026-01-01T12:00:00Z',
-  extractedDocuments: [],
+  body: '',
+  attachments: [],
 };
 
 const GRANT = {
@@ -36,6 +37,7 @@ const CONTROL_SUCCESS: ControlResult = {
     decisionId: 'decision-001',
     auditId: 'audit-control-001',
     grant: GRANT,
+    businessEmailConfig: null,
   },
 };
 
@@ -63,7 +65,9 @@ function makeDeps(
       requestControl: vi.fn().mockResolvedValue(controlResult),
       requestIngest: vi.fn().mockResolvedValue(ingestResult ?? makeIngestSuccess('INSERTED')),
     },
-  };
+    // Default treatment passthrough: forward raw attachments unchanged (no Chromium/network).
+    applyTreatment: vi.fn(async (input: { attachments: unknown[] }) => input.attachments),
+  } as unknown as OrchestratorDeps;
 }
 
 // ---------------------------------------------------------------------------
@@ -346,13 +350,67 @@ describe('orchestrate — end-to-end flow verification', () => {
     expect(controlArg.receivedAt).toBe('2026-06-01T08:00:00Z');
   });
 
-  it('passes extractedDocuments to ingest', async () => {
-    const docs = [{ hash: 'b'.repeat(64), sizeBytes: 1024, mimeType: 'application/pdf' }];
+  it('maps the treated document set to ingest metadata', async () => {
+    const attachments = [
+      {
+        filename: 'inv.pdf',
+        mimeType: 'application/pdf',
+        content: Buffer.from('x'),
+        size: 1024,
+        sha256: 'b'.repeat(64),
+      },
+    ];
     const deps = makeDeps(CONTROL_SUCCESS);
-    await orchestrate({ ...BASE_INPUT, extractedDocuments: docs }, deps);
+    await orchestrate({ ...BASE_INPUT, attachments }, deps);
     const ingestArg = (deps.serverClient.requestIngest as ReturnType<typeof vi.fn>).mock
       .calls[0][0];
-    expect(ingestArg.extractedDocuments).toEqual(docs);
+    expect(ingestArg.extractedDocuments).toEqual([
+      { hash: 'b'.repeat(64), sizeBytes: 1024, mimeType: 'application/pdf', filename: 'inv.pdf' },
+    ]);
+  });
+
+  it('runs treatment with the control config and sends the treated set to ingest', async () => {
+    const treatedDocs = [
+      {
+        filename: 'body.pdf',
+        mimeType: 'application/pdf',
+        content: Buffer.from('p'),
+        size: 10,
+        sha256: 'c'.repeat(64),
+      },
+    ];
+    const applyTreatment = vi.fn().mockResolvedValue(treatedDocs);
+    const controlWithConfig = {
+      success: true,
+      decision: {
+        id: 'dec-001',
+        tenantId: 'tenant-001',
+        decisionId: 'decision-001',
+        auditId: 'audit-control-001',
+        grant: GRANT,
+        businessEmailConfig: {
+          businessId: 'biz-1',
+          internalEmailLinks: null,
+          emailBody: true,
+          attachments: null,
+        },
+      },
+    } as unknown as ControlResult;
+    const deps = { ...makeDeps(controlWithConfig), applyTreatment } as unknown as OrchestratorDeps;
+
+    await orchestrate({ ...BASE_INPUT, body: '<p>hi</p>', attachments: [] }, deps);
+
+    expect(applyTreatment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: '<p>hi</p>',
+        config: expect.objectContaining({ businessId: 'biz-1', emailBody: true }),
+      }),
+    );
+    const ingestArg = (deps.serverClient.requestIngest as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(ingestArg.extractedDocuments).toEqual([
+      { hash: 'c'.repeat(64), sizeBytes: 10, mimeType: 'application/pdf', filename: 'body.pdf' },
+    ]);
   });
 
   it('passes senderEvidence to control for business recognition', async () => {

--- a/packages/email-ingestion-gateway/src/__tests__/server-client.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/server-client.test.ts
@@ -55,6 +55,7 @@ const CONTROL_SUCCESS_RESPONSE = {
         action: 'ingest',
         expiresAt: '2026-01-01T00:05:00Z',
       },
+      businessEmailConfig: null,
     },
   },
 };
@@ -192,6 +193,42 @@ describe('ServerClient.requestControl — success', () => {
     const [, opts] = (fetchFn as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
     const body = JSON.parse(opts.body as string) as { variables: { input: ControlInput } };
     expect(body.variables.input.correlationId).toBe('corr-abc');
+  });
+
+  it('returns null businessEmailConfig when control reports no recognized business', async () => {
+    const client = makeClient(makeFetch([{ body: CONTROL_SUCCESS_RESPONSE }]));
+    const result = await client.requestControl(CONTROL_INPUT);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.decision.businessEmailConfig).toBeNull();
+    }
+  });
+
+  it('parses the businessEmailConfig from the control decision', async () => {
+    const response = {
+      data: {
+        requestIngestControl: {
+          ...CONTROL_SUCCESS_RESPONSE.data.requestIngestControl,
+          businessEmailConfig: {
+            businessId: 'biz-1',
+            internalEmailLinks: ['https://vendor.com/invoices'],
+            emailBody: true,
+            attachments: ['PDF'],
+          },
+        },
+      },
+    };
+    const client = makeClient(makeFetch([{ body: response }]));
+    const result = await client.requestControl(CONTROL_INPUT);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.decision.businessEmailConfig).toEqual({
+        businessId: 'biz-1',
+        internalEmailLinks: ['https://vendor.com/invoices'],
+        emailBody: true,
+        attachments: ['PDF'],
+      });
+    }
   });
 
   it('sends senderEvidence in the request body when provided', async () => {

--- a/packages/email-ingestion-gateway/src/__tests__/treatment.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/treatment.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ExtractedDocument } from '../mime-extractor.js';
+import type { BusinessEmailConfig } from '../server-client.js';
+import { applyTreatment, type TreatmentDeps } from '../treatment.js';
+
+vi.spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'error').mockImplementation(() => {});
+
+function doc(mimeType: string, name = 'f'): ExtractedDocument {
+  const content = Buffer.from(name);
+  return { filename: name, mimeType, content, size: content.length, sha256: name };
+}
+
+function cfg(over: Partial<BusinessEmailConfig> = {}): BusinessEmailConfig {
+  return {
+    businessId: 'biz-1',
+    internalEmailLinks: null,
+    emailBody: false,
+    attachments: null,
+    ...over,
+  };
+}
+
+function makeDeps(over: Partial<TreatmentDeps> = {}): TreatmentDeps {
+  return {
+    renderHtmlToPdf: vi.fn().mockResolvedValue(doc('application/pdf', 'body.pdf')),
+    fetchInternalLinkDocuments: vi.fn().mockResolvedValue([]),
+    ...over,
+  };
+}
+
+describe('applyTreatment — attachment filter', () => {
+  it('keeps all attachments when config has no attachments allowlist', async () => {
+    const out = await applyTreatment(
+      { config: cfg({ attachments: null }), body: '', attachments: [doc('application/pdf'), doc('image/png')] },
+      makeDeps(),
+    );
+    expect(out).toHaveLength(2);
+  });
+
+  it('keeps all attachments when no business is recognized (config null)', async () => {
+    const out = await applyTreatment(
+      { config: null, body: '', attachments: [doc('application/pdf'), doc('image/png')] },
+      makeDeps({ renderHtmlToPdf: vi.fn() }),
+    );
+    expect(out).toHaveLength(2);
+  });
+
+  it('filters attachments to the configured allowlist', async () => {
+    const out = await applyTreatment(
+      { config: cfg({ attachments: ['PDF'] }), body: '', attachments: [doc('application/pdf'), doc('image/png')] },
+      makeDeps(),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.mimeType).toBe('application/pdf');
+  });
+
+  it('maps image/jpeg and image/jpg to JPEG', async () => {
+    const out = await applyTreatment(
+      {
+        config: cfg({ attachments: ['JPEG'] }),
+        body: '',
+        attachments: [doc('image/jpeg'), doc('image/jpg'), doc('image/png')],
+      },
+      makeDeps(),
+    );
+    expect(out).toHaveLength(2);
+  });
+});
+
+describe('applyTreatment — body→PDF', () => {
+  it('renders the body when no business is recognized', async () => {
+    const renderHtmlToPdf = vi.fn().mockResolvedValue(doc('application/pdf', 'body.pdf'));
+    const out = await applyTreatment(
+      { config: null, body: '<p>hi</p>', attachments: [] },
+      makeDeps({ renderHtmlToPdf }),
+    );
+    expect(renderHtmlToPdf).toHaveBeenCalledOnce();
+    expect(out).toHaveLength(1);
+  });
+
+  it('renders the body when emailBody === true', async () => {
+    const renderHtmlToPdf = vi.fn().mockResolvedValue(doc('application/pdf', 'body.pdf'));
+    await applyTreatment(
+      { config: cfg({ emailBody: true }), body: '<p>hi</p>', attachments: [] },
+      makeDeps({ renderHtmlToPdf }),
+    );
+    expect(renderHtmlToPdf).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT render the body for a recognized business with emailBody !== true', async () => {
+    const renderHtmlToPdf = vi.fn();
+    await applyTreatment(
+      { config: cfg({ emailBody: false }), body: '<p>hi</p>', attachments: [] },
+      makeDeps({ renderHtmlToPdf }),
+    );
+    expect(renderHtmlToPdf).not.toHaveBeenCalled();
+  });
+
+  it('skips body render for an empty body', async () => {
+    const renderHtmlToPdf = vi.fn();
+    await applyTreatment(
+      { config: null, body: '   ', attachments: [] },
+      makeDeps({ renderHtmlToPdf }),
+    );
+    expect(renderHtmlToPdf).not.toHaveBeenCalled();
+  });
+
+  it('swallows a render failure and keeps the other documents', async () => {
+    const renderHtmlToPdf = vi.fn().mockRejectedValue(new Error('no chromium'));
+    const out = await applyTreatment(
+      { config: null, body: '<p>hi</p>', attachments: [doc('application/pdf')] },
+      makeDeps({ renderHtmlToPdf }),
+    );
+    expect(out).toHaveLength(1);
+  });
+});
+
+describe('applyTreatment — internal links', () => {
+  it('fetches documents for each configured internalEmailLink, in order', async () => {
+    const fetchInternalLinkDocuments = vi
+      .fn()
+      .mockResolvedValueOnce([doc('application/pdf', 'a.pdf')])
+      .mockResolvedValueOnce([doc('application/pdf', 'b.pdf')]);
+    const out = await applyTreatment(
+      {
+        config: cfg({ internalEmailLinks: ['https://x.com/a', 'https://y.com/b'] }),
+        body: 'body',
+        attachments: [],
+      },
+      makeDeps({ fetchInternalLinkDocuments }),
+    );
+    expect(fetchInternalLinkDocuments).toHaveBeenCalledTimes(2);
+    expect(out.map(d => d.filename)).toEqual(['a.pdf', 'b.pdf']);
+  });
+
+  it('swallows a link-fetch failure and continues', async () => {
+    const fetchInternalLinkDocuments = vi.fn().mockRejectedValue(new Error('network'));
+    const out = await applyTreatment(
+      {
+        config: cfg({ internalEmailLinks: ['https://x.com/a'], attachments: null }),
+        body: 'body',
+        attachments: [doc('application/pdf')],
+      },
+      makeDeps({ fetchInternalLinkDocuments }),
+    );
+    expect(out).toHaveLength(1);
+  });
+});

--- a/packages/email-ingestion-gateway/src/__tests__/webhook.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/webhook.test.ts
@@ -280,6 +280,7 @@ describe('POST /webhook — createWebhookHandler', () => {
       verifier: makeVerifier({ valid: true }),
       featureFlags: { v2Enabled: true, shadowMode: false },
       serverClient,
+      applyTreatment: vi.fn().mockResolvedValue([]),
     });
     const body = [
       'From: Forwarder <forwarder@gmail.com>',
@@ -401,6 +402,7 @@ describe('POST /webhook — shadow mode', () => {
       verifier,
       featureFlags: { v2Enabled: true, shadowMode: true },
       serverClient,
+      applyTreatment: vi.fn().mockResolvedValue([]),
     });
     const { res, getStatus, getBody } = makeRes();
     await handler(makeReq(), res);
@@ -428,6 +430,7 @@ describe('POST /webhook — shadow mode', () => {
       verifier,
       featureFlags: { v2Enabled: true, shadowMode: true },
       serverClient,
+      applyTreatment: vi.fn().mockResolvedValue([]),
     });
     const { res, getStatus, getBody } = makeRes();
     await handler(makeReq(), res);

--- a/packages/email-ingestion-gateway/src/graphql/mutations.ts
+++ b/packages/email-ingestion-gateway/src/graphql/mutations.ts
@@ -14,6 +14,12 @@ export const REQUEST_INGEST_CONTROL_MUTATION = /* GraphQL */ `
           action
           expiresAt
         }
+        businessEmailConfig {
+          businessId
+          internalEmailLinks
+          emailBody
+          attachments
+        }
       }
       ... on CommonError {
         message

--- a/packages/email-ingestion-gateway/src/html-to-pdf.ts
+++ b/packages/email-ingestion-gateway/src/html-to-pdf.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import inlineCss from 'inline-css';
-import { chromium, type Browser } from 'playwright';
+import { chromium, type Browser, type Page } from 'playwright';
 import type { ExtractedDocument } from './mime-extractor.js';
 
 // A single shared browser instance is reused across renders to bound memory and
@@ -13,15 +13,21 @@ import type { ExtractedDocument } from './mime-extractor.js';
 let browserPromise: Promise<Browser> | null = null;
 
 function getBrowser(): Promise<Browser> {
-  if (!browserPromise) {
-    browserPromise = chromium
-      .launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] })
-      .catch((err: unknown) => {
-        // Reset so a later render can retry the launch.
+  browserPromise ??= chromium
+    .launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] })
+    .then(browser => {
+      // If the shared browser crashes or is closed, drop the cached promise so
+      // the next render relaunches a fresh instance instead of reusing a dead one.
+      browser.on('disconnected', () => {
         browserPromise = null;
-        throw err;
       });
-  }
+      return browser;
+    })
+    .catch((err: unknown) => {
+      // Reset so a later render can retry the launch.
+      browserPromise = null;
+      throw err;
+    });
   return browserPromise;
 }
 
@@ -33,8 +39,11 @@ function getBrowser(): Promise<Browser> {
 export async function renderHtmlToPdf(rawHtml: string): Promise<ExtractedDocument> {
   const browser = await getBrowser();
   const context = await browser.newContext();
-  const page = await context.newPage();
+  // `page` is created inside the try so that a newPage() failure still runs the
+  // finally and closes the context (otherwise the context would leak).
+  let page: Page | undefined;
   try {
+    page = await context.newPage();
     const html = await inlineCss(rawHtml, { url: '/' });
     await page.setContent(html, { waitUntil: 'networkidle' });
     const pdf = Buffer.from(await page.pdf());
@@ -46,7 +55,9 @@ export async function renderHtmlToPdf(rawHtml: string): Promise<ExtractedDocumen
       sha256: createHash('sha256').update(pdf).digest('hex'),
     };
   } finally {
-    await page.close().catch(() => {});
+    if (page) {
+      await page.close().catch(() => {});
+    }
     await context.close().catch(() => {});
   }
 }

--- a/packages/email-ingestion-gateway/src/html-to-pdf.ts
+++ b/packages/email-ingestion-gateway/src/html-to-pdf.ts
@@ -1,0 +1,61 @@
+import { createHash } from 'node:crypto';
+import inlineCss from 'inline-css';
+import { chromium, type Browser } from 'playwright';
+import type { ExtractedDocument } from './mime-extractor.js';
+
+// A single shared browser instance is reused across renders to bound memory and
+// avoid the cost of launching Chromium per request. It is created lazily on the
+// first render and kept warm for the lifetime of the gateway process.
+//
+// NOTE: the gateway runtime must have a Chromium binary available (e.g.
+// `playwright install --with-deps chromium` in the image). Render failures are
+// caught by callers (treatment), which simply omit the body→PDF document.
+let browserPromise: Promise<Browser> | null = null;
+
+function getBrowser(): Promise<Browser> {
+  if (!browserPromise) {
+    browserPromise = chromium
+      .launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] })
+      .catch((err: unknown) => {
+        // Reset so a later render can retry the launch.
+        browserPromise = null;
+        throw err;
+      });
+  }
+  return browserPromise;
+}
+
+/**
+ * Render an email's HTML body to a PDF document (ported from the legacy
+ * gmail-listener `convertHtmlToPdf`, including the `inline-css` step). Returns an
+ * {@link ExtractedDocument} with the rendered bytes + content hash.
+ */
+export async function renderHtmlToPdf(rawHtml: string): Promise<ExtractedDocument> {
+  const browser = await getBrowser();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  try {
+    const html = await inlineCss(rawHtml, { url: '/' });
+    await page.setContent(html, { waitUntil: 'networkidle' });
+    const pdf = Buffer.from(await page.pdf());
+    return {
+      filename: 'body.pdf',
+      mimeType: 'application/pdf',
+      content: pdf,
+      size: pdf.length,
+      sha256: createHash('sha256').update(pdf).digest('hex'),
+    };
+  } finally {
+    await page.close().catch(() => {});
+    await context.close().catch(() => {});
+  }
+}
+
+/** Close the shared browser (graceful shutdown / tests). */
+export async function closeBrowser(): Promise<void> {
+  const pending = browserPromise;
+  browserPromise = null;
+  if (pending) {
+    await pending.then(b => b.close()).catch(() => {});
+  }
+}

--- a/packages/email-ingestion-gateway/src/link-fetcher.ts
+++ b/packages/email-ingestion-gateway/src/link-fetcher.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { lookup } from 'node:dns/promises';
 import { renderHtmlToPdf } from './html-to-pdf.js';
 import type { ExtractedDocument } from './mime-extractor.js';
 
@@ -38,17 +39,9 @@ export function getLinkFromBody(body: string, partialUrl: string): string | null
   return null;
 }
 
-/** Block loopback / private / link-local hosts (defense-in-depth against SSRF). */
-export function isBlockedHost(hostname: string): boolean {
-  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
-  if (
-    host === 'localhost' ||
-    host.endsWith('.localhost') ||
-    host.endsWith('.local') ||
-    host.endsWith('.internal')
-  ) {
-    return true;
-  }
+/** Block loopback / private / link-local IP literals (v4, v6, IPv4-mapped v6). */
+export function isBlockedIp(ip: string): boolean {
+  const host = ip.toLowerCase().replace(/^\[|\]$/g, '');
   const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
   if (v4) {
     const a = Number(v4[1]);
@@ -64,6 +57,7 @@ export function isBlockedHost(hostname: string): boolean {
       return true;
     }
   }
+  // IPv6 loopback (::1), link-local (fe80::/10), and unique-local (fc00::/7).
   if (
     host === '::1' ||
     host.startsWith('fe80:') ||
@@ -72,7 +66,76 @@ export function isBlockedHost(hostname: string): boolean {
   ) {
     return true;
   }
+  // IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) — validate the embedded v4 address.
+  const mapped = host.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (mapped && isBlockedIp(mapped[1])) {
+    return true;
+  }
   return false;
+}
+
+/** Block loopback / private / link-local hosts (defense-in-depth against SSRF). */
+export function isBlockedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (
+    host === 'localhost' ||
+    host.endsWith('.localhost') ||
+    host.endsWith('.local') ||
+    host.endsWith('.internal')
+  ) {
+    return true;
+  }
+  return isBlockedIp(host);
+}
+
+/**
+ * Resolve a hostname and block when any resolved address is private/loopback.
+ * Defense-in-depth against a public-looking hostname that resolves to an
+ * internal IP (which the static {@link isBlockedHost} string check cannot catch)
+ * — the host/path allowlist in {@link getLinkFromBody} remains the primary SSRF
+ * control. Fails closed: a resolution error is treated as blocked.
+ *
+ * NOTE: this does not pin the connection to the validated address, so a
+ * determined DNS-rebinding attacker could still race the resolution. That
+ * residual is bounded by the exact-host allowlist (the host must equal an
+ * operator-configured vendor host, not an attacker-chosen one).
+ */
+async function resolvesToBlockedAddress(hostname: string): Promise<boolean> {
+  try {
+    const addresses = await lookup(hostname, { all: true });
+    return addresses.length === 0 || addresses.some(({ address }) => isBlockedIp(address));
+  } catch {
+    return true;
+  }
+}
+
+/** Read a response body into a Buffer, aborting once it exceeds `maxBytes`. */
+async function readCappedBody(response: Response, maxBytes: number): Promise<Buffer | null> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return null;
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        total += value.byteLength;
+        if (total > maxBytes) {
+          await reader.cancel().catch(() => {});
+          return null;
+        }
+        chunks.push(Buffer.from(value));
+      }
+    }
+  } catch {
+    return null;
+  }
+  return Buffer.concat(chunks);
 }
 
 /**
@@ -81,8 +144,8 @@ export function isBlockedHost(hostname: string): boolean {
  * the document only as a URL — a post-recognition treatment artifact.
  *
  * SSRF hardening: the host/path allowlist (via {@link getLinkFromBody}), a
- * private/loopback host block, http(s)-only, redirects disabled, a content-type
- * allowlist, and a response size cap.
+ * private/loopback host block plus a resolved-IP check, http(s)-only, redirects
+ * disabled, a content-type allowlist, and a streamed response size cap.
  */
 export async function fetchInternalLinkDocuments(
   body: string,
@@ -103,6 +166,9 @@ export async function fetchInternalLinkDocuments(
     return [];
   }
   if (isBlockedHost(url.hostname)) {
+    return [];
+  }
+  if (await resolvesToBlockedAddress(url.hostname)) {
     return [];
   }
 
@@ -128,8 +194,11 @@ export async function fetchInternalLinkDocuments(
     return [];
   }
 
-  const buf = Buffer.from(await response.arrayBuffer());
-  if (buf.length === 0 || buf.length > MAX_FETCH_BYTES) {
+  // content-length may be absent (chunked) or spoofed, so it is never trusted on
+  // its own — stream the body and abort once the cap is exceeded. This bounds
+  // memory and prevents an OOM DoS from an oversized (or lying) response.
+  const buf = await readCappedBody(response, MAX_FETCH_BYTES);
+  if (!buf || buf.length === 0) {
     return [];
   }
 

--- a/packages/email-ingestion-gateway/src/link-fetcher.ts
+++ b/packages/email-ingestion-gateway/src/link-fetcher.ts
@@ -1,0 +1,151 @@
+import { createHash } from 'node:crypto';
+import { renderHtmlToPdf } from './html-to-pdf.js';
+import type { ExtractedDocument } from './mime-extractor.js';
+
+const MAX_FETCH_BYTES = 20 * 1024 * 1024; // align with MAX_EXTRACTED_BYTES
+const FETCH_TIMEOUT_MS = 15_000;
+const ALLOWED_CONTENT_TYPES = ['application/pdf', 'text/html'];
+
+/**
+ * Find the first `<a href>` in the body whose URL matches the configured
+ * `internalLink` host + path prefix (ported from legacy `getLinkFromBody`).
+ * This host/path allowlist is the primary SSRF control — only links to the
+ * configured vendor host/path are eligible to be fetched.
+ */
+export function getLinkFromBody(body: string, partialUrl: string): string | null {
+  let partial: URL;
+  try {
+    partial = new URL(partialUrl);
+  } catch {
+    return null;
+  }
+  const re = /<a\s+(?:[^>]*?\s+)?href="([^"]*)"/gi;
+  for (const match of body.matchAll(re)) {
+    const urlString = match[1];
+    try {
+      const full = new URL(urlString);
+      const prefix = partial.pathname.endsWith('/') ? partial.pathname : `${partial.pathname}/`;
+      if (
+        full.hostname === partial.hostname &&
+        (full.pathname === partial.pathname || full.pathname.startsWith(prefix))
+      ) {
+        return urlString;
+      }
+    } catch {
+      // ignore invalid href URLs
+    }
+  }
+  return null;
+}
+
+/** Block loopback / private / link-local hosts (defense-in-depth against SSRF). */
+export function isBlockedHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (
+    host === 'localhost' ||
+    host.endsWith('.localhost') ||
+    host.endsWith('.local') ||
+    host.endsWith('.internal')
+  ) {
+    return true;
+  }
+  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const a = Number(v4[1]);
+    const b = Number(v4[2]);
+    if (
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 192 && b === 168) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31)
+    ) {
+      return true;
+    }
+  }
+  if (
+    host === '::1' ||
+    host.startsWith('fe80:') ||
+    host.startsWith('fc') ||
+    host.startsWith('fd')
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Fetch a document referenced by a configured internal link in the email body
+ * (ported from legacy `innerLinkDocumentFetcher`). Some provider emails carry
+ * the document only as a URL — a post-recognition treatment artifact.
+ *
+ * SSRF hardening: the host/path allowlist (via {@link getLinkFromBody}), a
+ * private/loopback host block, http(s)-only, redirects disabled, a content-type
+ * allowlist, and a response size cap.
+ */
+export async function fetchInternalLinkDocuments(
+  body: string,
+  internalLink: string,
+): Promise<ExtractedDocument[]> {
+  const link = getLinkFromBody(body, internalLink);
+  if (!link) {
+    return [];
+  }
+
+  let url: URL;
+  try {
+    url = new URL(link);
+  } catch {
+    return [];
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    return [];
+  }
+  if (isBlockedHost(url.hostname)) {
+    return [];
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      redirect: 'error', // block redirects — a redirect could bypass the host allowlist
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch {
+    return [];
+  }
+  if (!response.ok) {
+    return [];
+  }
+
+  const contentType = (response.headers.get('content-type') ?? '').toLowerCase();
+  if (!ALLOWED_CONTENT_TYPES.some(type => contentType.includes(type))) {
+    return [];
+  }
+  const declaredLength = Number(response.headers.get('content-length') ?? '0');
+  if (declaredLength > MAX_FETCH_BYTES) {
+    return [];
+  }
+
+  const buf = Buffer.from(await response.arrayBuffer());
+  if (buf.length === 0 || buf.length > MAX_FETCH_BYTES) {
+    return [];
+  }
+
+  if (contentType.includes('text/html')) {
+    const pdf = await renderHtmlToPdf(buf.toString('utf8')).catch(() => null);
+    return pdf ? [{ ...pdf, filename: 'external.pdf' }] : [];
+  }
+
+  // application/pdf
+  return [
+    {
+      filename: 'external.pdf',
+      mimeType: 'application/pdf',
+      content: buf,
+      size: buf.length,
+      sha256: createHash('sha256').update(buf).digest('hex'),
+    },
+  ];
+}

--- a/packages/email-ingestion-gateway/src/orchestrator.ts
+++ b/packages/email-ingestion-gateway/src/orchestrator.ts
@@ -1,4 +1,5 @@
 import { log } from './logger.js';
+import type { ExtractedDocument } from './mime-extractor.js';
 import type {
   ControlInput,
   ControlSenderEvidence,
@@ -6,6 +7,7 @@ import type {
   IngestInput,
   ServerClient,
 } from './server-client.js';
+import { applyTreatment } from './treatment.js';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -17,7 +19,10 @@ export interface OrchestrateInput {
   rawMessageHash: string;
   correlationId: string;
   receivedAt?: string;
-  extractedDocuments: IngestDocumentInput[];
+  /** Decoded email body, consumed by treatment (body→PDF, internal-link fetch). */
+  body: string;
+  /** Raw attachment documents (with bytes) from MIME extraction. */
+  attachments: ExtractedDocument[];
   /** Sender evidence forwarded to the control endpoint for business recognition. */
   senderEvidence?: ControlSenderEvidence;
 }
@@ -36,6 +41,8 @@ export type OrchestrateResult =
 
 export interface OrchestratorDeps {
   serverClient: Pick<ServerClient, 'requestControl' | 'requestIngest'>;
+  /** Override the treatment step (default: real attachment-filter / body→PDF / link-fetch). */
+  applyTreatment?: typeof applyTreatment;
 }
 
 // ---------------------------------------------------------------------------
@@ -83,7 +90,37 @@ export async function orchestrate(
     correlationId,
   );
 
-  // ── Step 2: call ingest endpoint with grant + extracted documents ──────────
+  // ── Step 2: treatment — assemble the final document set from the recognized
+  // business config + body + raw attachments (attachment filter, body→PDF,
+  // internal-link fetch). The document set (and thus emptiness) is decided here,
+  // post-recognition; the server ingest keeps a NO_DOCUMENTS quarantine backstop.
+  const treat = deps.applyTreatment ?? applyTreatment;
+  const finalDocuments = await treat({
+    config: decision.businessEmailConfig,
+    body: input.body,
+    attachments: input.attachments,
+    correlationId,
+  });
+
+  log(
+    'info',
+    'orchestrate:treatment:complete',
+    {
+      tenantId: decision.tenantId,
+      documentCount: finalDocuments.length,
+      businessId: decision.businessEmailConfig?.businessId ?? null,
+    },
+    correlationId,
+  );
+
+  const extractedDocuments: IngestDocumentInput[] = finalDocuments.map(doc => ({
+    hash: doc.sha256,
+    sizeBytes: doc.size,
+    mimeType: doc.mimeType,
+    filename: doc.filename,
+  }));
+
+  // ── Step 3: call ingest endpoint with grant + extracted documents ──────────
   // Key idempotency on the gateway-computed rawMessageHash (content-derived,
   // authoritative) rather than the sender-controlled Message-ID. Using the
   // Message-ID would let a party who can email a tenant alias pre-seed an ID so
@@ -96,7 +133,7 @@ export async function orchestrate(
     messageId: input.messageId,
     rawMessageHash: input.rawMessageHash,
     correlationId,
-    extractedDocuments: input.extractedDocuments,
+    extractedDocuments,
   };
 
   const ingestResult = await serverClient.requestIngest(ingestInput);

--- a/packages/email-ingestion-gateway/src/server-client.ts
+++ b/packages/email-ingestion-gateway/src/server-client.ts
@@ -47,12 +47,23 @@ export interface GrantData {
   expiresAt: string;
 }
 
+/** Per-business email-processing config returned by control (null = unrecognized). */
+export interface BusinessEmailConfig {
+  businessId: string;
+  internalEmailLinks: string[] | null;
+  emailBody: boolean | null;
+  /** Allowed attachment document types (e.g. 'PDF', 'PNG', 'JPEG'); null = keep all. */
+  attachments: string[] | null;
+}
+
 export interface ControlDecision {
   id: string;
   tenantId: string;
   decisionId: string;
   auditId: string;
   grant: GrantData;
+  /** Recognized issuing business + its treatment config; null when unrecognized. */
+  businessEmailConfig: BusinessEmailConfig | null;
 }
 
 export type ControlResult =
@@ -183,7 +194,31 @@ export class ServerClient {
           message: result.message ?? 'Unknown alias',
         };
       }
-      return { success: true, decision: result };
+      const cfg = result.businessEmailConfig;
+      return {
+        success: true,
+        decision: {
+          id: result.id,
+          tenantId: result.tenantId,
+          decisionId: result.decisionId,
+          auditId: result.auditId,
+          grant: {
+            id: result.grant.id,
+            jti: result.grant.jti,
+            tenantId: result.grant.tenantId,
+            action: result.grant.action,
+            expiresAt: result.grant.expiresAt,
+          },
+          businessEmailConfig: cfg
+            ? {
+                businessId: cfg.businessId,
+                internalEmailLinks: cfg.internalEmailLinks ?? null,
+                emailBody: cfg.emailBody ?? null,
+                attachments: cfg.attachments ?? null,
+              }
+            : null,
+        },
+      };
     } catch (err) {
       return {
         success: false,

--- a/packages/email-ingestion-gateway/src/treatment.ts
+++ b/packages/email-ingestion-gateway/src/treatment.ts
@@ -1,0 +1,94 @@
+import { renderHtmlToPdf } from './html-to-pdf.js';
+import { fetchInternalLinkDocuments } from './link-fetcher.js';
+import { log } from './logger.js';
+import type { ExtractedDocument } from './mime-extractor.js';
+import type { BusinessEmailConfig } from './server-client.js';
+
+export interface TreatmentInput {
+  /** Recognized business config from control; null when no business matched. */
+  config: BusinessEmailConfig | null;
+  /** Decoded email body (HTML preferred), from MIME extraction. */
+  body: string;
+  /** Raw attachment documents extracted from the MIME message. */
+  attachments: ExtractedDocument[];
+  correlationId?: string;
+}
+
+/** Injectable I/O so the assembly logic is testable without Chromium / network. */
+export interface TreatmentDeps {
+  renderHtmlToPdf: (html: string) => Promise<ExtractedDocument>;
+  fetchInternalLinkDocuments: (body: string, pattern: string) => Promise<ExtractedDocument[]>;
+}
+
+const defaultDeps: TreatmentDeps = { renderHtmlToPdf, fetchInternalLinkDocuments };
+
+/** Map a document's MIME type to the EmailAttachmentType label used in config. */
+function attachmentType(mimeType: string): string | null {
+  switch (mimeType.toLowerCase()) {
+    case 'application/pdf':
+      return 'PDF';
+    case 'image/png':
+      return 'PNG';
+    case 'image/jpeg':
+    case 'image/jpg':
+      return 'JPEG';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build the final document set from the recognized business config plus the
+ * email body and raw attachments — the gateway treatment step (ported from the
+ * legacy gmail-listener `handleMessage`):
+ *
+ *  1. keep attachments allowed by `config.attachments` (all, when unset);
+ *  2. render the body to a PDF when no business is recognized **or**
+ *     `config.emailBody === true`;
+ *  3. fetch documents from each configured `config.internalEmailLinks` pattern
+ *     found in the body.
+ *
+ * Emptiness is decided by the caller from the returned set (with the server
+ * ingest as the final NO_DOCUMENTS backstop).
+ */
+export async function applyTreatment(
+  input: TreatmentInput,
+  deps: TreatmentDeps = defaultDeps,
+): Promise<ExtractedDocument[]> {
+  const { config, body, attachments, correlationId } = input;
+  const out: ExtractedDocument[] = [];
+
+  // 1. Attachment filter — keep all when the business sets no allowlist.
+  const allowed = config?.attachments ?? null;
+  for (const doc of attachments) {
+    if (allowed && !allowed.includes(attachmentType(doc.mimeType) ?? '')) {
+      continue;
+    }
+    out.push(doc);
+  }
+
+  // 2. Body → PDF when there is no recognized business, or it opts in.
+  if ((!config?.businessId || config.emailBody === true) && body.trim().length > 0) {
+    try {
+      out.push(await deps.renderHtmlToPdf(body));
+    } catch (err) {
+      log('warn', 'treatment: body→PDF render failed', { error: String(err) }, correlationId);
+    }
+  }
+
+  // 3. Documents behind configured internal links in the body.
+  for (const link of config?.internalEmailLinks ?? []) {
+    try {
+      out.push(...(await deps.fetchInternalLinkDocuments(body, link)));
+    } catch (err) {
+      log(
+        'warn',
+        'treatment: internal-link fetch failed',
+        { link, error: String(err) },
+        correlationId,
+      );
+    }
+  }
+
+  return out;
+}

--- a/packages/email-ingestion-gateway/src/treatment.ts
+++ b/packages/email-ingestion-gateway/src/treatment.ts
@@ -59,7 +59,9 @@ export async function applyTreatment(
   const out: ExtractedDocument[] = [];
 
   // 1. Attachment filter — keep all when the business sets no allowlist.
-  const allowed = config?.attachments ?? null;
+  // Normalize to upper-case so the comparison stays robust even though the
+  // EmailAttachmentType enum (PDF/PNG/JPEG) is already upper-case on the wire.
+  const allowed = config?.attachments ? config.attachments.map(a => a.toUpperCase()) : null;
   for (const doc of attachments) {
     if (allowed && !allowed.includes(attachmentType(doc.mimeType) ?? '')) {
       continue;

--- a/packages/email-ingestion-gateway/src/webhook.ts
+++ b/packages/email-ingestion-gateway/src/webhook.ts
@@ -1,9 +1,9 @@
 import { createHash } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { generateCorrelationId, log } from './logger.js';
-import { extractFromMime, MAX_RAW_MIME_BYTES } from './mime-extractor.js';
+import { extractFromMime, MAX_RAW_MIME_BYTES, type ExtractedDocument } from './mime-extractor.js';
 import { orchestrate, type OrchestratorDeps } from './orchestrator.js';
-import type { ControlSenderEvidence, IngestDocumentInput } from './server-client.js';
+import type { ControlSenderEvidence } from './server-client.js';
 import type { AuthenticityInput, CloudflareAuthenticityVerifier } from './verifier.js';
 
 // Inbound requests carry the raw MIME message as their body, so the cap matches
@@ -35,10 +35,12 @@ export interface WebhookDeps {
   verifier: Pick<CloudflareAuthenticityVerifier, 'verify'>;
   featureFlags: { v2Enabled: boolean; shadowMode: boolean };
   serverClient?: OrchestratorDeps['serverClient'];
+  /** Override the gateway treatment step (default: real; tests inject a stub to avoid Chromium). */
+  applyTreatment?: OrchestratorDeps['applyTreatment'];
 }
 
 export function createWebhookHandler(deps: WebhookDeps) {
-  const { verifier, featureFlags, serverClient } = deps;
+  const { verifier, featureFlags, serverClient, applyTreatment } = deps;
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     // 1. Feature-flag gate — reject early if v2 ingestion is not enabled
@@ -142,24 +144,24 @@ export function createWebhookHandler(deps: WebhookDeps) {
     const rawMessageHash = createHash('sha256').update(rawBody).digest('hex');
     const extraction = extractFromMime(rawBody);
 
-    let extractedDocuments: IngestDocumentInput[] = [];
+    // Raw attachments (with bytes) + body are handed to orchestration, which runs
+    // treatment (attachment filter, body→PDF, internal-link fetch) after the
+    // business is recognized, then sends the final document set to ingest.
+    let attachments: ExtractedDocument[] = [];
+    let body = '';
     let senderEvidence: ControlSenderEvidence | undefined;
     if (extraction.success) {
-      extractedDocuments = extraction.documents.map(doc => ({
-        hash: doc.sha256,
-        sizeBytes: doc.size,
-        mimeType: doc.mimeType,
-        filename: doc.filename,
-      }));
+      attachments = extraction.documents;
+      body = extraction.body;
       // Forward sender evidence so the server can recognize the issuing business.
       // Present even when there are no attachments (the body may still yield a
       // document during treatment).
       senderEvidence = extraction.senderEvidence;
     } else {
       // Extraction failed (parse error or oversize). Proceed to orchestration so
-      // the server records an auditable quarantine outcome; the empty document
-      // list drives the server-side NO_DOCUMENTS quarantine. No trustworthy
-      // sender evidence is available in this case.
+      // the server records an auditable quarantine outcome; the empty document set
+      // drives the server-side NO_DOCUMENTS quarantine. No trustworthy sender
+      // evidence is available in this case.
       log(
         'warn',
         'webhook: MIME extraction failed',
@@ -171,7 +173,7 @@ export function createWebhookHandler(deps: WebhookDeps) {
     log(
       'info',
       'webhook accepted',
-      { recipientAlias, messageId, documentCount: extractedDocuments.length },
+      { recipientAlias, messageId, attachmentCount: attachments.length },
       effectiveCorrelationId,
     );
 
@@ -193,8 +195,9 @@ export function createWebhookHandler(deps: WebhookDeps) {
       rawMessageHash,
       correlationId: effectiveCorrelationId,
       receivedAt,
-      extractedDocuments,
       senderEvidence,
+      body,
+      attachments,
     };
 
     if (featureFlags.shadowMode) {
@@ -205,7 +208,7 @@ export function createWebhookHandler(deps: WebhookDeps) {
         correlationId: effectiveCorrelationId,
         shadow: true,
       });
-      orchestrate(orchestrateInput, { serverClient })
+      orchestrate(orchestrateInput, { serverClient, applyTreatment })
         .then(result => {
           if (result.success) {
             log(
@@ -235,7 +238,7 @@ export function createWebhookHandler(deps: WebhookDeps) {
     }
 
     // Production mode: await orchestration and include outcome in response.
-    const result = await orchestrate(orchestrateInput, { serverClient });
+    const result = await orchestrate(orchestrateInput, { serverClient, applyTreatment });
 
     if (result.success) {
       writeJson(res, 202, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,9 +152,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@accounter/email-ingestion-gateway@workspace:packages/email-ingestion-gateway"
   dependencies:
+    "@types/inline-css": "npm:3.0.4"
     "@types/node": "npm:25.9.2"
     dotenv: "npm:17.4.2"
     graphql-request: "npm:7.4.0"
+    inline-css: "npm:4.0.3"
+    playwright: "npm:1.61.0"
     tsx: "npm:4.22.4"
     typescript: "npm:6.0.3"
     wrangler: "npm:4.68.0"


### PR DESCRIPTION
## Workstream C — gateway treatment step

Implements Workstream C of `docs/multi-tenant-gmail-listener/business-recognition-plan.md`: after the server recognizes the issuing business (Workstream A) and the gateway has the decoded body + raw attachments (Workstream B), the gateway now **assembles the final document set from the returned `businessEmailConfig`** before calling ingest. This is the post-recognition "treatment" the plan requires — treatment must run *after* business recognition because provider-email handling differs per business.

### Flow

```
Cloudflare → Gateway /webhook
  → control  (server resolves alias→tenant, recognizes business, returns businessEmailConfig)
  → treatment (gateway, NEW)  ── assembles final documents from config + body + attachments
  → ingest   (server persists / quarantines on the final set)
```

### What's included

- **`treatment.ts`** — `applyTreatment({ config, body, attachments })`:
  1. **Attachment filter** — keep attachments whose type is in `config.attachments` (keep all when the business sets no allowlist);
  2. **Body → PDF** — render the email body to a PDF when *no business is recognized* **or** `config.emailBody === true`;
  3. **Internal links** — fetch documents from each configured `config.internalEmailLinks` pattern found in the body.

  I/O is injected (`TreatmentDeps`) so the assembly logic is unit-testable without Chromium/network. Per-document failures are swallowed + logged so one bad render/fetch can't drop the rest of the set. Emptiness is decided by the caller from the returned set, with the server ingest as the final `NO_DOCUMENTS` backstop.

- **`html-to-pdf.ts`** — `renderHtmlToPdf(html)` via a single lazily-launched, reused Playwright Chromium + the legacy `inline-css` step (ported from the gmail-listener `convertHtmlToPdf`).

- **`link-fetcher.ts`** — `fetchInternalLinkDocuments(body, internalLink)` (ported from legacy `getLinkFromBody` / `innerLinkDocumentFetcher`). SSRF hardening: host+path allowlist (only the configured vendor host/path is eligible), private/loopback host block, http(s)-only, redirects disabled (`redirect: 'error'`), content-type allowlist, and request/response size caps + timeout. HTML responses are rendered to PDF.

- **Orchestration** — `orchestrate` now takes `body` + `attachments` and runs treatment between control and ingest, mapping the final set to ingest document metadata. `webhook.ts` forwards body + raw attachments instead of pre-extracted metadata.

- **Config plumbing** — `BusinessEmailConfig` (`businessId`, `internalEmailLinks`, `emailBody`, `attachments`) is added to `ControlDecision` and selected in `REQUEST_INGEST_CONTROL_MUTATION`.

- Tests: new `treatment.test.ts`, `link-fetcher.test.ts`; updated `orchestrator`, `webhook`, `integration`, `server-client` suites.

### Notes / caveats

- **Chromium runtime requirement.** The gateway image must provide a Chromium binary (e.g. `playwright install --with-deps chromium`). Render failures are caught — a failed body→PDF simply omits that one document rather than failing the message.
- **Bytes transport still deferred.** Document bytes are *not yet* transported to the server — ingest still receives metadata only (hash/size/mime/filename). Inline byte transport + server-side persistence land in **Workstream D**.
- **CI does not run the gateway vitest suite** (the `server-tests` workflow is path-scoped to `packages/server/**` + `packages/migrations/**`, and the gateway is not typechecked in CI). The pure assembly logic (treatment filtering/decisions, `getLinkFromBody` prefix matching, `isBlockedHost` SSRF ranges, orchestrator config→ingest mapping) was validated locally via `tsx` with mocked I/O deps.
- New deps (`playwright`, `inline-css`, `@types/inline-css`) were added to `yarn.lock` via `--mode=update-lockfile` (the resolutions already exist from the gmail-listener) because a full `yarn install` is blocked in this environment by an unrelated registry fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNHHjHfq9G4snq7U42hcjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNHHjHfq9G4snq7U42hcjj)_