### PR TITLE
Workstream E: contract finalization — treatment parity tests + design docs

### DIFF
--- a/.changeset/email-ingestion-contract-finalization.md
+++ b/.changeset/email-ingestion-contract-finalization.md
@@ -1,0 +1,12 @@
+---
+---
+
+Workstream E (contract finalization): add gateway treatment **parity tests**
+(`treatment.parity.test.ts`) that pin the v2 treatment to the legacy `handleMessage` behavior per
+provider category, and update the design docs (`business-recognition-plan.md`, `data-flow.md`,
+`architecture-plan.md`) to reflect the shipped recognition-in-control + treatment-in-gateway +
+inline-bytes-persistence design.
+
+No package behavior change — the v2 contract (grant `business_id` + migration, `senderEvidence`
+control input, `businessEmailConfig` control output, inline `content` ingest field, gateway
+`server-client` types + mutations) was already implemented incrementally across Workstreams A–D.

--- a/docs/multi-tenant-gmail-listener/architecture-plan.md
+++ b/docs/multi-tenant-gmail-listener/architecture-plan.md
@@ -35,11 +35,20 @@ to a private Gateway, while keeping tenant resolution and data persistence autho
 1. Cloudflare Email receives inbound mail for tenant aliases (recommended: non-guessable aliases).
 2. Cloudflare forwards each event to a private Gateway endpoint.
 3. Gateway validates authenticity and replay constraints before parsing MIME.
-4. Gateway calls Server control endpoint to resolve tenant and request ingest grant.
-5. Server issues short-lived, message-bound, single-use ingest grant.
-6. Gateway extracts documents and sender evidence, then calls Server ingest endpoint.
+4. Gateway parses MIME (body, attachments, sender evidence) and calls the Server control endpoint to
+   resolve the tenant and recognize the issuing business.
+5. Server issues a short-lived, message-bound, single-use ingest grant with the recognized
+   business_id bound in, and returns that business's treatment config (businessEmailConfig).
+6. Gateway runs treatment (filter attachments, render body to PDF when unrecognized or opted-in,
+   fetch documents behind configured internal links), then calls the Server ingest endpoint with the
+   final document set inlined as base64.
 7. Server validates grant, idempotency, tenant scope, and dedup constraints.
-8. Server writes via existing tenant guardrails and returns auditable outcome.
+8. Server persists the documents and a charge under the grant's business_id (or quarantines an empty
+   set) via existing tenant guardrails, and returns an auditable outcome.
+
+> Business recognition (control) and per-provider treatment (gateway) — attachment filtering,
+> body→PDF rendering, and internal-link fetching — are detailed in
+> [`business-recognition-plan.md`](./business-recognition-plan.md).
 
 ## Trust and Privilege Model
 
@@ -66,12 +75,17 @@ to a private Gateway, while keeping tenant resolution and data persistence autho
 2. Cloudflare forwards recipient alias, headers, and raw payload to Gateway.
 3. Gateway validates authenticity, request age, and nonce replay.
 4. Gateway computes raw_message_hash and creates correlation_id.
-5. Gateway calls Server control endpoint with alias plus message metadata.
-6. Server resolves tenant and policy, emits decision_id, and returns ingest grant.
-7. Gateway parses MIME and extracts candidate documents plus sender evidence.
-8. Gateway calls ingest endpoint with grant, idempotency_key, and extraction payload.
+5. Gateway parses MIME (body, attachments, sender evidence), then calls the Server control endpoint
+   with the alias, message metadata, and sender evidence.
+6. Server resolves the tenant, recognizes the issuing business under tenant RLS, emits decision_id,
+   binds business_id into the grant, and returns the grant plus businessEmailConfig.
+7. Gateway runs treatment driven by businessEmailConfig (attachment filter, body to PDF,
+   internal-link fetch) and decides document emptiness from the result.
+8. Gateway calls the ingest endpoint with the grant, idempotency_key, and the post-treatment
+   documents inlined as base64.
 9. Server validates grant signature, expiry, scope, and single-use jti.
-10. Server enforces idempotency and dedup; inserts or returns duplicate outcome.
+10. Server enforces idempotency and dedup; persists documents + charge under the grant's
+    business_id, or returns a duplicate / NO_DOCUMENTS quarantine outcome.
 11. Server writes audit trail with correlation_id and decision_id.
 12. Gateway applies outcome handling: processed, quarantined, retry, or alert.
 
@@ -79,23 +93,25 @@ to a private Gateway, while keeping tenant resolution and data persistence autho
 
 1. Control endpoint request
    1. recipient_alias
-   2. provider_event_id, message_id, thread_id
-   3. envelope/from/to metadata
-   4. raw_message_hash
-   5. received_at
-   6. correlation_id
+   2. message_id
+   3. raw_message_hash
+   4. received_at
+   5. correlation_id
+   6. sender_evidence (from, reply_to, original_from, forwarded_to, issuer candidates from the body)
+      — drives server-side business recognition
 2. Control endpoint response
    1. tenant_id
    2. decision_id and audit_id
    3. ingest_grant (includes jti, tenant_id, message binding, action scope, expires_at)
-   4. optional policy/profile id
+   4. businessEmailConfig (recognized business_id + emailBody, attachments, internalEmailLinks);
+      null when no business matched
 3. Ingest endpoint request
    1. ingest_grant
-   2. idempotency_key
-   3. extracted_documents (hash, size, mime_type, filename, parse result)
-   4. sender_evidence (alias, from, reply_to, forwarding headers, issuer candidate)
-   5. message_metadata
-   6. correlation_id
+   2. idempotency_key (the raw_message_hash)
+   3. tenant_id, message_id, raw_message_hash
+   4. extracted_documents — the post-treatment set (hash, size, mime_type, filename, inline base64
+      content). No client-settable business_id; the issuing business is read back from the grant.
+   5. correlation_id
 4. Ingest endpoint response
    1. outcome (inserted, duplicate, quarantined, rejected)
    2. ingest_id or existing_ingest_id

--- a/docs/multi-tenant-gmail-listener/business-recognition-plan.md
+++ b/docs/multi-tenant-gmail-listener/business-recognition-plan.md
@@ -1,7 +1,8 @@
 # Business-Recognition-Driven Treatment in v2 Email Ingestion
 
-> **Status:** Design / not yet implemented. This document is the agreed plan; implementation lands
-> in follow-up commits on the same PR.
+> **Status:** Implemented across Workstreams A–E (PRs #3744, #3745, #3751, #3753, and the contract
+> finalization PR). The only remaining item is deprecating the legacy path, which waits for the
+> production cutover.
 
 ## Background
 
@@ -230,20 +231,23 @@ Medium-large.
 
 ## Implementation checklist
 
-- [ ] A. Server: raw-pool business recognition under tenant RLS in `EmailIngestionControlProvider`
-- [ ] A. Server: port issuer-selection policy (skip-lists + fallback chain)
-- [ ] A. Server: `requestIngestControl` accepts sender evidence, returns config
-- [ ] B. Gateway: `mime-extractor` captures body + `mailto:` candidates; extend sender evidence
-- [ ] B. Gateway: `orchestrator` passes sender evidence to control
-- [ ] B. Gateway: parse stops emitting `NO_DOCUMENTS`; emptiness decided post-treatment
-- [ ] C. Gateway: attachment filter
-- [ ] C. Gateway: `html-to-pdf` module (bundled Chromium/Playwright, shared browser instance)
-- [ ] C. Gateway: `link-fetcher` module (SSRF-hardened)
-- [ ] D. Implement bytes transport — Option B (inline base64 → server `getDocumentFromFile`)
-- [ ] D. Server: replace ingest `TODO` with charge + document persistence under grant `business_id`
-- [ ] E. Migration: `email_ingestion_grants.business_id` (+ test)
-- [ ] E. typeDefs + `yarn generate` (server + gateway gql)
-- [ ] E. Update gateway `server-client` contracts + mutation documents
-- [ ] Parity/shadow tests across both paths
-- [ ] Update `data-flow.md` / `architecture-plan.md`
+- [x] A. Server: raw-pool business recognition under tenant RLS in `EmailIngestionControlProvider`
+- [x] A. Server: port issuer-selection policy (skip-lists + fallback chain)
+- [x] A. Server: `requestIngestControl` accepts sender evidence, returns config
+- [x] B. Gateway: `mime-extractor` captures body + `mailto:` candidates; extend sender evidence
+- [x] B. Gateway: `orchestrator` passes sender evidence to control
+- [x] B. Gateway: parse stops emitting `NO_DOCUMENTS`; emptiness decided post-treatment
+- [x] C. Gateway: attachment filter
+- [x] C. Gateway: `html-to-pdf` module (bundled Chromium/Playwright, shared browser instance)
+- [x] C. Gateway: `link-fetcher` module (SSRF-hardened)
+- [x] D. Implement bytes transport — Option B (inline base64 → server)
+- [x] D. Server: replace ingest `TODO` with charge + document persistence under grant `business_id`
+      (inline tenant-pinned SQL — the auth-coupled `getDocumentFromFile` / `DocumentsProvider` /
+      `ChargesProvider` can't run in the gateway control-plane context)
+- [x] E. Migration: `email_ingestion_grants.business_id` (+ test)
+- [x] E. typeDefs + `yarn generate` (server + gateway gql)
+- [x] E. Update gateway `server-client` contracts + mutation documents
+- [x] Parity/shadow tests across both paths (gateway `treatment.parity.test.ts`; server issuer +
+      ingest provider tests)
+- [x] Update `data-flow.md` / `architecture-plan.md`
 - [ ] Deprecate legacy `businessEmailConfig` / `insertEmailDocuments` after cutover

--- a/docs/multi-tenant-gmail-listener/data-flow.md
+++ b/docs/multi-tenant-gmail-listener/data-flow.md
@@ -17,15 +17,14 @@ flowchart TD
     D -->|Invalid| E[Reject INVALID_AUTH or REPLAY_DETECTED + alert]
     D -->|Valid| F[Compute raw_message_hash + correlation_id]
 
-    F --> G[Call Server control endpoint]
+    F --> K[Parse MIME: body + attachments + sender evidence]
+    K --> G[Call Server control endpoint with alias + sender evidence]
     G --> H{Alias resolved and allowed?}
     H -->|No| I[Quarantine UNKNOWN_ALIAS + audit + alert]
-    H -->|Yes| J[Receive tenant-bound short-lived ingest grant]
+    H -->|Yes| J[Recognize issuing business under tenant RLS; return grant + businessEmailConfig]
 
-    J --> K[Parse MIME and extract documents + sender evidence]
-    K --> L{Extraction and limits valid?}
-    L -->|No| M[Quarantine NO_DOCUMENTS, PARSE_ERROR, or OVERSIZE_MESSAGE]
-    L -->|Yes| N[Call Server ingest endpoint with grant + idempotency_key]
+    J --> TR[Gateway treatment: filter attachments by config, render body to PDF when unrecognized or emailBody, fetch documents behind configured internal links]
+    TR --> N[Call Server ingest endpoint with grant + idempotency_key + inline base64 document bytes]
 
     N --> O{Grant valid + unconsumed + tenant-bound?}
     O -->|No| P[Reject GRANT_INVALID or TENANT_MISMATCH]
@@ -33,9 +32,12 @@ flowchart TD
 
     Q --> R{Duplicate request?}
     R -->|Yes| S[Return duplicate with existing_ingest_id]
-    R -->|No| T[Persist documents and charges via tenant guardrails]
+    R -->|No| L{Any documents after treatment?}
+    L -->|No| M[Quarantine NO_DOCUMENTS backstop]
+    L -->|Yes| T[Upload bytes, then persist charge + documents under the recognized business in tenant context]
 
-    T --> U[Write audit trail + return inserted outcome]
+    M --> U[Write audit trail + return outcome]
+    T --> U
     S --> U
     U --> V[Gateway applies processed or quarantine or retry handling]
     V --> W[Emit metrics, logs, and shadow parity signals]
@@ -61,34 +63,34 @@ sequenceDiagram
         GW-->>CF: Reject
     else Valid request
         GW->>GW: Compute raw_message_hash + correlation_id
-        GW->>CTRL: resolveAliasAndIssueGrant(control request)
+        GW->>GW: Parse MIME -> body + attachments + sender evidence
+        GW->>CTRL: control(alias, message metadata, sender_evidence)
 
         alt Unknown alias or policy reject
             CTRL-->>GW: decision=reject, reason=UNKNOWN_ALIAS
             GW->>QA: Quarantine + alert
         else Grant issued
-            CTRL-->>GW: tenant_id + decision_id + audit_id + ingest_grant
-            GW->>GW: Parse MIME and extract docs and sender evidence
+            CTRL->>CTRL: Resolve tenant; recognize issuing business (suggestion_data) under tenant RLS; bind business_id into grant
+            CTRL-->>GW: tenant_id + decision_id + audit_id + ingest_grant + businessEmailConfig
+            GW->>GW: Treatment: filter attachments, body->PDF (unrecognized or emailBody), fetch internal-link docs
+            GW->>ING: ingest(ingest_grant, idempotency_key, documents + inline base64 bytes)
+            ING->>ING: Validate grant scope + expiry + single-use jti
 
-            alt Parse or limits failure
-                GW->>QA: Quarantine NO_DOCUMENTS or PARSE_ERROR or OVERSIZE_MESSAGE
-            else Extracted payload ready
-                GW->>ING: ingest(ingest_grant, idempotency_key, extracted payload)
-                ING->>ING: Validate grant scope + expiry + single-use jti
+            alt Invalid or reused grant
+                ING-->>GW: rejected(reason_code)
+                GW->>QA: Quarantine or retry based on reason_code
+            else Valid grant
+                ING->>ING: Idempotency and tenant dedup
 
-                alt Invalid or reused grant
-                    ING-->>GW: rejected(reason_code)
-                    GW->>QA: Quarantine or retry based on reason_code
-                else Valid grant
-                    ING->>ING: Idempotency and tenant dedup
-
-                    alt Duplicate
-                        ING-->>GW: duplicate(existing_ingest_id, audit_id)
-                    else New insert
-                        ING->>DB: Persist charge and documents in tenant context
-                        DB-->>ING: ingest_id
-                        ING-->>GW: inserted(ingest_id, audit_id)
-                    end
+                alt Duplicate
+                    ING-->>GW: duplicate(existing_ingest_id, audit_id)
+                else No documents after treatment
+                    ING->>QA: Quarantine NO_DOCUMENTS (backstop)
+                    ING-->>GW: quarantined(reason_code, audit_id)
+                else New insert
+                    ING->>DB: Upload bytes; persist charge + documents under recognized business (tenant context)
+                    DB-->>ING: ingest_id
+                    ING-->>GW: inserted(ingest_id, audit_id)
                 end
             end
         end
@@ -97,32 +99,39 @@ sequenceDiagram
 
 ## Data Contract Handoff
 
-Control endpoint request should include:
+Control endpoint request includes:
 
 1. recipient_alias
-2. provider_event_id, message_id, thread_id
-3. envelope and from and to metadata
-4. raw_message_hash
-5. received_at
-6. correlation_id
+2. message_id
+3. raw_message_hash
+4. received_at
+5. correlation_id
+6. sender_evidence (from, reply_to, original_from, forwarded_to, and issuer candidates parsed from
+   the body) — used server-side to recognize the issuing business
 
-Control endpoint response should include:
+Control endpoint response includes:
 
 1. tenant_id
 2. decision_id and audit_id
-3. ingest_grant with jti, scope, tenant binding, and expires_at
-4. optional policy/profile metadata
+3. ingest_grant with jti, tenant binding, action scope, and expires_at
+4. businessEmailConfig — the recognized businessId plus its `emailBody`, `attachments`, and
+   `internalEmailLinks` treatment config; null when no business matched
 
-Ingest endpoint request should include:
+Ingest endpoint request includes:
 
 1. ingest_grant
-2. idempotency_key
-3. extracted_documents with hash, size, mime_type, filename, and parse result
-4. sender_evidence (alias, from, reply_to, forwarding headers, issuer candidate)
-5. message_metadata
-6. correlation_id
+2. idempotency_key (the raw_message_hash)
+3. tenant_id, message_id, raw_message_hash
+4. extracted_documents — the **post-treatment** set, each with hash, size, mime_type, filename, and
+   inline base64 content (Option B transport)
+5. correlation_id
 
-Ingest endpoint response should include:
+> `sender_evidence` travels on the **control** request (business recognition is server-side), not
+> the ingest request. The ingest input never carries a client-settable `business_id` — the issuing
+> business is read back from the grant, so the gateway cannot attribute documents to an arbitrary
+> business.
+
+Ingest endpoint response includes:
 
 1. outcome (inserted, duplicate, quarantined, rejected)
 2. ingest_id or existing_ingest_id
@@ -133,6 +142,9 @@ Ingest endpoint response should include:
 1. Invalid authenticity or replay detection: reject, alert, and audit.
 2. Unknown alias or policy reject: quarantine and alert; ops updates alias policy.
 3. Grant validation failure or tenant mismatch: reject or quarantine with audit trail.
-4. Parse or size-limit failures: quarantine with explicit reason_code.
+4. Parse or size-limit failures (PARSE_ERROR, OVERSIZE_MESSAGE): quarantine with explicit
+   reason_code. Document emptiness (NO_DOCUMENTS) is decided **after** treatment — the parse no
+   longer fails a document-less message — with the server ingest as the backstop.
 5. Transient upstream failures: scheduled retry; non-transient failures remain manual reprocess.
-6. Shadow mode rollout: legacy path remains active while v2 decisions and outcomes are measured.
+6. Shadow mode rollout: legacy path remains active while v2 decisions and outcomes are measured;
+   parity is enforced by tests (see `treatment.parity.test.ts`).

--- a/packages/email-ingestion-gateway/src/__tests__/treatment.parity.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/treatment.parity.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ExtractedDocument } from '../mime-extractor.js';
+import type { BusinessEmailConfig } from '../server-client.js';
+import { applyTreatment, type TreatmentDeps } from '../treatment.js';
+
+/**
+ * Behavioral parity tests for the v2 gateway treatment.
+ *
+ * Workstream C duplicated-and-adapted the legacy `gmail-listener` treatment into
+ * the gateway (architecture-plan.md: "Contract and behavior parity is enforced
+ * by tests, not by shared runtime modules"). These tests pin that parity: for
+ * each representative provider category, `applyTreatment` must produce the same
+ * document set the legacy `handleMessage` produced.
+ *
+ * Reference: packages/gmail-listener/src/gmail-service.ts `handleMessage`
+ * (~L464-509): (1) filter attachments by `config.attachments`; (2) render the
+ * body to a PDF when no business is recognized **or** `emailBody === true`;
+ * (3) fetch a document for each `internalEmailLinks` entry; the document set is
+ * then assembled in that order and emptiness decided afterwards.
+ *
+ * Unlike the per-step unit tests in `treatment.test.ts`, each case here is a
+ * full provider email run end-to-end through the pipeline, asserting the
+ * complete ordered document set — the same signal shadow mode compares.
+ *
+ * Out of scope here (covered elsewhere):
+ *  - Provider skip-list / issuer selection is server-side — see
+ *    server `email-ingestion-issuer.helper.test.ts`.
+ *  - One charge per email on persistence — see server
+ *    `email-ingestion-ingest.provider.test.ts`.
+ *
+ * Known intentional divergence: v2 skips the body→PDF for an empty body (legacy
+ * always rendered). See the `body→PDF` empty-body case in `treatment.test.ts`.
+ */
+
+vi.spyOn(console, 'log').mockImplementation(() => {});
+vi.spyOn(console, 'error').mockImplementation(() => {});
+
+function doc(mimeType: string, name: string): ExtractedDocument {
+  const content = Buffer.from(name);
+  return { filename: name, mimeType, content, size: content.length, sha256: name };
+}
+
+function cfg(over: Partial<BusinessEmailConfig> = {}): BusinessEmailConfig {
+  return {
+    businessId: 'biz-1',
+    internalEmailLinks: null,
+    emailBody: false,
+    attachments: null,
+    ...over,
+  };
+}
+
+function makeDeps(over: Partial<TreatmentDeps> = {}): TreatmentDeps {
+  return {
+    renderHtmlToPdf: vi.fn().mockResolvedValue(doc('application/pdf', 'body.pdf')),
+    fetchInternalLinkDocuments: vi.fn().mockResolvedValue([]),
+    ...over,
+  };
+}
+
+describe('treatment parity with legacy handleMessage', () => {
+  it('attachment-only provider → only allow-listed attachments (no body PDF, no links)', async () => {
+    // Recognized business, attachments allowlist [PDF], emailBody off, no links.
+    const renderHtmlToPdf = vi.fn();
+    const fetchInternalLinkDocuments = vi.fn();
+    const out = await applyTreatment(
+      {
+        config: cfg({ attachments: ['PDF'], emailBody: false, internalEmailLinks: null }),
+        body: '<p>see attached invoice</p>',
+        attachments: [doc('application/pdf', 'invoice.pdf'), doc('image/png', 'logo.png')],
+      },
+      makeDeps({ renderHtmlToPdf, fetchInternalLinkDocuments }),
+    );
+    // legacy L467-487: logo.png filtered out; L490 body PDF skipped (businessId set,
+    // emailBody !== true); L496 no links.
+    expect(out.map(d => d.filename)).toEqual(['invoice.pdf']);
+    expect(renderHtmlToPdf).not.toHaveBeenCalled();
+    expect(fetchInternalLinkDocuments).not.toHaveBeenCalled();
+  });
+
+  it('body-as-PDF provider → attachments plus the rendered body PDF', async () => {
+    // Recognized business that opts into emailBody.
+    const renderHtmlToPdf = vi.fn().mockResolvedValue(doc('application/pdf', 'body.pdf'));
+    const out = await applyTreatment(
+      {
+        config: cfg({ attachments: null, emailBody: true, internalEmailLinks: null }),
+        body: '<p>the invoice is the email body</p>',
+        attachments: [doc('application/pdf', 'invoice.pdf')],
+      },
+      makeDeps({ renderHtmlToPdf }),
+    );
+    // legacy: keep all attachments (no allowlist) then L490-493 append body PDF.
+    expect(out.map(d => d.filename)).toEqual(['invoice.pdf', 'body.pdf']);
+    expect(renderHtmlToPdf).toHaveBeenCalledOnce();
+  });
+
+  it('internal-link provider → fetches the document behind the configured link', async () => {
+    // Some providers email only a "download your invoice" link, not an attachment.
+    const renderHtmlToPdf = vi.fn();
+    const fetchInternalLinkDocuments = vi
+      .fn()
+      .mockResolvedValue([doc('application/pdf', 'external.pdf')]);
+    const out = await applyTreatment(
+      {
+        config: cfg({
+          attachments: null,
+          emailBody: false,
+          internalEmailLinks: ['https://vendor.com/invoice'],
+        }),
+        body: '<a href="https://vendor.com/invoice/123">download</a>',
+        attachments: [],
+      },
+      makeDeps({ renderHtmlToPdf, fetchInternalLinkDocuments }),
+    );
+    // legacy L496-503: fetch the link doc; L490 body PDF skipped (recognized, emailBody off).
+    expect(out.map(d => d.filename)).toEqual(['external.pdf']);
+    expect(fetchInternalLinkDocuments).toHaveBeenCalledOnce();
+    expect(renderHtmlToPdf).not.toHaveBeenCalled();
+  });
+
+  it('unrecognized sender → keeps all attachments and renders the body PDF (legacy default)', async () => {
+    // No business matched → config null → legacy L490 `!businessId` branch renders body.
+    const renderHtmlToPdf = vi.fn().mockResolvedValue(doc('application/pdf', 'body.pdf'));
+    const out = await applyTreatment(
+      {
+        config: null,
+        body: '<p>unknown sender invoice</p>',
+        attachments: [doc('application/pdf', 'invoice.pdf')],
+      },
+      makeDeps({ renderHtmlToPdf }),
+    );
+    expect(out.map(d => d.filename)).toEqual(['invoice.pdf', 'body.pdf']);
+    expect(renderHtmlToPdf).toHaveBeenCalledOnce();
+  });
+
+  it('combined provider → filtered attachments, then body PDF, then link doc (legacy order)', async () => {
+    const renderHtmlToPdf = vi.fn().mockResolvedValue(doc('application/pdf', 'body.pdf'));
+    const fetchInternalLinkDocuments = vi
+      .fn()
+      .mockResolvedValue([doc('application/pdf', 'external.pdf')]);
+    const out = await applyTreatment(
+      {
+        config: cfg({
+          attachments: ['PDF'],
+          emailBody: true,
+          internalEmailLinks: ['https://vendor.com/invoice'],
+        }),
+        body: '<a href="https://vendor.com/invoice/1">x</a>',
+        attachments: [doc('application/pdf', 'invoice.pdf'), doc('image/png', 'logo.png')],
+      },
+      makeDeps({ renderHtmlToPdf, fetchInternalLinkDocuments }),
+    );
+    // legacy assembly order: attachments (filtered) → body PDF → link docs.
+    expect(out.map(d => d.filename)).toEqual(['invoice.pdf', 'body.pdf', 'external.pdf']);
+  });
+
+  it('no relevant documents → empty set (downstream NO_DOCUMENTS, legacy L505)', async () => {
+    // Recognized business, the only attachment is filtered out, emailBody off, no links.
+    const out = await applyTreatment(
+      {
+        config: cfg({ attachments: ['PDF'], emailBody: false, internalEmailLinks: null }),
+        body: '<p>nothing useful</p>',
+        attachments: [doc('image/png', 'logo.png')],
+      },
+      makeDeps({ renderHtmlToPdf: vi.fn() }),
+    );
+    // legacy L505-509 logs "no relevant documents"; v2 returns [] and the server
+    // ingest applies the NO_DOCUMENTS quarantine backstop.
+    expect(out).toHaveLength(0);
+  });
+});

--- a/packages/email-ingestion-gateway/src/__tests__/treatment.parity.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/treatment.parity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, describe, expect, it, vi } from 'vitest';
 import type { ExtractedDocument } from '../mime-extractor.js';
 import type { BusinessEmailConfig } from '../server-client.js';
 import { applyTreatment, type TreatmentDeps } from '../treatment.js';
@@ -34,6 +34,11 @@ import { applyTreatment, type TreatmentDeps } from '../treatment.js';
 
 vi.spyOn(console, 'log').mockImplementation(() => {});
 vi.spyOn(console, 'error').mockImplementation(() => {});
+
+afterAll(() => {
+  // Restore the file-level console spies so they cannot leak into other suites.
+  vi.restoreAllMocks();
+});
 
 function doc(mimeType: string, name: string): ExtractedDocument {
   const content = Buffer.from(name);


### PR DESCRIPTION
## Workstream E — contract finalization (parity tests + docs)

The contract changes the plan listed under Workstream E were **implemented incrementally across Workstreams A–D**, because each workstream needed its slice to function:

| WS-E item | Landed in |
|---|---|
| Migration: `email_ingestion_grants.business_id` (FK + test) | WS-A |
| `IngestControlInput.senderEvidence` (typeDef) | WS-A |
| `IngestControlDecision.businessEmailConfig` block (typeDef) | WS-A |
| `IngestEmailInput` inline `content` field (typeDef) | WS-D |
| Codegen (server + gateway gql) | each WS |
| Gateway `server-client` `ControlInput`/`ControlDecision`/`IngestInput` + mutations | WS-B/C/D |

So there was no new contract *code* to write. This PR closes out the two genuinely-remaining plan items (the cross-cutting ones), per the scope you selected:

### Parity / shadow tests
`packages/email-ingestion-gateway/src/__tests__/treatment.parity.test.ts` — pins the v2 gateway treatment to the legacy `gmail-listener` `handleMessage` (gmail-service.ts:464-509) for each representative provider category, as combined **end-to-end** scenarios (vs. the per-step unit slices in `treatment.test.ts`):

- attachment-only provider → only allow-listed attachments
- body-as-PDF provider → attachments + rendered body PDF
- internal-link provider → document fetched behind the configured link
- unrecognized sender → all attachments + body PDF (legacy default)
- combined provider → filtered attachments, then body PDF, then link doc (legacy assembly order)
- no relevant documents → empty set (downstream `NO_DOCUMENTS` backstop)

The provider **skip-list / issuer-selection** parity is server-side and already covered by `email-ingestion-issuer.helper.test.ts`; **charge-per-email** parity by `email-ingestion-ingest.provider.test.ts` — both referenced in the file header. The one intentional v2 divergence (skip body→PDF for an empty body) is noted.

### Docs
- `business-recognition-plan.md` — status flipped to *implemented across A–E*; checklist A–E marked done (legacy-path deprecation left open until cutover).
- `data-flow.md` + `architecture-plan.md` — flowchart, sequence, and data contracts updated to show **recognition-in-control** and **treatment-in-gateway**: `sender_evidence` now on the *control* request (not ingest), `businessEmailConfig` on the *control* response, inline base64 `content` on ingest, and emptiness (`NO_DOCUMENTS`) decided **post-treatment** with the server ingest as backstop.

### Notes
- No package behavior change → an **empty changeset** (no version bump) is included.
- Server/migration tests are unaffected (no server change); the new gateway parity test isn't run by CI for this PR, so its 6 scenarios were validated locally via `tsx` (all pass) — same harness used for the WS-C/D gateway logic.
- **Deferred** (explicitly out of scope, the last open plan item): deprecating the legacy `businessEmailConfig` / `insertEmailDocuments` path — to be done after production cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNHHjHfq9G4snq7U42hcjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNHHjHfq9G4snq7U42hcjj)_