### PR TITLE
chore: deprecate the legacy gmail-listener email path (post-cutover)

### DIFF
--- a/.changeset/deprecate-legacy-gmail-listener.md
+++ b/.changeset/deprecate-legacy-gmail-listener.md
@@ -1,0 +1,17 @@
+---
+'@accounter/server': minor
+'@accounter/gmail-listener': patch
+---
+
+Deprecate the legacy gmail-listener email path now that the v2 multi-tenant
+`@accounter/email-ingestion-gateway` pipeline (Cloudflare → Gateway → Server) covers it.
+
+- The server GraphQL fields `businessEmailConfig` (query) and `insertEmailDocuments` (mutation) are
+  marked `@deprecated` (non-breaking — the legacy listener keeps working for rollback) and scheduled
+  for removal after cutover. Their resolvers carry matching `@deprecated` JSDoc.
+- `@accounter/gmail-listener` is marked deprecated (README banner + package description) and
+  superseded by the gateway. It is kept only for rollback during the cutover.
+- Docs updated to acknowledge the migration (root `CLAUDE.md`, `packages/server/CLAUDE.md`).
+
+The `gmail_listener` auth role and the package itself are intentionally retained for rollback; hard
+removal (and `npm deprecate` of the published package) is a follow-up once the cutover is complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,14 +18,15 @@ Yarn Berry (v4) monorepo with 18 packages under `packages/`:
 - **Integrations**: `green-invoice-graphql`, `hashavshevet-mesh`, `payper-mesh`, `deel` (via server
   app-providers)
 - **Email ingestion**: `email-ingestion-gateway` (v2 multi-tenant Cloudflare→gateway→server email
-  pipeline), `gmail-listener` (legacy single-tenant listener)
+  pipeline)
 - **Generators**: `pcn874-generator`, `opcn1214-generator`, `shaam6111-generator`,
-  `shaam-uniform-format-generator`
+  `shaam-uniform-format-generator` <<<<<<< HEAD
 - **Tools**: `scraper-app` (local scrape web app — Fastify server + React UI; replaces
   `scraper-local-app`)
 - **Deprecated**: `scraper-local-app` (legacy CLI scrape runner; superseded by `scraper-app` — kept
-  only for rollback until `scraper-app` is fully in production use), `old-accounter` (excluded from
-  workspaces)
+  only for rollback until `scraper-app` is fully in production use), `gmail-listener` (legacy
+  single-inbox email listener; superseded by `email-ingestion-gateway` — kept only for rollback
+  during cutover), `old-accounter` (excluded from workspaces)
 
 Package-specific conventions live in `packages/<name>/CLAUDE.md` (loaded on demand when you work in
 that package).

--- a/packages/gmail-listener/README.md
+++ b/packages/gmail-listener/README.md
@@ -1,5 +1,12 @@
 # Gmail Listener
 
+> ⚠️ **Deprecated.** This single-inbox listener is superseded by the multi-tenant v2 pipeline in
+> [`@accounter/email-ingestion-gateway`](../email-ingestion-gateway) (Cloudflare → Gateway →
+> Server). It is kept only for rollback during the cutover and receives no new features. Its server
+> GraphQL surface (`businessEmailConfig`, `insertEmailDocuments`) is `@deprecated` and will be
+> removed once the cutover is complete. New work should target the gateway — see
+> [`docs/multi-tenant-gmail-listener/`](../../docs/multi-tenant-gmail-listener).
+
 A service that watches a Gmail inbox, extracts financial documents from matching emails, and sends
 them to the Accounter server through GraphQL.
 

--- a/packages/gmail-listener/package.json
+++ b/packages/gmail-listener/package.json
@@ -2,7 +2,7 @@
   "name": "@accounter/gmail-listener",
   "version": "0.1.2",
   "type": "module",
-  "description": "A Gmail listener that listens for new emails, extracts financial documents, and sends them to the server",
+  "description": "[DEPRECATED — superseded by @accounter/email-ingestion-gateway] A Gmail listener that listens for new emails, extracts financial documents, and sends them to the server",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Urigo/accounter-fullstack.git",

--- a/packages/server/CLAUDE.md
+++ b/packages/server/CLAUDE.md
@@ -22,8 +22,10 @@ depreciation, dividends, documents, email-ingestion, exchange-rates, financial-a
 financial-entities, green-invoice, ledger, misc-expenses, priority, reports, salaries, sort-codes,
 tags, transactions, vat, workspace-settings
 
-> `gmail-listener` remains as a backward-compat re-export shim
-> (`gmailListenerModule = emailIngestionModule`) for the legacy listener package. New code must
+> **Deprecated:** `gmail-listener` remains only as a backward-compat re-export shim
+> (`gmailListenerModule = emailIngestionModule`) for the legacy listener package, which is
+> superseded by the v2 `email-ingestion-gateway`. Its GraphQL surface (`businessEmailConfig`,
+> `insertEmailDocuments`) is `@deprecated` and scheduled for removal after cutover. New code must
 > import from `email-ingestion` directly.
 
 ## Provider Patterns

--- a/packages/server/src/modules/email-ingestion/resolvers/email-ingestion.resolver.ts
+++ b/packages/server/src/modules/email-ingestion/resolvers/email-ingestion.resolver.ts
@@ -12,6 +12,11 @@ import { BusinessesProvider } from '../../financial-entities/providers/businesse
 import { EmailListenerConfig } from '../../financial-entities/types.js';
 import type { EmailIngestionModule } from '../types.js';
 
+/**
+ * @deprecated Legacy gmail-listener path. The v2 email-ingestion flow recognizes the business
+ * server-side in `requestIngestControl` (see `email-ingestion-control.provider.ts`). Do not extend;
+ * scheduled for removal after the gmail-listener cutover.
+ */
 const businessEmailConfig: EmailIngestionModule.QueryResolvers['businessEmailConfig'] = async (
   _,
   { email },
@@ -49,6 +54,11 @@ const businessEmailConfig: EmailIngestionModule.QueryResolvers['businessEmailCon
   };
 };
 
+/**
+ * @deprecated Legacy gmail-listener path. The v2 email-ingestion flow persists documents via the
+ * `ingestEmail` mutation (see `email-ingestion-ingest.provider.ts`). Do not extend; scheduled for
+ * removal after the gmail-listener cutover.
+ */
 const insertEmailDocuments: EmailIngestionModule.MutationResolvers['insertEmailDocuments'] = async (
   _,
   { documents, userDescription, messageId, businessId },

--- a/packages/server/src/modules/email-ingestion/typeDefs/email-ingestion.graphql.ts
+++ b/packages/server/src/modules/email-ingestion/typeDefs/email-ingestion.graphql.ts
@@ -3,6 +3,9 @@ import { gql } from 'graphql-modules';
 export default gql`
   extend type Query {
     businessEmailConfig(email: String!): BusinessEmailConfig
+      @deprecated(
+        reason: "Legacy gmail-listener path, superseded by the v2 email-ingestion flow where requestIngestControl recognizes the business and returns businessEmailConfig. Scheduled for removal after the gmail-listener cutover."
+      )
       @requiresAuth
       @requiresRole(role: "gmail_listener")
 
@@ -18,7 +21,12 @@ export default gql`
       userDescription: String!
       messageId: String
       businessId: UUID
-    ): Boolean! @requiresAuth @requiresRole(role: "gmail_listener")
+    ): Boolean!
+      @deprecated(
+        reason: "Legacy gmail-listener path, superseded by the v2 ingestEmail mutation (gateway → server) which persists documents under the recognized business. Scheduled for removal after the gmail-listener cutover."
+      )
+      @requiresAuth
+      @requiresRole(role: "gmail_listener")
 
     " Provision a new email alias that routes incoming mail to the given business "
     createEmailIngestionAlias(input: CreateEmailIngestionAliasInput!): EmailIngestionAliasResult!


### PR DESCRIPTION
Post-merge follow-up to the multi-tenant email-ingestion work (Workstreams A–E, now on `main`). The v2 `@accounter/email-ingestion-gateway` pipeline (Cloudflare → Gateway → Server) covers inbound email, so this **marks the legacy path deprecated** — it does **not** remove anything, so rollback stays available during cutover.

### 1. Deprecate `businessEmailConfig` / `insertEmailDocuments`
- Added `@deprecated(reason: …)` to both fields in `email-ingestion.graphql.ts`, pointing to their v2 replacements (`requestIngestControl` recognition / `ingestEmail` persistence). This is **non-breaking** — the legacy listener keeps calling them until cutover.
- Added matching `@deprecated` JSDoc to the two resolvers so the "don't extend this" signal is visible in code too.

### 2. Deprecate the `@accounter/gmail-listener` package
- Prominent **deprecation banner** in its `README.md` and a `[DEPRECATED — superseded by …]` prefix on the package `description`, both pointing to the gateway.

### 3. Acknowledge the migration in docs
- Root `CLAUDE.md`: moved `gmail-listener` into **Deprecated** and surfaced `email-ingestion-gateway` as the active v2 pipeline.
- `packages/server/CLAUDE.md`: updated the re-export-shim note to flag deprecation + the `@deprecated` GraphQL surface.

### Scope notes (intentional)
- **Not removed / kept for rollback:** the `gmail_listener` **auth role** (used by charges-authorization, auth helpers, the client role UI, and its role migration) and the package code itself. The architecture plan keeps the legacy path live until full confidence.
- **No CI workflow** references `gmail-listener` by name, and the only root `package.json` reference is the codegen-clear path (still needed) — so there was nothing legacy-specific to change there. The package is left publishable (not set `private`); `npm deprecate` of the published package and hard code removal are **follow-ups after cutover completes**.

### Verification
Prettier-clean on all changed files; the `@deprecated` directives parse cleanly (validated via prettier's embedded-GraphQL formatter). Generated types/schema regenerate in CI as usual. Adding `@deprecated` is a non-breaking schema change, so the Hive schema check should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNHHjHfq9G4snq7U42hcjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNHHjHfq9G4snq7U42hcjj)_