### PR TITLE
Add human-readable charge descriptions for ingested emails

### DIFF
--- a/.changeset/@accounter_client-3762-dependencies.md
+++ b/.changeset/@accounter_client-3762-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`html2canvas-pro@2.1.1` ↗︎](https://www.npmjs.com/package/html2canvas-pro/v/2.1.1) (from `2.0.4`, in `dependencies`)

--- a/.changeset/@accounter_client-3762-dependencies.md
+++ b/.changeset/@accounter_client-3762-dependencies.md
@@ -2,4 +2,5 @@
 "@accounter/client": patch
 ---
 dependencies updates:
+  - Updated dependency [`@mui/material@9.1.2` ↗︎](https://www.npmjs.com/package/@mui/material/v/9.1.2) (from `9.1.1`, in `dependencies`)
   - Updated dependency [`html2canvas-pro@2.1.1` ↗︎](https://www.npmjs.com/package/html2canvas-pro/v/2.1.1) (from `2.0.4`, in `dependencies`)

--- a/.changeset/@accounter_israeli-vat-scraper-3762-dependencies.md
+++ b/.changeset/@accounter_israeli-vat-scraper-3762-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/israeli-vat-scraper": patch
+---
+dependencies updates:
+  - Updated dependency [`puppeteer@25.2.0` ↗︎](https://www.npmjs.com/package/puppeteer/v/25.2.0) (from `25.1.0`, in `dependencies`)

--- a/.changeset/@accounter_modern-poalim-scraper-3762-dependencies.md
+++ b/.changeset/@accounter_modern-poalim-scraper-3762-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/modern-poalim-scraper": patch
+---
+dependencies updates:
+  - Updated dependency [`puppeteer@25.2.0` ↗︎](https://www.npmjs.com/package/puppeteer/v/25.2.0) (from `25.1.0`, in `dependencies`)

--- a/.changeset/lemon-shoes-laugh.md
+++ b/.changeset/lemon-shoes-laugh.md
@@ -1,0 +1,11 @@
+---
+'@accounter/server': patch
+---
+
+Email ingestion: set a descriptive charge description matching the legacy gmail-listener —
+`Email documents: <subject> (from: <sender>, <date>)` — instead of the bare
+`email-ingestion: <messageId>`. The email subject, sender, and received date are threaded through
+`IngestEmailInput` (new optional `subject`/`sender`/`receivedAt` fields) → the `ingestEmail`
+resolver → `EmailIngestionIngestProvider`, with graceful fallback to the message id when any field
+is missing. The received date is formatted in UTC so the same email produces a stable description
+across dev/CI/prod.

--- a/.changeset/pink-crews-appear.md
+++ b/.changeset/pink-crews-appear.md
@@ -1,0 +1,11 @@
+---
+'@accounter/email-ingestion-gateway': patch
+---
+
+Gateway: parse incoming MIME with `postal-mime` (as recommended by Cloudflare's email-handler docs)
+instead of the hand-rolled parser. This decodes RFC 2047 encoded-word headers, so non-ASCII subjects
+and sender display names (e.g. Hebrew `=?UTF-8?B?…?=`) are no longer stored as raw encoded strings —
+fixing the email charge description that reads them. `extractFromMime` keeps the same public contract
+(document-type filtering, size/count limits, nesting-depth guard, and the `From: <mailto:…>`
+issuer-candidate heuristic) and now also forwards the email subject to the server for the charge
+description.

--- a/packages/email-ingestion-gateway/package.json
+++ b/packages/email-ingestion-gateway/package.json
@@ -53,6 +53,7 @@
     "graphql-request": "7.4.0",
     "inline-css": "4.0.3",
     "playwright": "1.61.0",
+    "postal-mime": "2.7.4",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
@@ -663,7 +663,9 @@ describe('extractFromMime — body capture & issuer candidates', () => {
     const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.body).toBe('אבג');
+      // postal-mime appends a trailing newline to decoded text bodies; the
+      // assertion only cares that the windows-1255 bytes decoded correctly.
+      expect(result.body).toContain('אבג');
     }
   });
 });

--- a/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { IngestReasonCode } from '../contracts.js';
 import {
   MAX_ATTACHMENT_COUNT,
@@ -123,7 +123,10 @@ function fakePng(sizeBytes = 256): Buffer {
   return buf;
 }
 
-import { vi } from 'vitest';
+/** Encode text as an RFC 2047 base64 UTF-8 encoded-word. */
+function encodeWord(text: string): string {
+  return `=?UTF-8?B?${Buffer.from(text, 'utf8').toString('base64')}?=`;
+}
 
 // ---------------------------------------------------------------------------
 // Limit constants
@@ -139,6 +142,9 @@ describe('exported limit constants', () => {
   it('MAX_EXTRACTED_BYTES is 20 MB', () => {
     expect(MAX_EXTRACTED_BYTES).toBe(20 * 1024 * 1024);
   });
+  it('MAX_MIME_DEPTH is 10', () => {
+    expect(MAX_MIME_DEPTH).toBe(10);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -146,39 +152,39 @@ describe('exported limit constants', () => {
 // ---------------------------------------------------------------------------
 
 describe('extractFromMime — OVERSIZE_MESSAGE', () => {
-  it('returns OVERSIZE_MESSAGE when raw MIME exceeds 25 MB', () => {
+  it('returns OVERSIZE_MESSAGE when raw MIME exceeds 25 MB', async () => {
     const big = Buffer.alloc(MAX_RAW_MIME_BYTES + 1);
-    const result = extractFromMime(big);
+    const result = await extractFromMime(big);
     expect(result).toEqual({ success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE });
   });
 
-  it('does NOT reject a message at exactly 25 MB as oversize', () => {
+  it('does NOT reject a message at exactly 25 MB as oversize', async () => {
     // A buffer of exactly MAX size must not trigger the oversize check.
     const exact = Buffer.alloc(MAX_RAW_MIME_BYTES);
-    const result = extractFromMime(exact);
+    const result = await extractFromMime(exact);
     if (!result.success) {
       expect(result.reason).not.toBe(IngestReasonCode.OVERSIZE_MESSAGE);
     }
   });
 
-  it('returns OVERSIZE_MESSAGE when attachment count exceeds 10', () => {
+  it('returns OVERSIZE_MESSAGE when attachment count exceeds 10', async () => {
     const attachments = Array.from({ length: MAX_ATTACHMENT_COUNT + 1 }, (_, i) => ({
       filename: `doc${i}.pdf`,
       mimeType: 'application/pdf',
       content: fakePdf(100),
     }));
     const mime = makeMultipartMime({ attachments });
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result).toEqual({ success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE });
   });
 
-  it('returns OVERSIZE_MESSAGE when total extracted bytes exceed 20 MB', () => {
+  it('returns OVERSIZE_MESSAGE when total extracted bytes exceed 20 MB', async () => {
     // One attachment that is just over 20 MB
     const big = Buffer.alloc(MAX_EXTRACTED_BYTES + 1);
     const mime = makeMultipartMime({
       attachments: [{ filename: 'big.pdf', mimeType: 'application/pdf', content: big }],
     });
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result).toEqual({ success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE });
   });
 });
@@ -188,8 +194,8 @@ describe('extractFromMime — OVERSIZE_MESSAGE', () => {
 // ---------------------------------------------------------------------------
 
 describe('extractFromMime — PARSE_ERROR', () => {
-  it('returns PARSE_ERROR for completely empty buffer', () => {
-    const result = extractFromMime(Buffer.alloc(0));
+  it('returns PARSE_ERROR for completely empty buffer', async () => {
+    const result = await extractFromMime(Buffer.alloc(0));
     expect(result).toEqual({ success: false, reason: IngestReasonCode.PARSE_ERROR });
   });
 });
@@ -199,9 +205,9 @@ describe('extractFromMime — PARSE_ERROR', () => {
 // ---------------------------------------------------------------------------
 
 describe('extractFromMime — attachment-less messages', () => {
-  it('succeeds with empty documents for a plain-text-only message', () => {
+  it('succeeds with empty documents for a plain-text-only message', async () => {
     const mime = makeTextMime('sender@example.com', 'Hello', 'just some text');
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.documents).toHaveLength(0);
@@ -210,39 +216,66 @@ describe('extractFromMime — attachment-less messages', () => {
     }
   });
 
-  it('extracts the Subject header for the downstream charge description', () => {
+  it('extracts the Subject header for the downstream charge description', async () => {
     const mime = makeTextMime('sender@example.com', 'Invoice #42', 'body');
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.subject).toBe('Invoice #42');
     }
   });
 
-  it('succeeds with empty documents for multipart with no document attachments', () => {
+  it('succeeds with empty documents for multipart with no document attachments', async () => {
     // Has a text attachment, not a PDF/image
     const mime = makeMultipartMime({
       attachments: [
         { filename: 'notes.txt', mimeType: 'text/plain', content: Buffer.from('notes') },
       ],
     });
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.documents).toHaveLength(0);
     }
   });
 
-  it('tolerates structureless/binary input as an empty message (no documents)', () => {
-    // Post-WS-B the emptiness decision is deferred downstream: input with no
-    // recognizable MIME structure parses as an empty message (no documents,
-    // empty body) and is quarantined later, rather than failing at parse time.
-    // (A genuinely empty buffer is still a PARSE_ERROR — see above.)
-    const result = extractFromMime(Buffer.from([0x00, 0x01, 0x02, 0x03]));
+  it('tolerates structureless/binary input as an empty message (no documents)', async () => {
+    // The emptiness decision is deferred downstream: input with no recognizable
+    // MIME structure parses as a message with no documents and is quarantined
+    // later, rather than failing at parse time. (A genuinely empty buffer is
+    // still a PARSE_ERROR — see above.)
+    const result = await extractFromMime(Buffer.from([0x00, 0x01, 0x02, 0x03]));
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.documents).toHaveLength(0);
-      expect(result.body).toBe('');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RFC 2047 encoded-word header decoding (non-ASCII subjects/senders)
+// ---------------------------------------------------------------------------
+
+describe('extractFromMime — RFC 2047 encoded headers', () => {
+  it('decodes an encoded-word Subject (e.g. Hebrew) to Unicode', async () => {
+    const subjectText = 'חשבונית 123';
+    const mime = makeTextMime('sender@example.com', encodeWord(subjectText), 'body');
+    const result = await extractFromMime(mime);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.subject).toBe(subjectText);
+    }
+  });
+
+  it('decodes an encoded-word From display name', async () => {
+    const mime = makeMultipartMime({
+      from: `${encodeWord('ספק')} <vendor@biz.co.il>`,
+      attachments: [{ filename: 'a.pdf', mimeType: 'application/pdf', content: fakePdf() }],
+    });
+    const result = await extractFromMime(mime);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.senderEvidence.from).toBe('ספק <vendor@biz.co.il>');
     }
   });
 });
@@ -262,35 +295,35 @@ describe('extractFromMime — success: PDF attachment', () => {
     });
   });
 
-  it('returns success: true', () => {
-    const result = extractFromMime(mime);
+  it('returns success: true', async () => {
+    const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
   });
 
-  it('includes one document', () => {
-    const result = extractFromMime(mime) as { success: true; documents: ExtractedDocument[] };
+  it('includes one document', async () => {
+    const result = (await extractFromMime(mime)) as { success: true; documents: ExtractedDocument[] };
     expect(result.documents).toHaveLength(1);
   });
 
-  it('document has correct filename and mimeType', () => {
-    const result = extractFromMime(mime) as { success: true; documents: ExtractedDocument[] };
+  it('document has correct filename and mimeType', async () => {
+    const result = (await extractFromMime(mime)) as { success: true; documents: ExtractedDocument[] };
     expect(result.documents[0]?.filename).toBe('invoice.pdf');
     expect(result.documents[0]?.mimeType).toBe('application/pdf');
   });
 
-  it('document size matches original bytes', () => {
-    const result = extractFromMime(mime) as { success: true; documents: ExtractedDocument[] };
+  it('document size matches original bytes', async () => {
+    const result = (await extractFromMime(mime)) as { success: true; documents: ExtractedDocument[] };
     expect(result.documents[0]?.size).toBe(pdfBytes.length);
   });
 
-  it('document sha256 matches crypto hash of original bytes', () => {
-    const result = extractFromMime(mime) as { success: true; documents: ExtractedDocument[] };
+  it('document sha256 matches crypto hash of original bytes', async () => {
+    const result = (await extractFromMime(mime)) as { success: true; documents: ExtractedDocument[] };
     const expected = createHash('sha256').update(pdfBytes).digest('hex');
     expect(result.documents[0]?.sha256).toBe(expected);
   });
 
-  it('document content matches original bytes', () => {
-    const result = extractFromMime(mime) as { success: true; documents: ExtractedDocument[] };
+  it('document content matches original bytes', async () => {
+    const result = (await extractFromMime(mime)) as { success: true; documents: ExtractedDocument[] };
     expect(result.documents[0]?.content).toEqual(pdfBytes);
   });
 });
@@ -300,12 +333,12 @@ describe('extractFromMime — success: PDF attachment', () => {
 // ---------------------------------------------------------------------------
 
 describe('extractFromMime — success: image attachment', () => {
-  it('extracts image/png attachment', () => {
+  it('extracts image/png attachment', async () => {
     const png = fakePng(512);
     const mime = makeMultipartMime({
       attachments: [{ filename: 'receipt.png', mimeType: 'image/png', content: png }],
     });
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.documents[0]?.mimeType).toBe('image/png');
@@ -313,12 +346,12 @@ describe('extractFromMime — success: image attachment', () => {
     }
   });
 
-  it('extracts image/jpeg attachment', () => {
+  it('extracts image/jpeg attachment', async () => {
     const jpg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, ...Buffer.alloc(100)]);
     const mime = makeMultipartMime({
       attachments: [{ filename: 'scan.jpg', mimeType: 'image/jpeg', content: jpg }],
     });
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
   });
 });
@@ -328,7 +361,7 @@ describe('extractFromMime — success: image attachment', () => {
 // ---------------------------------------------------------------------------
 
 describe('extractFromMime — octet-stream with .pdf filename', () => {
-  it('treats application/octet-stream with .pdf filename as PDF', () => {
+  it('treats application/octet-stream with .pdf filename as PDF', async () => {
     const pdf = fakePdf(256);
     const mime = makeMultipartMime({
       attachments: [
@@ -339,7 +372,7 @@ describe('extractFromMime — octet-stream with .pdf filename', () => {
         },
       ],
     });
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.documents[0]?.mimeType).toBe('application/pdf');
@@ -352,14 +385,14 @@ describe('extractFromMime — octet-stream with .pdf filename', () => {
 // ---------------------------------------------------------------------------
 
 describe('extractFromMime — multiple attachments', () => {
-  it('returns all document attachments up to the limit', () => {
+  it('returns all document attachments up to the limit', async () => {
     const attachments = Array.from({ length: MAX_ATTACHMENT_COUNT }, (_, i) => ({
       filename: `doc${i}.pdf`,
       mimeType: 'application/pdf',
       content: fakePdf(64),
     }));
     const mime = makeMultipartMime({ attachments });
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.documents).toHaveLength(MAX_ATTACHMENT_COUNT);
@@ -372,61 +405,49 @@ describe('extractFromMime — multiple attachments', () => {
 // ---------------------------------------------------------------------------
 
 describe('extractFromMime — senderEvidence', () => {
-  it('captures From header', () => {
+  it('captures From header', async () => {
     const mime = makeMultipartMime({
       from: 'Alice <alice@vendor.com>',
       attachments: [{ filename: 'a.pdf', mimeType: 'application/pdf', content: fakePdf() }],
     });
-    const result = extractFromMime(mime) as { success: true; senderEvidence: SenderEvidence };
+    const result = (await extractFromMime(mime)) as { success: true; senderEvidence: SenderEvidence };
     expect(result.senderEvidence.from).toBe('Alice <alice@vendor.com>');
   });
 
-  it('captures Reply-To header', () => {
+  it('captures Reply-To header', async () => {
     const mime = makeMultipartMime({
       replyTo: 'billing@vendor.com',
       attachments: [{ filename: 'a.pdf', mimeType: 'application/pdf', content: fakePdf() }],
     });
-    const result = extractFromMime(mime) as { success: true; senderEvidence: SenderEvidence };
+    const result = (await extractFromMime(mime)) as { success: true; senderEvidence: SenderEvidence };
     expect(result.senderEvidence.replyTo).toBe('billing@vendor.com');
   });
 
-  it('captures X-Original-From header', () => {
+  it('captures X-Original-From header', async () => {
     const mime = makeMultipartMime({
       originalFrom: 'original@sender.com',
       attachments: [{ filename: 'a.pdf', mimeType: 'application/pdf', content: fakePdf() }],
     });
-    const result = extractFromMime(mime) as { success: true; senderEvidence: SenderEvidence };
+    const result = (await extractFromMime(mime)) as { success: true; senderEvidence: SenderEvidence };
     expect(result.senderEvidence.originalFrom).toBe('original@sender.com');
   });
 
-  it('captures X-Original-Sender header (fallback when X-Original-From absent)', () => {
+  it('captures X-Original-Sender header (fallback when X-Original-From absent)', async () => {
     const mime = makeMultipartMime({
       originalSender: 'orig-sender@vendor.com',
       attachments: [{ filename: 'a.pdf', mimeType: 'application/pdf', content: fakePdf() }],
     });
-    const result = extractFromMime(mime) as { success: true; senderEvidence: SenderEvidence };
+    const result = (await extractFromMime(mime)) as { success: true; senderEvidence: SenderEvidence };
     expect(result.senderEvidence.originalFrom).toBe('orig-sender@vendor.com');
   });
 
-  it('returns undefined for absent optional headers', () => {
+  it('returns undefined for absent optional headers', async () => {
     const mime = makeMultipartMime({
       attachments: [{ filename: 'a.pdf', mimeType: 'application/pdf', content: fakePdf() }],
     });
-    const result = extractFromMime(mime) as { success: true; senderEvidence: SenderEvidence };
+    const result = (await extractFromMime(mime)) as { success: true; senderEvidence: SenderEvidence };
     expect(result.senderEvidence.replyTo).toBeUndefined();
     expect(result.senderEvidence.originalFrom).toBeUndefined();
-  });
-});
-
-import { beforeAll } from 'vitest';
-
-// ---------------------------------------------------------------------------
-// Limit constants (depth)
-// ---------------------------------------------------------------------------
-
-describe('exported limit constants — MAX_MIME_DEPTH', () => {
-  it('MAX_MIME_DEPTH is 10', () => {
-    expect(MAX_MIME_DEPTH).toBe(10);
   });
 });
 
@@ -454,14 +475,14 @@ describe('extractFromMime — deeply nested multipart', () => {
     ].join('\r\n');
   }
 
-  it('returns PARSE_ERROR for MIME nesting deeper than MAX_MIME_DEPTH', () => {
+  it('returns PARSE_ERROR for MIME nesting deeper than MAX_MIME_DEPTH', async () => {
     // Build a message nested deeper than the limit. The multipart Content-Type
     // must lead the top-level header block (no blank line before it), otherwise
     // it lands in the body and the top level parses as text/plain — never
     // recursing into the nested structure that the depth guard protects against.
     const nested = buildNestedMultipart(MAX_MIME_DEPTH + 2);
     const raw = Buffer.from(['From: attacker@evil.com', nested].join('\r\n'), 'utf8');
-    const result = extractFromMime(raw);
+    const result = await extractFromMime(raw);
     // Exceeding the nesting limit throws → PARSE_ERROR (never success).
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -471,21 +492,14 @@ describe('extractFromMime — deeply nested multipart', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Security: boundary string appearing inside base64 body is not a false delimiter
+// Security: boundary string appearing inside content is not a false delimiter
 // ---------------------------------------------------------------------------
 
 describe('extractFromMime — boundary collision in body', () => {
-  it('does not treat boundary string inside base64 content as a real boundary', () => {
-    // Craft a PDF whose base64 encoding contains the boundary string embedded
-    // in the middle of a line (not preceded by a newline). The parser should
-    // ignore it and successfully decode the attachment.
+  it('does not treat boundary string inside a text part as a real boundary', async () => {
     const boundary = 'COLLISION';
-    // Small PDF whose content doesn't accidentally contain --COLLISION at line start
     const pdf = fakePdf(64);
     const b64 = pdf.toString('base64');
-    // The base64 encoding of a small buffer won't naturally contain the boundary,
-    // but we verify that even with a crafted preamble text part that contains the
-    // boundary string, the attachment still decodes correctly.
     const mime = Buffer.from(
       [
         'From: sender@example.com',
@@ -507,7 +521,7 @@ describe('extractFromMime — boundary collision in body', () => {
       'utf8',
     );
 
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.documents).toHaveLength(1);
@@ -515,11 +529,7 @@ describe('extractFromMime — boundary collision in body', () => {
     }
   });
 
-  it('does not mistake a nested boundary that the outer boundary is a prefix of', () => {
-    // Outer boundary `BND` is a prefix of the inner boundary `BND-1`. A naive
-    // `indexOf("--BND")` matches inside `--BND-1`, so the outer parser would
-    // split parts at the inner boundary and drop the attachment. The delimiter
-    // must be followed by whitespace/CRLF or `--` to count as a real boundary.
+  it('parses a nested multipart whose outer boundary is a prefix of the inner one', async () => {
     const outer = 'BND';
     const inner = 'BND-1';
     const pdf = fakePdf(64);
@@ -556,7 +566,7 @@ describe('extractFromMime — boundary collision in body', () => {
       'utf8',
     );
 
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.documents).toHaveLength(1);
@@ -571,15 +581,15 @@ describe('extractFromMime — boundary collision in body', () => {
 // ---------------------------------------------------------------------------
 
 describe('extractFromMime — body capture & issuer candidates', () => {
-  it('captures the HTML body of a text/html message', () => {
-    const result = extractFromMime(makeHtmlMime('<p>hello body world</p>'));
+  it('captures the HTML body of a text/html message', async () => {
+    const result = await extractFromMime(makeHtmlMime('<p>hello body world</p>'));
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.body).toContain('hello body world');
     }
   });
 
-  it('prefers the HTML body over text/plain in multipart/alternative', () => {
+  it('prefers the HTML body over text/plain in multipart/alternative', async () => {
     const boundary = 'ALT001';
     const mime = Buffer.from(
       [
@@ -600,7 +610,7 @@ describe('extractFromMime — body capture & issuer candidates', () => {
       ].join('\r\n'),
       'utf8',
     );
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.body).toContain('html version');
@@ -608,34 +618,34 @@ describe('extractFromMime — body capture & issuer candidates', () => {
     }
   });
 
-  it('extracts (and URL-decodes) issuer mailto candidates from "From:" links in the body', () => {
+  it('extracts (and URL-decodes) issuer mailto candidates from "From:" links in the body', async () => {
     const html =
       '<div>From: Real Vendor &lt;<a href="mailto:real%40vendor.com">real@vendor.com</a>&gt;</div>';
-    const result = extractFromMime(makeHtmlMime(html));
+    const result = await extractFromMime(makeHtmlMime(html));
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.senderEvidence.issuerCandidates).toContain('real@vendor.com');
     }
   });
 
-  it('returns no issuer candidates when the body has no From: mailto link', () => {
-    const result = extractFromMime(makeHtmlMime('<p>no contact links here</p>'));
+  it('returns no issuer candidates when the body has no From: mailto link', async () => {
+    const result = await extractFromMime(makeHtmlMime('<p>no contact links here</p>'));
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.senderEvidence.issuerCandidates).toEqual([]);
     }
   });
 
-  it('matches issuer candidates across a newline-wrapped From: line', () => {
+  it('matches issuer candidates across a newline-wrapped From: line', async () => {
     const html = 'From: Real Vendor\r\n<a href="mailto:wrapped@vendor.com">link</a>';
-    const result = extractFromMime(makeHtmlMime(html));
+    const result = await extractFromMime(makeHtmlMime(html));
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.senderEvidence.issuerCandidates).toContain('wrapped@vendor.com');
     }
   });
 
-  it('decodes a non-UTF-8 (windows-1255) text body via its declared charset', () => {
+  it('decodes a non-UTF-8 (windows-1255) text body via its declared charset', async () => {
     const header = Buffer.from(
       [
         'From: sender@example.com',
@@ -650,7 +660,7 @@ describe('extractFromMime — body capture & issuer candidates', () => {
     );
     // 0xE0 0xE1 0xE2 = אבג in windows-1255
     const mime = Buffer.concat([header, Buffer.from([0xe0, 0xe1, 0xe2])]);
-    const result = extractFromMime(mime);
+    const result = await extractFromMime(mime);
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.body).toBe('אבג');

--- a/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
@@ -210,6 +210,15 @@ describe('extractFromMime — attachment-less messages', () => {
     }
   });
 
+  it('extracts the Subject header for the downstream charge description', () => {
+    const mime = makeTextMime('sender@example.com', 'Invoice #42', 'body');
+    const result = extractFromMime(mime);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.subject).toBe('Invoice #42');
+    }
+  });
+
   it('succeeds with empty documents for multipart with no document attachments', () => {
     // Has a text attachment, not a PDF/image
     const mime = makeMultipartMime({

--- a/packages/email-ingestion-gateway/src/__tests__/orchestrator.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/orchestrator.test.ts
@@ -147,6 +147,25 @@ describe('orchestrate — correlationId propagation', () => {
     expect(ingestArg.correlationId).toBe('trace-xyz');
   });
 
+  it('forwards subject, sender (From), and receivedAt to requestIngest for the charge description', async () => {
+    const deps = makeDeps(CONTROL_SUCCESS);
+    await orchestrate(
+      {
+        ...BASE_INPUT,
+        subject: 'Invoice #42',
+        receivedAt: '2026-06-24T08:30:00Z',
+        senderEvidence: { from: 'billing@vendor.com' },
+      },
+      deps,
+    );
+    const ingestArg = (
+      deps.serverClient.requestIngest as ReturnType<typeof vi.fn>
+    ).mock.calls[0][0];
+    expect(ingestArg.subject).toBe('Invoice #42');
+    expect(ingestArg.sender).toBe('billing@vendor.com');
+    expect(ingestArg.receivedAt).toBe('2026-06-24T08:30:00Z');
+  });
+
   it('uses the content-derived rawMessageHash as idempotencyKey (not the sender-controlled messageId)', async () => {
     const deps = makeDeps(CONTROL_SUCCESS);
     await orchestrate(BASE_INPUT, deps);

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -40,6 +40,8 @@ export type ExtractionFailureReason =
 export type ExtractionResult =
   | {
       success: true;
+      /** Subject header, used for the human-readable charge description. */
+      subject: string | undefined;
       senderEvidence: SenderEvidence;
       /** Decoded email body (HTML preferred, else plain text), for downstream treatment. */
       body: string;
@@ -76,6 +78,7 @@ export function extractFromMime(rawMime: Buffer): ExtractionResult {
 
     return {
       success: true,
+      subject: h(headers, 'subject'),
       senderEvidence: buildSenderEvidence(headers, body),
       body,
       documents,

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import PostalMime, { type Address } from 'postal-mime';
 import { IngestReasonCode } from './contracts.js';
 
 export const MAX_RAW_MIME_BYTES = 25 * 1024 * 1024; // 25 MB
@@ -40,7 +41,7 @@ export type ExtractionFailureReason =
 export type ExtractionResult =
   | {
       success: true;
-      /** Subject header, used for the human-readable charge description. */
+      /** Subject header (RFC 2047-decoded), used for the human-readable charge description. */
       subject: string | undefined;
       senderEvidence: SenderEvidence;
       /** Decoded email body (HTML preferred, else plain text), for downstream treatment. */
@@ -53,7 +54,16 @@ export type ExtractionResult =
 // Public entry point
 // ---------------------------------------------------------------------------
 
-export function extractFromMime(rawMime: Buffer): ExtractionResult {
+/**
+ * Parse a raw MIME message into the document set + sender evidence the ingest
+ * pipeline needs. Backed by `postal-mime`, which handles the fiddly parts of
+ * MIME correctly — RFC 2047 encoded-word headers (so non-ASCII subjects/senders,
+ * e.g. Hebrew, decode properly), nested multiparts, transfer-encodings, and
+ * per-part charsets. This module keeps only the domain-specific policy on top:
+ * which attachments count as "documents", the size/count guards, and the
+ * forwarded-sender (`From: <mailto:>`) issuer-candidate heuristic.
+ */
+export async function extractFromMime(rawMime: Buffer): Promise<ExtractionResult> {
   if (rawMime.length === 0) {
     return { success: false, reason: IngestReasonCode.PARSE_ERROR };
   }
@@ -62,168 +72,54 @@ export function extractFromMime(rawMime: Buffer): ExtractionResult {
     return { success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE };
   }
 
+  let email: Awaited<ReturnType<typeof PostalMime.parse>>;
   try {
-    const { headers, documents, textParts } = parseMimePart(rawMime);
-
-    if (documents.length > MAX_ATTACHMENT_COUNT) {
-      return { success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE };
-    }
-
-    const totalBytes = documents.reduce((sum, d) => sum + d.size, 0);
-    if (totalBytes > MAX_EXTRACTED_BYTES) {
-      return { success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE };
-    }
-
-    const body = pickBody(textParts);
-
-    return {
-      success: true,
-      subject: h(headers, 'subject'),
-      senderEvidence: buildSenderEvidence(headers, body),
-      body,
-      documents,
-    };
+    // maxNestingDepth caps pathological/maliciously nested messages; postal-mime
+    // throws when it is exceeded, which we map to PARSE_ERROR below.
+    email = await PostalMime.parse(rawMime, { maxNestingDepth: MAX_MIME_DEPTH });
   } catch {
     return { success: false, reason: IngestReasonCode.PARSE_ERROR };
   }
-}
 
-// ---------------------------------------------------------------------------
-// MIME header types
-// ---------------------------------------------------------------------------
-
-type Headers = Map<string, string>;
-
-interface TextPart {
-  mediaType: string;
-  content: string;
-}
-
-interface ParsedPart {
-  headers: Headers;
-  documents: ExtractedDocument[];
-  /** Inline text/html and text/plain parts, for body extraction. */
-  textParts: TextPart[];
-}
-
-// ---------------------------------------------------------------------------
-// Low-level buffer utilities
-// ---------------------------------------------------------------------------
-
-/** Find index of a byte pattern in a Buffer. Returns -1 if not found. */
-function bufferIndexOf(haystack: Buffer, needle: Buffer, start = 0): number {
-  return haystack.indexOf(needle, start);
-}
-
-/**
- * Split a raw MIME part buffer into header text and body buffer.
- * Handles both CRLF and bare-LF line endings.
- */
-function splitHeaderBody(raw: Buffer): { headerText: string; body: Buffer } {
-  const CRLFCRLF = Buffer.from('\r\n\r\n');
-  const LFLF = Buffer.from('\n\n');
-
-  const ci = bufferIndexOf(raw, CRLFCRLF);
-  const li = bufferIndexOf(raw, LFLF);
-
-  let splitAt: number;
-  let offset: number;
-
-  if (ci >= 0 && (li < 0 || ci <= li)) {
-    splitAt = ci;
-    offset = 4;
-  } else if (li >= 0) {
-    splitAt = li;
-    offset = 2;
-  } else {
-    // No body separator — treat whole buffer as headers with empty body
-    return { headerText: raw.toString('latin1'), body: Buffer.alloc(0) };
+  const documents: ExtractedDocument[] = [];
+  for (const attachment of email.attachments ?? []) {
+    if (!isDocumentAttachment(attachment.mimeType, attachment.filename)) {
+      continue;
+    }
+    const content = toBuffer(attachment.content);
+    documents.push({
+      filename: attachment.filename ?? undefined,
+      mimeType: resolvedMimeType(attachment.mimeType, attachment.filename),
+      content,
+      size: content.length,
+      sha256: createHash('sha256').update(content).digest('hex'),
+    });
   }
+
+  if (documents.length > MAX_ATTACHMENT_COUNT) {
+    return { success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE };
+  }
+
+  const totalBytes = documents.reduce((sum, d) => sum + d.size, 0);
+  if (totalBytes > MAX_EXTRACTED_BYTES) {
+    return { success: false, reason: IngestReasonCode.OVERSIZE_MESSAGE };
+  }
+
+  // Prefer the HTML body (richer, carries mailto links); fall back to plain text.
+  const body = email.html ?? email.text ?? '';
 
   return {
-    headerText: raw.slice(0, splitAt).toString('latin1'),
-    body: raw.slice(splitAt + offset),
+    success: true,
+    subject: email.subject,
+    senderEvidence: {
+      from: formatAddress(email.from),
+      replyTo: formatAddress(email.replyTo?.[0]),
+      originalFrom: headerValue(email.headers, 'x-original-from', 'x-original-sender'),
+      forwardedTo: headerValue(email.headers, 'x-forwarded-to', 'envelope-to'),
+      issuerCandidates: extractIssuerCandidates(body),
+    },
+    documents,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Header parsing
-// ---------------------------------------------------------------------------
-
-function parseHeaders(headerText: string): Headers {
-  // Unfold continuation lines (RFC 5322: lines starting with SP/HT are continuations)
-  const unfolded = headerText.replace(/\r?\n[ \t]+/g, ' ');
-  const headers: Headers = new Map();
-
-  for (const line of unfolded.split(/\r?\n/)) {
-    if (!line) continue;
-    const colon = line.indexOf(':');
-    if (colon < 1) continue;
-    const key = line.slice(0, colon).trim().toLowerCase();
-    const value = line.slice(colon + 1).trim();
-    if (!headers.has(key)) {
-      headers.set(key, value);
-    }
-  }
-
-  return headers;
-}
-
-function h(headers: Headers, name: string): string | undefined {
-  return headers.get(name.toLowerCase());
-}
-
-// ---------------------------------------------------------------------------
-// Content-Type parsing helpers
-// ---------------------------------------------------------------------------
-
-function getMediaType(contentType: string): string {
-  return (contentType.split(';')[0] ?? '').trim().toLowerCase();
-}
-
-function getParam(contentType: string, param: string): string | undefined {
-  // Require the param name to be preceded by ';', whitespace, or start-of-string
-  // to avoid matching suffixes (e.g. "x-boundary" when looking for "boundary").
-  const re = new RegExp(`(?:^|[\\s;])${param}=(?:"([^"]+)"|([^\\s;]+))`, 'i');
-  const m = contentType.match(re);
-  return m?.[1] ?? m?.[2];
-}
-
-function getFilename(headers: Headers): string | undefined {
-  const cd = h(headers, 'content-disposition');
-  if (cd) {
-    const fn = getParam(cd, 'filename');
-    if (fn) return fn;
-  }
-  const ct = h(headers, 'content-type');
-  if (ct) {
-    const fn = getParam(ct, 'name');
-    if (fn) return fn;
-  }
-  return undefined;
-}
-
-// ---------------------------------------------------------------------------
-// Transfer-encoding decode
-// ---------------------------------------------------------------------------
-
-function decodeBody(body: Buffer, encoding: string | undefined): Buffer {
-  const enc = (encoding ?? '7bit').trim().toLowerCase();
-  if (enc === 'base64') {
-    // Buffer.from(..., 'base64') already ignores all whitespace, including CRLF line endings.
-    return Buffer.from(body.toString('ascii'), 'base64');
-  }
-  if (enc === 'quoted-printable') {
-    return decodeQuotedPrintable(body.toString('latin1'));
-  }
-  return body; // 7bit, 8bit, binary
-}
-
-function decodeQuotedPrintable(text: string): Buffer {
-  const decoded = text
-    .replace(/=\r?\n/g, '') // soft line breaks
-    .replace(/=([0-9A-Fa-f]{2})/g, (_, hex: string) => String.fromCharCode(parseInt(hex, 16)));
-  return Buffer.from(decoded, 'latin1');
 }
 
 // ---------------------------------------------------------------------------
@@ -241,189 +137,54 @@ const DOCUMENT_MIME_TYPES = new Set([
   'image/webp',
 ]);
 
-function isDocumentPart(headers: Headers): boolean {
-  const ct = h(headers, 'content-type');
-  if (!ct) return false;
-  const mediaType = getMediaType(ct);
+function isDocumentAttachment(mimeType: string, filename: string | null): boolean {
+  const mediaType = mimeType.toLowerCase();
   if (DOCUMENT_MIME_TYPES.has(mediaType)) return true;
   // application/octet-stream with a .pdf filename
-  if (mediaType === 'application/octet-stream') {
-    const filename = getFilename(headers);
-    if (filename?.toLowerCase().endsWith('.pdf')) return true;
+  if (mediaType === 'application/octet-stream' && filename?.toLowerCase().endsWith('.pdf')) {
+    return true;
   }
   return false;
 }
 
-function resolvedMimeType(headers: Headers): string {
-  const ct = h(headers, 'content-type');
-  const mediaType = ct ? getMediaType(ct) : 'application/octet-stream';
-  if (mediaType === 'application/octet-stream') {
-    const filename = getFilename(headers);
-    if (filename?.toLowerCase().endsWith('.pdf')) return 'application/pdf';
+function resolvedMimeType(mimeType: string, filename: string | null): string {
+  const mediaType = mimeType.toLowerCase();
+  if (mediaType === 'application/octet-stream' && filename?.toLowerCase().endsWith('.pdf')) {
+    return 'application/pdf';
   }
   return mediaType;
 }
 
 // ---------------------------------------------------------------------------
-// Multipart boundary splitting
+// Header / address helpers
 // ---------------------------------------------------------------------------
 
-function splitMultipartParts(body: Buffer, boundary: string): Buffer[] {
-  const delim = Buffer.from(`--${boundary}`);
-  const closing = Buffer.from(`--${boundary}--`);
-  const parts: Buffer[] = [];
-
-  // RFC 2046 §5.1.1: each boundary must be preceded by a CRLF (or be at
-  // position 0). Without this check, boundary strings that appear inside
-  // base64 content could be incorrectly treated as delimiters.
-  //
-  // The delimiter must also be *followed* only by optional linear whitespace
-  // and a line break, or by `--` (a closing boundary). Without this check a
-  // boundary that is a prefix of a longer boundary (e.g. `foo` vs `foo-1` in
-  // nested multiparts) would match the longer boundary too, splitting parts at
-  // the wrong place and dropping attachments.
-  const findBoundary = (start: number): number => {
-    let s = start;
-    while (s < body.length) {
-      const idx = body.indexOf(delim, s);
-      if (idx < 0) return -1;
-      if (idx === 0 || body[idx - 1] === 0x0a) {
-        let p = idx + delim.length;
-        while (p < body.length && (body[p] === 0x20 || body[p] === 0x09)) {
-          p++;
-        }
-        if (
-          p >= body.length ||
-          body[p] === 0x0d ||
-          body[p] === 0x0a ||
-          (p + 1 < body.length && body[p] === 0x2d && body[p + 1] === 0x2d)
-        ) {
-          return idx;
-        }
-      }
-      s = idx + 1;
-    }
-    return -1;
-  };
-
-  // Find the first boundary
-  let pos = findBoundary(0);
-  if (pos < 0) return parts;
-
-  while (pos < body.length) {
-    const delimEnd = pos + delim.length;
-
-    // Peek at what follows the boundary marker
-    const peek = body.slice(delimEnd, delimEnd + 2);
-    const isClosing =
-      body.slice(pos, pos + closing.length).equals(closing) ||
-      (peek[0] === 0x2d && peek[1] === 0x2d); // '--'
-
-    if (isClosing) break;
-
-    // Skip past end of the boundary line (CRLF or LF)
-    let partStart = delimEnd;
-    if (body[partStart] === 0x0d) partStart++;
-    if (body[partStart] === 0x0a) partStart++;
-
-    // Find the next boundary occurrence
-    const nextDelim = findBoundary(partStart);
-
-    let partEnd: number;
-    if (nextDelim < 0) {
-      partEnd = body.length;
-    } else {
-      // Strip trailing CRLF before next boundary
-      partEnd = nextDelim;
-      if (partEnd > 0 && body[partEnd - 1] === 0x0a) partEnd--;
-      if (partEnd > 0 && body[partEnd - 1] === 0x0d) partEnd--;
-    }
-
-    if (partEnd > partStart) {
-      parts.push(body.slice(partStart, partEnd));
-    }
-
-    if (nextDelim < 0) break;
-    pos = nextDelim;
-  }
-
-  return parts;
+function toBuffer(content: ArrayBuffer | Uint8Array | string): Buffer {
+  if (typeof content === 'string') return Buffer.from(content);
+  if (content instanceof Uint8Array) return Buffer.from(content);
+  return Buffer.from(new Uint8Array(content));
 }
 
-// ---------------------------------------------------------------------------
-// Recursive MIME part parser
-// ---------------------------------------------------------------------------
-
-function parseMimePart(raw: Buffer, depth = 0): ParsedPart {
-  if (depth > MAX_MIME_DEPTH) {
-    throw new Error('Max MIME nesting depth exceeded');
-  }
-
-  const { headerText, body } = splitHeaderBody(raw);
-  const headers = parseHeaders(headerText);
-
-  const contentType = h(headers, 'content-type') ?? 'text/plain';
-  const mediaType = getMediaType(contentType);
-
-  const documents: ExtractedDocument[] = [];
-  const textParts: TextPart[] = [];
-
-  if (mediaType.startsWith('multipart/')) {
-    const boundary = getParam(contentType, 'boundary');
-    if (!boundary) throw new Error('multipart without boundary');
-
-    const subParts = splitMultipartParts(body, boundary);
-    for (const part of subParts) {
-      const sub = parseMimePart(part, depth + 1);
-      documents.push(...sub.documents);
-      textParts.push(...sub.textParts);
-    }
-  } else if (isDocumentPart(headers)) {
-    const encoding = h(headers, 'content-transfer-encoding');
-    const content = decodeBody(body, encoding);
-    const mimeType = resolvedMimeType(headers);
-    const sha256 = createHash('sha256').update(content).digest('hex');
-
-    documents.push({
-      filename: getFilename(headers),
-      mimeType,
-      content,
-      size: content.length,
-      sha256,
-    });
-  } else if (mediaType === 'text/html' || mediaType === 'text/plain') {
-    // Inline body part — skip text/* sent as a downloadable attachment.
-    const disposition = h(headers, 'content-disposition');
-    if (!disposition || !disposition.trim().toLowerCase().startsWith('attachment')) {
-      const encoding = h(headers, 'content-transfer-encoding');
-      const decoded = decodeBody(body, encoding);
-      // Decode using the part's declared charset (e.g. windows-1255 for Hebrew),
-      // falling back to UTF-8 for unknown/unsupported labels.
-      const charset = getParam(contentType, 'charset') ?? 'utf-8';
-      let content: string;
-      try {
-        content = new TextDecoder(charset).decode(decoded);
-      } catch {
-        content = decoded.toString('utf8');
-      }
-      textParts.push({ mediaType, content });
-    }
-  }
-
-  return { headers, documents, textParts };
+/** Render a parsed address as `Name <addr>` (or just the address / display name). */
+function formatAddress(addr: Address | undefined): string | undefined {
+  if (!addr) return undefined;
+  const name = addr.name?.trim();
+  const address = addr.address?.trim();
+  if (name && address) return `${name} <${address}>`;
+  return address || name || undefined;
 }
 
-// ---------------------------------------------------------------------------
-// Sender evidence extraction
-// ---------------------------------------------------------------------------
-
-/** Prefer the HTML body (richer, carries mailto links); fall back to plain text. */
-function pickBody(textParts: TextPart[]): string {
-  return (
-    textParts.find(p => p.mediaType === 'text/html')?.content ??
-    textParts.find(p => p.mediaType === 'text/plain')?.content ??
-    ''
-  );
+/** First non-empty value among the given (case-insensitive) header names. */
+function headerValue(
+  headers: Array<{ key: string; value: string }>,
+  ...names: string[]
+): string | undefined {
+  for (const name of names) {
+    const lower = name.toLowerCase();
+    const found = headers.find(header => header.key.toLowerCase() === lower);
+    if (found?.value) return found.value;
+  }
+  return undefined;
 }
 
 // Forwarded emails often carry the real sender as a `From: … <a href="mailto:…">`
@@ -446,14 +207,4 @@ function extractIssuerCandidates(body: string): string[] {
     candidates.push(email);
   }
   return candidates;
-}
-
-function buildSenderEvidence(headers: Headers, body: string): SenderEvidence {
-  return {
-    from: h(headers, 'from'),
-    replyTo: h(headers, 'reply-to'),
-    originalFrom: h(headers, 'x-original-from') ?? h(headers, 'x-original-sender'),
-    forwardedTo: h(headers, 'x-forwarded-to') ?? h(headers, 'envelope-to'),
-    issuerCandidates: extractIssuerCandidates(body),
-  };
 }

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -111,6 +111,7 @@ export async function extractFromMime(rawMime: Buffer): Promise<ExtractionResult
   return {
     success: true,
     subject: email.subject,
+    body,
     senderEvidence: {
       from: formatAddress(email.from),
       replyTo: formatAddress(email.replyTo?.[0]),

--- a/packages/email-ingestion-gateway/src/orchestrator.ts
+++ b/packages/email-ingestion-gateway/src/orchestrator.ts
@@ -19,6 +19,8 @@ export interface OrchestrateInput {
   rawMessageHash: string;
   correlationId: string;
   receivedAt?: string;
+  /** Subject header, forwarded to ingest for the human-readable charge description. */
+  subject?: string;
   /** Decoded email body, consumed by treatment (body→PDF, internal-link fetch). */
   body: string;
   /** Raw attachment documents (with bytes) from MIME extraction. */
@@ -136,6 +138,11 @@ export async function orchestrate(
     messageId: input.messageId,
     rawMessageHash: input.rawMessageHash,
     correlationId,
+    // Descriptive metadata for the server-side charge description. `sender` is the
+    // From header captured as sender evidence during extraction.
+    subject: input.subject,
+    sender: input.senderEvidence?.from,
+    receivedAt: input.receivedAt,
     extractedDocuments,
   };
 

--- a/packages/email-ingestion-gateway/src/server-client.ts
+++ b/packages/email-ingestion-gateway/src/server-client.ts
@@ -93,6 +93,12 @@ export interface IngestInput {
   messageId: string;
   rawMessageHash: string;
   correlationId?: string;
+  /** Email subject header, forwarded for the server-side charge description. */
+  subject?: string;
+  /** Sender (From header) address, forwarded for the server-side charge description. */
+  sender?: string;
+  /** ISO-8601 received-at timestamp, forwarded for the server-side charge description. */
+  receivedAt?: string;
   extractedDocuments: IngestDocumentInput[];
 }
 

--- a/packages/email-ingestion-gateway/src/webhook.ts
+++ b/packages/email-ingestion-gateway/src/webhook.ts
@@ -150,6 +150,7 @@ export function createWebhookHandler(deps: WebhookDeps) {
     let attachments: ExtractedDocument[] = [];
     let body = '';
     let senderEvidence: ControlSenderEvidence | undefined;
+    let subject: string | undefined;
     if (extraction.success) {
       attachments = extraction.documents;
       body = extraction.body;
@@ -157,6 +158,8 @@ export function createWebhookHandler(deps: WebhookDeps) {
       // Present even when there are no attachments (the body may still yield a
       // document during treatment).
       senderEvidence = extraction.senderEvidence;
+      // Subject feeds the human-readable charge description on the server.
+      subject = extraction.subject;
     } else {
       // Extraction failed (parse error or oversize). Proceed to orchestration so
       // the server records an auditable quarantine outcome; the empty document set
@@ -195,6 +198,7 @@ export function createWebhookHandler(deps: WebhookDeps) {
       rawMessageHash,
       correlationId: effectiveCorrelationId,
       receivedAt,
+      subject,
       senderEvidence,
       body,
       attachments,

--- a/packages/email-ingestion-gateway/src/webhook.ts
+++ b/packages/email-ingestion-gateway/src/webhook.ts
@@ -142,7 +142,7 @@ export function createWebhookHandler(deps: WebhookDeps) {
     // from the raw MIME body. The gateway — not the upstream worker — owns the
     // hash so the server can trust a value derived from the signed payload.
     const rawMessageHash = createHash('sha256').update(rawBody).digest('hex');
-    const extraction = extractFromMime(rawBody);
+    const extraction = await extractFromMime(rawBody);
 
     // Raw attachments (with bytes) + body are handed to orchestration, which runs
     // treatment (attachment filter, body→PDF, internal-link fetch) after the

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
@@ -426,6 +426,49 @@ describe('EmailIngestionIngestProvider.performIngest — document persistence', 
     expect(docInsert?.values).toContain(BUSINESS_ID);
   });
 
+  it('sets a descriptive charge description from subject, sender, and received date', async () => {
+    const { provider, dataCalls } = makeProvider(VALID_GRANT_WITH_BUSINESS, [
+      { rows: [], rowCount: 0 }, // document-by-hash miss (prepare tx, pre-upload)
+      { rows: [], rowCount: 0 }, // idempotency miss
+      { rows: [], rowCount: 0 }, // dedup fingerprint miss
+      { rows: [{ id: 'charge-1' }], rowCount: 1 }, // charge insert
+      { rows: [{ id: 'doc-1' }], rowCount: 1 }, // document insert
+      { rows: [idemRow], rowCount: 1 }, // idempotency insert
+      { rows: [dedupRow], rowCount: 1 }, // dedup insert
+    ]);
+
+    await provider.performIngest({
+      ...inputWithContent,
+      subject: 'Invoice #42',
+      sender: 'billing@vendor.com',
+      receivedAt: '2026-06-24T08:30:00.000Z',
+    });
+
+    const chargeInsert = dataCalls.find(c => c.text.includes('INTO accounter_schema.charges'));
+    expect(chargeInsert?.values).toContain(
+      `Email documents: Invoice #42 (from: billing@vendor.com, ${new Date(
+        '2026-06-24T08:30:00.000Z',
+      ).toDateString()})`,
+    );
+  });
+
+  it('falls back to the message id when no subject/sender/date is present', async () => {
+    const { provider, dataCalls } = makeProvider(VALID_GRANT_WITH_BUSINESS, [
+      { rows: [], rowCount: 0 }, // document-by-hash miss (prepare tx, pre-upload)
+      { rows: [], rowCount: 0 }, // idempotency miss
+      { rows: [], rowCount: 0 }, // dedup fingerprint miss
+      { rows: [{ id: 'charge-1' }], rowCount: 1 }, // charge insert
+      { rows: [{ id: 'doc-1' }], rowCount: 1 }, // document insert
+      { rows: [idemRow], rowCount: 1 }, // idempotency insert
+      { rows: [dedupRow], rowCount: 1 }, // dedup insert
+    ]);
+
+    await provider.performIngest(inputWithContent);
+
+    const chargeInsert = dataCalls.find(c => c.text.includes('INTO accounter_schema.charges'));
+    expect(chargeInsert?.values).toContain(`Email documents: ${MSG_ID}`);
+  });
+
   it('skips upload and charge creation when the document hash already exists', async () => {
     const { provider, uploadInvoiceToCloudinary, dataCalls } = makeProvider(
       VALID_GRANT_WITH_BUSINESS,

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
@@ -437,18 +437,20 @@ describe('EmailIngestionIngestProvider.performIngest — document persistence', 
       { rows: [dedupRow], rowCount: 1 }, // dedup insert
     ]);
 
-    await provider.performIngest({
-      ...inputWithContent,
-      subject: 'Invoice #42',
-      sender: 'billing@vendor.com',
-      receivedAt: '2026-06-24T08:30:00.000Z',
-    });
+    await provider.performIngest(
+      {
+        ...inputWithContent,
+        subject: 'Invoice #42',
+        sender: 'billing@vendor.com',
+        receivedAt: '2026-06-24T08:30:00.000Z',
+      },
+      ocrInjector,
+    );
 
     const chargeInsert = dataCalls.find(c => c.text.includes('INTO accounter_schema.charges'));
+    // Hardcoded date (UTC) so a timezone-dependent regression is caught.
     expect(chargeInsert?.values).toContain(
-      `Email documents: Invoice #42 (from: billing@vendor.com, ${new Date(
-        '2026-06-24T08:30:00.000Z',
-      ).toDateString()})`,
+      'Email documents: Invoice #42 (from: billing@vendor.com, Wed Jun 24 2026)',
     );
   });
 
@@ -463,7 +465,7 @@ describe('EmailIngestionIngestProvider.performIngest — document persistence', 
       { rows: [dedupRow], rowCount: 1 }, // dedup insert
     ]);
 
-    await provider.performIngest(inputWithContent);
+    await provider.performIngest(inputWithContent, ocrInjector);
 
     const chargeInsert = dataCalls.find(c => c.text.includes('INTO accounter_schema.charges'));
     expect(chargeInsert?.values).toContain(`Email documents: ${MSG_ID}`);

--- a/packages/server/src/modules/email-ingestion/providers/email-ingestion-ingest.provider.ts
+++ b/packages/server/src/modules/email-ingestion/providers/email-ingestion-ingest.provider.ts
@@ -145,9 +145,22 @@ function buildEmailChargeDescription(args: {
   const subject = args.subject?.trim() || args.messageId;
   const sender = args.sender?.trim();
 
+  // Format in UTC (not the server-local `toDateString()`) so the same email
+  // yields the same description across dev/CI/prod. Mirrors the legacy
+  // `toDateString()` shape, e.g. "Wed Jun 24 2026".
   const receivedDate = args.receivedAt ? new Date(args.receivedAt) : null;
   const dateStr =
-    receivedDate && !Number.isNaN(receivedDate.getTime()) ? receivedDate.toDateString() : null;
+    receivedDate && !Number.isNaN(receivedDate.getTime())
+      ? receivedDate
+          .toLocaleDateString('en-US', {
+            weekday: 'short',
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+            timeZone: 'UTC',
+          })
+          .replace(/,/g, '')
+      : null;
 
   const details = [sender ? `from: ${sender}` : null, dateStr].filter(Boolean).join(', ');
 

--- a/packages/server/src/modules/email-ingestion/providers/email-ingestion-ingest.provider.ts
+++ b/packages/server/src/modules/email-ingestion/providers/email-ingestion-ingest.provider.ts
@@ -110,6 +110,12 @@ export type IngestInput = {
   messageId: string;
   rawMessageHash: string;
   correlationId?: string;
+  /** Email subject header, used to build a human-readable charge description. */
+  subject?: string;
+  /** Sender (From header) address, used in the charge description. */
+  sender?: string;
+  /** ISO-8601 timestamp the message was received, used in the charge description. */
+  receivedAt?: string;
   extractedDocuments: Array<{
     hash: string;
     sizeBytes: number;
@@ -119,6 +125,34 @@ export type IngestInput = {
     content?: string | null;
   }>;
 };
+
+/**
+ * Build the human-readable charge description for an ingested email, mirroring
+ * the legacy gmail-listener phrasing:
+ * `Email documents: <subject> (from: <sender>, <date>)`.
+ *
+ * The v2 gateway pipeline can omit any of subject/sender/receivedAt (parse
+ * failures, missing headers), so each part degrades gracefully: a missing
+ * subject falls back to the message id, and the parenthetical sender/date
+ * details are dropped when neither is available.
+ */
+function buildEmailChargeDescription(args: {
+  messageId: string;
+  subject?: string;
+  sender?: string;
+  receivedAt?: string;
+}): string {
+  const subject = args.subject?.trim() || args.messageId;
+  const sender = args.sender?.trim();
+
+  const receivedDate = args.receivedAt ? new Date(args.receivedAt) : null;
+  const dateStr =
+    receivedDate && !Number.isNaN(receivedDate.getTime()) ? receivedDate.toDateString() : null;
+
+  const details = [sender ? `from: ${sender}` : null, dateStr].filter(Boolean).join(', ');
+
+  return details ? `Email documents: ${subject} (${details})` : `Email documents: ${subject}`;
+}
 
 export type IngestResult =
   | { outcome: typeof IngestOutcome.INSERTED; ingestId: string; auditId: string }
@@ -168,6 +202,9 @@ export class EmailIngestionIngestProvider {
       messageId,
       rawMessageHash,
       correlationId,
+      subject,
+      sender,
+      receivedAt,
       extractedDocuments,
     } = input;
 
@@ -265,7 +302,14 @@ export class EmailIngestionIngestProvider {
       // to persist (metadata-only, or all duplicates) a synthetic id is used.
       const chargeId =
         preparedDocuments.length > 0
-          ? await this.insertPreparedDocuments(client, { tenantId, messageId, preparedDocuments })
+          ? await this.insertPreparedDocuments(client, {
+              tenantId,
+              messageId,
+              subject,
+              sender,
+              receivedAt,
+              preparedDocuments,
+            })
           : null;
 
       const ingestId = chargeId ?? randomUUID();
@@ -386,14 +430,21 @@ export class EmailIngestionIngestProvider {
    */
   private async insertPreparedDocuments(
     client: PoolClient,
-    args: { tenantId: string; messageId: string; preparedDocuments: PreparedDocument[] },
+    args: {
+      tenantId: string;
+      messageId: string;
+      subject?: string;
+      sender?: string;
+      receivedAt?: string;
+      preparedDocuments: PreparedDocument[];
+    },
   ): Promise<string> {
-    const { tenantId, messageId, preparedDocuments } = args;
+    const { tenantId, messageId, subject, sender, receivedAt, preparedDocuments } = args;
 
     const [charge] = await insertIngestCharge.run(
       {
         ownerId: tenantId,
-        userDescription: `email-ingestion: ${messageId}`,
+        userDescription: buildEmailChargeDescription({ messageId, subject, sender, receivedAt }),
         accountantStatus: 'UNAPPROVED',
       },
       client,

--- a/packages/server/src/modules/email-ingestion/resolvers/email-ingestion-ingest.resolver.ts
+++ b/packages/server/src/modules/email-ingestion/resolvers/email-ingestion-ingest.resolver.ts
@@ -25,6 +25,9 @@ const ingestEmail: EmailIngestionModule.MutationResolvers['ingestEmail'] = async
         messageId: input.messageId,
         rawMessageHash: input.rawMessageHash,
         correlationId: input.correlationId ?? undefined,
+        subject: input.subject ?? undefined,
+        sender: input.sender ?? undefined,
+        receivedAt: input.receivedAt ?? undefined,
         extractedDocuments: input.extractedDocuments.map(doc => ({
           hash: doc.hash,
           sizeBytes: doc.sizeBytes,

--- a/packages/server/src/modules/email-ingestion/typeDefs/email-ingestion.graphql.ts
+++ b/packages/server/src/modules/email-ingestion/typeDefs/email-ingestion.graphql.ts
@@ -128,6 +128,12 @@ export default gql`
     rawMessageHash: String!
     " Optional correlation ID for distributed tracing "
     correlationId: String
+    " Subject header of the email, used to build a human-readable charge description "
+    subject: String
+    " Sender (From header) address, used in the charge description "
+    sender: String
+    " ISO-8601 timestamp the message was received, used in the charge description "
+    receivedAt: String
     " Extracted document metadata from MIME parsing "
     extractedDocuments: [ExtractedDocumentInput!]!
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,6 +147,7 @@ __metadata:
     graphql-request: "npm:7.4.0"
     inline-css: "npm:4.0.3"
     playwright: "npm:1.61.0"
+    postal-mime: "npm:2.7.4"
     tsx: "npm:4.22.4"
     typescript: "npm:6.0.3"
     wrangler: "npm:4.103.0"
@@ -22179,6 +22180,13 @@ __metadata:
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
   checksum: 10c0/c810983414142071da1d644662ce4caebce890203eb2bc7bf119f37f3fe5796226e117e6cca146b521921fa6531072674174a3325066ac66fce089a53e1e5196
+  languageName: node
+  linkType: hard
+
+"postal-mime@npm:2.7.4":
+  version: 2.7.4
+  resolution: "postal-mime@npm:2.7.4"
+  checksum: 10c0/836220ef876b8e3ae7236341a4fbff5b8bf6618952a1208966a4e3040c9f51c14572fa695b1863bd445e8d7894536d2eb4e5001f50795c3f7fbfe39c8946ba09
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Enhance email ingestion to generate descriptive charge descriptions that include email metadata (subject, sender, received date) instead of just the message ID. This mirrors the legacy gmail-listener behavior and improves auditability.

## Key Changes

- **Server-side charge description builder**: Added `buildEmailChargeDescription()` function that formats charge descriptions as `Email documents: <subject> (from: <sender>, <date>)`, with graceful fallbacks when metadata is missing (subject defaults to message ID, sender/date details omitted if unavailable).

- **Extended IngestInput type**: Added optional `subject`, `sender`, and `receivedAt` fields to the email ingestion input across all layers (server provider, GraphQL schema, gateway server-client interface).

- **Gateway MIME extraction**: Updated `extractFromMime()` to extract and return the Subject header alongside existing sender evidence and body.

- **Gateway orchestration**: Modified webhook handler and orchestrator to forward extracted subject and sender evidence (From header) to the server's ingest request.

- **Resolver integration**: Updated the GraphQL resolver to pass through the new metadata fields to the provider.

- **Comprehensive test coverage**: Added tests verifying:
  - Full charge description with all metadata present
  - Graceful fallback to message ID when metadata is missing
  - Proper forwarding of subject/sender/receivedAt through the gateway pipeline

## Implementation Details

- The charge description gracefully degrades: missing subject falls back to message ID; sender/date details are omitted entirely if neither is available.
- All new fields are optional to maintain backward compatibility with existing callers.
- The implementation preserves the exact phrasing from the legacy gmail-listener for consistency.

https://claude.ai/code/session_016H3Ka7UohaPn2UsScviazo