### PR TITLE
Email ingestion: run OCR at ingest time, persist full document metadata

### DIFF
--- a/.changeset/fancy-moons-joke.md
+++ b/.changeset/fancy-moons-joke.md
@@ -1,0 +1,11 @@
+---
+'@accounter/server': patch
+---
+
+- **OCR at ingest time**: `prepareDocuments` now calls `getOcrData` to classify documents via
+  Anthropic, matching the legacy upload path.
+- **Remarks override**: Email ingestion documents now override the OCR-derived remarks with an email
+  identifier (`email-ingestion: {messageId}`), consistent with the legacy resolver.
+- **Test coverage**: Updated tests to mock `AnthropicProvider.extractInvoiceDetails` and verify that
+  documents are classified (INVOICE) rather than UNPROCESSED, and that the recognized business is
+  attributed as the creditor.

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Injector } from 'graphql-modules';
+import { DocumentType } from '../../../shared/enums.js';
+import { AnthropicProvider } from '../../app-providers/anthropic.js';
 import { EmailIngestionIngestProvider } from '../providers/email-ingestion-ingest.provider.js';
 import { EmailIngestionControlProvider } from '../providers/email-ingestion-control.provider.js';
 import { IngestOutcome, IngestReasonCode } from '../contracts.js';
@@ -46,6 +49,14 @@ const BASE_INPUT = {
   correlationId: CORR_ID,
   extractedDocuments: [{ hash: 'doc-hash', sizeBytes: 1024, mimeType: 'application/pdf', filename: 'invoice.pdf' }],
 };
+
+// OCR runs via getOcrData(injector, file, false) → AnthropicProvider.extractInvoiceDetails.
+// A mock operation injector returns a stub Anthropic provider that yields an INVOICE,
+// so figureOutSides attributes the recognized business as the document creditor.
+const extractInvoiceDetails = vi.fn().mockResolvedValue({ type: DocumentType.Invoice });
+const ocrInjector = {
+  get: (token: unknown) => (token === AnthropicProvider ? { extractInvoiceDetails } : undefined),
+} as unknown as Injector;
 
 // ---------------------------------------------------------------------------
 // Mock helper
@@ -128,7 +139,7 @@ describe('EmailIngestionIngestProvider.performIngest — grant validation', () =
       [],
     );
 
-    const result = await provider.performIngest(BASE_INPUT);
+    const result = await provider.performIngest(BASE_INPUT, ocrInjector);
     expect(result).toEqual({ outcome: IngestOutcome.REJECTED, reasonCode: IngestReasonCode.GRANT_INVALID });
   });
 
@@ -138,7 +149,7 @@ describe('EmailIngestionIngestProvider.performIngest — grant validation', () =
       [],
     );
 
-    const result = await provider.performIngest(BASE_INPUT);
+    const result = await provider.performIngest(BASE_INPUT, ocrInjector);
     expect(result).toEqual({ outcome: IngestOutcome.REJECTED, reasonCode: IngestReasonCode.TENANT_MISMATCH });
   });
 
@@ -148,7 +159,7 @@ describe('EmailIngestionIngestProvider.performIngest — grant validation', () =
       [],
     );
 
-    await provider.performIngest(BASE_INPUT);
+    await provider.performIngest(BASE_INPUT, ocrInjector);
     expect(queryFn).not.toHaveBeenCalled();
   });
 
@@ -164,7 +175,7 @@ describe('EmailIngestionIngestProvider.performIngest — grant validation', () =
       ],
     );
 
-    await provider.performIngest(BASE_INPUT);
+    await provider.performIngest(BASE_INPUT, ocrInjector);
 
     expect(validateAndConsumeGrant).toHaveBeenCalledWith({
       jti: JTI,
@@ -195,7 +206,7 @@ describe('EmailIngestionIngestProvider.performIngest — idempotency', () => {
     };
     const { provider } = makeProvider(VALID_GRANT, [{ rows: [storedRow], rowCount: 1 }]);
 
-    const result = await provider.performIngest(BASE_INPUT);
+    const result = await provider.performIngest(BASE_INPUT, ocrInjector);
 
     expect(result).toMatchObject({
       outcome: IngestOutcome.DUPLICATE,
@@ -211,7 +222,7 @@ describe('EmailIngestionIngestProvider.performIngest — idempotency', () => {
     };
     const { provider, dataQueries } = makeProvider(VALID_GRANT, [{ rows: [storedRow], rowCount: 1 }]);
 
-    await provider.performIngest(BASE_INPUT);
+    await provider.performIngest(BASE_INPUT, ocrInjector);
     // Only one data query — the idempotency lookup; no dedup lookup
     expect(dataQueries).toHaveLength(1);
   });
@@ -236,7 +247,7 @@ describe('EmailIngestionIngestProvider.performIngest — dedup', () => {
       { rows: [dedupRow], rowCount: 1 }, // dedup hit
     ]);
 
-    const result = await provider.performIngest(BASE_INPUT);
+    const result = await provider.performIngest(BASE_INPUT, ocrInjector);
 
     expect(result).toMatchObject({
       outcome: IngestOutcome.DUPLICATE,
@@ -271,7 +282,10 @@ describe('EmailIngestionIngestProvider.performIngest — quarantine', () => {
       { rows: [dedupRow], rowCount: 1 },  // dedup insert
     ]);
 
-    const result = await provider.performIngest({ ...BASE_INPUT, extractedDocuments: [] });
+    const result = await provider.performIngest(
+      { ...BASE_INPUT, extractedDocuments: [] },
+      ocrInjector,
+    );
 
     expect(result).toMatchObject({
       outcome: IngestOutcome.QUARANTINED,
@@ -304,7 +318,7 @@ describe('EmailIngestionIngestProvider.performIngest — inserted', () => {
       { rows: [dedupRow], rowCount: 1 },// dedup insert
     ]);
 
-    const result = await provider.performIngest(BASE_INPUT);
+    const result = await provider.performIngest(BASE_INPUT, ocrInjector);
 
     expect(result).toMatchObject({
       outcome: IngestOutcome.INSERTED,
@@ -329,7 +343,7 @@ describe('EmailIngestionIngestProvider.performIngest — inserted', () => {
       { rows: [dedupRow], rowCount: 1 },
     ]);
 
-    await provider.performIngest(BASE_INPUT);
+    await provider.performIngest(BASE_INPUT, ocrInjector);
 
     expect(dataQueries).toHaveLength(4);
   });
@@ -393,18 +407,22 @@ describe('EmailIngestionIngestProvider.performIngest — document persistence', 
       ],
     );
 
-    const result = await provider.performIngest(inputWithContent);
+    const result = await provider.performIngest(inputWithContent, ocrInjector);
 
     expect(result).toMatchObject({ outcome: IngestOutcome.INSERTED, ingestId: 'charge-1' });
     expect(uploadInvoiceToCloudinary).toHaveBeenCalledTimes(1);
     expect(uploadInvoiceToCloudinary).toHaveBeenCalledWith(
       expect.stringContaining('data:application/pdf;base64,'),
     );
+    // OCR runs at ingest (matching the legacy path) rather than landing UNPROCESSED.
+    expect(extractInvoiceDetails).toHaveBeenCalled();
 
     expect(dataCalls.some(c => c.text.includes('INTO accounter_schema.charges'))).toBe(true);
     const docInsert = dataCalls.find(c => c.text.includes('INTO accounter_schema.documents'));
     expect(docInsert).toBeDefined();
-    // the recognized issuing business is attributed as the document counterparty
+    // the document is classified from OCR (INVOICE), not UNPROCESSED
+    expect(docInsert?.values).toContain(DocumentType.Invoice);
+    // and the recognized issuing business is attributed as the document creditor
     expect(docInsert?.values).toContain(BUSINESS_ID);
   });
 
@@ -420,7 +438,7 @@ describe('EmailIngestionIngestProvider.performIngest — document persistence', 
       ],
     );
 
-    const result = await provider.performIngest(inputWithContent);
+    const result = await provider.performIngest(inputWithContent, ocrInjector);
 
     expect(result).toMatchObject({ outcome: IngestOutcome.INSERTED });
     expect(uploadInvoiceToCloudinary).not.toHaveBeenCalled();
@@ -437,7 +455,7 @@ describe('EmailIngestionIngestProvider.performIngest — document persistence', 
     ]);
 
     // BASE_INPUT documents carry no `content` — persistence is a no-op.
-    await provider.performIngest(BASE_INPUT);
+    await provider.performIngest(BASE_INPUT, ocrInjector);
 
     expect(uploadInvoiceToCloudinary).not.toHaveBeenCalled();
     expect(dataQueries).toHaveLength(4);

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.resolver.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.resolver.test.ts
@@ -211,6 +211,8 @@ describe('Mutation.ingestEmail', () => {
         rawMessageHash: 'sha256-abc',
         correlationId: 'corr-001',
       }),
+      // the resolver forwards its operation injector so the provider can run OCR
+      injector,
     );
   });
 });

--- a/packages/server/src/modules/email-ingestion/providers/email-ingestion-ingest.provider.ts
+++ b/packages/server/src/modules/email-ingestion/providers/email-ingestion-ingest.provider.ts
@@ -22,40 +22,13 @@ import type {
   IInsertDedupFingerprintForIngestQuery,
   IInsertIdempotencyKeyForIngestQuery,
   IInsertIngestChargeQuery,
+  IInsertIngestDocumentFullQuery,
   IInsertQuarantineForIngestQuery,
 } from '../types.js';
 import { EmailIngestionControlProvider } from './email-ingestion-control.provider.js';
 
 /** A single OCR'd document, ready to insert (cf. DocumentsProvider.insertDocuments columns). */
 type PreparedDocument = IInsertDocumentsParams['documents'][number];
-
-// Inline type for the full document insert (mirrors DocumentsProvider.insertDocuments)
-// so persistence does not depend on a regenerated pgtyped type. The auth-coupled
-// DocumentsProvider cannot run in the gateway control-plane context.
-interface IInsertIngestDocumentFullQuery {
-  params: {
-    ownerId: string;
-    chargeId: string;
-    documentType: string;
-    fileUrl: string | null;
-    imageUrl: string | null;
-    fileHash: string | null;
-    serialNumber: string | null;
-    date: Date | null;
-    amount: number | null;
-    currencyCode: string | null;
-    vat: number | null;
-    vatReportDateOverride: Date | null;
-    noVatAmount: number | null;
-    allocationNumber: string | null;
-    exchangeRateOverride: number | null;
-    description: string | null;
-    remarks: string | null;
-    creditorId: string | null;
-    debtorId: string | null;
-  };
-  result: { id: string };
-}
 
 // ---------------------------------------------------------------------------
 // SQL queries
@@ -398,7 +371,9 @@ export class EmailIngestionIngestProvider {
         // OCR-derived remarks with an email identifier. (There it is the email
         // description; the v2 ingest payload carries only the message id.) All
         // other OCR fields — amount, currency, date, serial — are persisted as-is.
-        params.remarks = `email-ingestion: ${messageId}`;
+        params.remarks = [params.remarks, `email-ingestion: ${messageId}`]
+          .filter(Boolean)
+          .join('; ');
         return params;
       }),
     );

--- a/packages/server/src/modules/email-ingestion/providers/email-ingestion-ingest.provider.ts
+++ b/packages/server/src/modules/email-ingestion/providers/email-ingestion-ingest.provider.ts
@@ -1,11 +1,17 @@
 import { randomUUID } from 'node:crypto';
-import { Injectable, Scope } from 'graphql-modules';
+import { Injectable, Scope, type Injector } from 'graphql-modules';
 import type { PoolClient } from 'pg';
 import { sql } from '@pgtyped/runtime';
 import { DocumentType } from '../../../shared/enums.js';
 import { hashStringToInt } from '../../../shared/helpers/index.js';
 import { CloudinaryProvider } from '../../app-providers/cloudinary.js';
 import { DBProvider } from '../../app-providers/db.provider.js';
+import {
+  getDocumentFromUrlsAndOcrData,
+  getOcrData,
+  type OcrData,
+} from '../../documents/helpers/upload.helper.js';
+import type { IInsertDocumentsParams } from '../../documents/types.js';
 import { IngestOutcome, IngestReasonCode } from '../contracts.js';
 import { computeDedupFingerprint } from '../helpers/email-ingestion-dedup.helper.js';
 import { withTenantContext } from '../helpers/email-ingestion-tenant-context.helper.js';
@@ -16,10 +22,40 @@ import type {
   IInsertDedupFingerprintForIngestQuery,
   IInsertIdempotencyKeyForIngestQuery,
   IInsertIngestChargeQuery,
-  IInsertIngestDocumentQuery,
   IInsertQuarantineForIngestQuery,
 } from '../types.js';
 import { EmailIngestionControlProvider } from './email-ingestion-control.provider.js';
+
+/** A single OCR'd document, ready to insert (cf. DocumentsProvider.insertDocuments columns). */
+type PreparedDocument = IInsertDocumentsParams['documents'][number];
+
+// Inline type for the full document insert (mirrors DocumentsProvider.insertDocuments)
+// so persistence does not depend on a regenerated pgtyped type. The auth-coupled
+// DocumentsProvider cannot run in the gateway control-plane context.
+interface IInsertIngestDocumentFullQuery {
+  params: {
+    ownerId: string;
+    chargeId: string;
+    documentType: string;
+    fileUrl: string | null;
+    imageUrl: string | null;
+    fileHash: string | null;
+    serialNumber: string | null;
+    date: Date | null;
+    amount: number | null;
+    currencyCode: string | null;
+    vat: number | null;
+    vatReportDateOverride: Date | null;
+    noVatAmount: number | null;
+    allocationNumber: string | null;
+    exchangeRateOverride: number | null;
+    description: string | null;
+    remarks: string | null;
+    creditorId: string | null;
+    debtorId: string | null;
+  };
+  result: { id: string };
+}
 
 // ---------------------------------------------------------------------------
 // SQL queries
@@ -79,10 +115,14 @@ const insertIngestCharge = sql<IInsertIngestChargeQuery>`
   RETURNING id
 `;
 
-const insertIngestDocument = sql<IInsertIngestDocumentQuery>`
+const insertIngestDocumentFull = sql<IInsertIngestDocumentFullQuery>`
   INSERT INTO accounter_schema.documents
-    (owner_id, charge_id, type, file_url, image_url, file_hash, creditor_id)
-  VALUES ($ownerId, $chargeId, $documentType, $fileUrl, $imageUrl, $fileHash, $creditorId)
+    (owner_id, charge_id, type, file_url, image_url, file_hash, serial_number, date,
+     total_amount, currency_code, vat_amount, vat_report_date_override, no_vat_amount,
+     allocation_number, exchange_rate_override, description, remarks, creditor_id, debtor_id)
+  VALUES ($ownerId, $chargeId, $documentType, $fileUrl, $imageUrl, $fileHash, $serialNumber, $date,
+     $amount, $currencyCode, $vat, $vatReportDateOverride, $noVatAmount,
+     $allocationNumber, $exchangeRateOverride, $description, $remarks, $creditorId, $debtorId)
   RETURNING id
 `;
 
@@ -106,9 +146,6 @@ export type IngestInput = {
     content?: string | null;
   }>;
 };
-
-/** An uploaded document ready to be inserted (bytes already in Cloudinary). */
-type PreparedDocument = { fileUrl: string; imageUrl: string; fileHash: string };
 
 export type IngestResult =
   | { outcome: typeof IngestOutcome.INSERTED; ingestId: string; auditId: string }
@@ -150,7 +187,7 @@ export class EmailIngestionIngestProvider {
     private cloudinaryProvider: CloudinaryProvider,
   ) {}
 
-  async performIngest(input: IngestInput): Promise<IngestResult> {
+  async performIngest(input: IngestInput, injector: Injector): Promise<IngestResult> {
     const {
       grantJti,
       idempotencyKey,
@@ -176,11 +213,15 @@ export class EmailIngestionIngestProvider {
     const corrId = correlationId ?? randomUUID();
     const fingerprint = computeDedupFingerprint(tenantId, rawMessageHash);
 
-    // Prepare documents (hash dedup read + Cloudinary upload) BEFORE the write
-    // transaction, so the network I/O never holds a pooled connection / open
-    // transaction while uploading. The dedup short-circuits re-deliveries (their
-    // documents already exist) so they don't re-upload.
-    const preparedDocuments = await this.prepareDocuments(tenantId, extractedDocuments);
+    // Prepare documents (hash dedup read + Cloudinary upload + OCR) BEFORE the
+    // write transaction, so the network I/O never holds a pooled connection / open
+    // transaction. The dedup short-circuits re-deliveries (their documents already
+    // exist) so they don't re-upload or re-OCR.
+    const preparedDocuments = await this.prepareDocuments(tenantId, extractedDocuments, {
+      injector,
+      businessId: grantResult.grant.businessId,
+      messageId,
+    });
 
     // 2–5. All tenant-bound work runs under the grant tenant's RLS context.
     return withTenantContext(this.dbProvider.pool, tenantId, async client => {
@@ -251,12 +292,7 @@ export class EmailIngestionIngestProvider {
       // to persist (metadata-only, or all duplicates) a synthetic id is used.
       const chargeId =
         preparedDocuments.length > 0
-          ? await this.insertPreparedDocuments(client, {
-              tenantId,
-              businessId: grantResult.grant.businessId,
-              messageId,
-              preparedDocuments,
-            })
+          ? await this.insertPreparedDocuments(client, { tenantId, messageId, preparedDocuments })
           : null;
 
       const ingestId = chargeId ?? randomUUID();
@@ -282,21 +318,27 @@ export class EmailIngestionIngestProvider {
   }
 
   /**
-   * Prepare the inline document bytes (Option B transport) for persistence
-   * WITHOUT holding the write transaction open: dedup new documents by hash (a
-   * short read context) and upload the new ones to Cloudinary in parallel,
-   * outside any transaction. Keeping the network I/O off the main ingest
-   * transaction avoids holding a pooled connection during slow/large uploads.
+   * Prepare documents for persistence WITHOUT holding the write transaction open:
+   * dedup new documents by hash (a short read), then upload to Cloudinary and OCR
+   * (Anthropic) in parallel, outside any transaction. This mirrors the legacy
+   * `getDocumentFromFile` path (Cloudinary upload + `getOcrData` + `figureOutSides`)
+   * so v2 produces the same classified documents as `insertEmailDocuments`, but
+   * owned by the grant tenant (the auth-coupled providers cannot run in the gateway
+   * control-plane context).
    *
-   * The hash matches the legacy `hashStringToInt(file.text())` scheme so the
-   * dedup is consistent with documents inserted via `insertEmailDocuments`;
-   * re-deliveries short-circuit here (their documents already exist) and never
-   * re-upload. Metadata-only entries (no inline bytes) yield an empty result.
+   * The hash matches the legacy `hashStringToInt(file.text())` scheme so the dedup
+   * is consistent across both paths; re-deliveries short-circuit here and never
+   * re-upload or re-OCR. Metadata-only entries (no inline bytes) yield an empty
+   * result. OCR failure is non-fatal — the document falls back to UNPROCESSED
+   * rather than failing the whole ingest.
    */
   private async prepareDocuments(
     tenantId: string,
     documents: IngestInput['extractedDocuments'],
+    opts: { injector: Injector; businessId: string | null; messageId: string },
   ): Promise<PreparedDocument[]> {
+    const { injector, businessId, messageId } = opts;
+
     type DocWithContent = (typeof documents)[number] & { content: string };
     const withContent = documents.filter(
       (doc): doc is DocWithContent => typeof doc.content === 'string' && doc.content.length > 0,
@@ -307,7 +349,7 @@ export class EmailIngestionIngestProvider {
 
     const candidates = withContent.map(doc => ({
       doc,
-      fileHash: hashStringToInt(Buffer.from(doc.content, 'base64').toString('utf8')).toString(),
+      fileHash: hashStringToInt(Buffer.from(doc.content, 'base64').toString('utf8')),
     }));
 
     // Find the documents new to this tenant under its RLS context (a short read,
@@ -316,7 +358,7 @@ export class EmailIngestionIngestProvider {
       const fresh: typeof candidates = [];
       for (const candidate of candidates) {
         const existing = await checkDocumentByHashForIngest.run(
-          { ownerId: tenantId, fileHash: candidate.fileHash },
+          { ownerId: tenantId, fileHash: candidate.fileHash.toString() },
           client,
         );
         if (existing.length === 0) {
@@ -326,34 +368,52 @@ export class EmailIngestionIngestProvider {
       return fresh;
     });
 
-    // Upload the new documents in parallel, outside any transaction.
+    // Upload + OCR the new documents in parallel, outside any transaction.
     return Promise.all(
       newCandidates.map(async ({ doc, fileHash }) => {
+        const file = new File([Buffer.from(doc.content, 'base64')], doc.filename ?? 'document', {
+          type: doc.mimeType,
+        });
         const dataUri = `data:${doc.mimeType};base64,${doc.content}`;
-        const { fileUrl, imageUrl } =
-          await this.cloudinaryProvider.uploadInvoiceToCloudinary(dataUri);
-        return { fileUrl, imageUrl, fileHash };
+        const [{ fileUrl, imageUrl }, ocrData] = await Promise.all([
+          this.cloudinaryProvider.uploadInvoiceToCloudinary(dataUri),
+          // isSensitive=false → run OCR (Anthropic), as the legacy path does.
+          getOcrData(injector, file, false).catch(
+            (): OcrData => ({ documentType: DocumentType.Unprocessed }),
+          ),
+        ]);
+        // The recognized issuing business is the counterparty (null when none).
+        if (businessId) {
+          ocrData.counterpartyId = businessId;
+        }
+        const params = getDocumentFromUrlsAndOcrData(
+          fileUrl,
+          imageUrl,
+          ocrData,
+          tenantId,
+          null,
+          fileHash,
+        );
+        // Mirror the legacy `insertEmailDocuments` resolver, which overrides the
+        // OCR-derived remarks with an email identifier. (There it is the email
+        // description; the v2 ingest payload carries only the message id.) All
+        // other OCR fields — amount, currency, date, serial — are persisted as-is.
+        params.remarks = `email-ingestion: ${messageId}`;
+        return params;
       }),
     );
   }
 
   /**
-   * Insert already-uploaded documents under the grant tenant, attributing them
-   * to the recognized issuing business as the document counterparty (creditor).
-   * One charge owns the documents; documents land as UNPROCESSED
-   * (classification/OCR happens later via the normal flow). Runs entirely inside
-   * the caller's transaction with no network I/O. Returns the created charge id.
+   * Insert already-prepared (uploaded + OCR'd) documents under one charge, owned
+   * by the grant tenant. Runs entirely inside the caller's transaction with no
+   * network I/O. Returns the created charge id.
    */
   private async insertPreparedDocuments(
     client: PoolClient,
-    args: {
-      tenantId: string;
-      businessId: string | null;
-      messageId: string;
-      preparedDocuments: PreparedDocument[];
-    },
+    args: { tenantId: string; messageId: string; preparedDocuments: PreparedDocument[] },
   ): Promise<string> {
-    const { tenantId, businessId, messageId, preparedDocuments } = args;
+    const { tenantId, messageId, preparedDocuments } = args;
 
     const [charge] = await insertIngestCharge.run(
       {
@@ -366,16 +426,27 @@ export class EmailIngestionIngestProvider {
     const chargeId = charge.id;
 
     for (const doc of preparedDocuments) {
-      await insertIngestDocument.run(
+      await insertIngestDocumentFull.run(
         {
           ownerId: tenantId,
           chargeId,
-          // Null when no business was recognized.
-          creditorId: businessId,
-          documentType: DocumentType.Unprocessed,
-          fileUrl: doc.fileUrl,
-          imageUrl: doc.imageUrl,
-          fileHash: doc.fileHash,
+          documentType: doc.documentType,
+          fileUrl: doc.file ?? null,
+          imageUrl: doc.image ?? null,
+          fileHash: doc.fileHash ?? null,
+          serialNumber: doc.serialNumber ?? null,
+          date: doc.date ?? null,
+          amount: doc.amount ?? null,
+          currencyCode: doc.currencyCode ?? null,
+          vat: doc.vat ?? null,
+          vatReportDateOverride: doc.vatReportDateOverride ?? null,
+          noVatAmount: doc.noVatAmount ?? null,
+          allocationNumber: doc.allocationNumber ?? null,
+          exchangeRateOverride: doc.exchangeRateOverride ?? null,
+          description: doc.description ?? null,
+          remarks: doc.remarks ?? null,
+          creditorId: doc.creditorId ?? null,
+          debtorId: doc.debtorId ?? null,
         },
         client,
       );

--- a/packages/server/src/modules/email-ingestion/resolvers/email-ingestion-ingest.resolver.ts
+++ b/packages/server/src/modules/email-ingestion/resolvers/email-ingestion-ingest.resolver.ts
@@ -17,21 +17,26 @@ const ingestEmail: EmailIngestionModule.MutationResolvers['ingestEmail'] = async
   const ingestProvider = injector.get(EmailIngestionIngestProvider);
 
   try {
-    const result = await ingestProvider.performIngest({
-      grantJti: input.grantJti,
-      idempotencyKey: input.idempotencyKey,
-      tenantId: input.tenantId,
-      messageId: input.messageId,
-      rawMessageHash: input.rawMessageHash,
-      correlationId: input.correlationId ?? undefined,
-      extractedDocuments: input.extractedDocuments.map(doc => ({
-        hash: doc.hash,
-        sizeBytes: doc.sizeBytes,
-        mimeType: doc.mimeType,
-        filename: doc.filename ?? undefined,
-        content: doc.content ?? undefined,
-      })),
-    });
+    const result = await ingestProvider.performIngest(
+      {
+        grantJti: input.grantJti,
+        idempotencyKey: input.idempotencyKey,
+        tenantId: input.tenantId,
+        messageId: input.messageId,
+        rawMessageHash: input.rawMessageHash,
+        correlationId: input.correlationId ?? undefined,
+        extractedDocuments: input.extractedDocuments.map(doc => ({
+          hash: doc.hash,
+          sizeBytes: doc.sizeBytes,
+          mimeType: doc.mimeType,
+          filename: doc.filename ?? undefined,
+          content: doc.content ?? undefined,
+        })),
+      },
+      // Pass the operation injector so the provider can run OCR (getOcrData →
+      // AnthropicProvider) without injecting an Injector into the singleton.
+      injector,
+    );
 
     const outcome = OUTCOME_MAP[result.outcome];
 

--- a/packages/server/src/modules/email-ingestion/types.ts
+++ b/packages/server/src/modules/email-ingestion/types.ts
@@ -1,4 +1,5 @@
 export type * from './__generated__/types.js';
+export type { DateOrString } from './__generated__/email-ingestion-control.types.js';
 export type * from './__generated__/email-ingestion-control.types.js';
 export type * from './__generated__/email-ingestion-alias.types.js';
 export type * from './__generated__/email-ingestion-ingest.types.js';


### PR DESCRIPTION
## Summary

Enhance the email ingestion pipeline to perform OCR (via Anthropic) during document preparation and persist the full classified document metadata (amount, currency, date, serial number, VAT, etc.) to the database, rather than landing all documents as UNPROCESSED. This mirrors the legacy `insertEmailDocuments` resolver behavior while operating in the gateway control-plane context.

## Key Changes

- **OCR at ingest time**: `prepareDocuments` now calls `getOcrData(injector, file, false)` to classify documents via Anthropic, matching the legacy upload path. OCR failures are non-fatal and fall back to UNPROCESSED.
- **Full document metadata persistence**: Expanded the `insertIngestDocumentFull` SQL query to insert all document fields (serial number, date, amount, currency, VAT, allocation number, exchange rate override, description, remarks, creditor/debtor IDs) instead of just the basic fields.
- **Injector threading**: `performIngest` now accepts an `Injector` parameter so the provider can instantiate `AnthropicProvider` for OCR without coupling the singleton to the operation context.
- **Prepared document type**: Redefined `PreparedDocument` to match `IInsertDocumentsParams['documents'][number]` (the full document shape from `DocumentsProvider.insertDocuments`), ensuring v2 produces the same classified documents as the legacy path.
- **Remarks override**: Email ingestion documents now override the OCR-derived remarks with an email identifier (`email-ingestion: {messageId}`), consistent with the legacy resolver.
- **Resolver update**: `ingestEmail` resolver now forwards its operation injector to `performIngest`.
- **Test coverage**: Updated tests to mock `AnthropicProvider.extractInvoiceDetails` and verify that documents are classified (INVOICE) rather than UNPROCESSED, and that the recognized business is attributed as the creditor.

## Implementation Details

- The `fileHash` is now stored as an integer (via `hashStringToInt`) rather than a string, matching the legacy dedup scheme.
- Document preparation (Cloudinary upload + OCR) runs in parallel outside the write transaction to avoid holding pooled connections during network I/O.
- The counterparty business ID is set from the grant's recognized business and passed to `getDocumentFromUrlsAndOcrData` to populate the creditor field.

https://claude.ai/code/session_01NNHHjHfq9G4snq7U42hcjj