### PR TITLE
docs(email-ingestion-gateway): add README, troubleshooting, and CLAUDE docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,11 @@ Yarn Berry (v4) monorepo with 18 packages under `packages/`:
   `israeli-vat-scraper`
 - **Integrations**: `green-invoice-graphql`, `hashavshevet-mesh`, `payper-mesh`, `deel` (via server
   app-providers)
+- **Email ingestion**: `email-ingestion-gateway` (v2 multi-tenant Cloudflare→gateway→server email
+  pipeline), `gmail-listener` (legacy single-tenant listener)
 - **Generators**: `pcn874-generator`, `opcn1214-generator`, `shaam6111-generator`,
   `shaam-uniform-format-generator`
-- **Tools**: `gmail-listener`, `scraper-local-app`
+- **Tools**: `scraper-local-app`
 - **Deprecated**: `old-accounter` (excluded from workspaces)
 
 Package-specific conventions live in `packages/<name>/CLAUDE.md` (loaded on demand when you work in

--- a/packages/email-ingestion-gateway/CLAUDE.md
+++ b/packages/email-ingestion-gateway/CLAUDE.md
@@ -1,0 +1,108 @@
+# Email Ingestion Gateway Package
+
+V2 multi-tenant email→document ingestion. Receives raw MIME (relayed by a Cloudflare Email Worker),
+verifies authenticity, parses documents, recognizes the issuing business, and calls the Accounter
+GraphQL server to persist them.
+
+See [`README.md`](./README.md) for the full overview and
+[`TROUBLESHOOTING.md`](./TROUBLESHOOTING.md) for diagnosing failed/quarantined emails.
+
+## Two runtimes, one package
+
+- `src/worker.ts` — **Cloudflare Worker**. Thin: HMAC-signs the raw MIME and POSTs it to the
+  gateway; forwards to `FALLBACK_EMAIL` if the gateway is down. Runs on the Workers runtime
+  (`wrangler`).
+- `src/index.ts` — **Node.js gateway service**. The HTTP server (`/health`, `/readiness`,
+  `POST /webhook`) that does all the real work. Needs Chromium (Playwright) for body→PDF.
+
+Keep the Worker minimal and secret-free beyond the shared HMAC key — all logic belongs in the
+gateway.
+
+## Module map (`src/`)
+
+| File                   | Responsibility                                                                                |
+| ---------------------- | --------------------------------------------------------------------------------------------- |
+| `index.ts`             | HTTP server, routing, correlation-id setup, prod kill-switch on missing secret.               |
+| `worker.ts`            | Cloudflare `email()` handler: sign + POST, health-probe fallback to forward.                  |
+| `webhook.ts`           | `/webhook` handler: flag gate → header validation → body read → verify → parse → orchestrate. |
+| `verifier.ts`          | Authenticity: IP allowlist, timestamp window, HMAC-SHA256, in-memory nonce replay store.      |
+| `mime-extractor.ts`    | `postal-mime` parsing → documents + sender evidence + body; size/count/depth guards.          |
+| `orchestrator.ts`      | control → treatment → ingest sequence; the core flow.                                         |
+| `treatment.ts`         | Build the final document set: attachment filter + body→PDF + internal-link fetch.             |
+| `link-fetcher.ts`      | Fetch documents behind configured links, with SSRF hardening.                                 |
+| `html-to-pdf.ts`       | Render HTML body → PDF via headless Chromium (JS disabled), shared browser instance.          |
+| `server-client.ts`     | GraphQL client for `requestIngestControl` / `ingestEmail`, with timeouts + retries.           |
+| `environment.ts`       | `zod`-validated env; exits on invalid config.                                                 |
+| `contracts.ts`         | `IngestOutcome` / `IngestReasonCode` constants (duplicated from server, parity-tested).       |
+| `logger.ts`            | Structured JSON logging + correlation-id generation.                                          |
+| `graphql/mutations.ts` | The two GraphQL mutation documents the client sends.                                          |
+
+## Conventions
+
+- **ESM only**, with `.js` import suffixes on relative paths (even in `.ts` source) — repo-wide
+  rule.
+- **No CommonJS**, no `require`.
+- TypeScript strict mode.
+- **Always use `yarn`** (never npm/npx/pnpm). Run scripts via
+  `yarn workspace @accounter/email-ingestion-gateway <script>`.
+- Structured logging only: call `log(level, message, fields, correlationId)` from `logger.ts`. Never
+  `console.log` directly (the `logger` is the one exception, internally). Thread `correlationId`
+  through every code path.
+- I/O is **dependency-injected** for testability: `OrchestratorDeps`, `WebhookDeps`,
+  `TreatmentDeps`, `ServerClientDeps`, and a pluggable `NonceStore` all accept overrides so tests
+  avoid Chromium and the network. Preserve this — don't hard-wire `fetch`/Chromium/clock into logic.
+- The `currentTimeSeconds` / `sleep` clocks are injectable; don't call `Date.now()` directly in
+  verifiable logic paths.
+
+## Generated code
+
+- `src/gql/` is **generated** by `graphql-codegen` (root `yarn generate:graphql`) and git-ignored.
+  Never edit it by hand. `server-client.ts` imports its operation types from `./gql/index.js`.
+- After changing the server's email-ingestion typeDefs or the mutation documents in
+  `graphql/mutations.ts`, re-run `yarn generate:graphql`.
+
+## Contract parity with the server
+
+`contracts.ts` here and `packages/server/src/modules/email-ingestion/contracts.ts` are **deliberate
+duplicates** (no runtime import across packages). If you change an outcome or reason code, change
+**both** and keep the parity tests (`treatment.parity.test.ts` here, plus the server's contract
+tests) green.
+
+The wire contract is the two GraphQL mutations (`requestIngestControl`, `ingestEmail`) owned by the
+server's `email-ingestion` module. The gateway sends `senderEvidence` on **control** (business
+recognition is server-side) and never sends a client-chosen `businessId` — the issuing business is
+read back from the grant.
+
+## Security invariants (don't regress)
+
+- Verify **before** consuming the nonce (avoid replay-store pollution); verify auth **before** any
+  heavy work.
+- Idempotency/dedup keys derive from the gateway-computed `rawMessageHash`, never the
+  sender-controlled `Message-ID`.
+- Internal-link fetching keeps the SSRF guard stack in `link-fetcher.ts` (host/path allowlist,
+  private-IP + resolved-IP block, http(s)-only, `redirect: 'error'`, content-type allowlist,
+  streamed size cap). Don't loosen any of these without review.
+- Body HTML renders with `javaScriptEnabled: false`.
+- `CF_WEBHOOK_SECRET` is required in production (`index.ts` throws on startup if missing).
+
+## Testing
+
+```bash
+# from repo root
+yarn test --project unit packages/email-ingestion-gateway
+```
+
+Tests live in `src/__tests__/`. When adding behavior, inject stubs via the `*Deps` interfaces rather
+than reaching for global mocks; follow the existing suites (`orchestrator.test.ts`,
+`webhook.test.ts`, `worker-pipe.integration.test.ts`).
+
+## Commands
+
+```bash
+yarn workspace @accounter/email-ingestion-gateway dev           # gateway service (tsx watch)
+yarn workspace @accounter/email-ingestion-gateway build         # tsc → dist/
+yarn workspace @accounter/email-ingestion-gateway typecheck     # tsc --noEmit
+yarn workspace @accounter/email-ingestion-gateway worker:dev    # wrangler dev (Worker)
+yarn workspace @accounter/email-ingestion-gateway worker:deploy # wrangler deploy
+yarn generate:graphql                                           # regenerate src/gql/
+```

--- a/packages/email-ingestion-gateway/README.md
+++ b/packages/email-ingestion-gateway/README.md
@@ -1,0 +1,216 @@
+# Email Ingestion Gateway
+
+The **email-ingestion-gateway** is the v2 multi-tenant entry point for turning inbound emails into
+accounting documents. It receives raw MIME messages (relayed from a Cloudflare Email Worker), proves
+they are authentic, parses out candidate documents, recognizes the issuing business, and hands the
+final document set to the Accounter GraphQL server for tenant-scoped persistence.
+
+It replaces the single-tenant [`gmail-listener`](../gmail-listener) polling approach with a
+push-based, authenticated, multi-tenant pipeline.
+
+> For the design rationale, threat model, and rollout plan see
+> [`docs/multi-tenant-gmail-listener/`](../../docs/multi-tenant-gmail-listener/):
+> [architecture-plan](../../docs/multi-tenant-gmail-listener/architecture-plan.md),
+> [data-flow](../../docs/multi-tenant-gmail-listener/data-flow.md),
+> [security-architecture-review](../../docs/multi-tenant-gmail-listener/security-architecture-review.md),
+> and the
+> [cloudflare-setup-runbook](../../docs/multi-tenant-gmail-listener/cloudflare-setup-runbook.md).
+
+## Two deployable units
+
+This package ships **two** runtimes built from the same source tree:
+
+| Unit                  | Entry point     | Runtime              | Role                                                                                                                                                   |
+| --------------------- | --------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Cloudflare Worker** | `src/worker.ts` | Cloudflare Workers   | Receives the `email()` event, HMAC-signs the raw MIME, and `POST`s it to the gateway. Falls back to forwarding if the gateway is unreachable.          |
+| **Gateway service**   | `src/index.ts`  | Node.js (Playwright) | HTTP server that verifies authenticity, parses MIME, runs treatment (body→PDF, link fetch), and calls the server's GraphQL control + ingest mutations. |
+
+The Worker is intentionally thin: it does no parsing and holds no secrets beyond the shared HMAC
+key. All business logic lives in the gateway service.
+
+## Pipeline at a glance
+
+```
+Inbound email
+  │
+  ▼
+Cloudflare Email Worker (src/worker.ts)
+  │  HMAC-SHA256 sign  →  POST /webhook  (raw MIME as body, metadata in x-cf-* headers)
+  ▼
+Gateway service (src/index.ts → src/webhook.ts)
+  │  1. feature-flag gate (EMAIL_INGESTION_V2_ENABLED)
+  │  2. authenticity verify (IP allowlist + timestamp + HMAC + nonce replay)  → src/verifier.ts
+  │  3. compute rawMessageHash (sha256 of body) + parse MIME                  → src/mime-extractor.ts
+  ▼
+Orchestrator (src/orchestrator.ts)
+  │  4. control mutation  → resolve tenant from alias, recognize business, get single-use grant
+  │  5. treatment         → attachment filter + body→PDF + internal-link fetch   → src/treatment.ts
+  │  6. ingest mutation   → server validates grant, dedups, persists (or quarantines)
+  ▼
+Accounter GraphQL server (packages/server, module: email-ingestion)
+```
+
+The server side of this contract lives in
+[`packages/server/src/modules/email-ingestion`](../server/src/modules/email-ingestion). The two
+`requestIngestControl` and `ingestEmail` mutations are defined there.
+
+## HTTP API
+
+The gateway service exposes three routes (see `src/index.ts`):
+
+| Method | Path         | Purpose                                                            |
+| ------ | ------------ | ------------------------------------------------------------------ |
+| `GET`  | `/health`    | Liveness probe — always `200 {"status":"ok"}`.                     |
+| `GET`  | `/readiness` | Readiness probe — `200 {"ready":true}`.                            |
+| `POST` | `/webhook`   | Main ingestion endpoint. Expects raw MIME body + `x-cf-*` headers. |
+
+### `POST /webhook` request contract
+
+| Header             | Required | Meaning                                                   |
+| ------------------ | -------- | --------------------------------------------------------- |
+| `x-cf-timestamp`   | yes      | Unix epoch **seconds** the request was signed.            |
+| `x-cf-signature`   | yes      | Hex HMAC-SHA256 of `` `${timestamp}.${rawBody}` ``.       |
+| `x-cf-nonce`       | yes      | Unique per-request value (replay protection).             |
+| `x-cf-recipient`   | yes      | The tenant alias the mail was addressed to.               |
+| `x-cf-message-id`  | yes      | Upstream `Message-ID`.                                    |
+| `x-cf-received-at` | no       | ISO-8601 received time (used for the charge description). |
+| `x-correlation-id` | no       | Propagated through all logs; generated if absent.         |
+
+The body is the **raw MIME message** (`Content-Type: message/rfc822`). The gateway — not the Worker
+— computes the authoritative `rawMessageHash` from the signed body.
+
+The endpoint always responds `202 Accepted` once authenticity passes; the ingest `outcome`
+(`INSERTED` / `DUPLICATE` / `QUARANTINED` / `REJECTED`) is included in the JSON body in production
+mode. Authenticity failures return `401`, malformed requests `400`, oversize bodies `413`.
+
+## Configuration
+
+Configuration is validated by `zod` at startup (`src/environment.ts`); invalid values exit the
+process with code `1`.
+
+### Gateway service env (`.env` in the package root)
+
+| Variable                      | Default                 | Description                                                                                     |
+| ----------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------- |
+| `PORT`                        | `3000`                  | HTTP listen port.                                                                               |
+| `EMAIL_INGESTION_V2_ENABLED`  | `0`                     | `1` enables `/webhook`; `0` returns `503`. Master kill-switch.                                  |
+| `EMAIL_INGESTION_SHADOW_MODE` | `0`                     | `1` = run orchestration async and respond immediately (legacy path stays authoritative).        |
+| `CF_WEBHOOK_SECRET`           | _(none)_                | Shared HMAC-SHA256 secret. **Required in production** (startup throws otherwise).               |
+| `CF_IP_ALLOWLIST`             | `''` (disabled)         | Comma-separated source IPs / IPv4 CIDRs. Empty disables the IP check.                           |
+| `GATEWAY_SERVER_URL`          | `http://localhost:4000` | Base URL of the Accounter GraphQL server (`/graphql` is appended).                              |
+| `GATEWAY_CP_TOKEN`            | `''`                    | Shared secret sent as `X-Gateway-CP-Token` to authenticate as the `gateway_control_plane` role. |
+
+> Set `TEST_ENV_FILE` to load an alternate dotenv file (used by tests).
+
+### Cloudflare Worker env (`.dev.vars` / Wrangler secrets)
+
+See [`.dev.vars.example`](./.dev.vars.example):
+
+| Variable            | Description                                                               |
+| ------------------- | ------------------------------------------------------------------------- |
+| `CF_WEBHOOK_SECRET` | Must match the gateway's secret — the Worker signs, the gateway verifies. |
+| `GATEWAY_URL`       | URL the Worker `POST`s the webhook to.                                    |
+| `FALLBACK_EMAIL`    | Address the Worker forwards to when the gateway is unreachable.           |
+
+## Local development
+
+```bash
+# Install (from repo root — always use yarn)
+yarn install
+
+# Generate the GraphQL types this package consumes (writes src/gql/)
+yarn generate:graphql
+
+# Run the gateway service in watch mode (tsx)
+yarn workspace @accounter/email-ingestion-gateway dev
+
+# Run the Cloudflare Worker locally (wrangler)
+yarn workspace @accounter/email-ingestion-gateway worker:dev
+```
+
+A minimal local `.env`:
+
+```sh
+EMAIL_INGESTION_V2_ENABLED=1
+CF_WEBHOOK_SECRET=local-secret
+GATEWAY_SERVER_URL=http://localhost:4000
+GATEWAY_CP_TOKEN=local-cp-token
+```
+
+`GATEWAY_CP_TOKEN` must match the server's `GATEWAY_CP_TOKEN` so the gateway can authenticate as the
+`gateway_control_plane` role.
+
+### Sending a test webhook
+
+The signature covers `` `${timestamp}.${rawBody}` ``. Example with `openssl`:
+
+```bash
+SECRET=local-secret
+TS=$(date +%s)
+BODY=$(cat fixture.eml)
+SIG=$(printf '%s.%s' "$TS" "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
+
+curl -sS http://localhost:3000/webhook \
+  -H "Content-Type: message/rfc822" \
+  -H "x-cf-timestamp: $TS" \
+  -H "x-cf-signature: $SIG" \
+  -H "x-cf-nonce: $(uuidgen)" \
+  -H "x-cf-recipient: invoices@acme.example.com" \
+  -H "x-cf-message-id: <test-1@example.com>" \
+  --data-binary @fixture.eml
+```
+
+## Testing
+
+```bash
+# Unit tests (vitest) for this package
+yarn workspace @accounter/email-ingestion-gateway test # if defined, else from root:
+yarn test --project unit packages/email-ingestion-gateway
+```
+
+Notable suites (`src/__tests__/`):
+
+- `verifier.test.ts` — HMAC / timestamp / IP allowlist / nonce replay.
+- `mime-extractor.test.ts` — MIME parsing, document detection, size/count guards.
+- `treatment.test.ts` / `treatment.parity.test.ts` — treatment logic and parity with the legacy
+  listener.
+- `orchestrator.test.ts` — control → treatment → ingest flow with mocked server client.
+- `worker-pipe.integration.test.ts` — end-to-end Worker → gateway → mocked server.
+- `link-fetcher.test.ts` — SSRF guards for internal-link fetching.
+
+## Building & deployment
+
+```bash
+# Gateway service (Node) — tsc to dist/
+yarn workspace @accounter/email-ingestion-gateway build
+
+# Docker image (Playwright base, includes Chromium for body→PDF)
+yarn workspace @accounter/email-ingestion-gateway docker:build
+
+# Cloudflare Worker
+yarn workspace @accounter/email-ingestion-gateway worker:deploy
+```
+
+The gateway image is based on `mcr.microsoft.com/playwright` because body→PDF rendering
+(`src/html-to-pdf.ts`) launches headless Chromium. A runtime without a Chromium binary will fail
+body→PDF rendering (caught and logged; the body document is simply omitted).
+
+## Security model (summary)
+
+- **Authenticity**: IP allowlist (defense-in-depth) + timestamp window (±300s) + HMAC-SHA256
+  signature (primary) + single-use nonce replay protection. See `src/verifier.ts`.
+- **Idempotency key**: the gateway-computed `rawMessageHash` (content-derived), never the
+  sender-controlled `Message-ID` — preventing data-suppression and bulk-sender collisions.
+- **Server-side business recognition**: sender evidence is sent on the **control** request; the
+  recognized business is bound into the grant. The gateway can never attribute documents to an
+  arbitrary business.
+- **SSRF hardening** for internal-link fetching: host/path allowlist, private/loopback host +
+  resolved-IP blocks, http(s)-only, redirects disabled, content-type allowlist, streamed size cap.
+  See `src/link-fetcher.ts`.
+- **Untrusted HTML**: email bodies render with JavaScript disabled in headless Chromium.
+
+## Troubleshooting
+
+When emails fail to insert, become quarantined, or get rejected, see
+[`TROUBLESHOOTING.md`](./TROUBLESHOOTING.md) for a reason-code reference and a step-by-step
+diagnosis guide.

--- a/packages/email-ingestion-gateway/README.md
+++ b/packages/email-ingestion-gateway/README.md
@@ -148,7 +148,7 @@ The signature covers `` `${timestamp}.${rawBody}` ``. Example with `openssl`:
 SECRET=local-secret
 TS=$(date +%s)
 BODY=$(cat fixture.eml)
-SIG=$(printf '%s.%s' "$TS" "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $2}')
+SIG=$(printf '%s.%s' "$TS" "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print $NF}')
 
 curl -sS http://localhost:3000/webhook \
   -H "Content-Type: message/rfc822" \

--- a/packages/email-ingestion-gateway/TROUBLESHOOTING.md
+++ b/packages/email-ingestion-gateway/TROUBLESHOOTING.md
@@ -1,0 +1,283 @@
+# Troubleshooting: why an email didn't become a document
+
+This guide helps developers and operators diagnose why an inbound email **failed to insert**, was
+**quarantined**, **rejected**, or silently treated as a **duplicate**. It covers the full v2 path:
+Cloudflare Worker → gateway service → Accounter server.
+
+Work top-to-bottom: an email passes through stages, and each stage can stop it. Identify the **last
+log line you can find** for the message and jump to that stage.
+
+---
+
+## 0. The single most useful key: `correlationId`
+
+Every request is stamped with a `correlationId` (the `x-correlation-id` header, or a generated
+UUID). It appears in:
+
+- Every gateway log line (`src/logger.ts` emits structured JSON with `correlationId`).
+- The `X-Correlation-Id` response header.
+- The server's `email_ingestion_quarantine.correlation_id` and
+  `email_ingestion_dedup_fingerprints.correlation_id` columns.
+
+**Always start by grabbing the correlationId** (from the Worker logs, the `/webhook` response
+header, or the quarantine row) and grepping every log/table by it.
+
+The other durable identifiers:
+
+- `rawMessageHash` — SHA-256 of the raw MIME, computed by the gateway. This is the idempotency key
+  and the dedup input. Same content ⇒ same hash.
+- `messageId` — the upstream `Message-ID`. Bound into the grant; **not** used for dedup.
+- `auditId` — returned on every ingest outcome for cross-referencing.
+
+---
+
+## 1. Outcome & reason-code reference
+
+Outcomes (`IngestOutcome`) and reason codes (`IngestReasonCode`) are defined **twice** — once in the
+gateway (`src/contracts.ts`) and once in the server
+(`packages/server/src/modules/email-ingestion/contracts.ts`). They are intentionally duplicated (no
+cross-package runtime import) and kept in sync by parity tests.
+
+### Outcomes
+
+| Outcome       | Meaning                                                                                   |
+| ------------- | ----------------------------------------------------------------------------------------- |
+| `INSERTED`    | A charge + document(s) were persisted under the recognized business.                      |
+| `DUPLICATE`   | Idempotency key or dedup fingerprint already seen — returns the prior `existingIngestId`. |
+| `QUARANTINED` | Accepted and audited but **not** inserted — needs triage (see quarantine table).          |
+| `REJECTED`    | Grant validation failed; nothing persisted, nothing quarantined.                          |
+
+### Reason codes — where each is produced
+
+| Reason code          | Stage / file                              | What happened                                                                     |
+| -------------------- | ----------------------------------------- | --------------------------------------------------------------------------------- |
+| `INVALID_AUTH`       | gateway `verifier.ts`                     | IP not allowlisted, timestamp outside ±300s, or bad HMAC signature. → `401`.      |
+| `REPLAY_DETECTED`    | gateway `verifier.ts`                     | Nonce already seen within the retention window (default 600s). → `401`.           |
+| `OVERSIZE_MESSAGE`   | gateway `mime-extractor.ts`               | Raw MIME > 25 MB, > 10 attachments, or extracted bytes > 20 MB.                   |
+| `PARSE_ERROR`        | gateway `mime-extractor.ts`               | Empty body or `postal-mime` failed (e.g. nesting depth > 10).                     |
+| `UNKNOWN_ALIAS`      | server `email-ingestion-control.provider` | `recipientAlias` does not resolve to an active tenant alias.                      |
+| `TIMEOUT`            | gateway `server-client.ts`                | Control (3s) or ingest (10s) call timed out after retries.                        |
+| `TRANSIENT_UPSTREAM` | gateway `server-client.ts`                | Server returned 5xx / network error after retries, or empty response.             |
+| `GRANT_INVALID`      | server `email-ingestion-control.provider` | Grant missing, expired, already consumed, wrong action, or message/hash mismatch. |
+| `TENANT_MISMATCH`    | server `email-ingestion-control.provider` | Grant's `owner_id` ≠ the claimed `tenantId`.                                      |
+| `NO_DOCUMENTS`       | server `email-ingestion-ingest.provider`  | After treatment, the document set was empty. **Most common quarantine reason.**   |
+
+---
+
+## 2. Stage-by-stage diagnosis
+
+### Stage A — the email never reached the gateway
+
+Symptom: no gateway log line for the message at all.
+
+- **Worker fell back to forwarding.** `src/worker.ts` probes `GET /health` before consuming the
+  stream; if the gateway is unreachable it calls `message.forward(FALLBACK_EMAIL)` and the email
+  goes to the legacy mailbox instead. Check Worker logs for `Gateway unreachable` and verify
+  `GATEWAY_URL` + gateway health.
+- **Feature flag off.** If `EMAIL_INGESTION_V2_ENABLED=0`, `/webhook` returns `503` immediately
+  (`webhook.ts` step 1). Look for a `503` in the gateway access logs.
+- **Cloudflare routing.** The alias may not be routed to the Worker at all. See the
+  [cloudflare-setup-runbook](../../docs/multi-tenant-gmail-listener/cloudflare-setup-runbook.md).
+
+### Stage B — authenticity rejected (`401`, `INVALID_AUTH` / `REPLAY_DETECTED`)
+
+Gateway log: `webhook authenticity check failed` with `reason`.
+
+Checklist (`src/verifier.ts`, order of checks):
+
+1. **IP allowlist** — only enforced when `CF_IP_ALLOWLIST` is non-empty. A misconfigured allowlist
+   (or Cloudflare IP change) rejects everything. Confirm the source IP (`cf-connecting-ip` /
+   `x-forwarded-for`) is covered.
+2. **Timestamp window** — `|now − x-cf-timestamp| ≤ 300s`. Clock skew between Worker and gateway, or
+   a replayed-but-stale request, fails here. Note the timestamp is in **seconds**, not ms.
+3. **HMAC signature** — `CF_WEBHOOK_SECRET` must be **identical** on the Worker and the gateway. A
+   mismatched secret is the #1 cause. The signature is hex HMAC-SHA256 of
+   `` `${timestamp}.${rawBody}` ``; if a proxy mutates the body, the signature breaks.
+4. **Nonce replay** — a re-sent request with the same `x-cf-nonce` within 600s yields
+   `REPLAY_DETECTED`. The nonce store is **in-memory** (`MemoryNonceStore`), so a gateway restart
+   clears it — legitimate retries after a restart are fine; a genuinely duplicated delivery is not.
+
+> Verification order matters: the nonce is only stored **after** the signature is verified, so
+> forged requests can't pollute the replay store.
+
+### Stage C — MIME parse / size failure (`PARSE_ERROR`, `OVERSIZE_MESSAGE`)
+
+Gateway log: `webhook: MIME extraction failed` with `reason`.
+
+- `src/mime-extractor.ts` enforces: `MAX_RAW_MIME_BYTES` (25 MB), `MAX_ATTACHMENT_COUNT` (10),
+  `MAX_EXTRACTED_BYTES` (20 MB), `MAX_MIME_DEPTH` (10).
+- **Important:** extraction failure does **not** stop the pipeline. The gateway still calls
+  orchestration with an empty document set so the server records an auditable quarantine
+  (`NO_DOCUMENTS`). So a `PARSE_ERROR` email typically surfaces as a `NO_DOCUMENTS` quarantine row
+  on the server side, with the gateway log showing the real `PARSE_ERROR`/`OVERSIZE` cause. **Check
+  gateway logs, not just the quarantine table, to learn why it was empty.**
+- Document detection is selective: only PDF and common image types (PNG/JPEG/GIF/TIFF/BMP/WebP),
+  plus `application/octet-stream` with a `.pdf` filename, count as documents. A spreadsheet or
+  `.docx` attachment is **ignored** and won't produce a document on its own.
+
+### Stage D — control / tenant resolution (`UNKNOWN_ALIAS`)
+
+Gateway logs: `orchestrate:control:start` then either `orchestrate:control:granted` or
+`orchestrate:control:denied`.
+
+- `UNKNOWN_ALIAS` ⇒ the `recipientAlias` has no **active** row in
+  `accounter_schema.email_ingestion_alias_routing`. Alias match is case-insensitive on
+  `lower(alias)`, and only `is_active = TRUE` rows resolve.
+
+  ```sql
+  SELECT id, alias, owner_id, is_active
+  FROM accounter_schema.email_ingestion_alias_routing
+  WHERE lower(alias) = lower('invoices@acme.example.com');
+  ```
+
+  Fix by provisioning/activating an alias (`createEmailIngestionAlias` /
+  `setEmailIngestionAliasActive` mutations, `business_owner` role).
+
+- **Business not recognized** is _not_ an error. If sender evidence matches no business,
+  `businessEmailConfig` is `null` and the gateway applies **default treatment** (body→PDF). The
+  document is still inserted, just without a counterparty business attached. To make recognition
+  work, the sender address must appear in the target business's `suggestion_data->'emails'`.
+
+### Stage E — treatment produced no documents (→ `NO_DOCUMENTS`)
+
+Gateway log: `orchestrate:treatment:complete` with `documentCount`. If `documentCount: 0`, the
+server will quarantine `NO_DOCUMENTS`.
+
+Treatment (`src/treatment.ts`) assembles the final set from three sources:
+
+1. **Attachments**, filtered by `config.attachments` (an allowlist of `PDF`/`PNG`/`JPEG`). If the
+   business config allowlists only `PDF` and the mail carries a PNG, the PNG is dropped.
+2. **Body → PDF**, only when **no business is recognized** _or_ `config.emailBody === true`, and the
+   body is non-empty. Render failures are logged (`treatment: body→PDF render failed`) and the body
+   document is omitted — check for a missing/broken Chromium in the runtime.
+3. **Internal-link documents**, fetched for each configured `config.internalEmailLinks` pattern
+   found in the body. Failures log `treatment: internal-link fetch failed`. Note the SSRF guards in
+   `src/link-fetcher.ts` will silently return `[]` if the link host isn't allowlisted, resolves to a
+   private IP, redirects, has a disallowed content-type, or exceeds the size cap.
+
+So a `NO_DOCUMENTS` quarantine means: no qualifying attachment **and** body→PDF didn't run/failed
+**and** no internal-link document was fetched.
+
+### Stage F — grant validation on ingest (`REJECTED`: `GRANT_INVALID` / `TENANT_MISMATCH`)
+
+Gateway log: `orchestrate:ingest:failed`. Server side: `email-ingestion-control.provider.ts`
+`validateAndConsumeGrant`.
+
+A grant (`accounter_schema.email_ingestion_grants`) is single-use and short-lived (TTL 5 min). It is
+`REJECTED` if it is:
+
+- missing (wrong/typo'd `jti`),
+- already `consumed_at` (a retry of an already-completed ingest — the atomic consume-once UPDATE
+  returns 0 rows),
+- past `expires_at` (slow pipeline between control and ingest),
+- wrong `action` (not `ingest`),
+- bound to a different `message_id` or `raw_message_hash` than presented (`GRANT_INVALID`), or
+- owned by a different tenant than claimed (`TENANT_MISMATCH`).
+
+```sql
+SELECT jti, owner_id, message_id, action, expires_at, consumed_at
+FROM accounter_schema.email_ingestion_grants
+WHERE jti = '<grantJti>';
+```
+
+### Stage G — duplicate suppression (`DUPLICATE`)
+
+Server: `email-ingestion-ingest.provider.ts`. Two independent checks, both tenant-scoped:
+
+1. **Idempotency key** (`email_ingestion_idempotency_keys`) — keyed on `(idempotency_key, owner_id)`
+   where `idempotency_key = rawMessageHash`. A re-delivery of the exact same bytes returns the prior
+   outcome.
+2. **Dedup fingerprint** (`email_ingestion_dedup_fingerprints`) — keyed on `(owner_id, fingerprint)`
+   where `fingerprint = computeDedupFingerprint(tenantId, rawMessageHash)`. Catches re-delivery even
+   if the gateway supplied a different idempotency key.
+
+If a legitimately-new email is being swallowed as a duplicate, confirm its `rawMessageHash` actually
+differs:
+
+```sql
+SELECT idempotency_key, outcome, ingest_id, created_at
+FROM accounter_schema.email_ingestion_idempotency_keys
+WHERE owner_id = '<tenantId>' AND idempotency_key = '<rawMessageHash>';
+
+SELECT fingerprint, outcome, ingest_id, correlation_id, created_at
+FROM accounter_schema.email_ingestion_dedup_fingerprints
+WHERE owner_id = '<tenantId>';
+```
+
+### Stage H — inserted but "missing" in the UI
+
+Gateway log: `orchestrate:ingest:complete` with `outcome: INSERTED` and an `ingestId`.
+
+- The `ingestId` **is the created charge id**. Look the charge up directly:
+
+  ```sql
+  SELECT id, owner_id, user_description, created_at
+  FROM accounter_schema.charges
+  WHERE id = '<ingestId>';
+  ```
+
+- Documents are inserted with `remarks` containing `email-ingestion: <messageId>` — useful for
+  finding all documents from a given email:
+
+  ```sql
+  SELECT id, charge_id, type, file_hash, remarks
+  FROM accounter_schema.documents
+  WHERE owner_id = '<tenantId>' AND remarks LIKE '%email-ingestion: <messageId>%';
+  ```
+
+- The charge description follows `Email documents: <subject> (from: <sender>, <date>)`.
+- OCR failure is **non-fatal**: the document is still inserted with `documentType = UNPROCESSED`
+  rather than failing the ingest. A document that landed but has no parsed amount/date likely hit an
+  OCR error — not an ingestion failure.
+- A metadata-only payload (no inline `content`) or one where **every** document already exists by
+  hash inserts no new rows; the ingest still returns `INSERTED` with a synthetic `ingestId`.
+
+---
+
+## 3. Triaging the quarantine table
+
+Quarantined emails are recorded in `accounter_schema.email_ingestion_quarantine`:
+
+```sql
+SELECT id, reason_code, tenant_candidate, message_id, raw_message_hash,
+       correlation_id, status, retry_count, created_at
+FROM accounter_schema.email_ingestion_quarantine
+ORDER BY created_at DESC
+LIMIT 50;
+```
+
+- `reason_code` tells you why (almost always `NO_DOCUMENTS` from the ingest backstop).
+- `tenant_candidate` may be `NULL` for orphaned rows; those are **invisible to tenant sessions** by
+  RLS and only visible to ops tooling using the RLS-bypassing pool.
+- Join back to the gateway logs via `correlation_id` to find the upstream cause (e.g. the real
+  `PARSE_ERROR`/`OVERSIZE_MESSAGE` behind a `NO_DOCUMENTS`).
+- `status` / `retry_count` support reprocessing workflows.
+
+---
+
+## 4. Quick reference: gateway log events
+
+Grep gateway logs by these `message` values (all structured JSON, all carry `correlationId`):
+
+| Event                                      | Meaning                                                        |
+| ------------------------------------------ | -------------------------------------------------------------- |
+| `incoming request`                         | Request hit the router.                                        |
+| `webhook authenticity check failed`        | Stage B rejection (`reason`).                                  |
+| `webhook: MIME extraction failed`          | Stage C parse/size failure (`reason`).                         |
+| `webhook accepted`                         | Passed auth + parse; `attachmentCount` logged.                 |
+| `orchestrate:control:start/granted/denied` | Control call + tenant resolution.                              |
+| `orchestrate:treatment:complete`           | `documentCount` after treatment (0 ⇒ upcoming `NO_DOCUMENTS`). |
+| `treatment: body→PDF render failed`        | Chromium / render problem; body document dropped.              |
+| `treatment: internal-link fetch failed`    | Link fetch error (or SSRF guard returned empty).               |
+| `orchestrate:ingest:failed`                | Ingest call failed (`reason`).                                 |
+| `orchestrate:ingest:complete`              | Final `outcome`, `ingestId`, `reasonCode`, `durationMs`.       |
+| `shadow:orchestration:*`                   | Shadow-mode async run results.                                 |
+
+---
+
+## 5. Shadow mode caveat
+
+When `EMAIL_INGESTION_SHADOW_MODE=1`, `/webhook` responds `202` **immediately** and runs
+orchestration asynchronously (`webhook.ts`). The HTTP response will **not** contain the real outcome
+— look for `shadow:orchestration:complete` / `:failed` / `:error` log lines (by `correlationId`) to
+see what actually happened. The legacy listener remains the authoritative handler in this mode.


### PR DESCRIPTION
## What

Adds the missing package documentation for `@accounter/email-ingestion-gateway`, now that the v2 email ingestion pipeline is merged to `main`.

New files:

- **`packages/email-ingestion-gateway/README.md`** — general overview: the two-runtime model (Cloudflare Worker + Node gateway service), a pipeline diagram, the HTTP API (`/health`, `/readiness`, `POST /webhook`) and its header contract, full env-var configuration tables for both runtimes, local development & test-webhook instructions, testing, build/deploy, and a security-model summary.
- **`packages/email-ingestion-gateway/TROUBLESHOOTING.md`** — a developer/ops guide for diagnosing why an email **failed to insert**, got **quarantined**, **rejected**, or silently **deduped**. It is `correlationId`-driven and includes:
  - an outcome (`INSERTED`/`DUPLICATE`/`QUARANTINED`/`REJECTED`) and reason-code reference, with the file/stage that produces each code;
  - a stage-by-stage walkthrough (Worker fallback → feature flag → authenticity → MIME parse → control/alias → treatment → grant → dedup → inserted-but-missing);
  - ready-to-run SQL queries against the server-side ingestion tables (`email_ingestion_alias_routing`, `email_ingestion_grants`, `email_ingestion_idempotency_keys`, `email_ingestion_dedup_fingerprints`, `email_ingestion_quarantine`, `charges`, `documents`);
  - a gateway log-event cheat sheet and the shadow-mode caveat.
- **`packages/email-ingestion-gateway/CLAUDE.md`** — package-specific conventions: module map, DI-for-testability rules, generated-code (`src/gql/`) notes, server contract parity, and security invariants not to regress.

Also:

- **`CLAUDE.md`** (root) — registers `email-ingestion-gateway` in the monorepo package map (new "Email ingestion" group) and moves `gmail-listener` there as the legacy listener.

## Notes

- Docs-only change; no source or behavior changes.
- Content was derived directly from the package source (`verifier.ts`, `mime-extractor.ts`, `orchestrator.ts`, `treatment.ts`, `link-fetcher.ts`, `server-client.ts`, `environment.ts`) and the server's `email-ingestion` module + migrations, so reason codes, limits, env vars, and table/column names match the implementation.
- Cross-links to the existing design docs under `docs/multi-tenant-gmail-listener/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x)_