### PR TITLE
feat(ocr): resolve issuer/recipient to business UUIDs via matching + LLM fallback

### DIFF
--- a/.changeset/@accounter_client-3773-dependencies.md
+++ b/.changeset/@accounter_client-3773-dependencies.md
@@ -1,5 +1,0 @@
----
-"@accounter/client": patch
----
-dependencies updates:
-  - Updated dependency [`html2canvas-pro@2.2.0` ↗︎](https://www.npmjs.com/package/html2canvas-pro/v/2.2.0) (from `2.1.1`, in `dependencies`)

--- a/.changeset/@accounter_client-3773-dependencies.md
+++ b/.changeset/@accounter_client-3773-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`html2canvas-pro@2.2.0` ↗︎](https://www.npmjs.com/package/html2canvas-pro/v/2.2.0) (from `2.1.1`, in `dependencies`)

--- a/.changeset/olive-pianos-teach.md
+++ b/.changeset/olive-pianos-teach.md
@@ -1,0 +1,18 @@
+---
+'@accounter/server': patch
+---
+
+- **VAT extraction**: adds `issuerVatNumber` / `recipientVatNumber` to the Claude extraction schema
+  so VAT/registration numbers are pulled from the document in the same LLM call (near-zero extra
+  cost).
+- **Server-side matching**: new pure helper `business-matcher.helper.ts` resolves extracted
+  names/VAT numbers to business UUIDs in three priority tiers: (1) VAT exact match, (2)
+  name/Hebrew-name substring, (3) `suggestion_data.phrases` sorted by priority.
+- **LLM fallback**: for financial document types (INVOICE, RECEIPT, INVOICE_RECEIPT, CREDIT_INVOICE,
+  PROFORMA) where one or both sides remain unmatched after server-side matching, a second LLM call
+  reuses the existing conversation context — no file re-send — and asks Claude to pick the closest
+  business from the full businesses list.
+- **UUID-based side resolution**: `getDocumentFromFile` now resolves `isOwnerIssuer` and
+  `counterpartyId` from the UUID matches, replacing the previous hardcoded `"the guild"` text check.
+- **Graceful fallback**: `fetchBusinessesForMatching` wraps the `BusinessesProvider` call in
+  try/catch, so email-ingestion paths (gateway auth, no tenant context) continue to work unchanged.

--- a/packages/server/src/modules/app-providers/anthropic.ts
+++ b/packages/server/src/modules/app-providers/anthropic.ts
@@ -206,15 +206,19 @@ export class AnthropicProvider {
           });
 
           if (matchOutput) {
-            if (suggestedIssuer === null && matchOutput.issuerMatch) {
-              if (businessList.some(b => b.id === matchOutput.issuerMatch)) {
-                suggestedIssuer = matchOutput.issuerMatch;
-              }
+            if (
+              suggestedIssuer === null &&
+              matchOutput.issuerMatch &&
+              businessList.some(b => b.id === matchOutput.issuerMatch)
+            ) {
+              suggestedIssuer = matchOutput.issuerMatch;
             }
-            if (suggestedRecipient === null && matchOutput.recipientMatch) {
-              if (businessList.some(b => b.id === matchOutput.recipientMatch)) {
-                suggestedRecipient = matchOutput.recipientMatch;
-              }
+            if (
+              suggestedRecipient === null &&
+              matchOutput.recipientMatch &&
+              businessList.some(b => b.id === matchOutput.recipientMatch)
+            ) {
+              suggestedRecipient = matchOutput.recipientMatch;
             }
           }
         } catch {

--- a/packages/server/src/modules/app-providers/anthropic.ts
+++ b/packages/server/src/modules/app-providers/anthropic.ts
@@ -4,6 +4,8 @@ import stripIndent from 'strip-indent';
 import { z } from 'zod';
 import { anthropic } from '@ai-sdk/anthropic';
 import { Currency, DocumentType } from '../../shared/enums.js';
+import type { BusinessMatchData } from './helpers/business-matcher.helper.js';
+import { matchBusiness } from './helpers/business-matcher.helper.js';
 
 const documentDataSchema = z.object({
   type: z.enum(DocumentType).nullable().optional().describe('The type of financial document'),
@@ -13,6 +15,16 @@ const documentDataSchema = z.object({
     .nullable()
     .optional()
     .describe('Legal name and details of the entity to whom the document is addressed'),
+  issuerVatNumber: z
+    .string()
+    .nullable()
+    .optional()
+    .describe('VAT or business registration number of the issuer (מספר עוסק / ח.פ / מע"מ)'),
+  recipientVatNumber: z
+    .string()
+    .nullable()
+    .optional()
+    .describe('VAT or business registration number of the recipient'),
   fullAmount: z
     .number()
     .nullable()
@@ -52,6 +64,30 @@ const documentDataSchema = z.object({
 
 type DocumentData = z.infer<typeof documentDataSchema>;
 
+export type DocumentDataWithMatches = DocumentData & {
+  suggestedIssuer: string | null;
+  suggestedRecipient: string | null;
+};
+
+const businessMatchSchema = z.object({
+  issuerMatch: z
+    .string()
+    .nullable()
+    .describe('UUID of the best-matching issuer business, or null if no confident match'),
+  recipientMatch: z
+    .string()
+    .nullable()
+    .describe('UUID of the best-matching recipient business, or null if no confident match'),
+});
+
+const FINANCIAL_DOC_TYPES = new Set<string>([
+  DocumentType.Invoice,
+  DocumentType.Receipt,
+  DocumentType.InvoiceReceipt,
+  DocumentType.CreditInvoice,
+  DocumentType.Proforma,
+]);
+
 const SUPPORTED_FILE_TYPES = [
   'image/jpeg',
   'image/png',
@@ -70,23 +106,15 @@ function isSupportedFileType(value: string): value is SupportedFileType {
   global: true,
 })
 export class AnthropicProvider {
-  /**
-   * Convert File or Blob to Base64
-   * @param fileOrBlob File or Blob to convert
-   * @returns Base64 encoded string
-   */
   private async fileToBase64(fileOrBlob: File | Blob): Promise<string> {
     const buffer = await fileOrBlob.arrayBuffer();
-    const base64string = Buffer.from(buffer).toString('base64');
-    return base64string;
+    return Buffer.from(buffer).toString('base64');
   }
 
-  /**
-   * Extract invoice details using Anthropic API
-   * @param fileOrBlob File or Blob to process
-   * @returns Parsed invoice data
-   */
-  async extractInvoiceDetails(fileOrBlob: File | Blob): Promise<DocumentData> {
+  async extractInvoiceDetails(
+    fileOrBlob: File | Blob,
+    businesses?: BusinessMatchData[],
+  ): Promise<DocumentDataWithMatches> {
     const fileType = fileOrBlob.type.toLowerCase();
     if (!isSupportedFileType(fileType)) {
       throw new Error('Unsupported file type. Please provide an image or PDF.');
@@ -94,18 +122,20 @@ export class AnthropicProvider {
 
     const fileData = await this.fileToBase64(fileOrBlob);
 
-    const { output } = await generateText({
-      model: anthropic('claude-sonnet-4-5'),
-      output: Output.object({ schema: documentDataSchema }),
-      messages: [
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'text',
-              text: stripIndent(`Please analyze the provided document and extract:
+    const fileContentBlock =
+      fileType === 'application/pdf'
+        ? ({ type: 'file', data: fileData, mediaType: fileType } as const)
+        : ({ type: 'image', image: fileData, mediaType: fileType } as const);
+
+    const inputMessages = [
+      {
+        role: 'user' as const,
+        content: [
+          {
+            type: 'text' as const,
+            text: stripIndent(`Please analyze the provided document and extract:
                         - Document type
-                        - Issuer and recipient details
+                        - Issuer and recipient details (names and VAT/registration numbers)
                         - Monetary amounts (total and VAT)
                         - Date and reference numbers
                         - Allocation number (if VAT exists and applicable)
@@ -114,23 +144,85 @@ export class AnthropicProvider {
                         Note that some receipts (e.g. by Stripe) carry the invoice details; pay extra attention not to misclassify them as INVOICE_RECEIPT.
 
                         Return only a JSON object without any explanation. Use NULL value for missing values, allocation number is optional.`),
-            },
-            fileType === 'application/pdf'
-              ? {
-                  type: 'file',
-                  data: fileData,
-                  mediaType: fileType,
-                }
-              : {
-                  type: 'image',
-                  image: fileData,
-                  mediaType: fileType,
-                },
-          ],
-        },
-      ],
+          },
+          fileContentBlock,
+        ],
+      },
+    ];
+
+    const { output, response } = await generateText({
+      model: anthropic('claude-sonnet-4-5'),
+      output: Output.object({ schema: documentDataSchema }),
+      messages: inputMessages,
     });
 
-    return output;
+    const draft = output;
+
+    const businessList = businesses ?? [];
+    let suggestedIssuer = matchBusiness(draft.issuer, draft.issuerVatNumber, businessList);
+    let suggestedRecipient = matchBusiness(draft.recipient, draft.recipientVatNumber, businessList);
+
+    // LLM fallback: for financial documents with unmatched sides, ask Claude to
+    // pick from the businesses list using the existing conversation context (no
+    // file re-send — the document is already in the prior turn).
+    if (
+      businessList.length > 0 &&
+      draft.type != null &&
+      FINANCIAL_DOC_TYPES.has(draft.type) &&
+      (suggestedIssuer === null || suggestedRecipient === null)
+    ) {
+      const unmatched: string[] = [];
+      if (suggestedIssuer === null && draft.issuer) {
+        unmatched.push(`issuer "${draft.issuer}"`);
+      }
+      if (suggestedRecipient === null && draft.recipient) {
+        unmatched.push(`recipient "${draft.recipient}"`);
+      }
+
+      if (unmatched.length > 0) {
+        const sortedBusinesses = [...businessList].sort(
+          (a, b) => (b.suggestion_data?.priority ?? 0) - (a.suggestion_data?.priority ?? 0),
+        );
+        const businessesText = sortedBusinesses
+          .map(b => `${b.id}|${b.name ?? b.hebrew_name ?? ''}`)
+          .join('\n');
+
+        const followUpText = [
+          `The document has unmatched ${unmatched.join(' and ')}.`,
+          `Below is a list of known businesses (format: UUID|name). Return the UUID of the closest matching business for each unmatched side, or null if no confident match. Do not guess.`,
+          businessesText,
+        ].join('\n\n');
+
+        try {
+          const { output: matchOutput } = await generateText({
+            model: anthropic('claude-sonnet-4-5'),
+            output: Output.object({ schema: businessMatchSchema }),
+            messages: [
+              ...inputMessages,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              ...(response.messages as any[]),
+              { role: 'user' as const, content: followUpText },
+            ],
+          });
+
+          if (matchOutput) {
+            if (suggestedIssuer === null && matchOutput.issuerMatch) {
+              if (businessList.some(b => b.id === matchOutput.issuerMatch)) {
+                suggestedIssuer = matchOutput.issuerMatch;
+              }
+            }
+            if (suggestedRecipient === null && matchOutput.recipientMatch) {
+              if (businessList.some(b => b.id === matchOutput.recipientMatch)) {
+                suggestedRecipient = matchOutput.recipientMatch;
+              }
+            }
+          }
+        } catch {
+          // LLM fallback failure is non-fatal — proceed with server-side match only
+        }
+      }
+    }
+
+    return { ...draft, suggestedIssuer, suggestedRecipient };
   }
 }

--- a/packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts
+++ b/packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts
@@ -10,14 +10,15 @@ function normalizeVat(vat: string): string {
   return vat.replace(/[\s-]/g, '');
 }
 
-const LEGAL_SUFFIXES = /\b(בע"מ|בעמ|בע'מ|ltd\.?|inc\.?|llc\.?|corp\.?|limited|incorporated|plc)\b/gi;
+const LEGAL_SUFFIXES =
+  /\b(בע"מ|בעמ|בע'מ|ltd\.?|inc\.?|llc\.?|corp\.?|limited|incorporated|plc)\b/gi;
 const MIN_MATCH_LENGTH = 3;
 
 function normalizeText(text: string): string {
   return text
     .toLowerCase()
     .replace(LEGAL_SUFFIXES, '')
-    .replace(/[״׳"'.,\-_()\[\]]/g, '')
+    .replace(/[״׳"'.,\-_()[\]]/g, '')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts
+++ b/packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts
@@ -1,0 +1,77 @@
+export type BusinessMatchData = {
+  id: string;
+  name: string | null;
+  hebrew_name: string | null;
+  vat_number: string | null;
+  suggestion_data: { phrases?: string[]; priority?: number } | null;
+};
+
+function normalizeVat(vat: string): string {
+  return vat.replace(/[\s-]/g, '');
+}
+
+function normalizeText(text: string): string {
+  return text.toLowerCase().trim();
+}
+
+/**
+ * Attempt to match an extracted name/VAT to a known business.
+ *
+ * Priority:
+ *  1. VAT exact match  — definitive for Israeli invoices.
+ *  2. Name exact / substring match (case-insensitive, both Latin and Hebrew).
+ *  3. suggestion_data.phrases substring match, sorted by priority descending.
+ *
+ * Returns the matching business UUID, or null if no confident match.
+ */
+export function matchBusiness(
+  extractedName: string | null | undefined,
+  extractedVatNumber: string | null | undefined,
+  businesses: BusinessMatchData[],
+): string | null {
+  if (!businesses.length) return null;
+
+  // 1. VAT exact match
+  if (extractedVatNumber) {
+    const normalizedVat = normalizeVat(extractedVatNumber);
+    for (const b of businesses) {
+      if (b.vat_number && normalizeVat(b.vat_number) === normalizedVat) {
+        return b.id;
+      }
+    }
+  }
+
+  if (!extractedName) return null;
+  const normalizedName = normalizeText(extractedName);
+
+  // 2. Name exact / substring match
+  for (const b of businesses) {
+    const names = [b.name, b.hebrew_name].filter((n): n is string => n != null);
+    for (const name of names) {
+      const normalizedBizName = normalizeText(name);
+      if (
+        normalizedBizName === normalizedName ||
+        normalizedName.includes(normalizedBizName) ||
+        normalizedBizName.includes(normalizedName)
+      ) {
+        return b.id;
+      }
+    }
+  }
+
+  // 3. Suggestion phrases, sorted by priority descending
+  const sorted = [...businesses].sort(
+    (a, b) => (b.suggestion_data?.priority ?? 0) - (a.suggestion_data?.priority ?? 0),
+  );
+  for (const b of sorted) {
+    const phrases = b.suggestion_data?.phrases ?? [];
+    for (const phrase of phrases) {
+      const normalizedPhrase = normalizeText(phrase);
+      if (normalizedName.includes(normalizedPhrase) || normalizedPhrase.includes(normalizedName)) {
+        return b.id;
+      }
+    }
+  }
+
+  return null;
+}

--- a/packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts
+++ b/packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts
@@ -10,8 +10,16 @@ function normalizeVat(vat: string): string {
   return vat.replace(/[\s-]/g, '');
 }
 
+const LEGAL_SUFFIXES = /\b(בע"מ|בעמ|בע'מ|ltd\.?|inc\.?|llc\.?|corp\.?|limited|incorporated|plc)\b/gi;
+const MIN_MATCH_LENGTH = 3;
+
 function normalizeText(text: string): string {
-  return text.toLowerCase().trim();
+  return text
+    .toLowerCase()
+    .replace(LEGAL_SUFFIXES, '')
+    .replace(/[״׳"'.,\-_()\[\]]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 /**
@@ -43,12 +51,14 @@ export function matchBusiness(
 
   if (!extractedName) return null;
   const normalizedName = normalizeText(extractedName);
+  if (normalizedName.length < MIN_MATCH_LENGTH) return null;
 
   // 2. Name exact / substring match
   for (const b of businesses) {
     const names = [b.name, b.hebrew_name].filter((n): n is string => n != null);
     for (const name of names) {
       const normalizedBizName = normalizeText(name);
+      if (normalizedBizName.length < MIN_MATCH_LENGTH) continue;
       if (
         normalizedBizName === normalizedName ||
         normalizedName.includes(normalizedBizName) ||
@@ -67,6 +77,7 @@ export function matchBusiness(
     const phrases = b.suggestion_data?.phrases ?? [];
     for (const phrase of phrases) {
       const normalizedPhrase = normalizeText(phrase);
+      if (normalizedPhrase.length < MIN_MATCH_LENGTH) continue;
       if (normalizedName.includes(normalizedPhrase) || normalizedPhrase.includes(normalizedName)) {
         return b.id;
       }

--- a/packages/server/src/modules/documents/helpers/upload.helper.ts
+++ b/packages/server/src/modules/documents/helpers/upload.helper.ts
@@ -198,12 +198,20 @@ function resolveOwnerSideFromUuids(
     if (suggestedIssuer) {
       ocrData.counterpartyId ??= suggestedIssuer;
     }
+  } else if (suggestedIssuer != null && suggestedRecipient != null) {
+    // Both sides matched to non-owner businesses — ambiguous which side the owner is.
+    // Preserve the OCR-derived isOwnerIssuer and use it only to pick counterpartyId.
+    if (ocrData.isOwnerIssuer === true) {
+      ocrData.counterpartyId ??= suggestedRecipient;
+    } else if (ocrData.isOwnerIssuer === false) {
+      ocrData.counterpartyId ??= suggestedIssuer;
+    }
   } else if (suggestedIssuer != null) {
-    // Issuer matched to a non-owner business → owner must be the recipient side
+    // Only issuer matched to a non-owner business → owner must be the recipient side
     ocrData.isOwnerIssuer = false;
     ocrData.counterpartyId ??= suggestedIssuer;
   } else if (suggestedRecipient != null) {
-    // Recipient matched to a non-owner business → owner must be the issuer side
+    // Only recipient matched to a non-owner business → owner must be the issuer side
     ocrData.isOwnerIssuer = true;
     ocrData.counterpartyId ??= suggestedRecipient;
   }

--- a/packages/server/src/modules/documents/helpers/upload.helper.ts
+++ b/packages/server/src/modules/documents/helpers/upload.helper.ts
@@ -3,7 +3,10 @@ import { Currency, DocumentType } from '../../../shared/enums.js';
 import { hashStringToInt } from '../../../shared/helpers/index.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
 import { AnthropicProvider } from '../../app-providers/anthropic.js';
+import type { BusinessMatchData } from '../../app-providers/helpers/business-matcher.helper.js';
 import { CloudinaryProvider } from '../../app-providers/cloudinary.js';
+import { suggestionDataSchema } from '../../financial-entities/helpers/business-suggestion-data-schema.helper.js';
+import { BusinessesProvider } from '../../financial-entities/providers/businesses.provider.js';
 import type { IInsertDocumentsParams } from '../types.js';
 
 const toBase64 = async (file: File | Blob): Promise<string> => {
@@ -37,7 +40,24 @@ export type OcrData = {
   allocationNumber?: string;
   description?: string;
   remarks?: string;
+  suggestedIssuer?: string;
+  suggestedRecipient?: string;
 };
+
+async function fetchBusinessesForMatching(injector: Injector): Promise<BusinessMatchData[]> {
+  try {
+    const rawBusinesses = await injector.get(BusinessesProvider).getAllBusinesses();
+    return rawBusinesses.map(b => ({
+      id: b.id,
+      name: b.name ?? null,
+      hebrew_name: b.hebrew_name ?? null,
+      vat_number: b.vat_number ?? null,
+      suggestion_data: suggestionDataSchema.safeParse(b.suggestion_data).data ?? null,
+    }));
+  } catch {
+    return [];
+  }
+}
 
 export async function getOcrData(
   injector: Injector,
@@ -60,22 +80,16 @@ export async function getOcrData(
     };
   }
 
-  const draft = await injector.get(AnthropicProvider).extractInvoiceDetails(file);
+  const businesses = await fetchBusinessesForMatching(injector);
+  const draft = await injector.get(AnthropicProvider).extractInvoiceDetails(file, businesses);
 
   if (!draft) {
     throw new Error('No data returned from Anthropic OCR');
   }
 
-  let isOwnerIssuer: boolean | undefined = undefined;
-  if (draft.recipient?.toLocaleLowerCase().includes('the guild')) {
-    isOwnerIssuer = false;
-  }
-  if (draft.issuer?.toLocaleLowerCase().includes('the guild')) {
-    isOwnerIssuer = true;
-  }
-
   return {
-    isOwnerIssuer,
+    suggestedIssuer: draft.suggestedIssuer ?? undefined,
+    suggestedRecipient: draft.suggestedRecipient ?? undefined,
     documentType: draft.type ?? DocumentType.Unprocessed,
     serial: draft.referenceCode ?? undefined,
     date: validateDate(draft.date ?? undefined),
@@ -167,6 +181,34 @@ export function getDocumentFromUrlsAndOcrData(
   return newDocument;
 }
 
+function resolveOwnerSideFromUuids(
+  ocrData: OcrData,
+  ownerId: string,
+): void {
+  const { suggestedIssuer, suggestedRecipient } = ocrData;
+  if (suggestedIssuer == null && suggestedRecipient == null) return;
+
+  if (suggestedIssuer === ownerId) {
+    ocrData.isOwnerIssuer = true;
+    if (suggestedRecipient) {
+      ocrData.counterpartyId ??= suggestedRecipient;
+    }
+  } else if (suggestedRecipient === ownerId) {
+    ocrData.isOwnerIssuer = false;
+    if (suggestedIssuer) {
+      ocrData.counterpartyId ??= suggestedIssuer;
+    }
+  } else if (suggestedIssuer != null) {
+    // Issuer matched to a non-owner business → owner must be the recipient side
+    ocrData.isOwnerIssuer = false;
+    ocrData.counterpartyId ??= suggestedIssuer;
+  } else if (suggestedRecipient != null) {
+    // Recipient matched to a non-owner business → owner must be the issuer side
+    ocrData.isOwnerIssuer = true;
+    ocrData.counterpartyId ??= suggestedRecipient;
+  }
+}
+
 export async function getDocumentFromFile(
   injector: Injector,
   file: File | Blob,
@@ -195,6 +237,9 @@ export async function getDocumentFromFile(
     if (counterPartyId) {
       ocrData.counterpartyId = counterPartyId;
     }
+
+    // Resolve isOwnerIssuer and counterpartyId from UUID matches (primary path).
+    resolveOwnerSideFromUuids(ocrData, ownerId);
 
     return getDocumentFromUrlsAndOcrData(fileUrl, imageUrl, ocrData, ownerId, chargeId, fileHash);
   } catch (e) {

--- a/packages/server/src/modules/documents/helpers/upload.helper.ts
+++ b/packages/server/src/modules/documents/helpers/upload.helper.ts
@@ -3,8 +3,8 @@ import { Currency, DocumentType } from '../../../shared/enums.js';
 import { hashStringToInt } from '../../../shared/helpers/index.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
 import { AnthropicProvider } from '../../app-providers/anthropic.js';
-import type { BusinessMatchData } from '../../app-providers/helpers/business-matcher.helper.js';
 import { CloudinaryProvider } from '../../app-providers/cloudinary.js';
+import type { BusinessMatchData } from '../../app-providers/helpers/business-matcher.helper.js';
 import { suggestionDataSchema } from '../../financial-entities/helpers/business-suggestion-data-schema.helper.js';
 import { BusinessesProvider } from '../../financial-entities/providers/businesses.provider.js';
 import type { IInsertDocumentsParams } from '../types.js';
@@ -181,10 +181,7 @@ export function getDocumentFromUrlsAndOcrData(
   return newDocument;
 }
 
-function resolveOwnerSideFromUuids(
-  ocrData: OcrData,
-  ownerId: string,
-): void {
+function resolveOwnerSideFromUuids(ocrData: OcrData, ownerId: string): void {
   const { suggestedIssuer, suggestedRecipient } = ocrData;
   if (suggestedIssuer == null && suggestedRecipient == null) return;
 

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
@@ -53,7 +53,9 @@ const BASE_INPUT = {
 // OCR runs via getOcrData(injector, file, false) → AnthropicProvider.extractInvoiceDetails.
 // A mock operation injector returns a stub Anthropic provider that yields an INVOICE,
 // so figureOutSides attributes the recognized business as the document creditor.
-const extractInvoiceDetails = vi.fn().mockResolvedValue({ type: DocumentType.Invoice });
+const extractInvoiceDetails = vi
+  .fn()
+  .mockResolvedValue({ type: DocumentType.Invoice, suggestedIssuer: null, suggestedRecipient: null });
 const ocrInjector = {
   get: (token: unknown) => (token === AnthropicProvider ? { extractInvoiceDetails } : undefined),
 } as unknown as Injector;


### PR DESCRIPTION
## Summary

- **VAT extraction**: adds `issuerVatNumber` / `recipientVatNumber` to the Claude extraction schema so VAT/registration numbers are pulled from the document in the same LLM call (near-zero extra cost).
- **Server-side matching**: new pure helper `business-matcher.helper.ts` resolves extracted names/VAT numbers to business UUIDs in three priority tiers: (1) VAT exact match, (2) name/Hebrew-name substring, (3) `suggestion_data.phrases` sorted by priority.
- **LLM fallback**: for financial document types (INVOICE, RECEIPT, INVOICE_RECEIPT, CREDIT_INVOICE, PROFORMA) where one or both sides remain unmatched after server-side matching, a second LLM call reuses the existing conversation context — no file re-send — and asks Claude to pick the closest business from the full businesses list.
- **UUID-based side resolution**: `getDocumentFromFile` now resolves `isOwnerIssuer` and `counterpartyId` from the UUID matches, replacing the previous hardcoded `"the guild"` text check.
- **Graceful fallback**: `fetchBusinessesForMatching` wraps the `BusinessesProvider` call in try/catch, so email-ingestion paths (gateway auth, no tenant context) continue to work unchanged.

## Files changed

| File | Change |
|------|--------|
| `packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts` | **New** — pure matching logic (VAT → name → phrases) |
| `packages/server/src/modules/app-providers/anthropic.ts` | Extended schema with VAT fields, updated prompt, businesses param, server-side matching + LLM fallback second call |
| `packages/server/src/modules/documents/helpers/upload.helper.ts` | Fetch businesses, pass to OCR, use UUID results for `isOwnerIssuer` / `counterpartyId` |
| `packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts` | Updated mock to include new `suggestedIssuer`/`suggestedRecipient` fields |

## Test plan

- [ ] Upload an invoice with a known VAT number → verify `creditor_id`/`debtor_id` are populated via VAT match
- [ ] Upload an invoice where the business name matches a `suggestion_data.phrases` entry → verify phrase match fires
- [ ] Upload a document where neither side matches server-side → verify the LLM fallback second call runs and picks the right business
- [ ] Upload an UNPROCESSED/OTHER document → verify the LLM fallback is NOT triggered
- [ ] Email ingestion path → verify OCR still works (businesses fetch fails gracefully, documents classified correctly)
- [ ] `yarn test` passes (unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jqdcy82DZAddEoVsX9kpq

---
_Generated by [Claude Code](https://claude.ai/code/session_017jqdcy82DZAddEoVsX9kpq)_