### PR TITLE
Fix sort code update to include owner_id in query params

### DIFF
--- a/.changeset/young-lamps-pump.md
+++ b/.changeset/young-lamps-pump.md
@@ -1,0 +1,12 @@
+---
+'@accounter/server': patch
+---
+
+- **sort-codes.provider.ts**: Modified `updateSortCode` to retrieve the verified admin context and
+  pass the `ownerId` to the query via `reassureOwnerIdExists` helper
+- **sort-codes.provider.test.ts**: Added comprehensive test coverage for both `updateSortCode` and
+  `addSortCode` methods, including:
+  - Regression test verifying `owner_id` is included in update query values
+  - Test confirming all parameters (key, name, defaultIrsCode, ownerId) are forwarded correctly
+  - Test verifying cache is cleared after updates
+  - Test for `addSortCode` ensuring `owner_id` is injected into insert queries

--- a/packages/server/src/modules/sort-codes/providers/__tests__/sort-codes.provider.test.ts
+++ b/packages/server/src/modules/sort-codes/providers/__tests__/sort-codes.provider.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AdminContextProvider } from '../../../admin-context/providers/admin-context.provider.js';
+import type { TenantAwareDBClient } from '../../../app-providers/tenant-db-client.js';
+import { SortCodesProvider } from '../sort-codes.provider.js';
+
+type SortCodeRow = {
+  key: number;
+  name: string;
+  default_irs_code: number | null;
+  owner_id: string;
+};
+
+function createProvider(rows: SortCodeRow[] = [], ownerId = 'owner-a') {
+  const query = vi.fn().mockResolvedValue({ rows, rowCount: rows.length });
+  const db = {
+    query,
+  } as unknown as TenantAwareDBClient;
+
+  const getVerifiedAdminContext = vi.fn().mockResolvedValue({ ownerId });
+  const adminContextProvider = {
+    getVerifiedAdminContext,
+  } as unknown as AdminContextProvider;
+
+  return {
+    provider: new SortCodesProvider(db, adminContextProvider),
+    db,
+    query,
+    getVerifiedAdminContext,
+  };
+}
+
+describe('SortCodesProvider.updateSortCode', () => {
+  it('injects the context ownerId into the update query values (regression for #3787)', async () => {
+    const { provider, query, getVerifiedAdminContext } = createProvider([], 'owner-a');
+
+    await provider.updateSortCode({ key: 100, name: 'New Name', defaultIrsCode: undefined });
+
+    expect(getVerifiedAdminContext).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledTimes(1);
+
+    const [queryText, values] = query.mock.calls[0];
+    expect(queryText).toContain('UPDATE accounter_schema.sort_codes');
+    // The WHERE clause is scoped by both key and owner_id; the ownerId must be supplied.
+    expect(values).toContain('owner-a');
+  });
+
+  it('forwards key, name and defaultIrsCode to the update query', async () => {
+    const { provider, query } = createProvider([], 'owner-a');
+
+    await provider.updateSortCode({ key: 100, name: 'New Name', defaultIrsCode: 42 });
+
+    const [, values] = query.mock.calls[0];
+    expect(values).toContain(100);
+    expect(values).toContain('New Name');
+    expect(values).toContain(42);
+    expect(values).toContain('owner-a');
+  });
+
+  it('clears the cached sort codes after an update', async () => {
+    const { provider, query } = createProvider(
+      [{ key: 100, name: 'Old', default_irs_code: null, owner_id: 'owner-a' }],
+      'owner-a',
+    );
+
+    await provider.getAllSortCodes();
+    expect(query).toHaveBeenCalledTimes(1);
+
+    // cache hit: no additional query
+    await provider.getAllSortCodes();
+    expect(query).toHaveBeenCalledTimes(1);
+
+    await provider.updateSortCode({ key: 100, name: 'New', defaultIrsCode: undefined });
+
+    // cache was cleared, so the next read re-queries
+    await provider.getAllSortCodes();
+    expect(query).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('SortCodesProvider.addSortCode', () => {
+  it('injects the context ownerId into the insert query values', async () => {
+    const { provider, query, getVerifiedAdminContext } = createProvider([], 'owner-b');
+
+    await provider.addSortCode({ key: 200, name: 'Cash', defaultIrsCode: undefined });
+
+    expect(getVerifiedAdminContext).toHaveBeenCalledTimes(1);
+    const [queryText, values] = query.mock.calls[0];
+    expect(queryText).toContain('INSERT INTO accounter_schema.sort_codes');
+    expect(values).toContain('owner-b');
+    expect(values).toContain(200);
+    expect(values).toContain('Cash');
+  });
+});

--- a/packages/server/src/modules/sort-codes/providers/sort-codes.provider.ts
+++ b/packages/server/src/modules/sort-codes/providers/sort-codes.provider.ts
@@ -136,7 +136,8 @@ export class SortCodesProvider {
 
   public async updateSortCode(params: IUpdateSortCodeParams) {
     this.clearCache();
-    return updateSortCode.run(params, this.db);
+    const { ownerId } = await this.adminContextProvider.getVerifiedAdminContext();
+    return updateSortCode.run(reassureOwnerIdExists(params, ownerId), this.db);
   }
 
   public clearCache() {

--- a/packages/server/src/modules/sort-codes/providers/sort-codes.provider.ts
+++ b/packages/server/src/modules/sort-codes/providers/sort-codes.provider.ts
@@ -135,9 +135,10 @@ export class SortCodesProvider {
   }
 
   public async updateSortCode(params: IUpdateSortCodeParams) {
-    this.clearCache();
     const { ownerId } = await this.adminContextProvider.getVerifiedAdminContext();
-    return updateSortCode.run(reassureOwnerIdExists(params, ownerId), this.db);
+    const result = await updateSortCode.run(reassureOwnerIdExists(params, ownerId), this.db);
+    this.clearCache();
+    return result;
   }
 
   public clearCache() {


### PR DESCRIPTION
## Summary
Fixes a regression in the `SortCodesProvider.updateSortCode` method where the `owner_id` was not being injected into the update query parameters, causing the WHERE clause to be incomplete.

## Changes
- **sort-codes.provider.ts**: Modified `updateSortCode` to retrieve the verified admin context and pass the `ownerId` to the query via `reassureOwnerIdExists` helper
- **sort-codes.provider.test.ts**: Added comprehensive test coverage for both `updateSortCode` and `addSortCode` methods, including:
  - Regression test verifying `owner_id` is included in update query values
  - Test confirming all parameters (key, name, defaultIrsCode, ownerId) are forwarded correctly
  - Test verifying cache is cleared after updates
  - Test for `addSortCode` ensuring `owner_id` is injected into insert queries

## Implementation Details
The fix ensures that multi-tenant data isolation is maintained by scoping all sort code operations to the authenticated owner's context. The WHERE clause in the UPDATE statement now correctly filters by both `key` and `owner_id`, preventing cross-tenant data mutations.

https://claude.ai/code/session_01FNsqrBYEeZvWdJDjexmixR