### PR TITLE
feat(server): business management screen — Phase B usage query

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -151,7 +151,6 @@ export default [
               'BusinessEmailConfig',
               'BusinessTripSummary',
               'BusinessTripSummaryRow',
-              'BusinessUsage',
               'ChangedField',
               'ChargeMatch',
               'ChargeMatchesResult',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -151,6 +151,7 @@ export default [
               'BusinessEmailConfig',
               'BusinessTripSummary',
               'BusinessTripSummaryRow',
+              'BusinessUsage',
               'ChangedField',
               'ChargeMatch',
               'ChargeMatchesResult',

--- a/packages/server/src/modules/financial-entities/index.ts
+++ b/packages/server/src/modules/financial-entities/index.ts
@@ -1,6 +1,7 @@
 import { createModule } from 'graphql-modules';
 import { AdminBusinessesProvider } from './providers/admin-businesses.provider.js';
 import { BusinessesOperationProvider } from './providers/businesses-operation.provider.js';
+import { BusinessUsageProvider } from './providers/businesses-usage.provider.js';
 import { BusinessesProvider } from './providers/businesses.provider.js';
 import { ClientsProvider } from './providers/clients.provider.js';
 import { EntityEnsureProvider } from './providers/entity-ensure.provider.js';
@@ -8,12 +9,14 @@ import { FinancialEntitiesProvider } from './providers/financial-entities.provid
 import { TaxCategoriesProvider } from './providers/tax-categories.provider.js';
 import { adminBusinessesResolvers } from './resolvers/admin-businesses.resolver.js';
 import { businessTransactionsResolvers } from './resolvers/business-transactions.resolver.js';
+import { businessesUsageResolvers } from './resolvers/businesses-usage.resolver.js';
 import { businessesResolvers } from './resolvers/businesses.resolver.js';
 import { clientsResolvers } from './resolvers/clients.resolvers.js';
 import { financialEntitiesResolvers } from './resolvers/financial-entities.resolver.js';
 import { taxCategoriesResolvers } from './resolvers/tax-categories.resolver.js';
 import adminBusinesses from './typeDefs/admin-businesses.graphql.js';
 import businessesTransactions from './typeDefs/businesses-transactions.graphql.js';
+import businessesUsage from './typeDefs/businesses-usage.graphql.js';
 import businesses from './typeDefs/businesses.graphql.js';
 import clients from './typeDefs/clients.graphql.js';
 import financialEntities from './typeDefs/financial-entities.graphql.js';
@@ -27,6 +30,7 @@ export const financialEntitiesModule = createModule({
   typeDefs: [
     businesses,
     businessesTransactions,
+    businessesUsage,
     financialEntities,
     taxCategories,
     adminBusinesses,
@@ -35,6 +39,7 @@ export const financialEntitiesModule = createModule({
   resolvers: [
     financialEntitiesResolvers,
     businessTransactionsResolvers,
+    businessesUsageResolvers,
     taxCategoriesResolvers,
     businessesResolvers,
     adminBusinessesResolvers,
@@ -43,6 +48,7 @@ export const financialEntitiesModule = createModule({
   providers: () => [
     BusinessesProvider,
     BusinessesOperationProvider,
+    BusinessUsageProvider,
     TaxCategoriesProvider,
     FinancialEntitiesProvider,
     AdminBusinessesProvider,

--- a/packages/server/src/modules/financial-entities/providers/__tests__/businesses-usage.provider.test.ts
+++ b/packages/server/src/modules/financial-entities/providers/__tests__/businesses-usage.provider.test.ts
@@ -2,49 +2,33 @@ import { describe, expect, it, vi } from 'vitest';
 import { BusinessUsageProvider } from '../businesses-usage.provider.js';
 import type { TenantAwareDBClient } from '../../../app-providers/tenant-db-client.js';
 
-type Row = { business_id: string | null; count: string | null };
+type Row = { business_id: string | null; source: string | null; count: string | null };
 
-function createProvider(rowsByTable: {
-  transactions?: Row[];
-  documents?: Row[];
-  misc_expenses?: Row[];
-  ledger_records?: Row[];
-}) {
-  const query = vi.fn().mockImplementation((text: string) => {
-    let rows: Row[] = [];
-    if (text.includes('accounter_schema.transactions')) {
-      rows = rowsByTable.transactions ?? [];
-    } else if (text.includes('accounter_schema.misc_expenses')) {
-      rows = rowsByTable.misc_expenses ?? [];
-    } else if (text.includes('accounter_schema.ledger_records')) {
-      rows = rowsByTable.ledger_records ?? [];
-    } else if (text.includes('accounter_schema.documents')) {
-      rows = rowsByTable.documents ?? [];
-    }
-    return Promise.resolve({ rows, rowCount: rows.length });
-  });
+function createProvider(rows: Row[]) {
+  const query = vi.fn().mockResolvedValue({ rows, rowCount: rows.length });
   const db = { query } as unknown as TenantAwareDBClient;
   return { provider: new BusinessUsageProvider(db), query };
 }
 
 describe('BusinessUsageProvider', () => {
   it('returns an empty map when no ids are requested', async () => {
-    const { provider, query } = createProvider({});
+    const { provider, query } = createProvider([]);
     const result = await provider.getUsageByBusinessIds([]);
     expect(result.size).toBe(0);
     expect(query).not.toHaveBeenCalled();
   });
 
-  it('merges per-source counts into a single map keyed by business id', async () => {
-    const { provider } = createProvider({
-      transactions: [{ business_id: 'b1', count: '3' }],
-      documents: [{ business_id: 'b1', count: '2' }],
-      misc_expenses: [{ business_id: 'b1', count: '1' }],
-      ledger_records: [{ business_id: 'b1', count: '5' }],
-    });
+  it('runs a single combined query and merges per-source rows by business id', async () => {
+    const { provider, query } = createProvider([
+      { business_id: 'b1', source: 'transactions', count: '3' },
+      { business_id: 'b1', source: 'documents', count: '2' },
+      { business_id: 'b1', source: 'misc_expenses', count: '1' },
+      { business_id: 'b1', source: 'ledger', count: '5' },
+    ]);
 
     const result = await provider.getUsageByBusinessIds(['b1']);
 
+    expect(query).toHaveBeenCalledTimes(1);
     expect(result.get('b1')).toEqual({
       transactions: 3,
       documents: 2,
@@ -54,9 +38,9 @@ describe('BusinessUsageProvider', () => {
   });
 
   it('defaults every requested business to zero counts', async () => {
-    const { provider } = createProvider({
-      transactions: [{ business_id: 'b1', count: '4' }],
-    });
+    const { provider } = createProvider([
+      { business_id: 'b1', source: 'transactions', count: '4' },
+    ]);
 
     const result = await provider.getUsageByBusinessIds(['b1', 'b2']);
 

--- a/packages/server/src/modules/financial-entities/providers/__tests__/businesses-usage.provider.test.ts
+++ b/packages/server/src/modules/financial-entities/providers/__tests__/businesses-usage.provider.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BusinessUsageProvider } from '../businesses-usage.provider.js';
+import type { TenantAwareDBClient } from '../../../app-providers/tenant-db-client.js';
+
+type Row = { business_id: string | null; count: string | null };
+
+function createProvider(rowsByTable: {
+  transactions?: Row[];
+  documents?: Row[];
+  misc_expenses?: Row[];
+  ledger_records?: Row[];
+}) {
+  const query = vi.fn().mockImplementation((text: string) => {
+    let rows: Row[] = [];
+    if (text.includes('accounter_schema.transactions')) {
+      rows = rowsByTable.transactions ?? [];
+    } else if (text.includes('accounter_schema.misc_expenses')) {
+      rows = rowsByTable.misc_expenses ?? [];
+    } else if (text.includes('accounter_schema.ledger_records')) {
+      rows = rowsByTable.ledger_records ?? [];
+    } else if (text.includes('accounter_schema.documents')) {
+      rows = rowsByTable.documents ?? [];
+    }
+    return Promise.resolve({ rows, rowCount: rows.length });
+  });
+  const db = { query } as unknown as TenantAwareDBClient;
+  return { provider: new BusinessUsageProvider(db), query };
+}
+
+describe('BusinessUsageProvider', () => {
+  it('returns an empty map when no ids are requested', async () => {
+    const { provider, query } = createProvider({});
+    const result = await provider.getUsageByBusinessIds([]);
+    expect(result.size).toBe(0);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('merges per-source counts into a single map keyed by business id', async () => {
+    const { provider } = createProvider({
+      transactions: [{ business_id: 'b1', count: '3' }],
+      documents: [{ business_id: 'b1', count: '2' }],
+      misc_expenses: [{ business_id: 'b1', count: '1' }],
+      ledger_records: [{ business_id: 'b1', count: '5' }],
+    });
+
+    const result = await provider.getUsageByBusinessIds(['b1']);
+
+    expect(result.get('b1')).toEqual({
+      transactions: 3,
+      documents: 2,
+      miscExpenses: 1,
+      ledgerRecords: 5,
+    });
+  });
+
+  it('defaults every requested business to zero counts', async () => {
+    const { provider } = createProvider({
+      transactions: [{ business_id: 'b1', count: '4' }],
+    });
+
+    const result = await provider.getUsageByBusinessIds(['b1', 'b2']);
+
+    expect(result.get('b1')).toEqual({
+      transactions: 4,
+      documents: 0,
+      miscExpenses: 0,
+      ledgerRecords: 0,
+    });
+    expect(result.get('b2')).toEqual({
+      transactions: 0,
+      documents: 0,
+      miscExpenses: 0,
+      ledgerRecords: 0,
+    });
+  });
+});

--- a/packages/server/src/modules/financial-entities/providers/businesses-usage.provider.ts
+++ b/packages/server/src/modules/financial-entities/providers/businesses-usage.provider.ts
@@ -15,6 +15,11 @@ export type BusinessUsageCounts = {
   ledgerRecords: number;
 };
 
+// Cap the number of ids bound per query. The ledger query references the id array four
+// times, so each chunk binds up to 4 * CHUNK_SIZE parameters — kept well under Postgres'
+// 65,535 parameter limit.
+const CHUNK_SIZE = 1000;
+
 const getTransactionsCountByBusinessIds = sql<IGetTransactionsCountByBusinessIdsQuery>`
   SELECT business_id, COUNT(*) AS count
   FROM accounter_schema.transactions
@@ -96,13 +101,6 @@ export class BusinessUsageProvider {
       usage.set(id, { transactions: 0, documents: 0, miscExpenses: 0, ledgerRecords: 0 });
     }
 
-    const [transactions, documents, miscExpenses, ledgerRecords] = await Promise.all([
-      getTransactionsCountByBusinessIds.run({ businessIds: uniqueIds }, this.db),
-      getDocumentsCountByBusinessIds.run({ businessIds: uniqueIds }, this.db),
-      getMiscExpensesCountByBusinessIds.run({ businessIds: uniqueIds }, this.db),
-      getLedgerRecordsCountByBusinessIds.run({ businessIds: uniqueIds }, this.db),
-    ]);
-
     const apply = (
       rows: { business_id: string | null; count: string | null }[],
       key: keyof BusinessUsageCounts,
@@ -118,10 +116,21 @@ export class BusinessUsageProvider {
       }
     };
 
-    apply(transactions, 'transactions');
-    apply(documents, 'documents');
-    apply(miscExpenses, 'miscExpenses');
-    apply(ledgerRecords, 'ledgerRecords');
+    // chunk the ids to stay within Postgres' bind-parameter limit (see CHUNK_SIZE)
+    for (let i = 0; i < uniqueIds.length; i += CHUNK_SIZE) {
+      const chunk = uniqueIds.slice(i, i + CHUNK_SIZE);
+      const [transactions, documents, miscExpenses, ledgerRecords] = await Promise.all([
+        getTransactionsCountByBusinessIds.run({ businessIds: chunk }, this.db),
+        getDocumentsCountByBusinessIds.run({ businessIds: chunk }, this.db),
+        getMiscExpensesCountByBusinessIds.run({ businessIds: chunk }, this.db),
+        getLedgerRecordsCountByBusinessIds.run({ businessIds: chunk }, this.db),
+      ]);
+
+      apply(transactions, 'transactions');
+      apply(documents, 'documents');
+      apply(miscExpenses, 'miscExpenses');
+      apply(ledgerRecords, 'ledgerRecords');
+    }
 
     return usage;
   }

--- a/packages/server/src/modules/financial-entities/providers/businesses-usage.provider.ts
+++ b/packages/server/src/modules/financial-entities/providers/businesses-usage.provider.ts
@@ -1,0 +1,128 @@
+import { Injectable, Scope } from 'graphql-modules';
+import { sql } from '@pgtyped/runtime';
+import { TenantAwareDBClient } from '../../app-providers/tenant-db-client.js';
+import type {
+  IGetDocumentsCountByBusinessIdsQuery,
+  IGetLedgerRecordsCountByBusinessIdsQuery,
+  IGetMiscExpensesCountByBusinessIdsQuery,
+  IGetTransactionsCountByBusinessIdsQuery,
+} from '../types.js';
+
+export type BusinessUsageCounts = {
+  transactions: number;
+  documents: number;
+  miscExpenses: number;
+  ledgerRecords: number;
+};
+
+const getTransactionsCountByBusinessIds = sql<IGetTransactionsCountByBusinessIdsQuery>`
+  SELECT business_id, COUNT(*) AS count
+  FROM accounter_schema.transactions
+  WHERE business_id IN $$businessIds
+  GROUP BY business_id;`;
+
+// A business may be referenced as either the debtor or the creditor of a document, so
+// the two columns are unioned into a single business_id projection before grouping. A
+// document that references the same business on both sides is therefore counted twice
+// (once per side); this is acceptable for a usage indicator.
+const getDocumentsCountByBusinessIds = sql<IGetDocumentsCountByBusinessIdsQuery>`
+  SELECT business_id, COUNT(*) AS count
+  FROM (
+    SELECT debtor_id AS business_id
+    FROM accounter_schema.documents
+    WHERE debtor_id IN $$businessIds
+    UNION ALL
+    SELECT creditor_id AS business_id
+    FROM accounter_schema.documents
+    WHERE creditor_id IN $$businessIds
+  ) AS documents
+  GROUP BY business_id;`;
+
+// Same debtor/creditor union as documents.
+const getMiscExpensesCountByBusinessIds = sql<IGetMiscExpensesCountByBusinessIdsQuery>`
+  SELECT business_id, COUNT(*) AS count
+  FROM (
+    SELECT debtor_id AS business_id
+    FROM accounter_schema.misc_expenses
+    WHERE debtor_id IN $$businessIds
+    UNION ALL
+    SELECT creditor_id AS business_id
+    FROM accounter_schema.misc_expenses
+    WHERE creditor_id IN $$businessIds
+  ) AS misc_expenses
+  GROUP BY business_id;`;
+
+// A ledger record can reference a business in any of its four debit/credit entity
+// columns, so all four are unioned before grouping.
+const getLedgerRecordsCountByBusinessIds = sql<IGetLedgerRecordsCountByBusinessIdsQuery>`
+  SELECT business_id, COUNT(*) AS count
+  FROM (
+    SELECT debit_entity1 AS business_id
+    FROM accounter_schema.ledger_records
+    WHERE debit_entity1 IN $$businessIds
+    UNION ALL
+    SELECT debit_entity2 AS business_id
+    FROM accounter_schema.ledger_records
+    WHERE debit_entity2 IN $$businessIds
+    UNION ALL
+    SELECT credit_entity1 AS business_id
+    FROM accounter_schema.ledger_records
+    WHERE credit_entity1 IN $$businessIds
+    UNION ALL
+    SELECT credit_entity2 AS business_id
+    FROM accounter_schema.ledger_records
+    WHERE credit_entity2 IN $$businessIds
+  ) AS ledger_records
+  GROUP BY business_id;`;
+
+@Injectable({
+  scope: Scope.Operation,
+  global: true,
+})
+export class BusinessUsageProvider {
+  constructor(private db: TenantAwareDBClient) {}
+
+  public async getUsageByBusinessIds(
+    ids: readonly string[],
+  ): Promise<Map<string, BusinessUsageCounts>> {
+    const usage = new Map<string, BusinessUsageCounts>();
+    const uniqueIds = [...new Set(ids)];
+    if (uniqueIds.length === 0) {
+      return usage;
+    }
+
+    // default every requested id to zero so unused businesses are represented
+    for (const id of uniqueIds) {
+      usage.set(id, { transactions: 0, documents: 0, miscExpenses: 0, ledgerRecords: 0 });
+    }
+
+    const [transactions, documents, miscExpenses, ledgerRecords] = await Promise.all([
+      getTransactionsCountByBusinessIds.run({ businessIds: uniqueIds }, this.db),
+      getDocumentsCountByBusinessIds.run({ businessIds: uniqueIds }, this.db),
+      getMiscExpensesCountByBusinessIds.run({ businessIds: uniqueIds }, this.db),
+      getLedgerRecordsCountByBusinessIds.run({ businessIds: uniqueIds }, this.db),
+    ]);
+
+    const apply = (
+      rows: { business_id: string | null; count: string | null }[],
+      key: keyof BusinessUsageCounts,
+    ): void => {
+      for (const row of rows) {
+        if (!row.business_id) {
+          continue;
+        }
+        const counts = usage.get(row.business_id);
+        if (counts) {
+          counts[key] = Number(row.count ?? 0);
+        }
+      }
+    };
+
+    apply(transactions, 'transactions');
+    apply(documents, 'documents');
+    apply(miscExpenses, 'miscExpenses');
+    apply(ledgerRecords, 'ledgerRecords');
+
+    return usage;
+  }
+}

--- a/packages/server/src/modules/financial-entities/providers/businesses-usage.provider.ts
+++ b/packages/server/src/modules/financial-entities/providers/businesses-usage.provider.ts
@@ -1,12 +1,7 @@
 import { Injectable, Scope } from 'graphql-modules';
 import { sql } from '@pgtyped/runtime';
 import { TenantAwareDBClient } from '../../app-providers/tenant-db-client.js';
-import type {
-  IGetDocumentsCountByBusinessIdsQuery,
-  IGetLedgerRecordsCountByBusinessIdsQuery,
-  IGetMiscExpensesCountByBusinessIdsQuery,
-  IGetTransactionsCountByBusinessIdsQuery,
-} from '../types.js';
+import type { IGetUsageCountsByBusinessIdsQuery } from '../types.js';
 
 export type BusinessUsageCounts = {
   transactions: number;
@@ -15,70 +10,67 @@ export type BusinessUsageCounts = {
   ledgerRecords: number;
 };
 
-// Cap the number of ids bound per query. The ledger query references the id array four
-// times, so each chunk binds up to 4 * CHUNK_SIZE parameters — kept well under Postgres'
-// 65,535 parameter limit.
+// Cap the number of ids bound per query. The combined query references the id array nine
+// times (one per UNION ALL branch), so each chunk binds up to 9 * CHUNK_SIZE parameters —
+// kept well under Postgres' 65,535 parameter limit.
 const CHUNK_SIZE = 1000;
 
-const getTransactionsCountByBusinessIds = sql<IGetTransactionsCountByBusinessIdsQuery>`
-  SELECT business_id, COUNT(*) AS count
-  FROM accounter_schema.transactions
-  WHERE business_id IN $$businessIds
-  GROUP BY business_id;`;
+// Maps the `source` discriminator emitted by each UNION ALL branch to its counts key.
+const SOURCE_TO_KEY: Record<string, keyof BusinessUsageCounts> = {
+  transactions: 'transactions',
+  documents: 'documents',
+  misc_expenses: 'miscExpenses',
+  ledger: 'ledgerRecords',
+};
 
-// A business may be referenced as either the debtor or the creditor of a document, so
-// the two columns are unioned into a single business_id projection before grouping. A
-// document that references the same business on both sides is therefore counted twice
-// (once per side); this is acceptable for a usage indicator.
-const getDocumentsCountByBusinessIds = sql<IGetDocumentsCountByBusinessIdsQuery>`
-  SELECT business_id, COUNT(*) AS count
+// A single statement that counts, per business id, how often the business is referenced
+// across each source. Every id-bearing column is projected into a common (business_id,
+// source) shape via UNION ALL so a business that appears in more than one column
+// (documents/misc_expenses debtor+creditor, ledger debit/credit entities) is attributed
+// correctly. A row that references the same business on two columns is counted once per
+// column, which is acceptable for a usage indicator. Combining all sources into one query
+// matters because TenantAwareDBClient serializes queries on a single mutex-guarded
+// connection, so four separate queries would be four sequential transactions.
+const getUsageCountsByBusinessIds = sql<IGetUsageCountsByBusinessIdsQuery>`
+  SELECT business_id, source, COUNT(*) AS count
   FROM (
-    SELECT debtor_id AS business_id
+    SELECT business_id, 'transactions' AS source
+    FROM accounter_schema.transactions
+    WHERE business_id IN $$businessIds
+    UNION ALL
+    SELECT debtor_id AS business_id, 'documents' AS source
     FROM accounter_schema.documents
     WHERE debtor_id IN $$businessIds
     UNION ALL
-    SELECT creditor_id AS business_id
+    SELECT creditor_id AS business_id, 'documents' AS source
     FROM accounter_schema.documents
     WHERE creditor_id IN $$businessIds
-  ) AS documents
-  GROUP BY business_id;`;
-
-// Same debtor/creditor union as documents.
-const getMiscExpensesCountByBusinessIds = sql<IGetMiscExpensesCountByBusinessIdsQuery>`
-  SELECT business_id, COUNT(*) AS count
-  FROM (
-    SELECT debtor_id AS business_id
+    UNION ALL
+    SELECT debtor_id AS business_id, 'misc_expenses' AS source
     FROM accounter_schema.misc_expenses
     WHERE debtor_id IN $$businessIds
     UNION ALL
-    SELECT creditor_id AS business_id
+    SELECT creditor_id AS business_id, 'misc_expenses' AS source
     FROM accounter_schema.misc_expenses
     WHERE creditor_id IN $$businessIds
-  ) AS misc_expenses
-  GROUP BY business_id;`;
-
-// A ledger record can reference a business in any of its four debit/credit entity
-// columns, so all four are unioned before grouping.
-const getLedgerRecordsCountByBusinessIds = sql<IGetLedgerRecordsCountByBusinessIdsQuery>`
-  SELECT business_id, COUNT(*) AS count
-  FROM (
-    SELECT debit_entity1 AS business_id
+    UNION ALL
+    SELECT debit_entity1 AS business_id, 'ledger' AS source
     FROM accounter_schema.ledger_records
     WHERE debit_entity1 IN $$businessIds
     UNION ALL
-    SELECT debit_entity2 AS business_id
+    SELECT debit_entity2 AS business_id, 'ledger' AS source
     FROM accounter_schema.ledger_records
     WHERE debit_entity2 IN $$businessIds
     UNION ALL
-    SELECT credit_entity1 AS business_id
+    SELECT credit_entity1 AS business_id, 'ledger' AS source
     FROM accounter_schema.ledger_records
     WHERE credit_entity1 IN $$businessIds
     UNION ALL
-    SELECT credit_entity2 AS business_id
+    SELECT credit_entity2 AS business_id, 'ledger' AS source
     FROM accounter_schema.ledger_records
     WHERE credit_entity2 IN $$businessIds
-  ) AS ledger_records
-  GROUP BY business_id;`;
+  ) AS usage
+  GROUP BY business_id, source;`;
 
 @Injectable({
   scope: Scope.Operation,
@@ -101,35 +93,21 @@ export class BusinessUsageProvider {
       usage.set(id, { transactions: 0, documents: 0, miscExpenses: 0, ledgerRecords: 0 });
     }
 
-    const apply = (
-      rows: { business_id: string | null; count: string | null }[],
-      key: keyof BusinessUsageCounts,
-    ): void => {
-      for (const row of rows) {
-        if (!row.business_id) {
-          continue;
-        }
-        const counts = usage.get(row.business_id);
-        if (counts) {
-          counts[key] = Number(row.count ?? 0);
-        }
-      }
-    };
-
     // chunk the ids to stay within Postgres' bind-parameter limit (see CHUNK_SIZE)
     for (let i = 0; i < uniqueIds.length; i += CHUNK_SIZE) {
       const chunk = uniqueIds.slice(i, i + CHUNK_SIZE);
-      const [transactions, documents, miscExpenses, ledgerRecords] = await Promise.all([
-        getTransactionsCountByBusinessIds.run({ businessIds: chunk }, this.db),
-        getDocumentsCountByBusinessIds.run({ businessIds: chunk }, this.db),
-        getMiscExpensesCountByBusinessIds.run({ businessIds: chunk }, this.db),
-        getLedgerRecordsCountByBusinessIds.run({ businessIds: chunk }, this.db),
-      ]);
+      const rows = await getUsageCountsByBusinessIds.run({ businessIds: chunk }, this.db);
 
-      apply(transactions, 'transactions');
-      apply(documents, 'documents');
-      apply(miscExpenses, 'miscExpenses');
-      apply(ledgerRecords, 'ledgerRecords');
+      for (const row of rows) {
+        if (!row.business_id || !row.source) {
+          continue;
+        }
+        const key = SOURCE_TO_KEY[row.source];
+        const counts = usage.get(row.business_id);
+        if (key && counts) {
+          counts[key] = Number(row.count ?? 0);
+        }
+      }
     }
 
     return usage;

--- a/packages/server/src/modules/financial-entities/resolvers/businesses-usage.resolver.ts
+++ b/packages/server/src/modules/financial-entities/resolvers/businesses-usage.resolver.ts
@@ -13,6 +13,7 @@ export const businessesUsageResolvers: FinancialEntitiesModule.Resolvers = {
           ledgerRecords: 0,
         };
         return {
+          id,
           businessId: id,
           totalTransactions: counts.transactions,
           totalDocuments: counts.documents,

--- a/packages/server/src/modules/financial-entities/resolvers/businesses-usage.resolver.ts
+++ b/packages/server/src/modules/financial-entities/resolvers/businesses-usage.resolver.ts
@@ -1,0 +1,25 @@
+import { BusinessUsageProvider } from '../providers/businesses-usage.provider.js';
+import type { FinancialEntitiesModule } from '../types.js';
+
+export const businessesUsageResolvers: FinancialEntitiesModule.Resolvers = {
+  Query: {
+    businessesUsage: async (_, { ids }, { injector }) => {
+      const usageMap = await injector.get(BusinessUsageProvider).getUsageByBusinessIds(ids);
+      return ids.map(id => {
+        const counts = usageMap.get(id) ?? {
+          transactions: 0,
+          documents: 0,
+          miscExpenses: 0,
+          ledgerRecords: 0,
+        };
+        return {
+          businessId: id,
+          totalTransactions: counts.transactions,
+          totalDocuments: counts.documents,
+          totalMiscExpenses: counts.miscExpenses,
+          totalLedgerRecords: counts.ledgerRecords,
+        };
+      });
+    },
+  },
+};

--- a/packages/server/src/modules/financial-entities/typeDefs/businesses-usage.graphql.ts
+++ b/packages/server/src/modules/financial-entities/typeDefs/businesses-usage.graphql.ts
@@ -7,6 +7,8 @@ export default gql`
 
   " usage summary of a business across the system, used to spot unused businesses "
   type BusinessUsage {
+    " same value as businessId; present so the type has a unique identifier "
+    id: UUID!
     businessId: UUID!
     totalTransactions: Int!
     totalDocuments: Int!

--- a/packages/server/src/modules/financial-entities/typeDefs/businesses-usage.graphql.ts
+++ b/packages/server/src/modules/financial-entities/typeDefs/businesses-usage.graphql.ts
@@ -1,0 +1,16 @@
+import { gql } from 'graphql-modules';
+
+export default gql`
+  extend type Query {
+    businessesUsage(ids: [UUID!]!): [BusinessUsage!]! @requiresAuth
+  }
+
+  " usage summary of a business across the system, used to spot unused businesses "
+  type BusinessUsage {
+    businessId: UUID!
+    totalTransactions: Int!
+    totalDocuments: Int!
+    totalMiscExpenses: Int!
+    totalLedgerRecords: Int!
+  }
+`;

--- a/packages/server/src/modules/financial-entities/types.ts
+++ b/packages/server/src/modules/financial-entities/types.ts
@@ -1,6 +1,7 @@
 export type * from './__generated__/types.js';
 export type { Json, pcn874_record_type } from './__generated__/businesses.types.js';
 export type * from './__generated__/businesses.types.js';
+export type * from './__generated__/businesses-usage.types.js';
 export type * from './__generated__/entity-ensure.types.js';
 export type * from './__generated__/businesses-operation.types.js';
 export type * from './__generated__/admin-businesses.types.js';


### PR DESCRIPTION
## Summary

Phase B (server usage query) of the business management screen, per
`docs/businesses-page-refactor/blueprint.md`. Adds the batched per-business usage
counts that back the lazy, opt-in "usage" columns used to locate unused businesses.
Each step is a separate commit.

- **B1 — `BusinessUsageProvider`**: new `@Injectable()` provider
  (`providers/businesses-usage.provider.ts`) exposing
  `getUsageByBusinessIds(ids): Map<id, { transactions, documents, miscExpenses, ledgerRecords }>`.
  One grouped count query per source. For sources where a business can appear in
  more than one column, each id-bearing column is projected into a common
  `business_id` via `UNION ALL` before grouping, so counts attribute to the correct
  id (a single `OR … GROUP BY business_id` would not):
  - `transactions` → `business_id`
  - `documents` → `debtor_id` ∪ `creditor_id`
  - `misc_expenses` → `debtor_id` ∪ `creditor_id`
  - `ledger_records` → `debit_entity1/2` ∪ `credit_entity1/2`

  Every requested id defaults to zero so unused businesses are represented. Column
  names confirmed against the `replaceBusiness` merge query and the misc-expenses
  provider.

- **B2 — `businessesUsage` query**: new typeDef + resolver returning
  `[BusinessUsage!]!`, wired into the financial-entities module (typeDef, resolver,
  provider registration, pgtyped types re-export).

```graphql
type BusinessUsage {
  businessId: UUID!
  totalTransactions: Int!
  totalDocuments: Int!
  totalMiscExpenses: Int!
  totalLedgerRecords: Int!
}
extend type Query {
  businessesUsage(ids: [UUID!]!): [BusinessUsage!]! @requiresAuth
}
```

## Tests

Added a provider unit test (mirrors `businesses.provider.test.ts`, mocking
`db.query` by SQL text) covering the empty-input short-circuit, per-source merge,
and zero-defaulting.

## Verification not run in this environment

`yarn install` cannot complete here (the `xlsx` dependency resolves from an external
CDN host blocked by this session's egress policy, 403), so `yarn generate`,
`yarn lint`, the test suite, and the build could not be executed. As a best effort I
ran the pinned-version Prettier from the offline cache with the project's core
options against every changed file — all pass. Import ordering follows the existing
module's pattern. The new SQL uses the established pgtyped `sql<…>` pattern and will
have its types generated by `yarn generate:sql` in CI. Please confirm via CI / a
local run with full network access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017sEQX9bozBUUTiPcXxXL87)_