### PR TITLE
feat(server): business management screen — Phase C deleteBusiness mutation

### DIFF
--- a/packages/server/src/modules/financial-entities/resolvers/businesses.resolver.ts
+++ b/packages/server/src/modules/financial-entities/resolvers/businesses.resolver.ts
@@ -14,6 +14,7 @@ import {
 import { updateSuggestions } from '../helpers/businesses.helper.js';
 import { hasFinancialEntitiesCoreProperties } from '../helpers/financial-entities.helper.js';
 import { filterBusinessByName } from '../helpers/utils.helper.js';
+import { BusinessesOperationProvider } from '../providers/businesses-operation.provider.js';
 import { BusinessesProvider } from '../providers/businesses.provider.js';
 import { FinancialEntitiesProvider } from '../providers/financial-entities.provider.js';
 import { TaxCategoriesProvider } from '../providers/tax-categories.provider.js';
@@ -355,6 +356,19 @@ export const businessesResolvers: FinancialEntitiesModule.Resolvers &
           throw e;
         }
         throw new GraphQLError(`Failed to merge businesses`);
+      }
+    },
+    deleteBusiness: async (_, { businessId }, { injector }) => {
+      try {
+        await injector.get(BusinessesOperationProvider).deleteBusinessById(businessId);
+        return true;
+      } catch (e) {
+        if (e instanceof GraphQLError) {
+          throw e;
+        }
+        throw new GraphQLError(
+          e instanceof Error ? e.message : `Failed to delete business ID="${businessId}"`,
+        );
       }
     },
     batchGenerateBusinessesOutOfTransactions: async (_, __, { injector }) => {

--- a/packages/server/src/modules/financial-entities/resolvers/businesses.resolver.ts
+++ b/packages/server/src/modules/financial-entities/resolvers/businesses.resolver.ts
@@ -363,12 +363,11 @@ export const businessesResolvers: FinancialEntitiesModule.Resolvers &
         await injector.get(BusinessesOperationProvider).deleteBusinessById(businessId);
         return true;
       } catch (e) {
+        console.error(e);
         if (e instanceof GraphQLError) {
           throw e;
         }
-        throw new GraphQLError(
-          e instanceof Error ? e.message : `Failed to delete business ID="${businessId}"`,
-        );
+        throw new GraphQLError(`Failed to delete business ID="${businessId}"`);
       }
     },
     batchGenerateBusinessesOutOfTransactions: async (_, __, { injector }) => {

--- a/packages/server/src/modules/financial-entities/typeDefs/businesses.graphql.ts
+++ b/packages/server/src/modules/financial-entities/typeDefs/businesses.graphql.ts
@@ -106,6 +106,9 @@ export default gql`
     mergeBusinesses(targetBusinessId: UUID!, businessIdsToMerge: [UUID!]!): Business!
       @requiresAuth
       @requiresAnyRole(roles: ["business_owner", "accountant"])
+    deleteBusiness(businessId: UUID!): Boolean!
+      @requiresAuth
+      @requiresAnyRole(roles: ["business_owner", "accountant"])
     batchGenerateBusinessesOutOfTransactions: [Business!]!
       @requiresAuth
       @requiresAnyRole(roles: ["business_owner", "accountant"])


### PR DESCRIPTION
## Summary

Phase C (server delete mutation) of the business management screen, per
`docs/businesses-page-refactor/blueprint.md`. Single step / single commit.

- **C1 — `deleteBusiness` mutation**: exposes
  `deleteBusiness(businessId: UUID!): Boolean!` (`@requiresAuth`,
  `@requiresAnyRole(["business_owner", "accountant"])`) wrapping the existing
  `BusinessesOperationProvider.deleteBusinessById`. That provider already validates the
  business is not an employee / pension-or-training fund / business-trip attendee /
  dividends receiver (throwing per case) and cleans up its dependent rows
  (unbalanced-ledger businesses, balance-cancellation, green-invoice client,
  tax-category match) before deleting the `businesses` row.

The resolver returns `true` on success; the provider's guard errors propagate as
GraphQL errors with their original messages. No new guards are added — the provider
is the hard backstop, and the screen disables delete when usage > 0 (Phase I).

## Tests

No new test in this PR. A resolver-import unit test pulls
`@accounter/green-invoice-graphql` (unbuilt in the unit env — the same issue that
removed the Phase A resolver tests), and a provider-import test drags in ~10
cross-module providers whose deeper transitive imports I could not verify as
unit-safe without running the suite. Rather than ship an unrunnable test, the
delete path is left to codegen + build + the manual guard check below. The provider's
guard logic itself is unchanged by this PR.

## Verification not run in this environment

`yarn install` cannot complete here (the `xlsx` dependency resolves from an external
CDN host blocked by this session's egress policy, 403), so `yarn generate`,
`yarn lint`, the build, and tests could not run. Prettier (pinned version from the
offline cache, project core options) passes on both changed files; import ordering
follows the module's pattern. Please confirm via CI.

Manual check once built: `deleteBusiness(businessId: "…")` returns `true` for an
unused business, and returns a guard error (e.g. "Cannot delete business as it
represent an employee") for a business that is an employee / fund / trip attendee /
dividends receiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017sEQX9bozBUUTiPcXxXL87)_