### PR TITLE
fix(email-ingestion): recognize issuer for manually forwarded invoices

### DIFF
--- a/.changeset/email-recognition-forwarded.md
+++ b/.changeset/email-recognition-forwarded.md
@@ -1,0 +1,11 @@
+---
+'@accounter/server': patch
+---
+
+Recognize the issuing business for **manually forwarded** invoice emails. The real issuer address
+often survives only inside the quoted "Forwarded message" header block (e.g. the original
+`Reply-To`), which the gateway previously ignored. The gateway now also recovers
+`From`/`Reply-To`/`Sender` addresses from forwarded-header blocks, and the server tries every
+candidate (case-insensitively) until one matches a business — so a forwarded Cloudflare invoice is
+attributed to the right business and its email-processing config (e.g. "ignore the body") is applied
+instead of falling back to default treatment.

--- a/packages/email-ingestion-gateway/package.json
+++ b/packages/email-ingestion-gateway/package.json
@@ -42,6 +42,7 @@
     "email-ingestion-gateway:worker:deploy": "yarn worker:deploy",
     "email-ingestion-gateway:worker:dev": "yarn worker:dev",
     "generate": "yarn generate:graphql",
+    "inspect:eml": "tsx scripts/inspect-eml.ts",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "worker:deploy": "wrangler deploy",

--- a/packages/email-ingestion-gateway/scripts/inspect-eml.ts
+++ b/packages/email-ingestion-gateway/scripts/inspect-eml.ts
@@ -1,0 +1,53 @@
+/**
+ * Local diagnostic: print exactly what the gateway extracts from a raw `.eml`
+ * file — subject, every sender-evidence field (including the issuer candidates
+ * recovered from forwarded-header blocks), and the document list. Use it to see
+ * which addresses are available for business recognition before/after forwarding.
+ *
+ * Capture a real sample from Gmail: open the message → ⋮ → "Show original" →
+ * "Download Original", then:
+ *
+ *   yarn workspace @accounter/email-ingestion-gateway inspect:eml path/to/message.eml
+ */
+import { readFile } from 'node:fs/promises';
+import { extractFromMime } from '../src/mime-extractor.js';
+
+async function main(): Promise<void> {
+  const path = process.argv[2];
+  if (!path) {
+    console.error('Usage: inspect:eml <path-to-.eml>');
+    process.exitCode = 1;
+    return;
+  }
+
+  const raw = await readFile(path);
+  const result = await extractFromMime(raw);
+
+  if (!result.success) {
+    console.error(`Extraction failed: ${result.reason}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { subject, senderEvidence, documents } = result;
+  console.log('Subject:', subject ?? '(none)');
+  console.log('\nSender evidence:');
+  console.log('  from:            ', senderEvidence.from ?? '(none)');
+  console.log('  replyTo:         ', senderEvidence.replyTo ?? '(none)');
+  console.log('  originalFrom:    ', senderEvidence.originalFrom ?? '(none)');
+  console.log('  forwardedTo:     ', senderEvidence.forwardedTo ?? '(none)');
+  console.log(
+    '  issuerCandidates:',
+    senderEvidence.issuerCandidates.length ? senderEvidence.issuerCandidates : '(none)',
+  );
+
+  console.log(`\nDocuments (${documents.length}):`);
+  for (const doc of documents) {
+    console.log(`  - ${doc.filename ?? '(unnamed)'} | ${doc.mimeType} | ${doc.size} bytes`);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/packages/email-ingestion-gateway/src/__tests__/fixtures/forwarded-cloudflare.eml
+++ b/packages/email-ingestion-gateway/src/__tests__/fixtures/forwarded-cloudflare.eml
@@ -1,0 +1,31 @@
+From: "Gil Gardosh" <gil@the-guild.dev>
+To: guild-k61td2@accounter.tax
+Subject: Fwd: Your invoice is attached
+Date: Mon, 29 Jun 2026 09:00:00 +0000
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="b1_forwarded_cloudflare"
+
+--b1_forwarded_cloudflare
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+<div dir="ltr"><br><br><div class="gmail_quote">
+<div>---------- Forwarded message ---------</div>
+<div>From: &#39;Cloudflare&#39; via Account Payables &lt;<a href="mailto:ap@the-guild.dev">ap@the-guild.dev</a>&gt;</div>
+<div>Date: Thu, Jun 25, 2026 at 7:07&#8239;AM</div>
+<div>Subject: Your invoice is attached</div>
+<div>To: &lt;<a href="mailto:ap@the-guild.dev">ap@the-guild.dev</a>&gt;</div>
+<div>Reply-To: Cloudflare &lt;<a href="mailto:noreply@notify.cloudflare.com">noreply@notify.cloudflare.com</a>&gt;</div>
+<br>
+<p>Your latest Cloudflare invoice is attached to this email.</p>
+<p>Invoice ID: IN-69360442 &middot; Due on: June 25, 2026 &middot; Amount: $36.20</p>
+</div></div>
+
+--b1_forwarded_cloudflare
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="cloudflare-invoice.pdf"
+Content-Transfer-Encoding: base64
+
+JVBERi0xLjQKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZz4+ZW5kb2JqCkNsb3VkZmxhcmUgaW52b2ljZSBJTi02OTM2MDQ0MiAkMzYuMjAKJSVFT0YK
+
+--b1_forwarded_cloudflare--

--- a/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { IngestReasonCode } from '../contracts.js';
 import {
@@ -642,6 +643,60 @@ describe('extractFromMime — body capture & issuer candidates', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.senderEvidence.issuerCandidates).toContain('wrapped@vendor.com');
+    }
+  });
+
+  it('recovers From and Reply-To addresses from a plain-text forwarded block', async () => {
+    // A manually forwarded Cloudflare invoice: the live From is the forwarder,
+    // and the real issuer (the original Reply-To) survives only in the quoted
+    // header block in the body.
+    const forwardedBody = [
+      '---------- Forwarded message ---------',
+      "From: 'Cloudflare' via Account Payables <ap@the-guild.dev>",
+      'Date: Thu, Jun 25, 2026 at 7:07 AM',
+      'Subject: Your invoice is attached',
+      'To: <ap@the-guild.dev>',
+      'Reply-To: Cloudflare <noreply@notify.cloudflare.com>',
+      '',
+      'Your latest Cloudflare invoice is attached.',
+    ].join('\r\n');
+    const result = await extractFromMime(
+      makeTextMime('Gil Gardosh <gil@the-guild.dev>', 'Fwd: Your invoice is attached', forwardedBody),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.senderEvidence.issuerCandidates).toContain('noreply@notify.cloudflare.com');
+      expect(result.senderEvidence.issuerCandidates).toContain('ap@the-guild.dev');
+      // does not pick up the `To:` recipient
+      expect(result.senderEvidence.issuerCandidates).not.toContain('invoices@example.com');
+    }
+  });
+
+  it('recovers the real issuer from a Gmail HTML forwarded block (mailto anchors)', async () => {
+    const html = [
+      '<div>---------- Forwarded message ---------</div>',
+      '<div>From: <a href="mailto:ap@the-guild.dev">ap@the-guild.dev</a></div>',
+      '<div>Reply-To: <a href="mailto:noreply%40notify.cloudflare.com">Cloudflare</a></div>',
+    ].join('');
+    const result = await extractFromMime(makeHtmlMime(html));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.senderEvidence.issuerCandidates).toContain('noreply@notify.cloudflare.com');
+    }
+  });
+
+  it('extracts the issuer and the PDF from the forwarded-cloudflare.eml fixture', async () => {
+    const raw = readFileSync(new URL('./fixtures/forwarded-cloudflare.eml', import.meta.url));
+    const result = await extractFromMime(raw);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // the real issuer is recovered from the quoted Reply-To, despite the live
+      // From being the forwarder (gil@the-guild.dev)
+      expect(result.senderEvidence.from).toContain('gil@the-guild.dev');
+      expect(result.senderEvidence.issuerCandidates).toContain('noreply@notify.cloudflare.com');
+      // exactly the one real attachment — the body is not a document at this stage
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0].mimeType).toBe('application/pdf');
     }
   });
 

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -35,7 +35,8 @@ export interface SenderEvidence {
 // internal-link fetch). Emptiness is decided after treatment, with the server
 // ingest as the final backstop.
 export type ExtractionFailureReason =
-  typeof IngestReasonCode.PARSE_ERROR | typeof IngestReasonCode.OVERSIZE_MESSAGE;
+  | typeof IngestReasonCode.PARSE_ERROR
+  | typeof IngestReasonCode.OVERSIZE_MESSAGE;
 
 export type ExtractionResult =
   | {
@@ -187,24 +188,44 @@ function headerValue(
   return undefined;
 }
 
-// Forwarded emails often carry the real sender as a `From: … <a href="mailto:…">`
-// span in the body. Collect those addresses (decoded), in document order, for
-// the server's issuer-selection policy. The bounded lazy quantifier keeps the
-// match span small: it tolerates a newline-wrapped `From:` line, avoids matching
-// an unrelated mailto far down a minified single-line body, and bounds regex
-// backtracking on very large bodies.
-const ISSUER_MAILTO_RE = /From:[\s\S]{0,250}?<a\s+href="mailto:([^"]+)"/gi;
+// Forwarded mail carries the real issuer inside a quoted header block — the
+// original `From:` / `Reply-To:` / `Sender:` lines — because a manual Gmail
+// forward rewrites the live `From`, drops the original `Reply-To`, and doesn't
+// set `X-Original-From`. We recover those addresses from the body so the
+// server's issuer-selection policy can still match them. For each header label
+// we take the first address that follows, accepting both a `<a href="mailto:…">`
+// link (group 1, percent-decoded) and a plain/angle-bracketed (`<addr>` or bare
+// `addr`) form (group 2). The bounded lazy quantifier keeps each match span
+// small: it tolerates a newline-wrapped label, avoids reaching an unrelated
+// address far down a minified single-line body, and bounds regex backtracking.
+const ISSUER_EMAIL = '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}';
+const ISSUER_CANDIDATE_RE = new RegExp(
+  `(?:From|Reply-To|Sender):[\\s\\S]{0,250}?(?:href="mailto:([^"?]+)"|(${ISSUER_EMAIL}))`,
+  'gi',
+);
+const MAX_ISSUER_CANDIDATES = 25;
 
 function extractIssuerCandidates(body: string): string[] {
   const candidates: string[] = [];
-  for (const match of body.matchAll(ISSUER_MAILTO_RE)) {
-    let email = match[1];
-    try {
-      email = decodeURIComponent(email);
-    } catch {
-      // keep the raw value if it is not valid percent-encoding
+  const seen = new Set<string>();
+  for (const match of body.matchAll(ISSUER_CANDIDATE_RE)) {
+    let email = match[1] ?? match[2] ?? '';
+    if (match[1]) {
+      try {
+        email = decodeURIComponent(email);
+      } catch {
+        // keep the raw value if it is not valid percent-encoding
+      }
     }
-    candidates.push(email);
+    email = email.trim();
+    const key = email.toLowerCase();
+    if (email && !seen.has(key)) {
+      seen.add(key);
+      candidates.push(email);
+      if (candidates.length >= MAX_ISSUER_CANDIDATES) {
+        break;
+      }
+    }
   }
   return candidates;
 }

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -35,8 +35,7 @@ export interface SenderEvidence {
 // internal-link fetch). Emptiness is decided after treatment, with the server
 // ingest as the final backstop.
 export type ExtractionFailureReason =
-  | typeof IngestReasonCode.PARSE_ERROR
-  | typeof IngestReasonCode.OVERSIZE_MESSAGE;
+  typeof IngestReasonCode.PARSE_ERROR | typeof IngestReasonCode.OVERSIZE_MESSAGE;
 
 export type ExtractionResult =
   | {

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-control.provider.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-control.provider.test.ts
@@ -285,3 +285,80 @@ describe('EmailIngestionControlProvider.recognizeBusiness', () => {
     expect(setConfigCall![1]).toContain('tenant-xyz');
   });
 });
+
+// ---------------------------------------------------------------------------
+// recognizeBusinessFromEvidence
+// ---------------------------------------------------------------------------
+
+describe('EmailIngestionControlProvider.recognizeBusinessFromEvidence', () => {
+  // Mock the businesses lookup to match a single email (case-insensitively),
+  // mirroring the real lower()-based SQL.
+  function dbMatchingEmail(target: string, row: Record<string, unknown>) {
+    return makeDbProvider((sql, params) => {
+      if (/from\s+accounter_schema\.businesses/.test(sql.toLowerCase())) {
+        const email = (params?.[0] as string | undefined)?.toLowerCase();
+        if (email === target.toLowerCase()) {
+          return { rows: [row], rowCount: 1 };
+        }
+      }
+      return { rows: [], rowCount: 0 };
+    });
+  }
+
+  it('recognizes the issuer from a forwarded body candidate when the live From is the forwarder', async () => {
+    const db = dbMatchingEmail('noreply@notify.cloudflare.com', {
+      id: 'cloudflare-biz',
+      suggestion_data: {
+        emails: ['noreply@notify.cloudflare.com'],
+        emailListener: { emailBody: false, attachments: ['PDF'] },
+      },
+    });
+    const provider = new EmailIngestionControlProvider(db);
+
+    const result = await provider.recognizeBusinessFromEvidence('tenant-1', {
+      from: 'Gil Gardosh <gil@the-guild.dev>',
+      issuerCandidates: ['ap@the-guild.dev', 'noreply@notify.cloudflare.com'],
+    });
+
+    expect(result.businessId).toBe('cloudflare-biz');
+    expect(result.config).toEqual({ emailBody: false, attachments: ['PDF'] });
+  });
+
+  it('matches case-insensitively', async () => {
+    const db = dbMatchingEmail('vendor@acme.com', {
+      id: 'biz-1',
+      suggestion_data: { emails: ['vendor@acme.com'] },
+    });
+    const provider = new EmailIngestionControlProvider(db);
+
+    const result = await provider.recognizeBusinessFromEvidence('tenant-1', {
+      from: 'VENDOR@ACME.COM',
+    });
+
+    expect(result.businessId).toBe('biz-1');
+  });
+
+  it('returns null when no candidate matches a business', async () => {
+    const db = makeDbProvider(() => ({ rows: [], rowCount: 0 }));
+    const provider = new EmailIngestionControlProvider(db);
+
+    const result = await provider.recognizeBusinessFromEvidence('tenant-1', {
+      from: 'nobody@nowhere.com',
+    });
+
+    expect(result).toEqual({ businessId: null, config: {} });
+  });
+
+  it('short-circuits without touching the DB when there is no usable evidence', async () => {
+    const query = vi.fn();
+    const connect = vi.fn();
+    const db = { pool: { query, connect } } as unknown as DBProvider;
+    const provider = new EmailIngestionControlProvider(db);
+
+    const result = await provider.recognizeBusinessFromEvidence('tenant-1', undefined);
+
+    expect(result).toEqual({ businessId: null, config: {} });
+    expect(query).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-control.resolver.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-control.resolver.test.ts
@@ -32,7 +32,7 @@ const mockGrant = {
 function makeInjector(overrides: Partial<EmailIngestionControlProvider> = {}): Injector {
   const controlProvider: Partial<EmailIngestionControlProvider> = {
     resolveAlias: vi.fn().mockResolvedValue({ found: true, tenantId: 'tenant-uuid-1' }),
-    recognizeBusiness: vi.fn().mockResolvedValue({ businessId: null, config: {} }),
+    recognizeBusinessFromEvidence: vi.fn().mockResolvedValue({ businessId: null, config: {} }),
     issueGrant: vi.fn().mockResolvedValue(mockGrant),
     ...overrides,
   };
@@ -148,8 +148,8 @@ describe('Mutation.requestIngestControl', () => {
     expect(callArg.messageId).toBe(baseInput.messageId);
   });
 
-  it('selects the issuer from senderEvidence and returns the business config', async () => {
-    const recognizeBusiness = vi.fn().mockResolvedValue({
+  it('recognizes the issuer from senderEvidence and returns the business config', async () => {
+    const recognizeBusinessFromEvidence = vi.fn().mockResolvedValue({
       businessId: 'biz-1',
       config: {
         emailBody: true,
@@ -157,7 +157,7 @@ describe('Mutation.requestIngestControl', () => {
         internalEmailLinks: ['https://acme.com/inv'],
       },
     });
-    const injector = makeInjector({ recognizeBusiness });
+    const injector = makeInjector({ recognizeBusinessFromEvidence });
 
     const result = await resolver(
       {} as never,
@@ -166,7 +166,9 @@ describe('Mutation.requestIngestControl', () => {
       {} as never,
     );
 
-    expect(recognizeBusiness).toHaveBeenCalledWith('tenant-uuid-1', 'vendor@acme.com');
+    expect(recognizeBusinessFromEvidence).toHaveBeenCalledWith('tenant-uuid-1', {
+      from: 'vendor@acme.com',
+    });
     expect(result).toMatchObject({
       businessEmailConfig: {
         businessId: 'biz-1',
@@ -191,8 +193,10 @@ describe('Mutation.requestIngestControl', () => {
 
   it('binds the recognized businessId into the issued grant', async () => {
     const issueGrant = vi.fn().mockResolvedValue(mockGrant);
-    const recognizeBusiness = vi.fn().mockResolvedValue({ businessId: 'biz-7', config: {} });
-    const injector = makeInjector({ issueGrant, recognizeBusiness });
+    const recognizeBusinessFromEvidence = vi
+      .fn()
+      .mockResolvedValue({ businessId: 'biz-7', config: {} });
+    const injector = makeInjector({ issueGrant, recognizeBusinessFromEvidence });
 
     await resolver(
       {} as never,

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-issuer.helper.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-issuer.helper.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { selectIssuerEmail } from '../helpers/email-ingestion-issuer.helper.js';
+import {
+  selectIssuerCandidates,
+  selectIssuerEmail,
+} from '../helpers/email-ingestion-issuer.helper.js';
 
 describe('selectIssuerEmail', () => {
   it('returns null for missing evidence', () => {
@@ -79,5 +82,55 @@ describe('selectIssuerEmail', () => {
         issuerCandidates: [null, '', '   '],
       }),
     ).toBe('vendor@acme.com');
+  });
+});
+
+describe('selectIssuerCandidates', () => {
+  it('returns an empty list for missing or empty evidence', () => {
+    expect(selectIssuerCandidates(undefined)).toEqual([]);
+    expect(selectIssuerCandidates(null)).toEqual([]);
+    expect(selectIssuerCandidates({})).toEqual([]);
+  });
+
+  it('orders the real (non-provider) body candidate ahead of forwarders and headers', () => {
+    // The forwarded-Cloudflare case: live From is the forwarder; the real issuer
+    // and the mailing-list provider both come from the quoted header block.
+    const candidates = selectIssuerCandidates({
+      from: 'Gil Gardosh <gil@the-guild.dev>',
+      issuerCandidates: ['ap@the-guild.dev', 'noreply@notify.cloudflare.com'],
+    });
+
+    expect(candidates[0]).toBe('noreply@notify.cloudflare.com');
+    // the known-provider forwarder is still included, but last
+    expect(candidates).toContain('gil@the-guild.dev');
+    expect(candidates).toContain('ap@the-guild.dev');
+    expect(candidates.indexOf('ap@the-guild.dev')).toBeGreaterThan(
+      candidates.indexOf('gil@the-guild.dev'),
+    );
+  });
+
+  it('lower-cases and de-duplicates addresses', () => {
+    expect(
+      selectIssuerCandidates({
+        from: 'VENDOR@ACME.COM',
+        replyTo: 'vendor@acme.com',
+        issuerCandidates: ['Vendor@Acme.com'],
+      }),
+    ).toEqual(['vendor@acme.com']);
+  });
+
+  it('extracts the bare address from a "Name <addr>" form', () => {
+    expect(selectIssuerCandidates({ from: 'Acme Billing <billing@acme.com>' })).toEqual([
+      'billing@acme.com',
+    ]);
+  });
+
+  it('puts Reply-To ahead of a known-provider From', () => {
+    const candidates = selectIssuerCandidates({
+      from: 'notify@morning.co',
+      replyTo: 'real@vendor.com',
+    });
+    expect(candidates[0]).toBe('real@vendor.com');
+    expect(candidates).toContain('notify@morning.co');
   });
 });

--- a/packages/server/src/modules/email-ingestion/helpers/email-ingestion-issuer.helper.ts
+++ b/packages/server/src/modules/email-ingestion/helpers/email-ingestion-issuer.helper.ts
@@ -92,3 +92,64 @@ export function selectIssuerEmail(evidence: SenderEvidence | null | undefined): 
 
   return normalize(evidence.from) ?? null;
 }
+
+/**
+ * Build the ordered, de-duplicated list of issuer emails to try against the
+ * `suggestion_data.emails` lookup, most-likely-real issuer first. Unlike
+ * {@link selectIssuerEmail} (which commits to a single address), this lets the
+ * caller try each candidate until one matches a business — important for
+ * **manually forwarded** mail, where the real issuer survives only as a
+ * quoted-header address in the body and the live `From`/`Reply-To` belong to the
+ * forwarder.
+ *
+ * Order:
+ *   1. body candidates that are not known forwarding providers (the real issuer);
+ *   2. `originalFrom` / `from` when not a known provider;
+ *   3. `replyTo`;
+ *   4. `from` (any, including a provider);
+ *   5. body candidates that ARE known providers (a business may be keyed on a
+ *      forwarder address);
+ *   6. `originalFrom` (any).
+ *
+ * All addresses are bare-extracted and lower-cased so the lookup can match
+ * case-insensitively.
+ */
+export function selectIssuerCandidates(evidence: SenderEvidence | null | undefined): string[] {
+  if (!evidence) {
+    return [];
+  }
+
+  const ordered: string[] = [];
+  const add = (raw: string | null | undefined): void => {
+    const email = normalize(raw);
+    if (email) {
+      ordered.push(email.toLowerCase());
+    }
+  };
+
+  const bodyCandidates = (evidence.issuerCandidates ?? [])
+    .map(candidate => normalize(candidate))
+    .filter((email): email is string => email !== undefined);
+
+  for (const email of bodyCandidates) {
+    if (!isKnownProvider(email)) {
+      add(email);
+    }
+  }
+  for (const header of [evidence.originalFrom, evidence.from]) {
+    const email = normalize(header);
+    if (email && !isKnownProvider(email)) {
+      add(email);
+    }
+  }
+  add(evidence.replyTo);
+  add(evidence.from);
+  for (const email of bodyCandidates) {
+    if (isKnownProvider(email)) {
+      add(email);
+    }
+  }
+  add(evidence.originalFrom);
+
+  return [...new Set(ordered)];
+}

--- a/packages/server/src/modules/email-ingestion/providers/email-ingestion-control.provider.ts
+++ b/packages/server/src/modules/email-ingestion/providers/email-ingestion-control.provider.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { Injectable, Scope } from 'graphql-modules';
+import type { PoolClient } from 'pg';
 import { sql } from '@pgtyped/runtime';
 import { DBProvider } from '../../app-providers/db.provider.js';
 import {
@@ -7,6 +8,10 @@ import {
   type EmailListenerConfig,
 } from '../../financial-entities/helpers/business-suggestion-data-schema.helper.js';
 import { IngestReasonCode } from '../contracts.js';
+import {
+  selectIssuerCandidates,
+  type SenderEvidence,
+} from '../helpers/email-ingestion-issuer.helper.js';
 import { withTenantContext } from '../helpers/email-ingestion-tenant-context.helper.js';
 import type {
   IConsumeGrantByJtiQuery,
@@ -38,11 +43,17 @@ const insertIngestGrant = sql<IInsertIngestGrantQuery>`
 // Resolve the issuing business by a sender email listed in its
 // suggestion_data.emails. Mirrors BusinessesProvider.getBusinessByEmail, but
 // runs on a tenant-pinned client (the control plane has no auth session), so
-// businesses RLS scopes the match to the resolved tenant.
+// businesses RLS scopes the match to the resolved tenant. The match is
+// case-insensitive (email addresses are case-insensitive in practice and
+// neither the stored value nor the sender evidence is normalized upstream).
 const getBusinessByEmailForIngest = sql<IGetBusinessByEmailForIngestQuery>`
   SELECT id, suggestion_data
     FROM accounter_schema.businesses
-   WHERE suggestion_data->'emails' ? $email::text
+   WHERE EXISTS (
+     SELECT 1
+       FROM jsonb_array_elements_text(suggestion_data->'emails') AS candidate
+      WHERE lower(candidate) = lower($email)
+   )
    LIMIT 1
 `;
 
@@ -96,6 +107,28 @@ export type BusinessRecognitionResult = {
   /** The business's email-processing config (empty when unrecognized). */
   config: EmailListenerConfig;
 };
+
+/**
+ * Parse a matched business's `suggestion_data.emailListener` config, tolerating
+ * a missing or malformed blob (returns an empty config and logs on schema
+ * mismatch — recognition still succeeds, treatment just falls back to defaults).
+ */
+function parseEmailListenerConfig(business: {
+  id: string;
+  suggestion_data: unknown;
+}): EmailListenerConfig {
+  if (!business.suggestion_data) {
+    return {};
+  }
+  const parsed = suggestionDataSchema.safeParse(business.suggestion_data);
+  if (!parsed.success) {
+    console.error(
+      `Invalid suggestion_data schema for business [${business.id}]: ${JSON.stringify(parsed.error.issues)}`,
+    );
+    return {};
+  }
+  return parsed.data.emailListener ?? {};
+}
 
 export type ValidateGrantInput = {
   jti: string;
@@ -207,29 +240,46 @@ export class EmailIngestionControlProvider {
       return { businessId: null, config: {} };
     }
 
-    return withTenantContext(this.dbProvider.pool, tenantId, async client => {
-      const rows = await getBusinessByEmailForIngest.run({ email: issuerEmail }, client);
-      if (rows.length === 0) {
-        return { businessId: null, config: {} };
-      }
+    return withTenantContext(this.dbProvider.pool, tenantId, client =>
+      this.lookupBusinessByEmails(client, [issuerEmail]),
+    );
+  }
 
-      const business = rows[0];
-      let config: EmailListenerConfig = {};
-      if (business.suggestion_data) {
-        const parsed = suggestionDataSchema.safeParse(business.suggestion_data);
-        if (parsed.success) {
-          if (parsed.data.emailListener) {
-            config = parsed.data.emailListener;
-          }
-        } else {
-          console.error(
-            `Invalid suggestion_data schema for business [${business.id}]: ${JSON.stringify(parsed.error.issues)}`,
-          );
-        }
-      }
+  /**
+   * Recognize the issuing business from the full sender evidence, trying each
+   * candidate address (in {@link selectIssuerCandidates} priority order) until
+   * one matches a business. This is the path the resolver uses: it tolerates
+   * **manually forwarded** mail, where the real issuer is only a quoted-header
+   * address in the body while the live `From`/`Reply-To` belong to the
+   * forwarder. Runs the candidate lookups inside a single tenant-pinned
+   * transaction.
+   */
+  async recognizeBusinessFromEvidence(
+    tenantId: string,
+    evidence: SenderEvidence | null | undefined,
+  ): Promise<BusinessRecognitionResult> {
+    const candidates = selectIssuerCandidates(evidence);
+    if (candidates.length === 0) {
+      return { businessId: null, config: {} };
+    }
 
-      return { businessId: business.id, config };
-    });
+    return withTenantContext(this.dbProvider.pool, tenantId, client =>
+      this.lookupBusinessByEmails(client, candidates),
+    );
+  }
+
+  /** Return the first business whose suggestion_data.emails matches a candidate. */
+  private async lookupBusinessByEmails(
+    client: PoolClient,
+    emails: readonly string[],
+  ): Promise<BusinessRecognitionResult> {
+    for (const email of emails) {
+      const rows = await getBusinessByEmailForIngest.run({ email }, client);
+      if (rows.length > 0) {
+        return { businessId: rows[0].id, config: parseEmailListenerConfig(rows[0]) };
+      }
+    }
+    return { businessId: null, config: {} };
   }
 
   /**

--- a/packages/server/src/modules/email-ingestion/providers/email-ingestion-control.provider.ts
+++ b/packages/server/src/modules/email-ingestion/providers/email-ingestion-control.provider.ts
@@ -46,12 +46,20 @@ const insertIngestGrant = sql<IInsertIngestGrantQuery>`
 // businesses RLS scopes the match to the resolved tenant. The match is
 // case-insensitive (email addresses are case-insensitive in practice and
 // neither the stored value nor the sender evidence is normalized upstream).
+// The jsonb_typeof guard keeps jsonb_array_elements_text from throwing on a
+// malformed/legacy record whose `emails` is not a JSON array (a missing key or
+// non-array value simply yields no rows instead of a runtime error).
 const getBusinessByEmailForIngest = sql<IGetBusinessByEmailForIngestQuery>`
   SELECT id, suggestion_data
     FROM accounter_schema.businesses
    WHERE EXISTS (
      SELECT 1
-       FROM jsonb_array_elements_text(suggestion_data->'emails') AS candidate
+       FROM jsonb_array_elements_text(
+         CASE WHEN jsonb_typeof(suggestion_data->'emails') = 'array'
+              THEN suggestion_data->'emails'
+              ELSE '[]'::jsonb
+         END
+       ) AS candidate
       WHERE lower(candidate) = lower($email)
    )
    LIMIT 1

--- a/packages/server/src/modules/email-ingestion/resolvers/email-ingestion-control.resolver.ts
+++ b/packages/server/src/modules/email-ingestion/resolvers/email-ingestion-control.resolver.ts
@@ -1,6 +1,5 @@
 import { GraphQLError } from 'graphql';
 import type { MutationResolvers } from '../../../__generated__/types.js';
-import { selectIssuerEmail } from '../helpers/email-ingestion-issuer.helper.js';
 import { EmailIngestionControlProvider } from '../providers/email-ingestion-control.provider.js';
 
 const GRANT_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -24,10 +23,11 @@ const requestIngestControl: MutationResolvers['requestIngestControl'] = async (
 
     // Recognize the issuing business from sender evidence, then bind it into the
     // grant so the ingest step can attribute documents without trusting input.
-    const issuerEmail = selectIssuerEmail(input.senderEvidence ?? undefined);
-    const { businessId, config } = await control.recognizeBusiness(
+    // Tries every candidate address (incl. quoted forwarded-header addresses) so
+    // manually forwarded mail still resolves to the real issuer.
+    const { businessId, config } = await control.recognizeBusinessFromEvidence(
       aliasResult.tenantId,
-      issuerEmail,
+      input.senderEvidence ?? undefined,
     );
 
     const expiresAt = new Date(Date.now() + GRANT_TTL_MS);


### PR DESCRIPTION
## Problem

A manually forwarded invoice (e.g. a Cloudflare invoice forwarded via Gmail to the synthetic ingestion alias) fails business recognition: the resulting charge has 2 documents (the PDF **and** the email body rendered to a second PDF) and **no recognized creditor**, even though the business is keyed on `noreply@notify.cloudflare.com` and configured to keep PDFs / ignore the body.

## Root cause

Recognition picks a single issuer email and looks it up against `businesses.suggestion_data->'emails'`.

- The Cloudflare business is keyed on `noreply@notify.cloudflare.com`, which in the original mail is the **`Reply-To`**.
- **Direct delivery works** — the live `From` (`ap@the-guild.dev`) is a hard-coded "known provider" that gets skipped, so selection falls through to `Reply-To` → match.
- **A manual Gmail forward breaks it** — the live `From` becomes the forwarder (`gil@the-guild.dev`), the original `Reply-To` is dropped, and `X-Original-From` is not set. The real issuer survives only as text inside the quoted "`---------- Forwarded message ---------`" block. The gateway's `extractIssuerCandidates` only captured `From:` + `<a href="mailto:…">` links — it never read `Reply-To:` and never read plain-text addresses, so `noreply@notify.cloudflare.com` was never offered to the matcher.

Unrecognized business → `businessEmailConfig = null` → treatment renders the body to a 2nd PDF and attributes no creditor. **The 2-document result is a symptom of the recognition miss, not a separate bug.**

## Fix

**Gateway (`mime-extractor.ts`):** `extractIssuerCandidates` now also recovers `From` / `Reply-To` / `Sender` addresses from forwarded-header blocks, in both `mailto:` and plain/angle-bracket (`Name <addr>` / bare `addr`) forms — deduped, with the existing bounded-window guard against regex backtracking.

**Server:**
- `email-ingestion-issuer.helper.ts`: added `selectIssuerCandidates(evidence)` — an ordered, lower-cased, deduped candidate list (real issuer first, known forwarders last). `selectIssuerEmail` is kept intact.
- `email-ingestion-control.provider.ts`: added `recognizeBusinessFromEvidence`, which tries each candidate until a business matches (single tenant-pinned transaction); the business-by-email lookup is now **case-insensitive** (`jsonb_array_elements_text` + `lower()`).
- `email-ingestion-control.resolver.ts`: uses the new evidence-based recognition.

## Tooling

- `scripts/inspect-eml.ts` + `yarn workspace @accounter/email-ingestion-gateway inspect:eml <file.eml>` — prints the extracted subject, every sender-evidence field, the issuer candidates, and the document list for any raw `.eml`. Capture a real sample from Gmail via "Show original → Download Original".
- `src/__tests__/fixtures/forwarded-cloudflare.eml` — a forwarded-invoice fixture (HTML forwarded block + PDF attachment).

## Tests

- Server unit suite green locally (133 tests, +9): `selectIssuerCandidates` ordering/normalization and `recognizeBusinessFromEvidence` (the exact forwarded-Cloudflare case + case-insensitivity), plus updated resolver tests.
- Gateway extraction tests for plain-text and HTML forwarded blocks and the fixture.

> Note: the gateway test suite and lint couldn't run in the authoring sandbox (`postal-mime` not installed, network unavailable for `yarn install`); they run in CI. The new regex was validated with a standalone harness.

## Follow-up (out of scope)

- DB-backed integration test (seed a Cloudflare business, drive the control resolver end-to-end) — runs only against live Postgres.
- Replacing the hard-coded `INVOICE_ISSUING_PROVIDER_EMAILS` list with per-tenant config (existing TODO in `email-ingestion-issuer.helper.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTUwjQ4yuSBpKCkeo5nz8x)_