### PR TITLE
feat(client): business management screen — Phase E table + selection

### DIFF
--- a/packages/client/src/components/businesses/__tests__/business-rows.test.ts
+++ b/packages/client/src/components/businesses/__tests__/business-rows.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { businessNodesToRows, formatLocality } from '../business-rows.js';
+
+describe('businessNodesToRows', () => {
+  it('keeps only LtdFinancialEntity nodes and maps their fields', () => {
+    const createdAt = new Date('2024-01-02T00:00:00Z');
+    const updatedAt = new Date('2024-03-04T00:00:00Z');
+    const rows = businessNodesToRows([
+      {
+        __typename: 'LtdFinancialEntity',
+        id: 'b1',
+        name: 'Beta',
+        hebrewName: 'בטא',
+        governmentId: '123',
+        country: { code: 'ISR' },
+        city: 'Tel Aviv',
+        zipCode: '6000000',
+        createdAt,
+        updatedAt,
+      },
+      { __typename: 'PersonalFinancialEntity', id: 'p1', name: 'A Person' },
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({
+      id: 'b1',
+      name: 'Beta',
+      hebrewName: 'בטא',
+      governmentId: '123',
+      countryCode: 'ISR',
+      city: 'Tel Aviv',
+      zipCode: '6000000',
+      createdAt,
+      updatedAt,
+    });
+  });
+
+  it('sorts rows by name case-insensitively and defaults missing fields to null', () => {
+    const rows = businessNodesToRows([
+      { __typename: 'LtdFinancialEntity', id: 'b2', name: 'zeta' },
+      { __typename: 'LtdFinancialEntity', id: 'b1', name: 'Alpha' },
+    ]);
+
+    expect(rows.map(row => row.id)).toEqual(['b1', 'b2']);
+    expect(rows[0]).toMatchObject({
+      hebrewName: null,
+      governmentId: null,
+      countryCode: null,
+      city: null,
+      zipCode: null,
+      createdAt: null,
+      updatedAt: null,
+    });
+  });
+});
+
+describe('formatLocality', () => {
+  it('joins the present parts and skips the empty ones', () => {
+    expect(formatLocality({ city: 'Tel Aviv', zipCode: null, countryCode: 'ISR' })).toBe(
+      'Tel Aviv, ISR',
+    );
+    expect(formatLocality({ city: 'Tel Aviv', zipCode: '6000000', countryCode: 'ISR' })).toBe(
+      'Tel Aviv, 6000000, ISR',
+    );
+    expect(formatLocality({ city: null, zipCode: null, countryCode: null })).toBe('');
+  });
+});

--- a/packages/client/src/components/businesses/__tests__/business-rows.test.ts
+++ b/packages/client/src/components/businesses/__tests__/business-rows.test.ts
@@ -2,9 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { businessNodesToRows, formatLocality } from '../business-rows.js';
 
 describe('businessNodesToRows', () => {
-  it('keeps only LtdFinancialEntity nodes and maps their fields', () => {
-    const createdAt = new Date('2024-01-02T00:00:00Z');
-    const updatedAt = new Date('2024-03-04T00:00:00Z');
+  it('keeps only LtdFinancialEntity nodes and parses their ISO date fields', () => {
     const rows = businessNodesToRows([
       {
         __typename: 'LtdFinancialEntity',
@@ -15,8 +13,8 @@ describe('businessNodesToRows', () => {
         country: { code: 'ISR' },
         city: 'Tel Aviv',
         zipCode: '6000000',
-        createdAt,
-        updatedAt,
+        createdAt: '2024-01-02T00:00:00Z',
+        updatedAt: '2024-03-04T00:00:00Z',
       },
       { __typename: 'PersonalFinancialEntity', id: 'p1', name: 'A Person' },
     ]);
@@ -30,8 +28,8 @@ describe('businessNodesToRows', () => {
       countryCode: 'ISR',
       city: 'Tel Aviv',
       zipCode: '6000000',
-      createdAt,
-      updatedAt,
+      createdAt: new Date('2024-01-02T00:00:00Z'),
+      updatedAt: new Date('2024-03-04T00:00:00Z'),
     });
   });
 

--- a/packages/client/src/components/businesses/business-rows.ts
+++ b/packages/client/src/components/businesses/business-rows.ts
@@ -25,8 +25,10 @@ type RawBusinessNode = {
   country?: { code?: string | null } | null;
   city?: string | null;
   zipCode?: string | null;
-  createdAt?: Date | null;
-  updatedAt?: Date | null;
+  // DateTime scalars arrive as ISO strings at runtime (no urql scalar exchange), even though
+  // codegen types them as Date; accept both and parse below.
+  createdAt?: string | Date | null;
+  updatedAt?: string | Date | null;
 };
 
 /** Keep only company businesses, map them to table rows and sort by name (case-insensitive). */
@@ -41,10 +43,10 @@ export function businessNodesToRows(nodes: readonly RawBusinessNode[]): Business
       countryCode: node.country?.code ?? null,
       city: node.city ?? null,
       zipCode: node.zipCode ?? null,
-      createdAt: node.createdAt ?? null,
-      updatedAt: node.updatedAt ?? null,
+      createdAt: node.createdAt ? new Date(node.createdAt) : null,
+      updatedAt: node.updatedAt ? new Date(node.updatedAt) : null,
     }))
-    .sort((a, b) => (a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1));
+    .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
 }
 
 /** Human-readable locality from city / zip / country code, skipping the empty parts. */

--- a/packages/client/src/components/businesses/business-rows.ts
+++ b/packages/client/src/components/businesses/business-rows.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure helpers that turn the `allBusinesses` query nodes into flat rows for the
+ * business management table. Kept free of React/urql imports so they are easy to unit test.
+ */
+
+export type BusinessRow = {
+  id: string;
+  name: string;
+  hebrewName: string | null;
+  governmentId: string | null;
+  countryCode: string | null;
+  city: string | null;
+  zipCode: string | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+};
+
+/** Minimal shape of an `allBusinesses` node consumed by the table (LtdFinancialEntity fields). */
+type RawBusinessNode = {
+  __typename?: string | null;
+  id: string;
+  name: string;
+  hebrewName?: string | null;
+  governmentId?: string | null;
+  country?: { code?: string | null } | null;
+  city?: string | null;
+  zipCode?: string | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+};
+
+/** Keep only company businesses, map them to table rows and sort by name (case-insensitive). */
+export function businessNodesToRows(nodes: readonly RawBusinessNode[]): BusinessRow[] {
+  return nodes
+    .filter(node => node.__typename === 'LtdFinancialEntity')
+    .map(node => ({
+      id: node.id,
+      name: node.name,
+      hebrewName: node.hebrewName ?? null,
+      governmentId: node.governmentId ?? null,
+      countryCode: node.country?.code ?? null,
+      city: node.city ?? null,
+      zipCode: node.zipCode ?? null,
+      createdAt: node.createdAt ?? null,
+      updatedAt: node.updatedAt ?? null,
+    }))
+    .sort((a, b) => (a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1));
+}
+
+/** Human-readable locality from city / zip / country code, skipping the empty parts. */
+export function formatLocality(row: Pick<BusinessRow, 'city' | 'zipCode' | 'countryCode'>): string {
+  return [row.city, row.zipCode, row.countryCode].filter(Boolean).join(', ');
+}

--- a/packages/client/src/components/businesses/columns.tsx
+++ b/packages/client/src/components/businesses/columns.tsx
@@ -2,6 +2,7 @@ import { format } from 'date-fns';
 import { Link } from 'react-router-dom';
 import { type ColumnDef } from '@tanstack/react-table';
 import { ROUTES } from '../../router/routes.js';
+import { Checkbox } from '../ui/checkbox.js';
 import { formatLocality, type BusinessRow } from './business-rows.js';
 
 function formatDate(value: Date | null): string {
@@ -9,6 +10,27 @@ function formatDate(value: Date | null): string {
 }
 
 export const columns: ColumnDef<BusinessRow>[] = [
+  {
+    id: 'select',
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')
+        }
+        onCheckedChange={value => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={value => row.toggleSelected(!!value)}
+        aria-label="Select row"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
   {
     accessorKey: 'name',
     header: 'Name',

--- a/packages/client/src/components/businesses/columns.tsx
+++ b/packages/client/src/components/businesses/columns.tsx
@@ -1,0 +1,51 @@
+import { format } from 'date-fns';
+import { Link } from 'react-router-dom';
+import { type ColumnDef } from '@tanstack/react-table';
+import { ROUTES } from '../../router/routes.js';
+import { formatLocality, type BusinessRow } from './business-rows.js';
+
+function formatDate(value: Date | null): string {
+  return value ? format(value, 'dd/MM/yyyy') : '—';
+}
+
+export const columns: ColumnDef<BusinessRow>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Name',
+    cell: ({ row }) => {
+      const { id, name, hebrewName } = row.original;
+      return (
+        <Link
+          to={ROUTES.BUSINESSES.DETAIL(id)}
+          state={{ from: ROUTES.BUSINESSES.ALL }}
+          className="font-medium text-blue-600 hover:underline"
+        >
+          {name}
+          {hebrewName ? (
+            <span className="block text-xs text-muted-foreground">{hebrewName}</span>
+          ) : null}
+        </Link>
+      );
+    },
+  },
+  {
+    id: 'locality',
+    header: 'Locality',
+    cell: ({ row }) => formatLocality(row.original) || '—',
+  },
+  {
+    accessorKey: 'governmentId',
+    header: 'VAT number',
+    cell: ({ row }) => row.original.governmentId ?? '—',
+  },
+  {
+    accessorKey: 'createdAt',
+    header: 'Created',
+    cell: ({ row }) => formatDate(row.original.createdAt),
+  },
+  {
+    accessorKey: 'updatedAt',
+    header: 'Updated',
+    cell: ({ row }) => formatDate(row.original.updatedAt),
+  },
+];

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -1,12 +1,17 @@
 import { useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useQuery } from 'urql';
-import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  type RowSelectionState,
+} from '@tanstack/react-table';
 import { AllBusinessesForScreenDocument } from '../../gql/graphql.js';
 import { useUrlQuery } from '../../hooks/use-url-query.js';
 import { cn } from '../../lib/utils.js';
 import { FiltersContext } from '../../providers/filters-context.js';
-import { InsertBusiness } from '../common/index.js';
+import { InsertBusiness, MergeBusinessesButton } from '../common/index.js';
 import { PageLayout } from '../layout/page-layout.js';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table.js';
 import { businessNodesToRows } from './business-rows.js';
@@ -63,15 +68,25 @@ export const Businesses = (): ReactElement => {
     [data?.allBusinesses?.nodes],
   );
 
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
   const table = useReactTable({
     data: rows,
     columns,
     getRowId: row => row.id,
     getCoreRowModel: getCoreRowModel(),
+    enableRowSelection: true,
+    onRowSelectionChange: setRowSelection,
+    state: {
+      rowSelection,
+    },
   });
 
   // Footer
   useEffect(() => {
+    const selectedForMerge = table
+      .getSelectedRowModel()
+      .rows.map(row => ({ id: row.original.id, onChange: () => refetch() }));
     setFiltersContext(
       <div className="flex flex-row gap-x-5">
         <BusinessesFilters
@@ -81,9 +96,20 @@ export const Businesses = (): ReactElement => {
           setBusinessName={setBusinessName}
           totalPages={data?.allBusinesses?.pageInfo.totalPages}
         />
+        <MergeBusinessesButton selected={selectedForMerge} resetMerge={() => setRowSelection({})} />
       </div>,
     );
-  }, [data, activePage, businessName, setFiltersContext, setActivePage, setBusinessName]);
+  }, [
+    data,
+    activePage,
+    businessName,
+    setFiltersContext,
+    setActivePage,
+    setBusinessName,
+    rowSelection,
+    refetch,
+    table,
+  ]);
 
   return (
     <PageLayout

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -30,6 +30,7 @@ import { columns } from './columns.js';
           hebrewName
           governmentId
           country {
+            id
             code
           }
           city
@@ -84,9 +85,17 @@ export const Businesses = (): ReactElement => {
 
   // Footer
   useEffect(() => {
+    // MergeBusinessesButton calls onChange once per selected row, so guard to refetch only once
+    let refetched = false;
+    const onMergeChange = (): void => {
+      if (!refetched) {
+        refetched = true;
+        refetch();
+      }
+    };
     const selectedForMerge = table
       .getSelectedRowModel()
-      .rows.map(row => ({ id: row.original.id, onChange: () => refetch() }));
+      .rows.map(row => ({ id: row.original.id, onChange: onMergeChange }));
     setFiltersContext(
       <div className="flex flex-row gap-x-5">
         <BusinessesFilters

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -1,17 +1,17 @@
-import { useCallback, useContext, useEffect, useState, type ReactElement } from 'react';
+import { useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Loader2 } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
 import { useQuery } from 'urql';
+import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import { AllBusinessesForScreenDocument } from '../../gql/graphql.js';
 import { useUrlQuery } from '../../hooks/use-url-query.js';
 import { cn } from '../../lib/utils.js';
 import { FiltersContext } from '../../providers/filters-context.js';
-import { ROUTES } from '../../router/routes.js';
-import { BusinessHeader } from '../business/business-header.js';
-import { InsertBusiness, MergeBusinessesButton } from '../common/index.js';
+import { InsertBusiness } from '../common/index.js';
 import { PageLayout } from '../layout/page-layout.js';
-import { Checkbox } from '../ui/checkbox.js';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table.js';
+import { businessNodesToRows } from './business-rows.js';
 import { BusinessesFilters } from './businesses-filters.js';
+import { columns } from './columns.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -22,7 +22,15 @@ import { BusinessesFilters } from './businesses-filters.js';
         id
         name
         ... on LtdFinancialEntity {
-          ...BusinessHeader
+          hebrewName
+          governmentId
+          country {
+            code
+          }
+          city
+          zipCode
+          createdAt
+          updatedAt
         }
       }
       pageInfo {
@@ -50,27 +58,17 @@ export const Businesses = (): ReactElement => {
     },
   });
 
-  const navigate = useNavigate();
-  const [mergeSelectedBusinesses, setMergeSelectedBusinesses] = useState<
-    Array<{ id: string; onChange: () => void }>
-  >([]);
-
-  const toggleMergeBusiness = useCallback(
-    (businessId: string, onChange: () => void) => {
-      if (mergeSelectedBusinesses.map(selected => selected.id).includes(businessId)) {
-        setMergeSelectedBusinesses(
-          mergeSelectedBusinesses.filter(selected => selected.id !== businessId),
-        );
-      } else {
-        setMergeSelectedBusinesses([...mergeSelectedBusinesses, { id: businessId, onChange }]);
-      }
-    },
-    [mergeSelectedBusinesses],
+  const rows = useMemo(
+    () => businessNodesToRows(data?.allBusinesses?.nodes ?? []),
+    [data?.allBusinesses?.nodes],
   );
 
-  function onResetMerge(): void {
-    setMergeSelectedBusinesses([]);
-  }
+  const table = useReactTable({
+    data: rows,
+    columns,
+    getRowId: row => row.id,
+    getCoreRowModel: getCoreRowModel(),
+  });
 
   // Footer
   useEffect(() => {
@@ -83,25 +81,9 @@ export const Businesses = (): ReactElement => {
           setBusinessName={setBusinessName}
           totalPages={data?.allBusinesses?.pageInfo.totalPages}
         />
-        <MergeBusinessesButton selected={mergeSelectedBusinesses} resetMerge={onResetMerge} />
       </div>,
     );
-  }, [
-    data,
-    activePage,
-    businessName,
-    setFiltersContext,
-    setActivePage,
-    setBusinessName,
-    mergeSelectedBusinesses,
-  ]);
-
-  const businesses =
-    data?.allBusinesses?.nodes
-      .filter(business => business.__typename === 'LtdFinancialEntity')
-      .sort((a, b) => (a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1)) ?? [];
-
-  const selectedIds = new Set(mergeSelectedBusinesses.map(selected => selected.id));
+  }, [data, activePage, businessName, setFiltersContext, setActivePage, setBusinessName]);
 
   return (
     <PageLayout
@@ -118,46 +100,41 @@ export const Businesses = (): ReactElement => {
           <Loader2 className={cn('h-10 w-10 animate-spin mr-2')} />
         </div>
       ) : (
-        <div className="space-y-2">
-          {businesses.map(business => (
-            <div
-              key={business.id}
-              className="group relative border rounded-lg hover:shadow-md transition-shadow"
-            >
-              <div className="flex items-center gap-3">
-                <div className="pl-4 flex items-center">
-                  <Checkbox
-                    checked={selectedIds.has(business.id)}
-                    onCheckedChange={() => {
-                      toggleMergeBusiness(business.id, () => {});
-                    }}
-                    className="h-4 w-4 rounded border-gray-300 cursor-pointer"
-                    onClick={(e): void => e.stopPropagation()}
-                  />
-                </div>
-                <div
-                  role="button"
-                  tabIndex={0}
-                  className="flex-1 cursor-pointer"
-                  onClick={(): void => {
-                    navigate(ROUTES.BUSINESSES.DETAIL(business.id), {
-                      state: { from: ROUTES.BUSINESSES.ALL },
-                    });
-                  }}
-                  onKeyDown={(e): void => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      navigate(ROUTES.BUSINESSES.DETAIL(business.id), {
-                        state: { from: ROUTES.BUSINESSES.ALL },
-                      });
-                    }
-                  }}
-                >
-                  <BusinessHeader data={business} />
-                </div>
-              </div>
-            </div>
-          ))}
+        <div className="overflow-hidden rounded-md border">
+          <Table>
+            <TableHeader>
+              {table.getHeaderGroups().map(headerGroup => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map(header => (
+                    <TableHead key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {table.getRowModel().rows.length ? (
+                table.getRowModel().rows.map(row => (
+                  <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+                    {row.getVisibleCells().map(cell => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-24 text-center">
+                    No results.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
         </div>
       )}
     </PageLayout>


### PR DESCRIPTION
## Summary

Phase E (client table shell) of the business management screen, per
`docs/businesses-page-refactor/blueprint.md`. Two steps, two commits.

- **E1 — table replaces the card list**: the `/businesses` screen is now a
  `@tanstack/react-table` table instead of the `BusinessHeader` card list. Columns:
  **Core** (name + Hebrew name, linking to the business detail page) and **Main**
  (locality, VAT number, created, updated). The `AllBusinessesForScreen` query now
  selects the locality/date fields the table renders (`hebrewName`, `governmentId`,
  `country { code }`, `city`, `zipCode`, `createdAt`, `updatedAt`). Node→row mapping
  and locality formatting live in a dependency-free `business-rows.ts` module with
  unit tests. The name filter, pagination, and `InsertBusiness` action are preserved.

- **E2 — row selection + merge**: a leading selection-checkbox column (per-row +
  select-all) backed by `RowSelectionState` keyed by business id (`getRowId`). The
  selected ids feed the existing `MergeBusinessesButton` in the filters footer;
  selection resets after a merge completes.

## Files

- `components/businesses/business-rows.ts` — `BusinessRow` type, `businessNodesToRows`,
  `formatLocality` (pure).
- `components/businesses/columns.tsx` — `ColumnDef[]` (select + Core/Main).
- `components/businesses/index.tsx` — table wiring, query, selection, merge.
- `components/businesses/__tests__/business-rows.test.ts`.

## Tests

Unit tests cover the pure data layer (`businessNodesToRows` filtering/mapping/sorting,
`formatLocality`). No full screen-render test: the repo has very few component-render
tests and they need heavy hand-rolled mocking (urql + router + filters context) that
I can't validate in this environment — the data transform that E1/E2 introduce is
covered by the pure tests instead.

## Verification not run in this environment

`yarn install` cannot complete here (the `xlsx` dependency resolves from an external
CDN host blocked by this session's egress policy, 403), so `yarn generate`,
`yarn lint`, the client build, and tests could not run. Prettier (pinned version from
the offline cache, project core options) passes on all changed files; import ordering
follows the existing module/`charge-matches` patterns, and no over-100-col lines
remain. The router still resolves the named `Businesses` export. Please confirm via CI.

Manual check once built: open `/businesses` — the table lists businesses with Core +
Main columns, name filter and pagination work, row checkboxes + select-all drive the
merge button, and a completed merge clears the selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017sEQX9bozBUUTiPcXxXL87)_