### PR TITLE
feat(client): business management screen — Phase F column groups + visibility

### DIFF
--- a/packages/client/src/components/businesses/__tests__/business-rows.test.ts
+++ b/packages/client/src/components/businesses/__tests__/business-rows.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { businessNodesToRows, formatLocality } from '../business-rows.js';
 
 describe('businessNodesToRows', () => {
-  it('keeps only LtdFinancialEntity nodes and parses their ISO date fields', () => {
+  it('keeps only LtdFinancialEntity nodes and maps core, categorization and tag fields', () => {
     const rows = businessNodesToRows([
       {
         __typename: 'LtdFinancialEntity',
@@ -15,6 +15,14 @@ describe('businessNodesToRows', () => {
         zipCode: '6000000',
         createdAt: '2024-01-02T00:00:00Z',
         updatedAt: '2024-03-04T00:00:00Z',
+        sortCode: { key: 910, name: 'Income' },
+        taxCategory: { name: 'Revenue' },
+        irsCode: 42,
+        pcn874RecordType: 'S1',
+        isClient: true,
+        isAdmin: false,
+        isActive: true,
+        suggestions: { description: 'note', tags: [{ name: 'travel' }, { name: 'food' }] },
       },
       { __typename: 'PersonalFinancialEntity', id: 'p1', name: 'A Person' },
     ]);
@@ -30,10 +38,19 @@ describe('businessNodesToRows', () => {
       zipCode: '6000000',
       createdAt: new Date('2024-01-02T00:00:00Z'),
       updatedAt: new Date('2024-03-04T00:00:00Z'),
+      sortCodeKey: 910,
+      taxCategoryName: 'Revenue',
+      irsCode: 42,
+      pcn874RecordType: 'S1',
+      isClient: true,
+      isAdmin: false,
+      isActive: true,
+      suggestionDescription: 'note',
+      suggestionTags: ['travel', 'food'],
     });
   });
 
-  it('sorts rows by name case-insensitively and defaults missing fields to null', () => {
+  it('sorts rows by name case-insensitively and defaults missing fields', () => {
     const rows = businessNodesToRows([
       { __typename: 'LtdFinancialEntity', id: 'b2', name: 'zeta' },
       { __typename: 'LtdFinancialEntity', id: 'b1', name: 'Alpha' },
@@ -48,6 +65,15 @@ describe('businessNodesToRows', () => {
       zipCode: null,
       createdAt: null,
       updatedAt: null,
+      sortCodeKey: null,
+      taxCategoryName: null,
+      irsCode: null,
+      pcn874RecordType: null,
+      isClient: false,
+      isAdmin: false,
+      isActive: true,
+      suggestionDescription: null,
+      suggestionTags: [],
     });
   });
 });

--- a/packages/client/src/components/businesses/business-rows.ts
+++ b/packages/client/src/components/businesses/business-rows.ts
@@ -13,6 +13,18 @@ export type BusinessRow = {
   zipCode: string | null;
   createdAt: Date | null;
   updatedAt: Date | null;
+  // categorization
+  sortCodeKey: number | null;
+  taxCategoryName: string | null;
+  irsCode: number | null;
+  pcn874RecordType: string | null;
+  // extension tags
+  isClient: boolean;
+  isAdmin: boolean;
+  isActive: boolean;
+  // suggestion defaults
+  suggestionDescription: string | null;
+  suggestionTags: string[];
 };
 
 /** Minimal shape of an `allBusinesses` node consumed by the table (LtdFinancialEntity fields). */
@@ -29,6 +41,17 @@ type RawBusinessNode = {
   // codegen types them as Date; accept both and parse below.
   createdAt?: string | Date | null;
   updatedAt?: string | Date | null;
+  sortCode?: { key?: number | null; name?: string | null } | null;
+  taxCategory?: { name?: string | null } | null;
+  irsCode?: number | null;
+  pcn874RecordType?: string | null;
+  isClient?: boolean | null;
+  isAdmin?: boolean | null;
+  isActive?: boolean | null;
+  suggestions?: {
+    description?: string | null;
+    tags?: ReadonlyArray<{ name?: string | null }> | null;
+  } | null;
 };
 
 /** Keep only company businesses, map them to table rows and sort by name (case-insensitive). */
@@ -45,6 +68,18 @@ export function businessNodesToRows(nodes: readonly RawBusinessNode[]): Business
       zipCode: node.zipCode ?? null,
       createdAt: node.createdAt ? new Date(node.createdAt) : null,
       updatedAt: node.updatedAt ? new Date(node.updatedAt) : null,
+      sortCodeKey: node.sortCode?.key ?? null,
+      taxCategoryName: node.taxCategory?.name ?? null,
+      irsCode: node.irsCode ?? null,
+      pcn874RecordType: node.pcn874RecordType ?? null,
+      isClient: node.isClient ?? false,
+      isAdmin: node.isAdmin ?? false,
+      isActive: node.isActive ?? true,
+      suggestionDescription: node.suggestions?.description ?? null,
+      suggestionTags:
+        node.suggestions?.tags
+          ?.map(tag => tag.name)
+          .filter((name): name is string => Boolean(name)) ?? [],
     }))
     .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
 }

--- a/packages/client/src/components/businesses/business-rows.ts
+++ b/packages/client/src/components/businesses/business-rows.ts
@@ -77,9 +77,7 @@ export function businessNodesToRows(nodes: readonly RawBusinessNode[]): Business
       isActive: node.isActive ?? true,
       suggestionDescription: node.suggestions?.description ?? null,
       suggestionTags:
-        node.suggestions?.tags
-          ?.map(tag => tag.name)
-          .filter((name): name is string => Boolean(name)) ?? [],
+        node.suggestions?.tags?.map(tag => tag.name).filter((name): name is string => !!name) ?? [],
     }))
     .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
 }

--- a/packages/client/src/components/businesses/columns.tsx
+++ b/packages/client/src/components/businesses/columns.tsx
@@ -2,6 +2,7 @@ import { format } from 'date-fns';
 import { Link } from 'react-router-dom';
 import { type ColumnDef } from '@tanstack/react-table';
 import { ROUTES } from '../../router/routes.js';
+import { Badge } from '../ui/badge.js';
 import { Checkbox } from '../ui/checkbox.js';
 import { formatLocality, type BusinessRow } from './business-rows.js';
 
@@ -69,5 +70,69 @@ export const columns: ColumnDef<BusinessRow>[] = [
     accessorKey: 'updatedAt',
     header: 'Updated',
     cell: ({ row }) => formatDate(row.original.updatedAt),
+  },
+  // Categorization
+  {
+    id: 'sortCode',
+    header: 'Sort code',
+    cell: ({ row }) => row.original.sortCodeKey ?? '—',
+  },
+  {
+    id: 'taxCategory',
+    header: 'Tax category',
+    cell: ({ row }) => row.original.taxCategoryName ?? '—',
+  },
+  {
+    id: 'irsCode',
+    header: 'IRS code',
+    cell: ({ row }) => row.original.irsCode ?? '—',
+  },
+  {
+    id: 'pcn874RecordType',
+    header: 'PCN874 type',
+    cell: ({ row }) => row.original.pcn874RecordType ?? '—',
+  },
+  // Extension tags
+  {
+    id: 'isClient',
+    header: 'Client',
+    cell: ({ row }) => (row.original.isClient ? <Badge variant="outline">Client</Badge> : '—'),
+  },
+  {
+    id: 'isAdmin',
+    header: 'Admin',
+    cell: ({ row }) => (row.original.isAdmin ? <Badge variant="outline">Admin</Badge> : '—'),
+  },
+  {
+    id: 'status',
+    header: 'Status',
+    cell: ({ row }) =>
+      row.original.isActive ? (
+        <Badge variant="secondary">Active</Badge>
+      ) : (
+        <Badge variant="destructive">Inactive</Badge>
+      ),
+  },
+  // Suggestion defaults
+  {
+    id: 'description',
+    header: 'Description',
+    cell: ({ row }) => row.original.suggestionDescription ?? '—',
+  },
+  {
+    id: 'tags',
+    header: 'Tags',
+    cell: ({ row }) =>
+      row.original.suggestionTags.length ? (
+        <div className="flex flex-wrap gap-1">
+          {row.original.suggestionTags.map(tag => (
+            <Badge key={tag} variant="outline">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      ) : (
+        '—'
+      ),
   },
 ];

--- a/packages/client/src/components/businesses/columns.tsx
+++ b/packages/client/src/components/businesses/columns.tsx
@@ -1,6 +1,6 @@
 import { format } from 'date-fns';
 import { Link } from 'react-router-dom';
-import { type ColumnDef } from '@tanstack/react-table';
+import { type ColumnDef, type VisibilityState } from '@tanstack/react-table';
 import { ROUTES } from '../../router/routes.js';
 import { Badge } from '../ui/badge.js';
 import { Checkbox } from '../ui/checkbox.js';
@@ -136,3 +136,52 @@ export const columns: ColumnDef<BusinessRow>[] = [
       ),
   },
 ];
+
+/** Column groups, used by the column-visibility toggle. */
+export const COLUMN_GROUPS: { label: string; columns: { id: string; label: string }[] }[] = [
+  { label: 'Core', columns: [{ id: 'name', label: 'Name' }] },
+  {
+    label: 'Main',
+    columns: [
+      { id: 'locality', label: 'Locality' },
+      { id: 'governmentId', label: 'VAT number' },
+      { id: 'createdAt', label: 'Created' },
+      { id: 'updatedAt', label: 'Updated' },
+    ],
+  },
+  {
+    label: 'Categorization',
+    columns: [
+      { id: 'sortCode', label: 'Sort code' },
+      { id: 'taxCategory', label: 'Tax category' },
+      { id: 'irsCode', label: 'IRS code' },
+      { id: 'pcn874RecordType', label: 'PCN874 type' },
+    ],
+  },
+  {
+    label: 'Extension tags',
+    columns: [
+      { id: 'isClient', label: 'Client' },
+      { id: 'isAdmin', label: 'Admin' },
+      { id: 'status', label: 'Status' },
+    ],
+  },
+  {
+    label: 'Suggestion defaults',
+    columns: [
+      { id: 'description', label: 'Description' },
+      { id: 'tags', label: 'Tags' },
+    ],
+  },
+];
+
+// Categorization and Suggestion-defaults columns are hidden by default; Core, Main and
+// Extension tags are shown.
+export const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
+  sortCode: false,
+  taxCategory: false,
+  irsCode: false,
+  pcn874RecordType: false,
+  description: false,
+  tags: false,
+};

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -26,7 +26,7 @@ import {
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table.js';
 import { businessNodesToRows } from './business-rows.js';
 import { BusinessesFilters } from './businesses-filters.js';
-import { COLUMN_GROUPS, DEFAULT_COLUMN_VISIBILITY, columns } from './columns.js';
+import { COLUMN_GROUPS, columns, DEFAULT_COLUMN_VISIBILITY } from './columns.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -37,6 +37,27 @@ import { columns } from './columns.js';
           zipCode
           createdAt
           updatedAt
+          sortCode {
+            id
+            key
+            name
+          }
+          taxCategory {
+            id
+            name
+          }
+          irsCode
+          pcn874RecordType
+          isClient
+          isAdmin
+          isActive
+          suggestions {
+            description
+            tags {
+              id
+              name
+            }
+          }
         }
       }
       pageInfo {

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -1,11 +1,12 @@
-import { useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
-import { Loader2 } from 'lucide-react';
+import { Fragment, useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
+import { ChevronDown, Loader2 } from 'lucide-react';
 import { useQuery } from 'urql';
 import {
   flexRender,
   getCoreRowModel,
   useReactTable,
   type RowSelectionState,
+  type VisibilityState,
 } from '@tanstack/react-table';
 import { AllBusinessesForScreenDocument } from '../../gql/graphql.js';
 import { useUrlQuery } from '../../hooks/use-url-query.js';
@@ -13,10 +14,19 @@ import { cn } from '../../lib/utils.js';
 import { FiltersContext } from '../../providers/filters-context.js';
 import { InsertBusiness, MergeBusinessesButton } from '../common/index.js';
 import { PageLayout } from '../layout/page-layout.js';
+import { Button } from '../ui/button.js';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu.js';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table.js';
 import { businessNodesToRows } from './business-rows.js';
 import { BusinessesFilters } from './businesses-filters.js';
-import { columns } from './columns.js';
+import { COLUMN_GROUPS, DEFAULT_COLUMN_VISIBILITY, columns } from './columns.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -91,6 +101,8 @@ export const Businesses = (): ReactElement => {
   );
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [columnVisibility, setColumnVisibility] =
+    useState<VisibilityState>(DEFAULT_COLUMN_VISIBILITY);
 
   const table = useReactTable({
     data: rows,
@@ -99,8 +111,10 @@ export const Businesses = (): ReactElement => {
     getCoreRowModel: getCoreRowModel(),
     enableRowSelection: true,
     onRowSelectionChange: setRowSelection,
+    onColumnVisibilityChange: setColumnVisibility,
     state: {
       rowSelection,
+      columnVisibility,
     },
   });
 
@@ -148,6 +162,36 @@ export const Businesses = (): ReactElement => {
       headerActions={
         <div className="flex items-center py-4 gap-4">
           <InsertBusiness description="" onAdd={() => refetch()} />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline">
+                Columns <ChevronDown />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {COLUMN_GROUPS.map((group, groupIndex) => (
+                <Fragment key={group.label}>
+                  {groupIndex > 0 ? <DropdownMenuSeparator /> : null}
+                  <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
+                  {group.columns.map(column => {
+                    const tableColumn = table.getColumn(column.id);
+                    if (!tableColumn?.getCanHide()) {
+                      return null;
+                    }
+                    return (
+                      <DropdownMenuCheckboxItem
+                        key={column.id}
+                        checked={tableColumn.getIsVisible()}
+                        onCheckedChange={value => tableColumn.toggleVisibility(!!value)}
+                      >
+                        {column.label}
+                      </DropdownMenuCheckboxItem>
+                    );
+                  })}
+                </Fragment>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       }
     >

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -169,27 +169,29 @@ export const Businesses = (): ReactElement => {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              {COLUMN_GROUPS.map((group, groupIndex) => (
-                <Fragment key={group.label}>
-                  {groupIndex > 0 ? <DropdownMenuSeparator /> : null}
-                  <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
-                  {group.columns.map(column => {
-                    const tableColumn = table.getColumn(column.id);
-                    if (!tableColumn?.getCanHide()) {
-                      return null;
-                    }
-                    return (
-                      <DropdownMenuCheckboxItem
-                        key={column.id}
-                        checked={tableColumn.getIsVisible()}
-                        onCheckedChange={value => tableColumn.toggleVisibility(!!value)}
-                      >
-                        {column.label}
-                      </DropdownMenuCheckboxItem>
-                    );
-                  })}
-                </Fragment>
-              ))}
+              {COLUMN_GROUPS.map(group => ({
+                ...group,
+                columns: group.columns.filter(column => table.getColumn(column.id)?.getCanHide()),
+              }))
+                .filter(group => group.columns.length > 0)
+                .map((group, groupIndex) => (
+                  <Fragment key={group.label}>
+                    {groupIndex > 0 ? <DropdownMenuSeparator /> : null}
+                    <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
+                    {group.columns.map(column => {
+                      const tableColumn = table.getColumn(column.id);
+                      return tableColumn ? (
+                        <DropdownMenuCheckboxItem
+                          key={column.id}
+                          checked={tableColumn.getIsVisible()}
+                          onCheckedChange={value => tableColumn.toggleVisibility(!!value)}
+                        >
+                          {column.label}
+                        </DropdownMenuCheckboxItem>
+                      ) : null;
+                    })}
+                  </Fragment>
+                ))}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>


### PR DESCRIPTION
## Summary

Phase F (client column groups + visibility) of the business management screen, per
`docs/businesses-page-refactor/blueprint.md`. Two steps, two commits.

- **F1 — categorization, tag and suggestion columns**: extends the table with three
  more groups:
  - **Categorization** — sort code, tax category, IRS code, PCN874 type.
  - **Extension tags** — client / admin badges and an active/inactive status badge.
  - **Suggestion defaults** — description and tags (rendered as badges).

  The `allBusinesses` query selects the backing fields (`sortCode { id key name }`,
  `taxCategory { id name }`, `irsCode`, `pcn874RecordType`, `isClient`, `isAdmin`,
  `isActive`, `suggestions { description tags { id name } }`) and the pure row mapper
  flattens them.

- **F2 — grouped column-visibility toggle**: a "Columns" dropdown lists columns grouped
  by section (Core / Main / Categorization / Extension tags / Suggestion defaults) with
  a checkbox per column. Categorization and Suggestion-defaults columns start hidden
  (`DEFAULT_COLUMN_VISIBILITY`); Core, Main and Extension tags are shown. Visibility is
  held in component state and wired via `onColumnVisibilityChange`.

## Tests

Extended the pure `business-rows` unit tests to cover the new categorization / tag /
suggestion fields (mapping + defaults). As in earlier client phases, there's no full
screen-render test — the data transform is covered by the pure tests, and a
render test would need heavy urql/router/context mocking I can't validate here.

## Verification not run in this environment

`yarn install` cannot complete here (the `xlsx` dependency resolves from an external
CDN host blocked by this session's egress policy, 403), so `yarn generate`,
`yarn lint`, the client build, and tests could not run. Prettier (pinned version from
the offline cache, project core options) passes on all changed files; import ordering
follows the module conventions, `id` sub-fields are selected where the type exposes
them (`require-selections`), and no over-100-col lines remain. Please confirm via CI.

Manual check once built: open `/businesses` — the Columns dropdown groups the columns
and toggles them; Categorization + Suggestion-defaults start hidden; enabling a group
shows those columns; badges render for client/admin/status and suggestion tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017sEQX9bozBUUTiPcXxXL87)_