### PR TITLE
feat(charges): enrich freeText filter with amounts and business names

### DIFF
--- a/.changeset/charges-freetext-amounts-businesses.md
+++ b/.changeset/charges-freetext-amounts-businesses.md
@@ -1,0 +1,16 @@
+---
+'@accounter/server': patch
+---
+
+Enrich the charges `freeText` filter (`allCharges` query) so it matches more than just text
+descriptions. In addition to the existing `user_description` / transaction / document description
+matches, the `search_matches` CTE in `ChargesProvider.getChargesByFilters` now also matches:
+
+- **Amounts** — transaction `amount` and document `total_amount` / `vat_amount`. Both the raw and
+  `ABS()` values are compared so signed and unsigned inputs match. Thousands separators are stripped
+  from the search term (via a resolver-computed `freeTextNumeric` param) so both `1,234.56` and
+  `1234.56` match the plain value stored in the DB.
+- **Counterparty business names** — by joining `financial_entities` on the business ids referenced
+  by the charge's transactions (`business_id`) and documents (`creditor_id`, `debtor_id`). The
+  document match is split into separate creditor/debtor `UNION` branches so the planner can use the
+  foreign-key indexes.

--- a/packages/server/src/modules/charges/providers/charges.provider.ts
+++ b/packages/server/src/modules/charges/providers/charges.provider.ts
@@ -180,18 +180,46 @@ const getChargesByFilters = sql<IGetChargesByFiltersQuery>`
            OR user_description ILIKE '%' || $freeText || '%'
     )
     UNION
-    SELECT charge_id FROM accounter_schema.transactions 
+    SELECT charge_id FROM accounter_schema.transactions
     WHERE ($freeText::TEXT IS NOT NULL
            AND (source_description ILIKE '%' || $freeText || '%'
                 OR source_reference ILIKE '%' || $freeText || '%')
     )
     UNION
-    SELECT charge_id FROM accounter_schema.documents 
+    SELECT charge_id FROM accounter_schema.documents
     WHERE ($freeText::TEXT IS NOT NULL
            AND (description ILIKE '%' || $freeText || '%'
                 OR remarks ILIKE '%' || $freeText || '%'
                 OR serial_number ILIKE '%' || $freeText || '%')
     )
+    UNION
+    -- match transaction amounts (commas stripped so "1,234.56" matches stored "1234.56")
+    SELECT charge_id FROM accounter_schema.transactions
+    WHERE ($freeText::TEXT IS NOT NULL
+           AND (amount::TEXT ILIKE '%' || REPLACE($freeText, ',', '') || '%'
+                OR ABS(amount)::TEXT ILIKE '%' || REPLACE($freeText, ',', '') || '%')
+    )
+    UNION
+    -- match document amounts (total and vat), commas stripped
+    SELECT charge_id FROM accounter_schema.documents
+    WHERE ($freeText::TEXT IS NOT NULL
+           AND (total_amount::TEXT ILIKE '%' || REPLACE($freeText, ',', '') || '%'
+                OR ABS(total_amount)::TEXT ILIKE '%' || REPLACE($freeText, ',', '') || '%'
+                OR vat_amount::TEXT ILIKE '%' || REPLACE($freeText, ',', '') || '%')
+    )
+    UNION
+    -- match counterparty business names referenced by the charge's transactions
+    SELECT t.charge_id FROM accounter_schema.transactions t
+    JOIN accounter_schema.financial_entities fe ON fe.id = t.business_id
+    WHERE ($freeText::TEXT IS NOT NULL
+           AND fe.name ILIKE '%' || $freeText || '%')
+    UNION
+    -- match counterparty business names referenced by the charge's documents
+    SELECT d.charge_id FROM accounter_schema.documents d
+    JOIN accounter_schema.financial_entities fe
+      ON fe.id = d.creditor_id OR fe.id = d.debtor_id
+    WHERE ($freeText::TEXT IS NOT NULL
+           AND fe.name ILIKE '%' || $freeText || '%')
   ),
   filtered_charges AS MATERIALIZED (
     -- This is our "source of truth" for the rest of the query

--- a/packages/server/src/modules/charges/providers/charges.provider.ts
+++ b/packages/server/src/modules/charges/providers/charges.provider.ts
@@ -193,19 +193,21 @@ const getChargesByFilters = sql<IGetChargesByFiltersQuery>`
                 OR serial_number ILIKE '%' || $freeText || '%')
     )
     UNION
-    -- match transaction amounts (commas stripped so "1,234.56" matches stored "1234.56")
+    -- match transaction amounts. $freeTextNumeric has thousands separators stripped
+    -- so both "1,234.56" and "1234.56" match the plain value stored in the DB.
     SELECT charge_id FROM accounter_schema.transactions
-    WHERE ($freeText::TEXT IS NOT NULL
-           AND (amount::TEXT ILIKE '%' || REPLACE($freeText, ',', '') || '%'
-                OR ABS(amount)::TEXT ILIKE '%' || REPLACE($freeText, ',', '') || '%')
+    WHERE ($freeTextNumeric::TEXT IS NOT NULL
+           AND (amount::TEXT ILIKE '%' || $freeTextNumeric || '%'
+                OR ABS(amount)::TEXT ILIKE '%' || $freeTextNumeric || '%')
     )
     UNION
-    -- match document amounts (total and vat), commas stripped
+    -- match document amounts (total and vat), separators stripped
     SELECT charge_id FROM accounter_schema.documents
-    WHERE ($freeText::TEXT IS NOT NULL
-           AND (total_amount::TEXT ILIKE '%' || REPLACE($freeText, ',', '') || '%'
-                OR ABS(total_amount)::TEXT ILIKE '%' || REPLACE($freeText, ',', '') || '%'
-                OR vat_amount::TEXT ILIKE '%' || REPLACE($freeText, ',', '') || '%')
+    WHERE ($freeTextNumeric::TEXT IS NOT NULL
+           AND (total_amount::TEXT ILIKE '%' || $freeTextNumeric || '%'
+                OR ABS(total_amount)::TEXT ILIKE '%' || $freeTextNumeric || '%'
+                OR vat_amount::TEXT ILIKE '%' || $freeTextNumeric || '%'
+                OR ABS(vat_amount)::TEXT ILIKE '%' || $freeTextNumeric || '%')
     )
     UNION
     -- match counterparty business names referenced by the charge's transactions
@@ -214,10 +216,15 @@ const getChargesByFilters = sql<IGetChargesByFiltersQuery>`
     WHERE ($freeText::TEXT IS NOT NULL
            AND fe.name ILIKE '%' || $freeText || '%')
     UNION
-    -- match counterparty business names referenced by the charge's documents
+    -- match counterparty business names referenced by the charge's documents (creditor)
     SELECT d.charge_id FROM accounter_schema.documents d
-    JOIN accounter_schema.financial_entities fe
-      ON fe.id = d.creditor_id OR fe.id = d.debtor_id
+    JOIN accounter_schema.financial_entities fe ON fe.id = d.creditor_id
+    WHERE ($freeText::TEXT IS NOT NULL
+           AND fe.name ILIKE '%' || $freeText || '%')
+    UNION
+    -- match counterparty business names referenced by the charge's documents (debtor)
+    SELECT d.charge_id FROM accounter_schema.documents d
+    JOIN accounter_schema.financial_entities fe ON fe.id = d.debtor_id
     WHERE ($freeText::TEXT IS NOT NULL
            AND fe.name ILIKE '%' || $freeText || '%')
   ),
@@ -965,6 +972,7 @@ type IGetAdjustedChargesByFiltersParams = Optional<
     | 'tags'
     | 'isBusinessTripIds'
     | 'businessTripIds'
+    | 'freeTextNumeric'
   >,
   'ownerIds' | 'IDs' | 'asc' | 'sortColumn' | 'toDate' | 'fromDate'
 > & {
@@ -1121,6 +1129,8 @@ export class ChargesProvider {
       withoutTransactions: params.withoutTransactions ?? false,
       withoutLedger: params.withoutLedger ?? false,
       accountantStatuses: isAccountantStatuses ? params.accountantStatuses! : null,
+      // strip thousands separators so amount searches match the plain value stored in the DB
+      freeTextNumeric: params.freeText ? params.freeText.replaceAll(',', '') : null,
     };
     return getChargesByFilters.run(fullParams, this.db) as Promise<IGetChargesByFiltersResult[]>;
   }

--- a/packages/server/src/modules/charges/providers/charges.provider.ts
+++ b/packages/server/src/modules/charges/providers/charges.provider.ts
@@ -210,19 +210,19 @@ const getChargesByFilters = sql<IGetChargesByFiltersQuery>`
                 OR ABS(vat_amount)::TEXT ILIKE '%' || $freeTextNumeric || '%')
     )
     UNION
-    -- match counterparty business names referenced by the charge's transactions
+    -- match counterparty business names referenced by the charges transactions
     SELECT t.charge_id FROM accounter_schema.transactions t
     JOIN accounter_schema.financial_entities fe ON fe.id = t.business_id
     WHERE ($freeText::TEXT IS NOT NULL
            AND fe.name ILIKE '%' || $freeText || '%')
     UNION
-    -- match counterparty business names referenced by the charge's documents (creditor)
+    -- match counterparty business names referenced by the charges documents (creditor)
     SELECT d.charge_id FROM accounter_schema.documents d
     JOIN accounter_schema.financial_entities fe ON fe.id = d.creditor_id
     WHERE ($freeText::TEXT IS NOT NULL
            AND fe.name ILIKE '%' || $freeText || '%')
     UNION
-    -- match counterparty business names referenced by the charge's documents (debtor)
+    -- match counterparty business names referenced by the charges documents (debtor)
     SELECT d.charge_id FROM accounter_schema.documents d
     JOIN accounter_schema.financial_entities fe ON fe.id = d.debtor_id
     WHERE ($freeText::TEXT IS NOT NULL


### PR DESCRIPTION
Extend the `search_matches` CTE in `getChargesByFilters` so the charges free-text filter also matches:

- transaction amounts and document total/vat amounts. Commas are stripped from the search term so both plain ("1234.56") and decorated ("1,234.56") inputs match the plain numeric value stored in the DB. Both the raw and absolute value are compared so signed/unsigned inputs match.
- counterparty business names, by joining financial_entities on the business ids referenced by the charge's transactions and documents (creditor/debtor).

Closes #3457


Claude-Session: https://claude.ai/code/session_01Y4X1VwCC4taYUTbXB8jBuW