### PR TITLE
feat(client): business management screen — Phase G lazy usage columns

### DIFF
--- a/packages/client/src/components/businesses/__tests__/business-rows.test.ts
+++ b/packages/client/src/components/businesses/__tests__/business-rows.test.ts
@@ -1,5 +1,33 @@
 import { describe, expect, it } from 'vitest';
-import { businessNodesToRows, formatLocality } from '../business-rows.js';
+import {
+  businessNodesToRows,
+  formatLocality,
+  mergeBusinessUsage,
+  type BusinessRow,
+} from '../business-rows.js';
+
+function makeRow(id: string, name: string): BusinessRow {
+  return {
+    id,
+    name,
+    hebrewName: null,
+    governmentId: null,
+    countryCode: null,
+    city: null,
+    zipCode: null,
+    createdAt: null,
+    updatedAt: null,
+    sortCodeKey: null,
+    taxCategoryName: null,
+    irsCode: null,
+    pcn874RecordType: null,
+    isClient: false,
+    isAdmin: false,
+    isActive: true,
+    suggestionDescription: null,
+    suggestionTags: [],
+  };
+}
 
 describe('businessNodesToRows', () => {
   it('keeps only LtdFinancialEntity nodes and maps core, categorization and tag fields', () => {
@@ -74,6 +102,38 @@ describe('businessNodesToRows', () => {
       isActive: true,
       suggestionDescription: null,
       suggestionTags: [],
+    });
+  });
+});
+
+describe('mergeBusinessUsage', () => {
+  it('merges usage counts into rows by business id and defaults unmatched rows to null', () => {
+    const merged = mergeBusinessUsage(
+      [makeRow('b1', 'Alpha'), makeRow('b2', 'Beta')],
+      [
+        {
+          businessId: 'b1',
+          totalTransactions: 3,
+          totalDocuments: 2,
+          totalMiscExpenses: 1,
+          totalLedgerRecords: 5,
+        },
+      ],
+    );
+
+    expect(merged[0]).toMatchObject({
+      id: 'b1',
+      totalTransactions: 3,
+      totalDocuments: 2,
+      totalMiscExpenses: 1,
+      totalLedgerRecords: 5,
+    });
+    expect(merged[1]).toMatchObject({
+      id: 'b2',
+      totalTransactions: null,
+      totalDocuments: null,
+      totalMiscExpenses: null,
+      totalLedgerRecords: null,
     });
   });
 });

--- a/packages/client/src/components/businesses/business-rows.ts
+++ b/packages/client/src/components/businesses/business-rows.ts
@@ -27,6 +27,17 @@ export type BusinessRow = {
   suggestionTags: string[];
 };
 
+/** Usage counts merged into table rows once the lazy usage query resolves (null until loaded). */
+export type BusinessUsageCounts = {
+  totalTransactions: number | null;
+  totalDocuments: number | null;
+  totalMiscExpenses: number | null;
+  totalLedgerRecords: number | null;
+};
+
+/** A business table row: the mapped business plus its (optionally loaded) usage counts. */
+export type BusinessTableRow = BusinessRow & BusinessUsageCounts;
+
 /** Minimal shape of an `allBusinesses` node consumed by the table (LtdFinancialEntity fields). */
 type RawBusinessNode = {
   __typename?: string | null;
@@ -85,4 +96,27 @@ export function businessNodesToRows(nodes: readonly RawBusinessNode[]): Business
 /** Human-readable locality from city / zip / country code, skipping the empty parts. */
 export function formatLocality(row: Pick<BusinessRow, 'city' | 'zipCode' | 'countryCode'>): string {
   return [row.city, row.zipCode, row.countryCode].filter(Boolean).join(', ');
+}
+
+/** Merge per-business usage counts (from the lazy usage query) into the table rows by id. */
+export function mergeBusinessUsage(
+  rows: readonly BusinessRow[],
+  usage: readonly ({ businessId: string } & BusinessUsageCounts)[],
+): BusinessTableRow[] {
+  const byId = new Map<string, BusinessUsageCounts>();
+  for (const entry of usage) {
+    byId.set(entry.businessId, {
+      totalTransactions: entry.totalTransactions,
+      totalDocuments: entry.totalDocuments,
+      totalMiscExpenses: entry.totalMiscExpenses,
+      totalLedgerRecords: entry.totalLedgerRecords,
+    });
+  }
+  return rows.map(row => ({
+    ...row,
+    totalTransactions: byId.get(row.id)?.totalTransactions ?? null,
+    totalDocuments: byId.get(row.id)?.totalDocuments ?? null,
+    totalMiscExpenses: byId.get(row.id)?.totalMiscExpenses ?? null,
+    totalLedgerRecords: byId.get(row.id)?.totalLedgerRecords ?? null,
+  }));
 }

--- a/packages/client/src/components/businesses/business-rows.ts
+++ b/packages/client/src/components/businesses/business-rows.ts
@@ -105,18 +105,16 @@ export function mergeBusinessUsage(
 ): BusinessTableRow[] {
   const byId = new Map<string, BusinessUsageCounts>();
   for (const entry of usage) {
-    byId.set(entry.businessId, {
-      totalTransactions: entry.totalTransactions,
-      totalDocuments: entry.totalDocuments,
-      totalMiscExpenses: entry.totalMiscExpenses,
-      totalLedgerRecords: entry.totalLedgerRecords,
-    });
+    byId.set(entry.businessId, entry);
   }
-  return rows.map(row => ({
-    ...row,
-    totalTransactions: byId.get(row.id)?.totalTransactions ?? null,
-    totalDocuments: byId.get(row.id)?.totalDocuments ?? null,
-    totalMiscExpenses: byId.get(row.id)?.totalMiscExpenses ?? null,
-    totalLedgerRecords: byId.get(row.id)?.totalLedgerRecords ?? null,
-  }));
+  return rows.map(row => {
+    const counts = byId.get(row.id);
+    return {
+      ...row,
+      totalTransactions: counts?.totalTransactions ?? null,
+      totalDocuments: counts?.totalDocuments ?? null,
+      totalMiscExpenses: counts?.totalMiscExpenses ?? null,
+      totalLedgerRecords: counts?.totalLedgerRecords ?? null,
+    };
+  });
 }

--- a/packages/client/src/components/businesses/columns.tsx
+++ b/packages/client/src/components/businesses/columns.tsx
@@ -1,16 +1,26 @@
 import { format } from 'date-fns';
+import { Loader2 } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { type ColumnDef, type VisibilityState } from '@tanstack/react-table';
+import { type ColumnDef, type Table, type VisibilityState } from '@tanstack/react-table';
 import { ROUTES } from '../../router/routes.js';
 import { Badge } from '../ui/badge.js';
 import { Checkbox } from '../ui/checkbox.js';
-import { formatLocality, type BusinessRow } from './business-rows.js';
+import { formatLocality, type BusinessTableRow } from './business-rows.js';
 
 function formatDate(value: Date | null): string {
   return value ? format(value, 'dd/MM/yyyy') : '—';
 }
 
-export const columns: ColumnDef<BusinessRow>[] = [
+/** Usage cells show the count, a spinner while the lazy usage query is in flight, or a dash. */
+function usageCell(value: number | null, table: Table<BusinessTableRow>) {
+  if (value != null) {
+    return value;
+  }
+  const meta = table.options.meta as { usageFetching?: boolean } | undefined;
+  return meta?.usageFetching ? <Loader2 className="h-4 w-4 animate-spin" /> : '—';
+}
+
+export const columns: ColumnDef<BusinessTableRow>[] = [
   {
     id: 'select',
     header: ({ table }) => (
@@ -135,6 +145,35 @@ export const columns: ColumnDef<BusinessRow>[] = [
         '—'
       ),
   },
+  // Usage (lazy)
+  {
+    accessorKey: 'totalTransactions',
+    header: 'Transactions',
+    cell: ({ row, table }) => usageCell(row.original.totalTransactions, table),
+  },
+  {
+    accessorKey: 'totalDocuments',
+    header: 'Documents',
+    cell: ({ row, table }) => usageCell(row.original.totalDocuments, table),
+  },
+  {
+    accessorKey: 'totalMiscExpenses',
+    header: 'Misc expenses',
+    cell: ({ row, table }) => usageCell(row.original.totalMiscExpenses, table),
+  },
+  {
+    accessorKey: 'totalLedgerRecords',
+    header: 'Ledger records',
+    cell: ({ row, table }) => usageCell(row.original.totalLedgerRecords, table),
+  },
+];
+
+/** Usage column ids — the lazy group that triggers the usage query when enabled. */
+export const USAGE_COLUMN_IDS = [
+  'totalTransactions',
+  'totalDocuments',
+  'totalMiscExpenses',
+  'totalLedgerRecords',
 ];
 
 /** Column groups, used by the column-visibility toggle. */
@@ -173,10 +212,19 @@ export const COLUMN_GROUPS: { label: string; columns: { id: string; label: strin
       { id: 'tags', label: 'Tags' },
     ],
   },
+  {
+    label: 'Usage',
+    columns: [
+      { id: 'totalTransactions', label: 'Transactions' },
+      { id: 'totalDocuments', label: 'Documents' },
+      { id: 'totalMiscExpenses', label: 'Misc expenses' },
+      { id: 'totalLedgerRecords', label: 'Ledger records' },
+    ],
+  },
 ];
 
-// Categorization and Suggestion-defaults columns are hidden by default; Core, Main and
-// Extension tags are shown.
+// Categorization, Suggestion-defaults and Usage columns are hidden by default; Core, Main
+// and Extension tags are shown.
 export const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
   sortCode: false,
   taxCategory: false,
@@ -184,4 +232,8 @@ export const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
   pcn874RecordType: false,
   description: false,
   tags: false,
+  totalTransactions: false,
+  totalDocuments: false,
+  totalMiscExpenses: false,
+  totalLedgerRecords: false,
 };

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -8,7 +8,7 @@ import {
   type RowSelectionState,
   type VisibilityState,
 } from '@tanstack/react-table';
-import { AllBusinessesForScreenDocument } from '../../gql/graphql.js';
+import { AllBusinessesForScreenDocument, BusinessesUsageDocument } from '../../gql/graphql.js';
 import { useUrlQuery } from '../../hooks/use-url-query.js';
 import { cn } from '../../lib/utils.js';
 import { FiltersContext } from '../../providers/filters-context.js';
@@ -24,9 +24,9 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu.js';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table.js';
-import { businessNodesToRows } from './business-rows.js';
+import { businessNodesToRows, mergeBusinessUsage } from './business-rows.js';
 import { BusinessesFilters } from './businesses-filters.js';
-import { COLUMN_GROUPS, columns, DEFAULT_COLUMN_VISIBILITY } from './columns.js';
+import { COLUMN_GROUPS, columns, DEFAULT_COLUMN_VISIBILITY, USAGE_COLUMN_IDS } from './columns.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -78,6 +78,20 @@ import { COLUMN_GROUPS, columns, DEFAULT_COLUMN_VISIBILITY } from './columns.js'
   }
 `;
 
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  query BusinessesUsage($ids: [UUID!]!) {
+    businessesUsage(ids: $ids) {
+      id
+      businessId
+      totalTransactions
+      totalDocuments
+      totalMiscExpenses
+      totalLedgerRecords
+    }
+  }
+`;
+
 export const Businesses = (): ReactElement => {
   const { get } = useUrlQuery();
   const [activePage, setActivePage] = useState(get('page') ? Number(get('page')) : 0);
@@ -104,8 +118,22 @@ export const Businesses = (): ReactElement => {
   const [columnVisibility, setColumnVisibility] =
     useState<VisibilityState>(DEFAULT_COLUMN_VISIBILITY);
 
+  // Usage counts are lazy: only fetched once the user enables a usage column.
+  const businessIds = useMemo(() => rows.map(row => row.id), [rows]);
+  const usageEnabled = USAGE_COLUMN_IDS.some(id => columnVisibility[id]);
+  const [{ data: usageData, fetching: usageFetching }] = useQuery({
+    query: BusinessesUsageDocument,
+    variables: { ids: businessIds },
+    pause: !usageEnabled || businessIds.length === 0,
+  });
+
+  const tableRows = useMemo(
+    () => mergeBusinessUsage(rows, usageData?.businessesUsage ?? []),
+    [rows, usageData],
+  );
+
   const table = useReactTable({
-    data: rows,
+    data: tableRows,
     columns,
     getRowId: row => row.id,
     getCoreRowModel: getCoreRowModel(),
@@ -116,6 +144,9 @@ export const Businesses = (): ReactElement => {
       rowSelection,
       columnVisibility,
     },
+    // cast: @tanstack's TableMeta interface is empty by default (not augmented here); the usage
+    // columns read `usageFetching` back off table.options.meta with a matching cast.
+    meta: { usageFetching: usageEnabled && usageFetching } as Record<string, unknown>,
   });
 
   // Footer


### PR DESCRIPTION
## Summary

Phase G (client lazy usage columns) of the business management screen, per
`docs/businesses-page-refactor/blueprint.md`. Single step.

- Adds a **Usage** column group — transactions, documents, misc expenses, ledger
  records — hidden by default.
- A second `BusinessesUsage($ids)` query is paused (`pause: true`) until the user
  enables any usage column (or there are no loaded ids). Enabling one un-pauses it for
  the currently loaded business ids.
- The counts are merged into the table rows by id via a pure `mergeBusinessUsage`
  helper. Rows are typed `BusinessTableRow = BusinessRow & BusinessUsageCounts`, so the
  existing Core/Main/Categorization/Tag columns are unchanged.
- Usage cells show the count, a spinner while the query is in flight
  (`usageFetching` passed through `table.options.meta`), or a dash when unused.

## Notes

- The lazy trigger is derived from `columnVisibility` (usage ids default hidden in
  `DEFAULT_COLUMN_VISIBILITY`), so no query runs until a usage column is switched on.
- `table.options.meta` is written with a `Record<string, unknown>` cast and read back
  with a matching cast, rather than augmenting `@tanstack`'s empty `TableMeta`
  interface — the repo doesn't augment it anywhere, and this avoids the excess-property
  check without an unused-type-parameter module augmentation.

## Tests

Extended the pure `business-rows` unit tests with a `mergeBusinessUsage` case (merge by
id + null defaults for unmatched rows). As in the earlier client phases there's no full
screen-render test — the data transform is covered by the pure tests.

## Verification not run in this environment

`yarn install` cannot complete here (the `xlsx` dependency resolves from an external CDN
host blocked by this session's egress policy, 403), so `yarn generate`, `yarn lint`, the
client build, and tests could not run. Prettier (pinned version from the offline cache,
project core options) passes on all changed files; import ordering follows the module
conventions and `id` is selected on `BusinessUsage` (`require-selections`). Please
confirm via CI.

Manual check once built: open `/businesses`, enable a Usage column via the Columns
dropdown — the usage query fires once, a spinner shows briefly, then counts render;
disabling all usage columns stops further usage fetching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017sEQX9bozBUUTiPcXxXL87)_