### PR TITLE
feat(client): business management screen — Phase I (delete + batch update)

### DIFF
--- a/packages/client/src/components/businesses/batch-update-dialog.tsx
+++ b/packages/client/src/components/businesses/batch-update-dialog.tsx
@@ -1,0 +1,139 @@
+import { useState, type ReactElement } from 'react';
+import type { BatchUpdateBusinessInput } from '../../gql/graphql.js';
+import { useBatchUpdateBusinesses } from '../../hooks/use-batch-update-businesses.js';
+import { Button } from '../ui/button.js';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '../ui/dialog.js';
+import { Input } from '../ui/input.js';
+import { Label } from '../ui/label.js';
+
+interface BatchUpdateBusinessesDialogProps {
+  businessIds: string[];
+  onDone: () => void;
+}
+
+type FormState = {
+  country: string;
+  city: string;
+  zipCode: string;
+  sortCode: string;
+  irsCode: string;
+  taxCategory: string;
+  description: string;
+};
+
+const EMPTY_FORM: FormState = {
+  country: '',
+  city: '',
+  zipCode: '',
+  sortCode: '',
+  irsCode: '',
+  taxCategory: '',
+  description: '',
+};
+
+const FIELDS: { key: keyof FormState; label: string; placeholder?: string; numeric?: boolean }[] = [
+  { key: 'country', label: 'Country code', placeholder: 'e.g. ISR' },
+  { key: 'city', label: 'City' },
+  { key: 'zipCode', label: 'Zip code' },
+  { key: 'sortCode', label: 'Sort code', numeric: true },
+  { key: 'irsCode', label: 'IRS code', numeric: true },
+  { key: 'taxCategory', label: 'Tax category (UUID)' },
+  { key: 'description', label: 'Suggestion description' },
+];
+
+/** Build the mutation input from only the fields the user filled in. */
+function buildFields(form: FormState): BatchUpdateBusinessInput {
+  const fields: BatchUpdateBusinessInput = {};
+  if (form.country.trim()) {
+    fields.country = form.country.trim();
+  }
+  if (form.city.trim()) {
+    fields.city = form.city.trim();
+  }
+  if (form.zipCode.trim()) {
+    fields.zipCode = form.zipCode.trim();
+  }
+  if (form.sortCode.trim()) {
+    fields.sortCode = Number(form.sortCode);
+  }
+  if (form.irsCode.trim()) {
+    fields.irsCode = Number(form.irsCode);
+  }
+  if (form.taxCategory.trim()) {
+    fields.taxCategory = form.taxCategory.trim();
+  }
+  if (form.description.trim()) {
+    fields.suggestions = { description: form.description.trim() };
+  }
+  return fields;
+}
+
+export function BatchUpdateBusinessesDialog({
+  businessIds,
+  onDone,
+}: BatchUpdateBusinessesDialogProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const { fetching, batchUpdateBusinesses } = useBatchUpdateBusinesses();
+
+  const onSubmit = async (): Promise<void> => {
+    const fields = buildFields(form);
+    if (Object.keys(fields).length === 0) {
+      return;
+    }
+    const updated = await batchUpdateBusinesses({ businessIds, fields });
+    if (updated) {
+      setForm(EMPTY_FORM);
+      setOpen(false);
+      onDone();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" disabled={businessIds.length === 0}>
+          Batch update{businessIds.length ? ` (${businessIds.length})` : ''}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Batch update {businessIds.length} businesses</DialogTitle>
+          <DialogDescription>
+            Only the fields you fill in are applied to every selected business.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-3">
+          {FIELDS.map(field => (
+            <div key={field.key} className="grid gap-1">
+              <Label htmlFor={`batch-${field.key}`}>{field.label}</Label>
+              <Input
+                id={`batch-${field.key}`}
+                type={field.numeric ? 'number' : 'text'}
+                value={form[field.key]}
+                placeholder={field.placeholder}
+                onChange={event => setForm(prev => ({ ...prev, [field.key]: event.target.value }))}
+              />
+            </div>
+          ))}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => void onSubmit()} disabled={fetching}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/businesses/batch-update-dialog.tsx
+++ b/packages/client/src/components/businesses/batch-update-dialog.tsx
@@ -84,6 +84,11 @@ export function BatchUpdateBusinessesDialog({
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const { fetching, batchUpdateBusinesses } = useBatchUpdateBusinesses();
 
+  const isFormEmpty = Object.values(form).every(value => !value.trim());
+  const hasInvalidNumericFields =
+    (form.sortCode.trim() !== '' && Number.isNaN(Number(form.sortCode))) ||
+    (form.irsCode.trim() !== '' && Number.isNaN(Number(form.irsCode)));
+
   const onSubmit = async (): Promise<void> => {
     const fields = buildFields(form);
     if (Object.keys(fields).length === 0) {
@@ -129,7 +134,10 @@ export function BatchUpdateBusinessesDialog({
           <Button variant="outline" onClick={() => setOpen(false)}>
             Cancel
           </Button>
-          <Button onClick={() => void onSubmit()} disabled={fetching}>
+          <Button
+            onClick={() => void onSubmit()}
+            disabled={fetching || isFormEmpty || hasInvalidNumericFields}
+          >
             Save
           </Button>
         </DialogFooter>

--- a/packages/client/src/components/businesses/business-row-actions.tsx
+++ b/packages/client/src/components/businesses/business-row-actions.tsx
@@ -1,0 +1,83 @@
+import { useState, type ReactElement } from 'react';
+import { Trash2 } from 'lucide-react';
+import type { Table } from '@tanstack/react-table';
+import { useDeleteBusiness } from '../../hooks/use-delete-business.js';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '../ui/alert-dialog.js';
+import { Button } from '../ui/button.js';
+import {
+  isBusinessUnused,
+  type BusinessTableMeta,
+  type BusinessTableRow,
+} from './business-rows.js';
+
+interface BusinessRowActionsProps {
+  row: BusinessTableRow;
+  table: Table<BusinessTableRow>;
+}
+
+export function BusinessRowActions({ row, table }: BusinessRowActionsProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  const { fetching, deleteBusiness } = useDeleteBusiness();
+  const meta = table.options.meta as BusinessTableMeta | undefined;
+  // Only unused businesses may be deleted; usage must be loaded (non-null) and all zero.
+  const canDelete = isBusinessUnused(row);
+
+  const onConfirm = async (): Promise<void> => {
+    const deleted = await deleteBusiness({ businessId: row.id });
+    if (deleted) {
+      setOpen(false);
+      meta?.refetchBusinesses?.();
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-red-600 hover:text-red-700"
+          disabled={!canDelete}
+          title={
+            canDelete
+              ? 'Delete business'
+              : 'Only unused businesses can be deleted — enable a usage column to load usage'
+          }
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete &quot;{row.name}&quot;?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This permanently deletes the business and cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={event => {
+              event.preventDefault();
+              void onConfirm();
+            }}
+            disabled={fetching}
+            className="bg-red-600 hover:bg-red-700"
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/packages/client/src/components/businesses/business-row-actions.tsx
+++ b/packages/client/src/components/businesses/business-row-actions.tsx
@@ -40,6 +40,27 @@ export function BusinessRowActions({ row, table }: BusinessRowActionsProps): Rea
     }
   };
 
+  // A disabled <button> swallows pointer events, so a native `title` tooltip never shows. When
+  // deletion isn't allowed, render the disabled button inside a hoverable span that carries the
+  // tooltip, and skip the AlertDialog wrapper entirely (nothing can open it).
+  if (!canDelete) {
+    return (
+      <span
+        title="Only unused businesses can be deleted — enable a usage column to load usage"
+        className="inline-block cursor-not-allowed"
+      >
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-red-600 hover:text-red-700 pointer-events-none"
+          disabled
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </span>
+    );
+  }
+
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
@@ -47,12 +68,7 @@ export function BusinessRowActions({ row, table }: BusinessRowActionsProps): Rea
           variant="ghost"
           size="icon"
           className="text-red-600 hover:text-red-700"
-          disabled={!canDelete}
-          title={
-            canDelete
-              ? 'Delete business'
-              : 'Only unused businesses can be deleted — enable a usage column to load usage'
-          }
+          title="Delete business"
         >
           <Trash2 className="h-4 w-4" />
         </Button>

--- a/packages/client/src/components/businesses/business-rows.ts
+++ b/packages/client/src/components/businesses/business-rows.ts
@@ -38,6 +38,22 @@ export type BusinessUsageCounts = {
 /** A business table row: the mapped business plus its (optionally loaded) usage counts. */
 export type BusinessTableRow = BusinessRow & BusinessUsageCounts;
 
+/** Extra handles passed to the table via `table.options.meta` and read by cells. */
+export type BusinessTableMeta = {
+  usageFetching?: boolean;
+  refetchBusinesses?: () => void;
+};
+
+/** True once all four usage counts are known (loaded) and zero — the delete guard. */
+export function isBusinessUnused(row: BusinessUsageCounts): boolean {
+  return (
+    row.totalTransactions === 0 &&
+    row.totalDocuments === 0 &&
+    row.totalMiscExpenses === 0 &&
+    row.totalLedgerRecords === 0
+  );
+}
+
 /** Minimal shape of an `allBusinesses` node consumed by the table (LtdFinancialEntity fields). */
 type RawBusinessNode = {
   __typename?: string | null;
@@ -130,16 +146,6 @@ export type BusinessRowFilters = {
   taxCategory: string;
 };
 
-/** A row is "unused" only once all four usage counts are known and zero. */
-function isUnused(row: BusinessTableRow): boolean {
-  return (
-    row.totalTransactions === 0 &&
-    row.totalDocuments === 0 &&
-    row.totalMiscExpenses === 0 &&
-    row.totalLedgerRecords === 0
-  );
-}
-
 /** Filter rows by the extension-tag flags, usage and free-text sort-code / tax-category. */
 export function filterBusinessRows(
   rows: readonly BusinessTableRow[],
@@ -161,7 +167,7 @@ export function filterBusinessRows(
     if (filters.inactive && row.isActive) {
       return false;
     }
-    if (filters.unusedOnly && !isUnused(row)) {
+    if (filters.unusedOnly && !isBusinessUnused(row)) {
       return false;
     }
     if (sortCode && !String(row.sortCodeKey ?? '').includes(sortCode)) {

--- a/packages/client/src/components/businesses/columns.tsx
+++ b/packages/client/src/components/businesses/columns.tsx
@@ -6,7 +6,8 @@ import { ROUTES } from '../../router/routes.js';
 import { DataTableColumnHeader } from '../common/data-table-column-header.js';
 import { Badge } from '../ui/badge.js';
 import { Checkbox } from '../ui/checkbox.js';
-import { formatLocality, type BusinessTableRow } from './business-rows.js';
+import { BusinessRowActions } from './business-row-actions.js';
+import { formatLocality, type BusinessTableMeta, type BusinessTableRow } from './business-rows.js';
 
 function formatDate(value: Date | null): string {
   return value ? format(value, 'dd/MM/yyyy') : '—';
@@ -23,7 +24,7 @@ function usageCell(value: number | null, table: Table<BusinessTableRow>) {
   if (value != null) {
     return value;
   }
-  const meta = table.options.meta as { usageFetching?: boolean } | undefined;
+  const meta = table.options.meta as BusinessTableMeta | undefined;
   return meta?.usageFetching ? <Loader2 className="h-4 w-4 animate-spin" /> : '—';
 }
 
@@ -177,6 +178,12 @@ export const columns: ColumnDef<BusinessTableRow>[] = [
     accessorKey: 'totalLedgerRecords',
     header: ({ column }) => <DataTableColumnHeader column={column} title="Ledger records" />,
     cell: ({ row, table }) => usageCell(row.original.totalLedgerRecords, table),
+  },
+  {
+    id: 'actions',
+    enableHiding: false,
+    enableSorting: false,
+    cell: ({ row, table }) => <BusinessRowActions row={row.original} table={table} />,
   },
 ];
 

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -26,6 +26,7 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu.js';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table.js';
+import { BatchUpdateBusinessesDialog } from './batch-update-dialog.js';
 import {
   businessNodesToRows,
   filterBusinessRows,
@@ -176,13 +177,23 @@ export const Businesses = (): ReactElement => {
         refetch();
       }
     };
-    const selectedForMerge = table
-      .getSelectedRowModel()
-      .rows.map(row => ({ id: row.original.id, onChange: onMergeChange }));
+    const selectedRows = table.getSelectedRowModel().rows;
+    const selectedForMerge = selectedRows.map(row => ({
+      id: row.original.id,
+      onChange: onMergeChange,
+    }));
+    const selectedIds = selectedRows.map(row => row.original.id);
     setFiltersContext(
       <div className="flex flex-row gap-x-5">
         <BusinessesFilters filters={filters} setFilters={setFilters} />
         <MergeBusinessesButton selected={selectedForMerge} resetMerge={() => setRowSelection({})} />
+        <BatchUpdateBusinessesDialog
+          businessIds={selectedIds}
+          onDone={() => {
+            refetch();
+            setRowSelection({});
+          }}
+        />
       </div>,
     );
   }, [setFiltersContext, rowSelection, refetch, table, filters, setFilters]);

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -31,6 +31,7 @@ import {
   filterBusinessRows,
   mergeBusinessUsage,
   type BusinessRowFilters,
+  type BusinessTableMeta,
 } from './business-rows.js';
 import { BusinessesFilters } from './businesses-filters.js';
 import { COLUMN_GROUPS, columns, DEFAULT_COLUMN_VISIBILITY, USAGE_COLUMN_IDS } from './columns.js';
@@ -157,9 +158,12 @@ export const Businesses = (): ReactElement => {
       columnVisibility,
       sorting,
     },
-    // cast: @tanstack's TableMeta interface is empty by default (not augmented here); the usage
-    // columns read `usageFetching` back off table.options.meta with a matching cast.
-    meta: { usageFetching: usageEnabled && usageFetching } as Record<string, unknown>,
+    // cast: @tanstack's TableMeta interface is empty by default (not augmented here); cells read
+    // these handles back off table.options.meta with a matching cast.
+    meta: {
+      usageFetching: usageEnabled && usageFetching,
+      refetchBusinesses: () => refetch(),
+    } as BusinessTableMeta,
   });
 
   // Footer

--- a/packages/client/src/hooks/use-batch-update-businesses.ts
+++ b/packages/client/src/hooks/use-batch-update-businesses.ts
@@ -1,0 +1,57 @@
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { useMutation } from 'urql';
+import {
+  BatchUpdateBusinessesDocument,
+  type BatchUpdateBusinessesMutationVariables,
+} from '../gql/graphql.js';
+import { handleCommonErrors } from '../helpers/error-handling.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  mutation BatchUpdateBusinesses($businessIds: [UUID!]!, $fields: BatchUpdateBusinessInput!) {
+    batchUpdateBusinesses(businessIds: $businessIds, fields: $fields) {
+      id
+    }
+  }
+`;
+
+type UseBatchUpdateBusinesses = {
+  fetching: boolean;
+  batchUpdateBusinesses: (variables: BatchUpdateBusinessesMutationVariables) => Promise<boolean>;
+};
+
+const NOTIFICATION_ID = 'batchUpdateBusinesses';
+
+export const useBatchUpdateBusinesses = (): UseBatchUpdateBusinesses => {
+  const [{ fetching }, mutate] = useMutation(BatchUpdateBusinessesDocument);
+  const batchUpdateBusinesses = useCallback(
+    async (variables: BatchUpdateBusinessesMutationVariables) => {
+      const message = `Error updating ${variables.businessIds.length} businesses`;
+      toast.loading('Updating businesses', { id: NOTIFICATION_ID });
+      try {
+        const res = await mutate(variables);
+        const data = handleCommonErrors(res, message, NOTIFICATION_ID);
+        if (data) {
+          toast.success('Success', {
+            id: NOTIFICATION_ID,
+            description: 'Businesses updated',
+          });
+          return true;
+        }
+      } catch (e) {
+        console.error(`${message}: ${e}`);
+        toast.error('Error', {
+          id: NOTIFICATION_ID,
+          description: message,
+          duration: 100_000,
+          closeButton: true,
+        });
+      }
+      return false;
+    },
+    [mutate],
+  );
+
+  return { fetching, batchUpdateBusinesses };
+};

--- a/packages/client/src/hooks/use-delete-business.ts
+++ b/packages/client/src/hooks/use-delete-business.ts
@@ -1,0 +1,53 @@
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { useMutation } from 'urql';
+import { DeleteBusinessDocument, type DeleteBusinessMutationVariables } from '../gql/graphql.js';
+import { handleCommonErrors } from '../helpers/error-handling.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  mutation DeleteBusiness($businessId: UUID!) {
+    deleteBusiness(businessId: $businessId)
+  }
+`;
+
+type UseDeleteBusiness = {
+  fetching: boolean;
+  deleteBusiness: (variables: DeleteBusinessMutationVariables) => Promise<boolean>;
+};
+
+const NOTIFICATION_ID = 'deleteBusiness';
+
+export const useDeleteBusiness = (): UseDeleteBusiness => {
+  const [{ fetching }, mutate] = useMutation(DeleteBusinessDocument);
+  const deleteBusiness = useCallback(
+    async (variables: DeleteBusinessMutationVariables) => {
+      const message = `Error deleting business ID [${variables.businessId}]`;
+      const notificationId = `${NOTIFICATION_ID}-${variables.businessId}`;
+      toast.loading('Deleting business', { id: notificationId });
+      try {
+        const res = await mutate(variables);
+        const data = handleCommonErrors(res, message, notificationId);
+        if (data) {
+          toast.success('Success', {
+            id: notificationId,
+            description: 'Business deleted',
+          });
+          return true;
+        }
+      } catch (e) {
+        console.error(`${message}: ${e}`);
+        toast.error('Error', {
+          id: notificationId,
+          description: message,
+          duration: 100_000,
+          closeButton: true,
+        });
+      }
+      return false;
+    },
+    [mutate],
+  );
+
+  return { fetching, deleteBusiness };
+};


### PR DESCRIPTION
## Phase I — row-level & batch actions

Adds the two remaining write actions to the Business Management Screen, each in its own commit.

### I1 — per-row delete guarded by usage
- New `useDeleteBusiness` mutation hook (`DeleteBusiness` → `Boolean`, toast + `handleCommonErrors`).
- New `BusinessRowActions` cell: a trash button wrapped in an `AlertDialog` confirm. The button is **disabled unless the row is unused** (all four usage counts zero), so the client mirrors the server's hard delete guard; on success it triggers `refetchBusinesses` via `table.options.meta`.
- Added an `actions` column (non-hideable, non-sortable) to `columns.tsx`.
- Extracted a reusable `isBusinessUnused` helper and `BusinessTableMeta` type into the React-free `business-rows.ts` (dedupes the internal `isUnused` used by `filterBusinessRows`).

### I2 — batch update dialog
- New `useBatchUpdateBusinesses` mutation hook wrapping `batchUpdateBusinesses`.
- New `BatchUpdateBusinessesDialog`: a controlled form over the shared, batch-safe fields (country / city / zip / sort code / IRS code / tax category / suggestion description). Only the fields the user fills in are sent; on success it clears the form, closes, refetches, and clears the row selection.
- Wired into the screen footer next to the merge button, driven by the current row selection.

### Notes
- No server changes — the `deleteBusiness` and `batchUpdateBusinesses` mutations and `BatchUpdateBusinessInput` already exist from earlier phases.
- Delete remains defense-in-depth: the client disables it for used businesses, and the provider is still the authoritative backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sEQX9bozBUUTiPcXxXL87

---
_Generated by [Claude Code](https://claude.ai/code/session_017sEQX9bozBUUTiPcXxXL87)_