### PR TITLE
feat(client): business management screen — Phase J (polish: states + docs)

### DIFF
--- a/docs/businesses-page-refactor/plan.md
+++ b/docs/businesses-page-refactor/plan.md
@@ -158,8 +158,10 @@ body of the current `updateBusiness` resolver into a shared helper so both mutat
   `components/common/data-table-column-header.tsx`. Base table primitives: `components/ui/table.js`.
 - **Query:** replace the `AllBusinessesForScreen` document in `index.tsx` — add the new fields
   (`sortCode`, `taxCategory`, `isClient`, owner/admin flag, `suggestions { description tags }`) to
-  the `LtdFinancialEntity` selection. The `allBusinesses` query already supports `page/limit/name`;
-  rich filtering/sorting is done client-side over the loaded page (pagination optional per request).
+  the `LtdFinancialEntity` selection. **Divergence (final):** the screen fetches _all_ businesses
+  (query takes no `page/limit/name`) so that sorting/filtering/pagination are all client-side and
+  apply across the whole set, not just one page — the `allBusinesses` resolver already loads them
+  all in memory. Pagination is the shared `DataTablePagination` + `getPaginationRowModel`.
 - **Usage:** second `useQuery` against `businessesUsage(ids: …)`, run with `pause: true` until the
   user enables a usage column; merge counts into rows by id.
 - **Mutations:** wrap each in a `src/hooks/` hook (`useMutation` + `handleCommonErrors` + `sonner`
@@ -188,3 +190,18 @@ body of the current `updateBusiness` resolver into a shared helper so both mutat
 5. Manual UI (`yarn client:dev` + `yarn server:dev`): open `/businesses` — toggle column groups,
    sort/filter, filter "unused only", select rows → merge, batch-update, and delete an unused
    business; confirm toasts and that the table refetches.
+
+## States (Phase J)
+
+The screen renders four states in priority order:
+
+1. **Error** — `Alert variant="destructive"` with the query's `error.message` when the
+   `allBusinesses` query fails.
+2. **Loading** — centered `Loader2` spinner while the query is in flight.
+3. **Empty (no businesses)** — `ui/empty.js` `Empty` block with a `Building2` icon and an
+   `InsertBusiness` call-to-action when the whole set is empty.
+4. **No results (filtered)** — an in-table "No results." row when filters exclude every business but
+   the set is non-empty.
+
+Usage columns stay lazy: the `businessesUsage` query is `pause`d until a usage column is enabled or
+"unused only" is on, so the default table never fetches counts.

--- a/packages/client/src/components/businesses/batch-update-dialog.tsx
+++ b/packages/client/src/components/businesses/batch-update-dialog.tsx
@@ -49,6 +49,9 @@ const FIELDS: { key: keyof FormState; label: string; placeholder?: string; numer
   { key: 'description', label: 'Suggestion description' },
 ];
 
+/** Whole non-negative integers only (no decimals or scientific notation). */
+const INTEGER_PATTERN = /^\d+$/;
+
 /** Build the mutation input from only the fields the user filled in. */
 function buildFields(form: FormState): BatchUpdateBusinessInput {
   const fields: BatchUpdateBusinessInput = {};
@@ -85,9 +88,11 @@ export function BatchUpdateBusinessesDialog({
   const { fetching, batchUpdateBusinesses } = useBatchUpdateBusinesses();
 
   const isFormEmpty = Object.values(form).every(value => !value.trim());
+  // sortCode/irsCode map to GraphQL Int, so only whole non-negative integers are valid — reject
+  // decimals and scientific notation that Number() would otherwise coerce.
   const hasInvalidNumericFields =
-    (form.sortCode.trim() !== '' && Number.isNaN(Number(form.sortCode))) ||
-    (form.irsCode.trim() !== '' && Number.isNaN(Number(form.irsCode)));
+    (form.sortCode.trim() !== '' && !INTEGER_PATTERN.test(form.sortCode.trim())) ||
+    (form.irsCode.trim() !== '' && !INTEGER_PATTERN.test(form.irsCode.trim()));
 
   const onSubmit = async (): Promise<void> => {
     const fields = buildFields(form);

--- a/packages/client/src/components/businesses/business-row-actions.tsx
+++ b/packages/client/src/components/businesses/business-row-actions.tsx
@@ -44,11 +44,14 @@ export function BusinessRowActions({ row, table }: BusinessRowActionsProps): Rea
   // deletion isn't allowed, render the disabled button inside a hoverable span that carries the
   // tooltip, and skip the AlertDialog wrapper entirely (nothing can open it).
   if (!canDelete) {
+    // Usage counts are null until the lazy query loads them. Once loaded, a non-deletable business
+    // is genuinely in use — reflect that rather than telling the user to enable a usage column.
+    const isUsageLoaded = row.totalTransactions !== null;
+    const disabledTitle = isUsageLoaded
+      ? 'This business is in use and cannot be deleted'
+      : 'Only unused businesses can be deleted — enable a usage column to load usage';
     return (
-      <span
-        title="Only unused businesses can be deleted — enable a usage column to load usage"
-        className="inline-block cursor-not-allowed"
-      >
+      <span title={disabledTitle} className="inline-block cursor-not-allowed">
         <Button
           variant="ghost"
           size="icon"

--- a/packages/client/src/components/businesses/columns.tsx
+++ b/packages/client/src/components/businesses/columns.tsx
@@ -10,7 +10,9 @@ import { BusinessRowActions } from './business-row-actions.js';
 import { formatLocality, type BusinessTableMeta, type BusinessTableRow } from './business-rows.js';
 
 function formatDate(value: Date | null): string {
-  return value ? format(value, 'dd/MM/yyyy') : '—';
+  // A failed `new Date(...)` parse yields an Invalid Date (truthy), which makes date-fns `format`
+  // throw a RangeError and crash the row — guard on the timestamp being a real number.
+  return value && !Number.isNaN(value.getTime()) ? format(value, 'dd/MM/yyyy') : '—';
 }
 
 /** Null-safe date sort comparator (missing dates sort first ascending). */

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
-import { ChevronDown, Loader2 } from 'lucide-react';
+import { Building2, ChevronDown, Loader2 } from 'lucide-react';
 import { useQuery } from 'urql';
 import {
   flexRender,
@@ -16,6 +16,7 @@ import { cn } from '../../lib/utils.js';
 import { FiltersContext } from '../../providers/filters-context.js';
 import { DataTablePagination, InsertBusiness, MergeBusinessesButton } from '../common/index.js';
 import { PageLayout } from '../layout/page-layout.js';
+import { Alert, AlertDescription, AlertTitle } from '../ui/alert.js';
 import { Button } from '../ui/button.js';
 import {
   DropdownMenu,
@@ -25,6 +26,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu.js';
+import { Empty, EmptyContent, EmptyDescription, EmptyMedia, EmptyTitle } from '../ui/empty.js';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table.js';
 import { BatchUpdateBusinessesDialog } from './batch-update-dialog.js';
 import {
@@ -102,7 +104,7 @@ import { COLUMN_GROUPS, columns, DEFAULT_COLUMN_VISIBILITY, USAGE_COLUMN_IDS } f
 export const Businesses = (): ReactElement => {
   const { setFiltersContext } = useContext(FiltersContext);
 
-  const [{ data, fetching }, refetch] = useQuery({
+  const [{ data, fetching, error }, refetch] = useQuery({
     query: AllBusinessesForScreenDocument,
   });
 
@@ -246,10 +248,28 @@ export const Businesses = (): ReactElement => {
         </div>
       }
     >
-      {fetching ? (
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Failed to load businesses</AlertTitle>
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      ) : fetching ? (
         <div className="flex flex-row justify-center">
           <Loader2 className={cn('h-10 w-10 animate-spin mr-2')} />
         </div>
+      ) : rows.length === 0 ? (
+        <Empty className="py-8 sm:py-12">
+          <EmptyMedia>
+            <Building2 className="size-8 sm:size-10 text-muted-foreground" />
+          </EmptyMedia>
+          <EmptyTitle>No businesses yet</EmptyTitle>
+          <EmptyDescription>
+            Add your first business, or generate businesses from your transactions.
+          </EmptyDescription>
+          <EmptyContent>
+            <InsertBusiness description="" onAdd={() => refetch()} />
+          </EmptyContent>
+        </Empty>
       ) : (
         <div className="space-y-4">
           <div className="overflow-hidden rounded-md border">


### PR DESCRIPTION
## Phase J — polish

Final polish pass on the Business Management Screen: explicit render states and doc updates.

### States (`components/businesses/index.tsx`)
The screen now renders four states in priority order:
1. **Error** — `Alert variant="destructive"` surfacing the `allBusinesses` query `error.message` (previously the error was unhandled).
2. **Loading** — the existing centered `Loader2` spinner.
3. **Empty (no businesses)** — a `ui/empty.js` `Empty` block with a `Building2` icon and an `InsertBusiness` call-to-action, shown when the whole set is empty.
4. **No results (filtered)** — the existing in-table "No results." row, which now specifically covers the case where filters exclude every business but the set is non-empty.

### Confirmed (no change needed)
- Column-visibility defaults stay Core + Main + Extension tags; Categorization / Suggestion defaults / Usage hidden by default.
- Usage stays lazy — the `businessesUsage` query remains `pause`d until a usage column is enabled or "unused only" is on, so the default table never fetches counts.

### Docs
- Updated `docs/businesses-page-refactor/plan.md`: documented the final client-side fetch-all approach (diverged from the original server-pagination note) and added a "States (Phase J)" section.

### Verification note
`yarn install` can't run in this environment (registry egress is blocked), so `yarn lint` / `yarn prettier:check` / `build` were not run locally — code was hand-formatted to the repo's prettier 3.9.4 conventions. CI is the authoritative gate; I'll fix anything it flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sEQX9bozBUUTiPcXxXL87

---
_Generated by [Claude Code](https://claude.ai/code/session_017sEQX9bozBUUTiPcXxXL87)_