### PR TITLE
feat(client): business management screen — locality, sort code, batch country & loading refinements

### DIFF
--- a/packages/client/src/components/businesses/__tests__/business-rows.test.ts
+++ b/packages/client/src/components/businesses/__tests__/business-rows.test.ts
@@ -21,6 +21,7 @@ function makeRow(id: string, name: string): BusinessRow {
     createdAt: null,
     updatedAt: null,
     sortCodeKey: null,
+    sortCodeName: null,
     taxCategoryName: null,
     irsCode: null,
     pcn874RecordType: null,
@@ -91,6 +92,7 @@ describe('businessNodesToRows', () => {
       createdAt: new Date('2024-01-02T00:00:00Z'),
       updatedAt: new Date('2024-03-04T00:00:00Z'),
       sortCodeKey: 910,
+      sortCodeName: 'Income',
       taxCategoryName: 'Revenue',
       irsCode: 42,
       pcn874RecordType: 'S1',
@@ -118,6 +120,7 @@ describe('businessNodesToRows', () => {
       createdAt: null,
       updatedAt: null,
       sortCodeKey: null,
+      sortCodeName: null,
       taxCategoryName: null,
       irsCode: null,
       pcn874RecordType: null,
@@ -208,14 +211,24 @@ describe('filterBusinessRows', () => {
     );
   });
 
-  it('filters by sort-code and tax-category substrings', () => {
+  it('filters by sort-code key or name, and by tax-category substrings', () => {
     const rows = [
-      makeTableRow({ id: 'a', sortCodeKey: 910, taxCategoryName: 'Income' }),
-      makeTableRow({ id: 'b', sortCodeKey: 200, taxCategoryName: 'Expense' }),
+      makeTableRow({
+        id: 'a',
+        sortCodeKey: 310,
+        sortCodeName: 'לקוחות חול',
+        taxCategoryName: 'Income',
+      }),
+      makeTableRow({ id: 'b', sortCodeKey: 200, sortCodeName: 'ספקים', taxCategoryName: 'Expense' }),
     ];
-    expect(filterBusinessRows(rows, { ...NO_FILTERS, sortCode: '91' }).map(row => row.id)).toEqual([
+    // by key
+    expect(filterBusinessRows(rows, { ...NO_FILTERS, sortCode: '310' }).map(row => row.id)).toEqual([
       'a',
     ]);
+    // by name (case-insensitive substring)
+    expect(
+      filterBusinessRows(rows, { ...NO_FILTERS, sortCode: 'לקוחות' }).map(row => row.id),
+    ).toEqual(['a']);
     expect(
       filterBusinessRows(rows, { ...NO_FILTERS, taxCategory: 'exp' }).map(row => row.id),
     ).toEqual(['b']);
@@ -223,13 +236,16 @@ describe('filterBusinessRows', () => {
 });
 
 describe('formatLocality', () => {
-  it('joins the present parts and skips the empty ones', () => {
-    expect(formatLocality({ city: 'Tel Aviv', zipCode: null, countryCode: 'ISR' })).toBe(
-      'Tel Aviv, ISR',
-    );
-    expect(formatLocality({ city: 'Tel Aviv', zipCode: '6000000', countryCode: 'ISR' })).toBe(
-      'Tel Aviv, 6000000, ISR',
-    );
-    expect(formatLocality({ city: null, zipCode: null, countryCode: null })).toBe('');
+  it('resolves the country code to its display name', () => {
+    expect(formatLocality({ countryCode: 'ISR' })).toBe('Israel');
+    expect(formatLocality({ countryCode: 'USA' })).toBe('United States of America (the)');
+  });
+
+  it('returns an empty string when there is no country', () => {
+    expect(formatLocality({ countryCode: null })).toBe('');
+  });
+
+  it('falls back to the raw code when it is unknown', () => {
+    expect(formatLocality({ countryCode: 'ZZZ' })).toBe('ZZZ');
   });
 });

--- a/packages/client/src/components/businesses/batch-update-dialog.tsx
+++ b/packages/client/src/components/businesses/batch-update-dialog.tsx
@@ -1,6 +1,8 @@
 import { useState, type ReactElement } from 'react';
 import type { BatchUpdateBusinessInput } from '../../gql/graphql.js';
 import { useBatchUpdateBusinesses } from '../../hooks/use-batch-update-businesses.js';
+import { useAllCountries } from '../../hooks/use-get-countries.js';
+import { ComboBox } from '../common/index.js';
 import { Button } from '../ui/button.js';
 import {
   Dialog,
@@ -39,8 +41,8 @@ const EMPTY_FORM: FormState = {
   description: '',
 };
 
+// `country` is rendered separately as a searchable ComboBox; the rest are simple inputs.
 const FIELDS: { key: keyof FormState; label: string; placeholder?: string; numeric?: boolean }[] = [
-  { key: 'country', label: 'Country code', placeholder: 'e.g. ISR' },
   { key: 'city', label: 'City' },
   { key: 'zipCode', label: 'Zip code' },
   { key: 'sortCode', label: 'Sort code', numeric: true },
@@ -86,6 +88,7 @@ export function BatchUpdateBusinessesDialog({
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const { fetching, batchUpdateBusinesses } = useBatchUpdateBusinesses();
+  const { countries, fetching: fetchingCountries } = useAllCountries();
 
   const isFormEmpty = Object.values(form).every(value => !value.trim());
   // sortCode/irsCode map to GraphQL Int, so only whole non-negative integers are valid — reject
@@ -122,6 +125,16 @@ export function BatchUpdateBusinessesDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-3">
+          <div className="grid gap-1">
+            <Label>Country</Label>
+            <ComboBox
+              data={countries.map(country => ({ value: country.code, label: country.name }))}
+              value={form.country || null}
+              onChange={value => setForm(prev => ({ ...prev, country: value ?? '' }))}
+              disabled={fetchingCountries}
+              placeholder="Select country"
+            />
+          </div>
           {FIELDS.map(field => (
             <div key={field.key} className="grid gap-1">
               <Label htmlFor={`batch-${field.key}`}>{field.label}</Label>

--- a/packages/client/src/components/businesses/business-rows.ts
+++ b/packages/client/src/components/businesses/business-rows.ts
@@ -3,6 +3,8 @@
  * business management table. Kept free of React/urql imports so they are easy to unit test.
  */
 
+import { countryNameByCode } from '../../helpers/countries.js';
+
 export type BusinessRow = {
   id: string;
   name: string;
@@ -15,6 +17,7 @@ export type BusinessRow = {
   updatedAt: Date | null;
   // categorization
   sortCodeKey: number | null;
+  sortCodeName: string | null;
   taxCategoryName: string | null;
   irsCode: number | null;
   pcn874RecordType: string | null;
@@ -105,6 +108,7 @@ export function businessNodesToRows(nodes: readonly RawBusinessNode[]): Business
       createdAt: parseValidDate(node.createdAt),
       updatedAt: parseValidDate(node.updatedAt),
       sortCodeKey: node.sortCode?.key ?? null,
+      sortCodeName: node.sortCode?.name ?? null,
       taxCategoryName: node.taxCategory?.name ?? null,
       irsCode: node.irsCode ?? null,
       pcn874RecordType: node.pcn874RecordType ?? null,
@@ -118,9 +122,9 @@ export function businessNodesToRows(nodes: readonly RawBusinessNode[]): Business
     .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
 }
 
-/** Human-readable locality from city / zip / country code, skipping the empty parts. */
-export function formatLocality(row: Pick<BusinessRow, 'city' | 'zipCode' | 'countryCode'>): string {
-  return [row.city, row.zipCode, row.countryCode].filter(Boolean).join(', ');
+/** Locality shown in the table: the country name resolved from the stored country code. */
+export function formatLocality(row: Pick<BusinessRow, 'countryCode'>): string {
+  return countryNameByCode(row.countryCode) ?? '';
 }
 
 /** Merge per-business usage counts (from the lazy usage query) into the table rows by id. */
@@ -161,7 +165,7 @@ export function filterBusinessRows(
   filters: BusinessRowFilters,
 ): BusinessTableRow[] {
   const name = filters.name.trim().toLowerCase();
-  const sortCode = filters.sortCode.trim();
+  const sortCode = filters.sortCode.trim().toLowerCase();
   const taxCategory = filters.taxCategory.trim().toLowerCase();
   return rows.filter(row => {
     if (name && !`${row.name} ${row.hebrewName ?? ''}`.toLowerCase().includes(name)) {
@@ -179,8 +183,12 @@ export function filterBusinessRows(
     if (filters.unusedOnly && !isBusinessUnused(row)) {
       return false;
     }
-    if (sortCode && !String(row.sortCodeKey ?? '').includes(sortCode)) {
-      return false;
+    if (sortCode) {
+      const keyMatch = String(row.sortCodeKey ?? '').includes(sortCode);
+      const nameMatch = (row.sortCodeName ?? '').toLowerCase().includes(sortCode);
+      if (!keyMatch && !nameMatch) {
+        return false;
+      }
     }
     if (taxCategory && !(row.taxCategoryName ?? '').toLowerCase().includes(taxCategory)) {
       return false;

--- a/packages/client/src/components/businesses/columns.tsx
+++ b/packages/client/src/components/businesses/columns.tsx
@@ -106,10 +106,8 @@ export const columns: ColumnDef<BusinessTableRow>[] = [
       }
       return (
         <div className="flex flex-col leading-tight">
-          {sortCodeKey != null ? <span className="font-medium">{sortCodeKey}</span> : null}
-          {sortCodeName ? (
-            <span className="text-xs text-muted-foreground">{sortCodeName}</span>
-          ) : null}
+          {sortCodeKey != null && <span className="font-medium">{sortCodeKey}</span>}
+          {sortCodeName && <span className="text-xs text-muted-foreground">{sortCodeName}</span>}
         </div>
       );
     },

--- a/packages/client/src/components/businesses/columns.tsx
+++ b/packages/client/src/components/businesses/columns.tsx
@@ -99,7 +99,20 @@ export const columns: ColumnDef<BusinessTableRow>[] = [
     id: 'sortCode',
     accessorFn: row => row.sortCodeKey,
     header: ({ column }) => <DataTableColumnHeader column={column} title="Sort code" />,
-    cell: ({ row }) => row.original.sortCodeKey ?? '—',
+    cell: ({ row }) => {
+      const { sortCodeKey, sortCodeName } = row.original;
+      if (sortCodeKey == null && !sortCodeName) {
+        return '—';
+      }
+      return (
+        <div className="flex flex-col leading-tight">
+          {sortCodeKey != null ? <span className="font-medium">{sortCodeKey}</span> : null}
+          {sortCodeName ? (
+            <span className="text-xs text-muted-foreground">{sortCodeName}</span>
+          ) : null}
+        </div>
+      );
+    },
   },
   {
     id: 'taxCategory',

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
-import { Building2, ChevronDown, Loader2 } from 'lucide-react';
+import { Building2, ChevronDown } from 'lucide-react';
 import { useQuery } from 'urql';
 import {
   flexRender,
@@ -12,9 +12,13 @@ import {
   type VisibilityState,
 } from '@tanstack/react-table';
 import { AllBusinessesForScreenDocument, BusinessesUsageDocument } from '../../gql/graphql.js';
-import { cn } from '../../lib/utils.js';
 import { FiltersContext } from '../../providers/filters-context.js';
-import { DataTablePagination, InsertBusiness, MergeBusinessesButton } from '../common/index.js';
+import {
+  DataTablePagination,
+  InsertBusiness,
+  MergeBusinessesButton,
+  TableSkeleton,
+} from '../common/index.js';
 import { PageLayout } from '../layout/page-layout.js';
 import { Alert, AlertDescription, AlertTitle } from '../ui/alert.js';
 import { Button } from '../ui/button.js';
@@ -254,8 +258,8 @@ export const Businesses = (): ReactElement => {
           <AlertDescription>{error.message}</AlertDescription>
         </Alert>
       ) : fetching ? (
-        <div className="flex flex-row justify-center">
-          <Loader2 className={cn('h-10 w-10 animate-spin mr-2')} />
+        <div className="rounded-md border p-4">
+          <TableSkeleton columns={8} rows={10} />
         </div>
       ) : rows.length === 0 ? (
         <Empty className="py-8 sm:py-12">

--- a/packages/client/src/helpers/countries.ts
+++ b/packages/client/src/helpers/countries.ts
@@ -260,5 +260,5 @@ export function countryNameByCode(code: string | null | undefined): string | nul
   if (!code) {
     return null;
   }
-  return COUNTRY_NAME_BY_CODE[code] ?? code;
+  return COUNTRY_NAME_BY_CODE[code.toUpperCase()] ?? code;
 }

--- a/packages/client/src/helpers/countries.ts
+++ b/packages/client/src/helpers/countries.ts
@@ -249,3 +249,16 @@ export enum CountryCode {
   Zimbabwe = 'ZWE',
   'Åland Islands' = 'ALA',
 }
+
+/** Reverse lookup (ISO alpha-3 code → country name), built once from the `CountryCode` enum. */
+const COUNTRY_NAME_BY_CODE: Record<string, string> = Object.fromEntries(
+  Object.entries(CountryCode).map(([name, code]) => [code, name]),
+);
+
+/** Map an ISO alpha-3 country code (e.g. "ISR") to its display name (e.g. "Israel"). */
+export function countryNameByCode(code: string | null | undefined): string | null {
+  if (!code) {
+    return null;
+  }
+  return COUNTRY_NAME_BY_CODE[code] ?? code;
+}


### PR DESCRIPTION
Addresses five review notes on the new business management page.

### 1 & 2 — Locality shows only the country **name**
`formatLocality` now returns just the country display name resolved from the stored ISO code (dropping city/zip). Added a reverse `countryNameByCode` mapper in `helpers/countries.ts`, built once from the existing `CountryCode` enum; it falls back to the raw code for unknown values.

### 3 — Batch-update dialog: country is now selectable
The country field is a searchable `ComboBox` (backed by `useAllCountries`, same source as `insert-business.tsx`) instead of a free-text code input. The stored value remains the ISO code the mutation expects.

### 4 — Loading skeleton
The loading state now renders the shared `TableSkeleton` (from `components/common`) inside a bordered container, replacing the bare centered spinner.

### 5 — Sort code: key **and** name
- The Sort code column renders both the numeric key (emphasized) and the name (muted), stacked.
- The sort-code filter matches **either** the key or the name (case-insensitive), so users can filter by `310` or by `לקוחות חול`. Added `sortCodeName` to the mapped row (the query already selected `sortCode.name`).

### Tests
Updated `business-rows.test.ts`: added `sortCodeName` to fixtures/expectations, a sort-code-by-name filter case, and rewrote the `formatLocality` cases for the country-name behavior (incl. unknown-code fallback).

### Verification note
`yarn install` can't run in this environment (registry egress is blocked), so `yarn lint` / `yarn prettier:check` / `test` / `build` were not run locally — changes are hand-formatted to the repo's prettier 3.9.4 conventions. CI is the authoritative gate; I'll fix anything it flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sEQX9bozBUUTiPcXxXL87

---
_Generated by [Claude Code](https://claude.ai/code/session_017sEQX9bozBUUTiPcXxXL87)_