### PR TITLE
feat(businesses): extend batch update with tags, description & flags

### DIFF
--- a/.changeset/@accounter_client-3836-dependencies.md
+++ b/.changeset/@accounter_client-3836-dependencies.md
@@ -1,0 +1,8 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`@mui/material@9.2.0` ↗︎](https://www.npmjs.com/package/@mui/material/v/9.2.0) (from `9.1.2`, in `dependencies`)
+  - Updated dependency [`@mui/x-charts@8.29.2` ↗︎](https://www.npmjs.com/package/@mui/x-charts/v/8.29.2) (from `8.29.0`, in `dependencies`)
+  - Updated dependency [`csv-parse@7.0.1` ↗︎](https://www.npmjs.com/package/csv-parse/v/7.0.1) (from `7.0.0`, in `dependencies`)
+  - Updated dependency [`react-hook-form@7.81.0` ↗︎](https://www.npmjs.com/package/react-hook-form/v/7.81.0) (from `7.80.0`, in `dependencies`)

--- a/.changeset/@accounter_scraper-app-3836-dependencies.md
+++ b/.changeset/@accounter_scraper-app-3836-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/scraper-app": patch
+---
+dependencies updates:
+  - Updated dependency [`fastify@5.10.0` ↗︎](https://www.npmjs.com/package/fastify/v/5.10.0) (from `5.9.0`, in `dependencies`)

--- a/.changeset/@accounter_server-3836-dependencies.md
+++ b/.changeset/@accounter_server-3836-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@accounter/server": patch
+---
+dependencies updates:
+  - Updated dependency [`@opentelemetry/exporter-trace-otlp-http@0.220.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-http/v/0.220.0) (from `0.219.0`, in `dependencies`)
+  - Updated dependency [`@opentelemetry/resources@2.9.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/resources/v/2.9.0) (from `2.8.0`, in `dependencies`)
+  - Updated dependency [`@opentelemetry/sdk-node@0.220.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/sdk-node/v/0.220.0) (from `0.219.0`, in `dependencies`)

--- a/.changeset/@accounter_server-3836-dependencies.md
+++ b/.changeset/@accounter_server-3836-dependencies.md
@@ -1,7 +1,0 @@
----
-"@accounter/server": patch
----
-dependencies updates:
-  - Updated dependency [`@opentelemetry/exporter-trace-otlp-http@0.220.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-http/v/0.220.0) (from `0.219.0`, in `dependencies`)
-  - Updated dependency [`@opentelemetry/resources@2.9.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/resources/v/2.9.0) (from `2.8.0`, in `dependencies`)
-  - Updated dependency [`@opentelemetry/sdk-node@0.220.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/sdk-node/v/0.220.0) (from `0.219.0`, in `dependencies`)

--- a/.changeset/@accounter_server-3836-dependencies.md
+++ b/.changeset/@accounter_server-3836-dependencies.md
@@ -1,0 +1,7 @@
+---
+"@accounter/server": patch
+---
+dependencies updates:
+  - Updated dependency [`@ai-sdk/anthropic@4.0.7` ↗︎](https://www.npmjs.com/package/@ai-sdk/anthropic/v/4.0.7) (from `4.0.4`, in `dependencies`)
+  - Updated dependency [`@opentelemetry/auto-instrumentations-node@0.78.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node/v/0.78.0) (from `0.77.0`, in `dependencies`)
+  - Updated dependency [`ai@7.0.14` ↗︎](https://www.npmjs.com/package/ai/v/7.0.14) (from `7.0.9`, in `dependencies`)

--- a/.changeset/eager-mails-jam.md
+++ b/.changeset/eager-mails-jam.md
@@ -1,0 +1,12 @@
+---
+'@accounter/server': patch
+---
+
+- Add `exemptDealer`, `optionalVAT`, `isReceiptEnough`, `isDocumentsOptional` and `isActive` to
+  `BatchUpdateBusinessInput` in `financial-entities/typeDefs/businesses.graphql.ts`.
+- No resolver change is needed: these fields are already handled by the shared
+  `updateSingleBusiness` helper (`helpers/update-business.helper.ts`), and
+  `BatchUpdateBusinessInput` remains a strict structural subset of `UpdateBusinessInput`, so it is
+  still passed straight through. `isActive` flows to the core financial-entity update via
+  `hasFinancialEntitiesCoreProperties`; the rest map to the business row update. Tags and
+  description were already supported through the existing `suggestions` input.

--- a/.changeset/tough-hounds-sell.md
+++ b/.changeset/tough-hounds-sell.md
@@ -1,0 +1,13 @@
+---
+'@accounter/client': patch
+---
+
+- Extend `batch-update-dialog.tsx`:
+  - **Tags** — a `MultiSelect` (via `useGetTags`), merged with the existing description into a
+    single `suggestions` input.
+  - **Flags** — `isActive`, `isReceiptEnough`, `isDocumentsOptional` (No docs required),
+    `optionalVAT` (Is VAT optional) and `exemptDealer` as tri-state selects (**No change / Yes /
+    No**). A flag is only sent when the user explicitly picks Yes/No, preserving the "only fields
+    you fill in are applied" semantics of batch update.
+  - `isFormEmpty` is now derived from the built mutation input so the new controls correctly
+    enable/disable the Save button.

--- a/packages/client/src/components/businesses/batch-update-dialog.tsx
+++ b/packages/client/src/components/businesses/batch-update-dialog.tsx
@@ -28,11 +28,7 @@ type TriState = 'unset' | 'true' | 'false';
 
 // boolean flag keys shared 1:1 with `BatchUpdateBusinessInput`.
 type FlagKey =
-  | 'isActive'
-  | 'isReceiptEnough'
-  | 'isDocumentsOptional'
-  | 'optionalVAT'
-  | 'exemptDealer';
+  'isActive' | 'isReceiptEnough' | 'isDocumentsOptional' | 'optionalVAT' | 'exemptDealer';
 
 type FormState = {
   country: string;

--- a/packages/client/src/components/businesses/batch-update-dialog.tsx
+++ b/packages/client/src/components/businesses/batch-update-dialog.tsx
@@ -3,6 +3,7 @@ import type { BatchUpdateBusinessInput } from '../../gql/graphql.js';
 import { useBatchUpdateBusinesses } from '../../hooks/use-batch-update-businesses.js';
 import { useAllCountries } from '../../hooks/use-get-countries.js';
 import { useGetTags } from '../../hooks/use-get-tags.js';
+import { cn } from '../../lib/utils.js';
 import { ComboBox, MultiSelect } from '../common/index.js';
 import { Button } from '../ui/button.js';
 import {
@@ -58,13 +59,20 @@ const EMPTY_FORM: FormState = {
 };
 
 // `country` is rendered separately as a searchable ComboBox; the rest are simple inputs.
-const FIELDS: { key: keyof FormState; label: string; placeholder?: string; numeric?: boolean }[] = [
+// `fullWidth` fields span both columns on wider screens.
+const FIELDS: {
+  key: keyof FormState;
+  label: string;
+  placeholder?: string;
+  numeric?: boolean;
+  fullWidth?: boolean;
+}[] = [
   { key: 'city', label: 'City' },
   { key: 'zipCode', label: 'Zip code' },
   { key: 'sortCode', label: 'Sort code', numeric: true },
   { key: 'irsCode', label: 'IRS code', numeric: true },
-  { key: 'taxCategory', label: 'Tax category (UUID)' },
-  { key: 'description', label: 'Suggestion description' },
+  { key: 'taxCategory', label: 'Tax category (UUID)', fullWidth: true },
+  { key: 'description', label: 'Suggestion description', fullWidth: true },
 ];
 
 // boolean flags rendered as tri-state selects.
@@ -158,15 +166,15 @@ export function BatchUpdateBusinessesDialog({
           Batch update{businessIds.length ? ` (${businessIds.length})` : ''}
         </Button>
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent className="flex max-h-[90vh] flex-col sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Batch update {businessIds.length} businesses</DialogTitle>
           <DialogDescription>
             Only the fields you fill in are applied to every selected business.
           </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-3">
-          <div className="grid gap-1">
+        <div className="-mx-1 grid flex-1 grid-cols-1 gap-3 overflow-y-auto px-1 sm:grid-cols-2">
+          <div className="grid gap-1 sm:col-span-2">
             <Label>Country</Label>
             <ComboBox
               data={countries.map(country => ({ value: country.code, label: country.name }))}
@@ -177,7 +185,7 @@ export function BatchUpdateBusinessesDialog({
             />
           </div>
           {FIELDS.map(field => (
-            <div key={field.key} className="grid gap-1">
+            <div key={field.key} className={cn('grid gap-1', field.fullWidth && 'sm:col-span-2')}>
               <Label htmlFor={`batch-${field.key}`}>{field.label}</Label>
               <Input
                 id={`batch-${field.key}`}
@@ -188,7 +196,7 @@ export function BatchUpdateBusinessesDialog({
               />
             </div>
           ))}
-          <div className="grid gap-1">
+          <div className="grid gap-1 sm:col-span-2">
             <Label>Tags</Label>
             <MultiSelect
               options={selectableTags}

--- a/packages/client/src/components/businesses/batch-update-dialog.tsx
+++ b/packages/client/src/components/businesses/batch-update-dialog.tsx
@@ -197,7 +197,6 @@ export function BatchUpdateBusinessesDialog({
             <MultiSelect
               options={selectableTags}
               onValueChange={value => setForm(prev => ({ ...prev, tags: value }))}
-              value={form.tags}
               defaultValue={form.tags}
               placeholder="Select tags"
               variant="default"

--- a/packages/client/src/components/businesses/batch-update-dialog.tsx
+++ b/packages/client/src/components/businesses/batch-update-dialog.tsx
@@ -2,7 +2,8 @@ import { useState, type ReactElement } from 'react';
 import type { BatchUpdateBusinessInput } from '../../gql/graphql.js';
 import { useBatchUpdateBusinesses } from '../../hooks/use-batch-update-businesses.js';
 import { useAllCountries } from '../../hooks/use-get-countries.js';
-import { ComboBox } from '../common/index.js';
+import { useGetTags } from '../../hooks/use-get-tags.js';
+import { ComboBox, MultiSelect } from '../common/index.js';
 import { Button } from '../ui/button.js';
 import {
   Dialog,
@@ -15,11 +16,23 @@ import {
 } from '../ui/dialog.js';
 import { Input } from '../ui/input.js';
 import { Label } from '../ui/label.js';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select.js';
 
 interface BatchUpdateBusinessesDialogProps {
   businessIds: string[];
   onDone: () => void;
 }
+
+// tri-state for boolean flags: `unset` leaves the flag untouched across the batch.
+type TriState = 'unset' | 'true' | 'false';
+
+// boolean flag keys shared 1:1 with `BatchUpdateBusinessInput`.
+type FlagKey =
+  | 'isActive'
+  | 'isReceiptEnough'
+  | 'isDocumentsOptional'
+  | 'optionalVAT'
+  | 'exemptDealer';
 
 type FormState = {
   country: string;
@@ -29,7 +42,8 @@ type FormState = {
   irsCode: string;
   taxCategory: string;
   description: string;
-};
+  tags: string[];
+} & Record<FlagKey, TriState>;
 
 const EMPTY_FORM: FormState = {
   country: '',
@@ -39,6 +53,12 @@ const EMPTY_FORM: FormState = {
   irsCode: '',
   taxCategory: '',
   description: '',
+  tags: [],
+  isActive: 'unset',
+  isReceiptEnough: 'unset',
+  isDocumentsOptional: 'unset',
+  optionalVAT: 'unset',
+  exemptDealer: 'unset',
 };
 
 // `country` is rendered separately as a searchable ComboBox; the rest are simple inputs.
@@ -49,6 +69,15 @@ const FIELDS: { key: keyof FormState; label: string; placeholder?: string; numer
   { key: 'irsCode', label: 'IRS code', numeric: true },
   { key: 'taxCategory', label: 'Tax category (UUID)' },
   { key: 'description', label: 'Suggestion description' },
+];
+
+// boolean flags rendered as tri-state selects.
+const FLAG_FIELDS: { key: FlagKey; label: string }[] = [
+  { key: 'isActive', label: 'Is active' },
+  { key: 'isReceiptEnough', label: 'Is receipt enough' },
+  { key: 'isDocumentsOptional', label: 'No docs required' },
+  { key: 'optionalVAT', label: 'Is VAT optional' },
+  { key: 'exemptDealer', label: 'Exempt dealer' },
 ];
 
 /** Whole non-negative integers only (no decimals or scientific notation). */
@@ -75,9 +104,24 @@ function buildFields(form: FormState): BatchUpdateBusinessInput {
   if (form.taxCategory.trim()) {
     fields.taxCategory = form.taxCategory.trim();
   }
+
+  const suggestions: NonNullable<BatchUpdateBusinessInput['suggestions']> = {};
   if (form.description.trim()) {
-    fields.suggestions = { description: form.description.trim() };
+    suggestions.description = form.description.trim();
   }
+  if (form.tags.length > 0) {
+    suggestions.tags = form.tags.map(id => ({ id }));
+  }
+  if (Object.keys(suggestions).length > 0) {
+    fields.suggestions = suggestions;
+  }
+
+  for (const { key } of FLAG_FIELDS) {
+    if (form[key] !== 'unset') {
+      fields[key] = form[key] === 'true';
+    }
+  }
+
   return fields;
 }
 
@@ -89,8 +133,10 @@ export function BatchUpdateBusinessesDialog({
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const { fetching, batchUpdateBusinesses } = useBatchUpdateBusinesses();
   const { countries, fetching: fetchingCountries } = useAllCountries();
+  const { selectableTags, fetching: fetchingTags } = useGetTags();
 
-  const isFormEmpty = Object.values(form).every(value => !value.trim());
+  const fields = buildFields(form);
+  const isFormEmpty = Object.keys(fields).length === 0;
   // sortCode/irsCode map to GraphQL Int, so only whole non-negative integers are valid — reject
   // decimals and scientific notation that Number() would otherwise coerce.
   const hasInvalidNumericFields =
@@ -98,7 +144,6 @@ export function BatchUpdateBusinessesDialog({
     (form.irsCode.trim() !== '' && !INTEGER_PATTERN.test(form.irsCode.trim()));
 
   const onSubmit = async (): Promise<void> => {
-    const fields = buildFields(form);
     if (Object.keys(fields).length === 0) {
       return;
     }
@@ -141,10 +186,42 @@ export function BatchUpdateBusinessesDialog({
               <Input
                 id={`batch-${field.key}`}
                 type={field.numeric ? 'number' : 'text'}
-                value={form[field.key]}
+                value={form[field.key] as string}
                 placeholder={field.placeholder}
                 onChange={event => setForm(prev => ({ ...prev, [field.key]: event.target.value }))}
               />
+            </div>
+          ))}
+          <div className="grid gap-1">
+            <Label>Tags</Label>
+            <MultiSelect
+              options={selectableTags}
+              onValueChange={value => setForm(prev => ({ ...prev, tags: value }))}
+              value={form.tags}
+              defaultValue={form.tags}
+              placeholder="Select tags"
+              variant="default"
+              disabled={fetchingTags}
+            />
+          </div>
+          {FLAG_FIELDS.map(flag => (
+            <div key={flag.key} className="grid gap-1">
+              <Label htmlFor={`batch-${flag.key}`}>{flag.label}</Label>
+              <Select
+                value={form[flag.key]}
+                onValueChange={value =>
+                  setForm(prev => ({ ...prev, [flag.key]: value as TriState }))
+                }
+              >
+                <SelectTrigger id={`batch-${flag.key}`}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="unset">No change</SelectItem>
+                  <SelectItem value="true">Yes</SelectItem>
+                  <SelectItem value="false">No</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           ))}
         </div>

--- a/packages/server/src/modules/financial-entities/typeDefs/businesses.graphql.ts
+++ b/packages/server/src/modules/financial-entities/typeDefs/businesses.graphql.ts
@@ -181,6 +181,11 @@ export default gql`
     irsCode: Int
     pcn874RecordType: Pcn874RecordType
     suggestions: SuggestionsInput
+    exemptDealer: Boolean
+    optionalVAT: Boolean
+    isReceiptEnough: Boolean
+    isDocumentsOptional: Boolean
+    isActive: Boolean
   }
 
   " input for business suggestions "


### PR DESCRIPTION
## Summary

Closes #3808. Extends the `batchUpdateBusinesses` mutation (added in #3807) to cover the remaining per-business fields, so tags, a default suggestion description, and the boolean flags can be applied to many businesses at once.

### Server

- Add `exemptDealer`, `optionalVAT`, `isReceiptEnough`, `isDocumentsOptional` and `isActive` to `BatchUpdateBusinessInput` in `financial-entities/typeDefs/businesses.graphql.ts`.
- No resolver change is needed: these fields are already handled by the shared `updateSingleBusiness` helper (`helpers/update-business.helper.ts`), and `BatchUpdateBusinessInput` remains a strict structural subset of `UpdateBusinessInput`, so it is still passed straight through. `isActive` flows to the core financial-entity update via `hasFinancialEntitiesCoreProperties`; the rest map to the business row update. Tags and description were already supported through the existing `suggestions` input.

### Client

- Extend `batch-update-dialog.tsx`:
  - **Tags** — a `MultiSelect` (via `useGetTags`), merged with the existing description into a single `suggestions` input.
  - **Flags** — `isActive`, `isReceiptEnough`, `isDocumentsOptional` (No docs required), `optionalVAT` (Is VAT optional) and `exemptDealer` as tri-state selects (**No change / Yes / No**). A flag is only sent when the user explicitly picks Yes/No, preserving the "only fields you fill in are applied" semantics of batch update.
  - `isFormEmpty` is now derived from the built mutation input so the new controls correctly enable/disable the Save button.

## Verification

`yarn install` cannot complete in this environment — the `xlsx` transitive dependency (`node-xlsx`) resolves from `cdn.sheetjs.com`, which is blocked by the session's egress policy (403), and the local yarn cache is empty. As a result `yarn generate`, `yarn lint`, build, and tests could not be run here (the same constraint noted in #3807). The schema change is an additive subset and the client reuses existing components/patterns (`MultiSelect`, `Select`, `useGetTags`) mirrored from `business/configurations-section.tsx`. Please confirm via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzdDixpcEvU7j9jLmnobPE)_