### PR TITLE
Fix: use fileURLToPath for cross-platform __dirname resolution

### DIFF
--- a/.changeset/quick-seas-wave.md
+++ b/.changeset/quick-seas-wave.md
@@ -1,0 +1,12 @@
+---
+'@accounter/server': patch
+---
+
+- Replace `new URL('.', import.meta.url).pathname` with
+  `fileURLToPath(new URL('.', import.meta.url))` everywhere it's used to resolve `__dirname` in ESM.
+- `.pathname` breaks on Windows (prepends an extra leading slash before the drive letter, e.g.
+  `/C:/...`) and doesn't decode URL-encoded characters (e.g. `%20` for spaces). `fileURLToPath` from
+  the built-in `url` module is the standard, cross-platform way to do this.
+- Applied across all 34 GraphQL server modules' `index.ts` files, the root and server
+  `vitest.config.ts`, and the `graphql-module` skill's scaffold template (so newly generated modules
+  follow the same convention).

--- a/packages/server/.claude/skills/graphql-module/references/example-index.ts
+++ b/packages/server/.claude/skills/graphql-module/references/example-index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 // Example index.ts — module registration file.
 // This is the entry point that wires typeDefs, resolvers, and providers together.
 import { createModule } from 'graphql-modules';
@@ -6,7 +7,7 @@ import { itemsResolvers } from './resolvers/items.resolver.js';
 import itemsTypeDefs from './typeDefs/items.graphql.js';
 
 // __dirname for ESM — required by graphql-modules for module resolution
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const itemsModule = createModule({
   id: 'items', // Unique module ID — used internally by graphql-modules

--- a/packages/server/.claude/skills/graphql-module/references/example-index.ts
+++ b/packages/server/.claude/skills/graphql-module/references/example-index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 // Example index.ts — module registration file.
 // This is the entry point that wires typeDefs, resolvers, and providers together.
 import { createModule } from 'graphql-modules';
@@ -7,7 +6,7 @@ import { itemsResolvers } from './resolvers/items.resolver.js';
 import itemsTypeDefs from './typeDefs/items.graphql.js';
 
 // __dirname for ESM — required by graphql-modules for module resolution
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const itemsModule = createModule({
   id: 'items', // Unique module ID — used internally by graphql-modules

--- a/packages/server/src/modules/accountant-approval/index.ts
+++ b/packages/server/src/modules/accountant-approval/index.ts
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AccountantApprovalProvider } from './providers/accountant-approval.provider.js';
 import { accountantApprovalResolvers } from './resolvers/accountant-approval.resolver.js';
 import accountantApproval from './typeDefs/accountant-approval.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const accountantApprovalModule = createModule({
   id: 'accountantApproval',

--- a/packages/server/src/modules/accountant-approval/index.ts
+++ b/packages/server/src/modules/accountant-approval/index.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AccountantApprovalProvider } from './providers/accountant-approval.provider.js';
 import { accountantApprovalResolvers } from './resolvers/accountant-approval.resolver.js';
 import accountantApproval from './typeDefs/accountant-approval.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const accountantApprovalModule = createModule({
   id: 'accountantApproval',

--- a/packages/server/src/modules/admin-context/index.ts
+++ b/packages/server/src/modules/admin-context/index.ts
@@ -1,9 +1,8 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { adminContextResolvers } from './resolvers/admin-context.resolvers.js';
 import adminContext from './typeDefs/admin-context.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const adminContextModule = createModule({
   id: 'adminContext',

--- a/packages/server/src/modules/admin-context/index.ts
+++ b/packages/server/src/modules/admin-context/index.ts
@@ -1,8 +1,9 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { adminContextResolvers } from './resolvers/admin-context.resolvers.js';
 import adminContext from './typeDefs/admin-context.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const adminContextModule = createModule({
   id: 'adminContext',

--- a/packages/server/src/modules/annual-audit/index.ts
+++ b/packages/server/src/modules/annual-audit/index.ts
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AnnualAuditProvider } from './providers/annual-audit.provider.js';
 import { annualAuditResolvers } from './resolvers/annual-audit.resolver.js';
 import annualAudit from './typeDefs/annual-audit.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const annualAuditModule = createModule({
   id: 'annual-audit',

--- a/packages/server/src/modules/annual-audit/index.ts
+++ b/packages/server/src/modules/annual-audit/index.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AnnualAuditProvider } from './providers/annual-audit.provider.js';
 import { annualAuditResolvers } from './resolvers/annual-audit.resolver.js';
 import annualAudit from './typeDefs/annual-audit.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const annualAuditModule = createModule({
   id: 'annual-audit',

--- a/packages/server/src/modules/auth/index.ts
+++ b/packages/server/src/modules/auth/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AcceptInvitationsProvider } from './providers/accept-invitations.provider.js';
 import { ApiKeysProvider } from './providers/api-keys.provider.js';
@@ -12,7 +13,7 @@ import { businessUsersResolvers } from './resolvers/business-users.resolver.js';
 import { invitationsResolvers } from './resolvers/invitations.resolver.js';
 import auth from './typeDefs/auth.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const authModule = createModule({
   id: 'auth',

--- a/packages/server/src/modules/auth/index.ts
+++ b/packages/server/src/modules/auth/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AcceptInvitationsProvider } from './providers/accept-invitations.provider.js';
 import { ApiKeysProvider } from './providers/api-keys.provider.js';
@@ -13,7 +12,7 @@ import { businessUsersResolvers } from './resolvers/business-users.resolver.js';
 import { invitationsResolvers } from './resolvers/invitations.resolver.js';
 import auth from './typeDefs/auth.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const authModule = createModule({
   id: 'auth',

--- a/packages/server/src/modules/bank-deposits/index.ts
+++ b/packages/server/src/modules/bank-deposits/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { BankDepositChargesProvider } from './providers/bank-deposit-charges.provider.js';
 import { BankDepositsProvider } from './providers/bank-deposits.provider.js';
@@ -7,7 +6,7 @@ import { bankDepositsResolvers } from './resolvers/bank-deposits.resolver.js';
 import bankDepositCharges from './typeDefs/bank-deposit-charges.graphql.js';
 import bankDeposits from './typeDefs/bank-deposits.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const bankDepositsModule = createModule({
   id: 'bankDeposits',

--- a/packages/server/src/modules/bank-deposits/index.ts
+++ b/packages/server/src/modules/bank-deposits/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { BankDepositChargesProvider } from './providers/bank-deposit-charges.provider.js';
 import { BankDepositsProvider } from './providers/bank-deposits.provider.js';
@@ -6,7 +7,7 @@ import { bankDepositsResolvers } from './resolvers/bank-deposits.resolver.js';
 import bankDepositCharges from './typeDefs/bank-deposit-charges.graphql.js';
 import bankDeposits from './typeDefs/bank-deposits.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const bankDepositsModule = createModule({
   id: 'bankDeposits',

--- a/packages/server/src/modules/business-trips/index.ts
+++ b/packages/server/src/modules/business-trips/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { BusinessTripAttendeesProvider } from './providers/business-trips-attendees.provider.js';
 import { BusinessTripEmployeePaymentsProvider } from './providers/business-trips-employee-payments.provider.js';
@@ -17,7 +18,7 @@ import businessTripAttendees from './typeDefs/business-trip-attendees.graphql.js
 import businessTripExpenses from './typeDefs/business-trip-expenses.graphql.js';
 import businessTrips from './typeDefs/business-trips.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const businessTripsModule = createModule({
   id: 'businessTrips',

--- a/packages/server/src/modules/business-trips/index.ts
+++ b/packages/server/src/modules/business-trips/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { BusinessTripAttendeesProvider } from './providers/business-trips-attendees.provider.js';
 import { BusinessTripEmployeePaymentsProvider } from './providers/business-trips-employee-payments.provider.js';
@@ -18,7 +17,7 @@ import businessTripAttendees from './typeDefs/business-trip-attendees.graphql.js
 import businessTripExpenses from './typeDefs/business-trip-expenses.graphql.js';
 import businessTrips from './typeDefs/business-trips.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const businessTripsModule = createModule({
   id: 'businessTrips',

--- a/packages/server/src/modules/charges-matcher/index.ts
+++ b/packages/server/src/modules/charges-matcher/index.ts
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { ChargesMatcherProvider } from './providers/charges-matcher.provider.js';
 import { chargesMatcherResolvers } from './resolvers/index.js';
 import chargesMatcherTypeDefs from './typeDefs/charges-matcher.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const chargesMatcherModule = createModule({
   id: 'charges-matcher',

--- a/packages/server/src/modules/charges-matcher/index.ts
+++ b/packages/server/src/modules/charges-matcher/index.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { ChargesMatcherProvider } from './providers/charges-matcher.provider.js';
 import { chargesMatcherResolvers } from './resolvers/index.js';
 import chargesMatcherTypeDefs from './typeDefs/charges-matcher.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const chargesMatcherModule = createModule({
   id: 'charges-matcher',

--- a/packages/server/src/modules/charges/index.ts
+++ b/packages/server/src/modules/charges/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { ChargeSpreadProvider } from './providers/charge-spread.provider.js';
 import { ChargesAuthorizationProvider } from './providers/charges-authorization.provider.js';
@@ -11,7 +10,7 @@ import chargeValidation from './typeDefs/charge-validation.graphql.js';
 import charges from './typeDefs/charges.graphql.js';
 import financialCharges from './typeDefs/financial-charges.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const chargesModule = createModule({
   id: 'charges',

--- a/packages/server/src/modules/charges/index.ts
+++ b/packages/server/src/modules/charges/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { ChargeSpreadProvider } from './providers/charge-spread.provider.js';
 import { ChargesAuthorizationProvider } from './providers/charges-authorization.provider.js';
@@ -10,7 +11,7 @@ import chargeValidation from './typeDefs/charge-validation.graphql.js';
 import charges from './typeDefs/charges.graphql.js';
 import financialCharges from './typeDefs/financial-charges.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const chargesModule = createModule({
   id: 'charges',

--- a/packages/server/src/modules/charts/index.ts
+++ b/packages/server/src/modules/charts/index.ts
@@ -1,9 +1,8 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { chartsResolvers } from './resolvers/charts.resolver.js';
 import charts from './typeDefs/charts.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const chartsModule = createModule({
   id: 'charts',

--- a/packages/server/src/modules/charts/index.ts
+++ b/packages/server/src/modules/charts/index.ts
@@ -1,8 +1,9 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { chartsResolvers } from './resolvers/charts.resolver.js';
 import charts from './typeDefs/charts.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const chartsModule = createModule({
   id: 'charts',

--- a/packages/server/src/modules/common/index.ts
+++ b/packages/server/src/modules/common/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AuditLogsProvider } from './providers/audit-logs.provider.js';
 import { scalarsResolvers } from './resolvers/common.resolver.js';
@@ -6,7 +7,7 @@ import common from './typeDefs/common.graphql.js';
 import errors from './typeDefs/errors.graphql.js';
 import userContext from './typeDefs/user-context.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const commonModule = createModule({
   id: 'common',

--- a/packages/server/src/modules/common/index.ts
+++ b/packages/server/src/modules/common/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AuditLogsProvider } from './providers/audit-logs.provider.js';
 import { scalarsResolvers } from './resolvers/common.resolver.js';
@@ -7,7 +6,7 @@ import common from './typeDefs/common.graphql.js';
 import errors from './typeDefs/errors.graphql.js';
 import userContext from './typeDefs/user-context.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const commonModule = createModule({
   id: 'common',

--- a/packages/server/src/modules/contracts/index.ts
+++ b/packages/server/src/modules/contracts/index.ts
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { ContractsProvider } from './providers/contracts.provider.js';
 import { contractsResolvers } from './resolvers/contracts.resolver.js';
 import contracts from './typeDefs/contracts.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const contractsModule = createModule({
   id: 'contracts',

--- a/packages/server/src/modules/contracts/index.ts
+++ b/packages/server/src/modules/contracts/index.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { ContractsProvider } from './providers/contracts.provider.js';
 import { contractsResolvers } from './resolvers/contracts.resolver.js';
 import contracts from './typeDefs/contracts.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const contractsModule = createModule({
   id: 'contracts',

--- a/packages/server/src/modules/corn-jobs/index.ts
+++ b/packages/server/src/modules/corn-jobs/index.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { CornJobsProvider } from './providers/corn-jobs.provider.js';
 import { cornJobsResolvers } from './resolvers/corn-jobs.resolver.js';
 import cornJobs from './typeDefs/corn-jobs.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const cornJobsModule = createModule({
   id: 'corn-jobs',

--- a/packages/server/src/modules/corn-jobs/index.ts
+++ b/packages/server/src/modules/corn-jobs/index.ts
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { CornJobsProvider } from './providers/corn-jobs.provider.js';
 import { cornJobsResolvers } from './resolvers/corn-jobs.resolver.js';
 import cornJobs from './typeDefs/corn-jobs.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const cornJobsModule = createModule({
   id: 'corn-jobs',

--- a/packages/server/src/modules/corporate-taxes/index.ts
+++ b/packages/server/src/modules/corporate-taxes/index.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { CorporateTaxesProvider } from './providers/corporate-taxes.provider.js';
 import { corporateTaxesResolvers } from './resolvers/corporate-taxes.resolver.js';
 import corporateTaxes from './typeDefs/corporate-taxes.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const corporateTaxesModule = createModule({
   id: 'corporateTaxes',

--- a/packages/server/src/modules/corporate-taxes/index.ts
+++ b/packages/server/src/modules/corporate-taxes/index.ts
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { CorporateTaxesProvider } from './providers/corporate-taxes.provider.js';
 import { corporateTaxesResolvers } from './resolvers/corporate-taxes.resolver.js';
 import corporateTaxes from './typeDefs/corporate-taxes.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const corporateTaxesModule = createModule({
   id: 'corporateTaxes',

--- a/packages/server/src/modules/countries/index.ts
+++ b/packages/server/src/modules/countries/index.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { CountriesProvider } from './providers/countries.provider.js';
 import { countriesResolvers } from './resolvers/countries.resolver.js';
 import countries from './typeDefs/countries.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const countriesModule = createModule({
   id: 'countries',

--- a/packages/server/src/modules/countries/index.ts
+++ b/packages/server/src/modules/countries/index.ts
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { CountriesProvider } from './providers/countries.provider.js';
 import { countriesResolvers } from './resolvers/countries.resolver.js';
 import countries from './typeDefs/countries.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const countriesModule = createModule({
   id: 'countries',

--- a/packages/server/src/modules/deel/index.ts
+++ b/packages/server/src/modules/deel/index.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { DeelContractsProvider } from './providers/deel-contracts.provider.js';
 import { DeelInvoicesProvider } from './providers/deel-invoices.provider.js';
 import { deelResolvers } from './resolvers/deel.resolvers.js';
 import deel from './typeDefs/deel.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const deelModule = createModule({
   id: 'deel',

--- a/packages/server/src/modules/deel/index.ts
+++ b/packages/server/src/modules/deel/index.ts
@@ -1,11 +1,10 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { DeelContractsProvider } from './providers/deel-contracts.provider.js';
 import { DeelInvoicesProvider } from './providers/deel-invoices.provider.js';
 import { deelResolvers } from './resolvers/deel.resolvers.js';
 import deel from './typeDefs/deel.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const deelModule = createModule({
   id: 'deel',

--- a/packages/server/src/modules/depreciation/index.ts
+++ b/packages/server/src/modules/depreciation/index.ts
@@ -1,11 +1,10 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { DepreciationCategoriesProvider } from './providers/depreciation-categories.provider.js';
 import { DepreciationProvider } from './providers/depreciation.provider.js';
 import { depreciationResolvers } from './resolvers/depreciation.resolver.js';
 import depreciation from './typeDefs/depreciation.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const depreciationModule = createModule({
   id: 'depreciation',

--- a/packages/server/src/modules/depreciation/index.ts
+++ b/packages/server/src/modules/depreciation/index.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { DepreciationCategoriesProvider } from './providers/depreciation-categories.provider.js';
 import { DepreciationProvider } from './providers/depreciation.provider.js';
 import { depreciationResolvers } from './resolvers/depreciation.resolver.js';
 import depreciation from './typeDefs/depreciation.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const depreciationModule = createModule({
   id: 'depreciation',

--- a/packages/server/src/modules/dividends/index.ts
+++ b/packages/server/src/modules/dividends/index.ts
@@ -1,8 +1,9 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { DividendsProvider } from './providers/dividends.provider.js';
 import dividends from './typeDefs/dividends.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const dividendsModule = createModule({
   id: 'dividends',

--- a/packages/server/src/modules/dividends/index.ts
+++ b/packages/server/src/modules/dividends/index.ts
@@ -1,9 +1,8 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { DividendsProvider } from './providers/dividends.provider.js';
 import dividends from './typeDefs/dividends.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const dividendsModule = createModule({
   id: 'dividends',

--- a/packages/server/src/modules/documents/index.ts
+++ b/packages/server/src/modules/documents/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { DocumentsProvider } from './providers/documents.provider.js';
 import { IssuedDocumentsProvider } from './providers/issued-documents.provider.js';
@@ -11,7 +10,7 @@ import DocumentsIssuing from './typeDefs/documents-issuing.graphql.js';
 import documents from './typeDefs/documents.graphql.js';
 import issuedDocuments from './typeDefs/issued-documents.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const documentsModule = createModule({
   id: 'documents',

--- a/packages/server/src/modules/documents/index.ts
+++ b/packages/server/src/modules/documents/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { DocumentsProvider } from './providers/documents.provider.js';
 import { IssuedDocumentsProvider } from './providers/issued-documents.provider.js';
@@ -10,7 +11,7 @@ import DocumentsIssuing from './typeDefs/documents-issuing.graphql.js';
 import documents from './typeDefs/documents.graphql.js';
 import issuedDocuments from './typeDefs/issued-documents.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const documentsModule = createModule({
   id: 'documents',

--- a/packages/server/src/modules/email-ingestion/index.ts
+++ b/packages/server/src/modules/email-ingestion/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { EmailIngestionAliasProvider } from './providers/email-ingestion-alias.provider.js';
 import { EmailIngestionControlProvider } from './providers/email-ingestion-control.provider.js';
@@ -9,7 +8,7 @@ import { emailIngestionIngestResolver } from './resolvers/email-ingestion-ingest
 import { emailIngestionResolvers } from './resolvers/email-ingestion.resolver.js';
 import emailIngestion from './typeDefs/email-ingestion.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const emailIngestionModule = createModule({
   id: 'email-ingestion',

--- a/packages/server/src/modules/email-ingestion/index.ts
+++ b/packages/server/src/modules/email-ingestion/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { EmailIngestionAliasProvider } from './providers/email-ingestion-alias.provider.js';
 import { EmailIngestionControlProvider } from './providers/email-ingestion-control.provider.js';
@@ -8,7 +9,7 @@ import { emailIngestionIngestResolver } from './resolvers/email-ingestion-ingest
 import { emailIngestionResolvers } from './resolvers/email-ingestion.resolver.js';
 import emailIngestion from './typeDefs/email-ingestion.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const emailIngestionModule = createModule({
   id: 'email-ingestion',

--- a/packages/server/src/modules/exchange-rates/index.ts
+++ b/packages/server/src/modules/exchange-rates/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { CryptoExchangeProvider } from './providers/crypto-exchange.provider.js';
 import { ExchangeProvider } from './providers/exchange.provider.js';
@@ -6,7 +5,7 @@ import { FiatExchangeProvider } from './providers/fiat-exchange.provider.js';
 import { exchangeResolvers } from './resolvers/exchange.resolver.js';
 import exchange from './typeDefs/exchange.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const exchangeRatesModule = createModule({
   id: 'exchangeRates',

--- a/packages/server/src/modules/exchange-rates/index.ts
+++ b/packages/server/src/modules/exchange-rates/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { CryptoExchangeProvider } from './providers/crypto-exchange.provider.js';
 import { ExchangeProvider } from './providers/exchange.provider.js';
@@ -5,7 +6,7 @@ import { FiatExchangeProvider } from './providers/fiat-exchange.provider.js';
 import { exchangeResolvers } from './resolvers/exchange.resolver.js';
 import exchange from './typeDefs/exchange.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const exchangeRatesModule = createModule({
   id: 'exchangeRates',

--- a/packages/server/src/modules/financial-accounts/index.ts
+++ b/packages/server/src/modules/financial-accounts/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { FinancialAccountsTaxCategoriesProvider } from './providers/financial-accounts-tax-categories.provider.js';
 import { FinancialAccountsProvider } from './providers/financial-accounts.provider.js';
@@ -8,7 +7,7 @@ import { financialBankAccountsResolvers } from './resolvers/financial-bank-accou
 import financialAccounts from './typeDefs/financial-accounts.graphql.js';
 import financialBankAccounts from './typeDefs/financial-bank-accounts.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const financialAccountsModule = createModule({
   id: 'financialAccounts',

--- a/packages/server/src/modules/financial-accounts/index.ts
+++ b/packages/server/src/modules/financial-accounts/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { FinancialAccountsTaxCategoriesProvider } from './providers/financial-accounts-tax-categories.provider.js';
 import { FinancialAccountsProvider } from './providers/financial-accounts.provider.js';
@@ -7,7 +8,7 @@ import { financialBankAccountsResolvers } from './resolvers/financial-bank-accou
 import financialAccounts from './typeDefs/financial-accounts.graphql.js';
 import financialBankAccounts from './typeDefs/financial-bank-accounts.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const financialAccountsModule = createModule({
   id: 'financialAccounts',

--- a/packages/server/src/modules/financial-entities/index.ts
+++ b/packages/server/src/modules/financial-entities/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AdminBusinessesProvider } from './providers/admin-businesses.provider.js';
 import { BusinessesOperationProvider } from './providers/businesses-operation.provider.js';
@@ -22,7 +23,7 @@ import clients from './typeDefs/clients.graphql.js';
 import financialEntities from './typeDefs/financial-entities.graphql.js';
 import taxCategories from './typeDefs/tax-categories.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const financialEntitiesModule = createModule({
   id: 'financialEntities',

--- a/packages/server/src/modules/financial-entities/index.ts
+++ b/packages/server/src/modules/financial-entities/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AdminBusinessesProvider } from './providers/admin-businesses.provider.js';
 import { BusinessesOperationProvider } from './providers/businesses-operation.provider.js';
@@ -23,7 +22,7 @@ import clients from './typeDefs/clients.graphql.js';
 import financialEntities from './typeDefs/financial-entities.graphql.js';
 import taxCategories from './typeDefs/tax-categories.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const financialEntitiesModule = createModule({
   id: 'financialEntities',

--- a/packages/server/src/modules/green-invoice/index.ts
+++ b/packages/server/src/modules/green-invoice/index.ts
@@ -1,9 +1,8 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { greenInvoiceResolvers } from './resolvers/green-invoice.resolvers.js';
 import greenInvoice from './typeDefs/green-invoice.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const greenInvoiceModule = createModule({
   id: 'greenInvoice',

--- a/packages/server/src/modules/green-invoice/index.ts
+++ b/packages/server/src/modules/green-invoice/index.ts
@@ -1,8 +1,9 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { greenInvoiceResolvers } from './resolvers/green-invoice.resolvers.js';
 import greenInvoice from './typeDefs/green-invoice.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const greenInvoiceModule = createModule({
   id: 'greenInvoice',

--- a/packages/server/src/modules/ledger/index.ts
+++ b/packages/server/src/modules/ledger/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { BalanceCancellationProvider } from './providers/balance-cancellation.provider.js';
 import { LedgerProvider } from './providers/ledger.provider.js';
@@ -5,7 +6,7 @@ import { UnbalancedBusinessesProvider } from './providers/unbalanced-businesses.
 import { ledgerResolvers } from './resolvers/ledger.resolver.js';
 import ledger from './typeDefs/ledger.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const ledgerModule = createModule({
   id: 'ledger',

--- a/packages/server/src/modules/ledger/index.ts
+++ b/packages/server/src/modules/ledger/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { BalanceCancellationProvider } from './providers/balance-cancellation.provider.js';
 import { LedgerProvider } from './providers/ledger.provider.js';
@@ -6,7 +5,7 @@ import { UnbalancedBusinessesProvider } from './providers/unbalanced-businesses.
 import { ledgerResolvers } from './resolvers/ledger.resolver.js';
 import ledger from './typeDefs/ledger.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const ledgerModule = createModule({
   id: 'ledger',

--- a/packages/server/src/modules/misc-expenses/index.ts
+++ b/packages/server/src/modules/misc-expenses/index.ts
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { MiscExpensesProvider } from './providers/misc-expenses.provider.js';
 import { miscExpensesLedgerEntriesResolvers } from './resolvers/misc-expenses.resolver.js';
 import miscExpenses from './typeDefs/misc-expenses.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const miscExpensesModule = createModule({
   id: 'miscExpenses',

--- a/packages/server/src/modules/misc-expenses/index.ts
+++ b/packages/server/src/modules/misc-expenses/index.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { MiscExpensesProvider } from './providers/misc-expenses.provider.js';
 import { miscExpensesLedgerEntriesResolvers } from './resolvers/misc-expenses.resolver.js';
 import miscExpenses from './typeDefs/misc-expenses.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const miscExpensesModule = createModule({
   id: 'miscExpenses',

--- a/packages/server/src/modules/onboarding/index.ts
+++ b/packages/server/src/modules/onboarding/index.ts
@@ -1,11 +1,10 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AdminOnboardingProvider } from './providers/admin-onboarding.provider.js';
 import { ShaamImportProvider } from './providers/shaam-import.provider.js';
 import { onboardingResolvers } from './resolvers/onboarding.resolver.js';
 import onboarding from './typeDefs/onboarding.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const onboardingModule = createModule({
   id: 'onboarding',

--- a/packages/server/src/modules/onboarding/index.ts
+++ b/packages/server/src/modules/onboarding/index.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AdminOnboardingProvider } from './providers/admin-onboarding.provider.js';
 import { ShaamImportProvider } from './providers/shaam-import.provider.js';
 import { onboardingResolvers } from './resolvers/onboarding.resolver.js';
 import onboarding from './typeDefs/onboarding.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const onboardingModule = createModule({
   id: 'onboarding',

--- a/packages/server/src/modules/provider-credentials/index.ts
+++ b/packages/server/src/modules/provider-credentials/index.ts
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { ProviderCredentialsProvider } from './providers/provider-credentials.provider.js';
 import { providerCredentialsResolvers } from './resolvers/provider-credentials.resolvers.js';
 import providerCredentials from './typeDefs/provider-credentials.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const providerCredentialsModule = createModule({
   id: 'providerCredentials',

--- a/packages/server/src/modules/provider-credentials/index.ts
+++ b/packages/server/src/modules/provider-credentials/index.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { ProviderCredentialsProvider } from './providers/provider-credentials.provider.js';
 import { providerCredentialsResolvers } from './resolvers/provider-credentials.resolvers.js';
 import providerCredentials from './typeDefs/provider-credentials.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const providerCredentialsModule = createModule({
   id: 'providerCredentials',

--- a/packages/server/src/modules/reports/index.ts
+++ b/packages/server/src/modules/reports/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AnnualRevenueReportProvider } from './providers/annual-revenue-report.provider.js';
 import { BalanceReportProvider } from './providers/balance-report.provider.js';
@@ -24,7 +23,7 @@ import uniformFormat from './typeDefs/uniform-format.graphql.js';
 import vatReport from './typeDefs/vat-report.graphql.js';
 import yearlyLedger from './typeDefs/yearly-ledger.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const reportsModule = createModule({
   id: 'reports',

--- a/packages/server/src/modules/reports/index.ts
+++ b/packages/server/src/modules/reports/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { AnnualRevenueReportProvider } from './providers/annual-revenue-report.provider.js';
 import { BalanceReportProvider } from './providers/balance-report.provider.js';
@@ -23,7 +24,7 @@ import uniformFormat from './typeDefs/uniform-format.graphql.js';
 import vatReport from './typeDefs/vat-report.graphql.js';
 import yearlyLedger from './typeDefs/yearly-ledger.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const reportsModule = createModule({
   id: 'reports',

--- a/packages/server/src/modules/salaries/index.ts
+++ b/packages/server/src/modules/salaries/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { EmployeesProvider } from './providers/employees.provider.js';
 import { FundsProvider } from './providers/funds.provider.js';
@@ -11,7 +10,7 @@ import employees from './typeDefs/employees.graphql.js';
 import funds from './typeDefs/funds.graphql.js';
 import salaries from './typeDefs/salaries.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const salariesModule = createModule({
   id: 'salaries',

--- a/packages/server/src/modules/salaries/index.ts
+++ b/packages/server/src/modules/salaries/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { EmployeesProvider } from './providers/employees.provider.js';
 import { FundsProvider } from './providers/funds.provider.js';
@@ -10,7 +11,7 @@ import employees from './typeDefs/employees.graphql.js';
 import funds from './typeDefs/funds.graphql.js';
 import salaries from './typeDefs/salaries.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const salariesModule = createModule({
   id: 'salaries',

--- a/packages/server/src/modules/scraper-ingestion/index.ts
+++ b/packages/server/src/modules/scraper-ingestion/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { IsracardAmexScraperIngestionProvider } from './providers/isracard-amex-scraper-ingestion.provider.js';
 import { OtsarHahayalScraperIngestionProvider } from './providers/otsar-hahayal-scraper-ingestion.provider.js';
@@ -6,7 +7,7 @@ import { ScraperIngestionProvider } from './providers/scraper-ingestion.provider
 import { scraperIngestionResolvers } from './resolvers/scraper-ingestion.resolver.js';
 import scraperIngestion from './typeDefs/scraper-ingestion.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const scraperIngestionModule = createModule({
   id: 'scraperIngestion',

--- a/packages/server/src/modules/scraper-ingestion/index.ts
+++ b/packages/server/src/modules/scraper-ingestion/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { IsracardAmexScraperIngestionProvider } from './providers/isracard-amex-scraper-ingestion.provider.js';
 import { OtsarHahayalScraperIngestionProvider } from './providers/otsar-hahayal-scraper-ingestion.provider.js';
@@ -7,7 +6,7 @@ import { ScraperIngestionProvider } from './providers/scraper-ingestion.provider
 import { scraperIngestionResolvers } from './resolvers/scraper-ingestion.resolver.js';
 import scraperIngestion from './typeDefs/scraper-ingestion.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const scraperIngestionModule = createModule({
   id: 'scraperIngestion',

--- a/packages/server/src/modules/sort-codes/index.ts
+++ b/packages/server/src/modules/sort-codes/index.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { SortCodesProvider } from './providers/sort-codes.provider.js';
 import { sortCodesResolvers } from './resolvers/sort-codes.resolver.js';
 import sortCodes from './typeDefs/sort-codes.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const sortCodesModule = createModule({
   id: 'sortCodes',

--- a/packages/server/src/modules/sort-codes/index.ts
+++ b/packages/server/src/modules/sort-codes/index.ts
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { SortCodesProvider } from './providers/sort-codes.provider.js';
 import { sortCodesResolvers } from './resolvers/sort-codes.resolver.js';
 import sortCodes from './typeDefs/sort-codes.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const sortCodesModule = createModule({
   id: 'sortCodes',

--- a/packages/server/src/modules/tags/index.ts
+++ b/packages/server/src/modules/tags/index.ts
@@ -1,11 +1,10 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { ChargeTagsProvider } from './providers/charge-tags.provider.js';
 import { TagsProvider } from './providers/tags.provider.js';
 import { tagsResolvers } from './resolvers/tags.resolvers.js';
 import tags from './typeDefs/tags.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const tagsModule = createModule({
   id: 'tags',

--- a/packages/server/src/modules/tags/index.ts
+++ b/packages/server/src/modules/tags/index.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { ChargeTagsProvider } from './providers/charge-tags.provider.js';
 import { TagsProvider } from './providers/tags.provider.js';
 import { tagsResolvers } from './resolvers/tags.resolvers.js';
 import tags from './typeDefs/tags.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const tagsModule = createModule({
   id: 'tags',

--- a/packages/server/src/modules/transactions/index.ts
+++ b/packages/server/src/modules/transactions/index.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { CreditCardTransactionsProvider } from './providers/creditcard-transactions.provider.js';
 import { TransactionsProvider } from './providers/transactions.provider.js';
@@ -8,7 +9,7 @@ import creditcardTransactions from './typeDefs/creditcard-transactions.graphql.j
 import transactionSuggestions from './typeDefs/transaction-suggestions.graphql.js';
 import transactions from './typeDefs/transactions.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const transactionsModule = createModule({
   id: 'transactions',

--- a/packages/server/src/modules/transactions/index.ts
+++ b/packages/server/src/modules/transactions/index.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { CreditCardTransactionsProvider } from './providers/creditcard-transactions.provider.js';
 import { TransactionsProvider } from './providers/transactions.provider.js';
@@ -9,7 +8,7 @@ import creditcardTransactions from './typeDefs/creditcard-transactions.graphql.j
 import transactionSuggestions from './typeDefs/transaction-suggestions.graphql.js';
 import transactions from './typeDefs/transactions.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const transactionsModule = createModule({
   id: 'transactions',

--- a/packages/server/src/modules/vat/index.ts
+++ b/packages/server/src/modules/vat/index.ts
@@ -1,9 +1,8 @@
-import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { VatProvider } from './providers/vat.provider.js';
 import vat from './typeDefs/vat.graphql.js';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export const vatModule = createModule({
   id: 'vat',

--- a/packages/server/src/modules/vat/index.ts
+++ b/packages/server/src/modules/vat/index.ts
@@ -1,8 +1,9 @@
+import { fileURLToPath } from 'node:url';
 import { createModule } from 'graphql-modules';
 import { VatProvider } from './providers/vat.provider.js';
 import vat from './typeDefs/vat.graphql.js';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const vatModule = createModule({
   id: 'vat',

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,10 +1,9 @@
-import { fileURLToPath } from 'node:url';
 import 'reflect-metadata';
 import path from 'node:path';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defaultExclude, defineConfig } from 'vitest/config';
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export default defineConfig({
   plugins: [

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import 'reflect-metadata';
 import path from 'node:path';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defaultExclude, defineConfig } from 'vitest/config';
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export default defineConfig({
   plugins: [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url';
 import 'reflect-metadata';
 import { resolve } from 'node:path';
 import tsconfigPaths from 'vite-tsconfig-paths';
@@ -12,7 +11,7 @@ if (nodeMajor >= 24) {
   process.env['NODE_OPTIONS'] = `${process.env['NODE_OPTIONS'] ?? ''} --no-webstorage`.trim();
 }
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const __dirname = import.meta.dirname;
 
 export default defineConfig({
   plugins: [tsconfigPaths()],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import 'reflect-metadata';
 import { resolve } from 'node:path';
 import tsconfigPaths from 'vite-tsconfig-paths';
@@ -11,7 +12,7 @@ if (nodeMajor >= 24) {
   process.env['NODE_OPTIONS'] = `${process.env['NODE_OPTIONS'] ?? ''} --no-webstorage`.trim();
 }
 
-const __dirname = new URL('.', import.meta.url).pathname;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export default defineConfig({
   plugins: [tsconfigPaths()],


### PR DESCRIPTION
## Summary

- Replace `new URL('.', import.meta.url).pathname` with `fileURLToPath(new URL('.', import.meta.url))` everywhere it's used to resolve `__dirname` in ESM.
- `.pathname` breaks on Windows (prepends an extra leading slash before the drive letter, e.g. `/C:/...`) and doesn't decode URL-encoded characters (e.g. `%20` for spaces). `fileURLToPath` from the built-in `url` module is the standard, cross-platform way to do this.
- Applied across all 34 GraphQL server modules' `index.ts` files, the root and server `vitest.config.ts`, and the `graphql-module` skill's scaffold template (so newly generated modules follow the same convention).

## Test plan

- [x] `yarn generate` (GraphQL codegen) runs successfully with the changes
- [x] `yarn lint` — 0 errors (867 pre-existing `no-console` warnings, unrelated to this change)
- [x] `yarn prettier:check` — no formatting issues in changed files

Fixes #3659


---
_Generated by [Claude Code](https://claude.ai/code/session_01TfKxjkj6icWKXf6pXTnBgR)_