### PR TITLE
feat(ledger): support conversion charges with multiple transactions per side

### DIFF
--- a/.changeset/conversion-multiple-transactions-per-side.md
+++ b/.changeset/conversion-multiple-transactions-per-side.md
@@ -1,0 +1,14 @@
+---
+'@accounter/server': patch
+---
+
+**Conversion charges with multiple transactions per side**: conversion ledger generation no longer
+requires exactly two main transactions. A single conversion can now be split across two or more
+transactions on the base or quote side (for example two ILS credits against one USD debit).
+
+- Main transactions are grouped by sign; each side is validated to be single-currency and the two
+  sides to differ in currency, with failures recorded as ledger errors instead of aborting
+  generation.
+- Each side is aggregated into one representative entry (`aggregateConversionSideEntries`) that feeds
+  the existing fee and exchange-revaluation calculations, so the classic two-transaction case is
+  unchanged.

--- a/packages/server/src/modules/ledger/helpers/__tests__/conversion-charge-ledger.helper.test.ts
+++ b/packages/server/src/modules/ledger/helpers/__tests__/conversion-charge-ledger.helper.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { Currency } from '../../../../shared/enums.js';
+import type { LedgerProto } from '../../../../shared/types/index.js';
+import { aggregateConversionSideEntries } from '../conversion-charge-ledger.helper.js';
+
+function makeEntry(overrides: Partial<LedgerProto> = {}): LedgerProto {
+  return {
+    id: 'entry-1',
+    invoiceDate: new Date('2024-11-27'),
+    valueDate: new Date('2024-11-27'),
+    currency: Currency.Ils,
+    localCurrencyCreditAmount1: 100,
+    localCurrencyDebitAmount1: 100,
+    isCreditorCounterparty: true,
+    ownerId: 'owner-1',
+    chargeId: 'charge-1',
+    ...overrides,
+  };
+}
+
+describe('aggregateConversionSideEntries', () => {
+  it('returns the single entry unchanged when the side has one transaction', () => {
+    const entry = makeEntry({ creditAmount1: 50, debitAmount1: 50 });
+    expect(aggregateConversionSideEntries([entry])).toBe(entry);
+  });
+
+  it('sums local currency amounts across multiple same-currency entries', () => {
+    const result = aggregateConversionSideEntries([
+      makeEntry({
+        id: 'a',
+        localCurrencyCreditAmount1: 23_468.9,
+        localCurrencyDebitAmount1: 23_468.9,
+      }),
+      makeEntry({
+        id: 'b',
+        localCurrencyCreditAmount1: 41_517.3,
+        localCurrencyDebitAmount1: 41_517.3,
+      }),
+    ]);
+    expect(result.localCurrencyCreditAmount1).toBeCloseTo(64_986.2, 5);
+    expect(result.localCurrencyDebitAmount1).toBeCloseTo(64_986.2, 5);
+    // meta copied from the first entry
+    expect(result.id).toBe('a');
+    expect(result.currency).toBe(Currency.Ils);
+  });
+
+  it('sums foreign amounts when present', () => {
+    const result = aggregateConversionSideEntries([
+      makeEntry({
+        id: 'a',
+        currency: Currency.Usd,
+        creditAmount1: 10_000,
+        debitAmount1: 10_000,
+        localCurrencyCreditAmount1: 36_000,
+        localCurrencyDebitAmount1: 36_000,
+      }),
+      makeEntry({
+        id: 'b',
+        currency: Currency.Usd,
+        creditAmount1: 8_000,
+        debitAmount1: 8_000,
+        localCurrencyCreditAmount1: 28_800,
+        localCurrencyDebitAmount1: 28_800,
+      }),
+    ]);
+    expect(result.creditAmount1).toBe(18_000);
+    expect(result.debitAmount1).toBe(18_000);
+    expect(result.localCurrencyCreditAmount1).toBe(64_800);
+  });
+
+  it('leaves foreign amount undefined when the side is the local currency', () => {
+    const result = aggregateConversionSideEntries([
+      makeEntry({ id: 'a', localCurrencyCreditAmount1: 100, localCurrencyDebitAmount1: 100 }),
+      makeEntry({ id: 'b', localCurrencyCreditAmount1: 200, localCurrencyDebitAmount1: 200 }),
+    ]);
+    expect(result.creditAmount1).toBeUndefined();
+    expect(result.debitAmount1).toBeUndefined();
+    expect(result.localCurrencyCreditAmount1).toBe(300);
+  });
+
+  it('throws when the side is empty', () => {
+    expect(() => aggregateConversionSideEntries([])).toThrow();
+  });
+});

--- a/packages/server/src/modules/ledger/helpers/conversion-charge-ledger.helper.ts
+++ b/packages/server/src/modules/ledger/helpers/conversion-charge-ledger.helper.ts
@@ -2,6 +2,39 @@ import { Currency } from '../../../shared/enums.js';
 import type { LedgerProto } from '../../../shared/types/index.js';
 import { LedgerError } from './utils.helper.js';
 
+/**
+ * Aggregates all main ledger entries of a single conversion side (base or quote) into one
+ * representative LedgerProto. The entries are expected to share the same currency; foreign and
+ * local amounts are summed while meta fields are copied from the first entry. For a side with a
+ * single entry the result is equivalent to that entry.
+ */
+export function aggregateConversionSideEntries(entries: LedgerProto[]): LedgerProto {
+  const [first, ...rest] = entries;
+  if (!first) {
+    throw new LedgerError('Cannot aggregate an empty conversion side');
+  }
+  if (rest.length === 0) {
+    return first;
+  }
+
+  let foreignAmount = 0;
+  let localAmount = 0;
+  for (const entry of entries) {
+    foreignAmount += entry.creditAmount1 ?? 0;
+    localAmount += entry.localCurrencyCreditAmount1;
+  }
+
+  const absForeignAmount = foreignAmount || undefined;
+
+  return {
+    ...first,
+    creditAmount1: absForeignAmount,
+    debitAmount1: absForeignAmount,
+    localCurrencyCreditAmount1: localAmount,
+    localCurrencyDebitAmount1: localAmount,
+  };
+}
+
 export function conversionFeeCalculator(
   base: LedgerProto,
   quote: LedgerProto,

--- a/packages/server/src/modules/ledger/resolvers/ledger-generation/conversion-ledger-generation.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger-generation/conversion-ledger-generation.resolver.ts
@@ -9,7 +9,10 @@ import type { LedgerProto, StrictLedgerProto } from '../../../../shared/types/in
 import { AdminContextProvider } from '../../../admin-context/providers/admin-context.provider.js';
 import { ExchangeProvider } from '../../../exchange-rates/providers/exchange.provider.js';
 import { TransactionsProvider } from '../../../transactions/providers/transactions.provider.js';
-import { conversionFeeCalculator } from '../../helpers/conversion-charge-ledger.helper.js';
+import {
+  aggregateConversionSideEntries,
+  conversionFeeCalculator,
+} from '../../helpers/conversion-charge-ledger.helper.js';
 import {
   isSupplementalFeeTransaction,
   splitFeeTransactions,
@@ -18,7 +21,6 @@ import { storeInitialGeneratedRecords } from '../../helpers/ledgrer-storage.help
 import {
   getFinancialAccountTaxCategoryId,
   getLedgerBalanceInfo,
-  isTransactionsOppositeSign,
   LedgerError,
   ledgerProtoToRecordsConverter,
   updateLedgerBalanceByEntry,
@@ -59,20 +61,8 @@ export const generateLedgerRecordsForConversion: ResolverFn<
       .transactionsByChargeIDLoader.load(chargeId);
     const { mainTransactions, feeTransactions } = splitFeeTransactions(transactions);
 
-    if (mainTransactions.length !== 2) {
-      errors.add(`Conversion Charge must include two main transactions`);
-    }
-
-    try {
-      if (!isTransactionsOppositeSign(mainTransactions)) {
-        errors.add(`Conversion Charge must include two main transactions with opposite sign`);
-      }
-    } catch (e) {
-      if (e instanceof LedgerError) {
-        errors.add(e.message);
-      } else {
-        throw e;
-      }
+    if (mainTransactions.length < 2) {
+      errors.add(`Conversion Charge must include at least two main transactions`);
     }
 
     // for each transaction, create a ledger record
@@ -135,16 +125,48 @@ export const generateLedgerRecordsForConversion: ResolverFn<
 
     await Promise.all(mainTransactionsPromises);
 
+    // group main entries into the two conversion sides by sign
+    const quoteEntries: LedgerProto[] = [];
+    const baseEntries: LedgerProto[] = [];
     for (const entry of mainFinancialAccountLedgerEntries) {
       if (entry.isCreditorCounterparty) {
-        quoteEntry = entry;
+        quoteEntries.push(entry);
       } else {
-        baseEntry = entry;
+        baseEntries.push(entry);
       }
     }
 
+    // validate each side is single-currency and the two sides differ in currency
+    const baseCurrencies = new Set(baseEntries.map(entry => entry.currency));
+    const quoteCurrencies = new Set(quoteEntries.map(entry => entry.currency));
+    if (baseCurrencies.size > 1) {
+      errors.add(`Conversion Charge base transactions must all share the same currency`);
+    }
+    if (quoteCurrencies.size > 1) {
+      errors.add(`Conversion Charge quote transactions must all share the same currency`);
+    }
+    if (
+      baseCurrencies.size === 1 &&
+      quoteCurrencies.size === 1 &&
+      [...baseCurrencies][0] === [...quoteCurrencies][0]
+    ) {
+      errors.add(`Conversion Charge base and quote must use different currencies`);
+    }
+
+    if (
+      baseEntries.length > 0 &&
+      quoteEntries.length > 0 &&
+      baseCurrencies.size === 1 &&
+      quoteCurrencies.size === 1 &&
+      [...baseCurrencies][0] !== [...quoteCurrencies][0]
+    ) {
+      // aggregate each side into a single representative entry for fee & revaluation calculations
+      baseEntry = aggregateConversionSideEntries(baseEntries);
+      quoteEntry = aggregateConversionSideEntries(quoteEntries);
+    }
+
     if (!baseEntry || !quoteEntry) {
-      errors.add(`Conversion Charge must include two main transactions`);
+      errors.add(`Conversion Charge must include base and quote main transactions`);
     } else {
       // create a ledger record for fee transactions
       for (const transaction of feeTransactions) {

--- a/packages/server/src/modules/ledger/resolvers/ledger-generation/conversion-ledger-generation.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger-generation/conversion-ledger-generation.resolver.ts
@@ -166,7 +166,11 @@ export const generateLedgerRecordsForConversion: ResolverFn<
     }
 
     if (!baseEntry || !quoteEntry) {
-      errors.add(`Conversion Charge must include base and quote main transactions`);
+      // only report a missing side when it is genuinely absent; currency-validation
+      // failures above already add specific, more accurate errors
+      if (baseEntries.length === 0 || quoteEntries.length === 0) {
+        errors.add(`Conversion Charge must include base and quote main transactions`);
+      }
     } else {
       // create a ledger record for fee transactions
       for (const transaction of feeTransactions) {


### PR DESCRIPTION
## What & why

Closes #3669.

Conversion ledger generation previously assumed **exactly two** main transactions after fee transactions were filtered out — one "base" (money sold, negative) and one "quote" (money received, positive) in two different currencies. Real cases now split a single conversion across **two or more transactions on a side** (e.g. two positive ILS credits against one negative USD debit, plus a fee). The old code hard-failed `mainTransactions.length !== 2`, used `isTransactionsOppositeSign` (which only inspects the first two), and picked base/quote with a last-wins loop that silently corrupted results.

## Changes

- **`conversion-ledger-generation.resolver.ts`**
  - Relaxed the "exactly two" gate to "at least two" and removed the two-element `isTransactionsOppositeSign` check.
  - Group main ledger entries by sign into `baseEntries` / `quoteEntries`, then validate (recorded as ledger `errors`, not fatal):
    - each side is non-empty,
    - all transactions within a side share the same currency,
    - the two sides use different currencies.
  - When valid, aggregate each side into a single representative entry that feeds the existing fee-transaction and exchange-revaluation logic unchanged.
- **`conversion-charge-ledger.helper.ts`** — new `aggregateConversionSideEntries()` that sums a side's foreign and local amounts while copying meta from the first entry. A single-transaction side returns the lone entry unchanged, so the classic two-transaction path is byte-identical.
- **New unit test** for `aggregateConversionSideEntries` (single pass-through, local-amount summing, foreign-amount summing, local-currency side with no foreign amount, empty-side throw).

## Why aggregation is correct

The exchange spread computed by `conversionFeeCalculator` is additive across a side's transactions, so summing the sides before the single calculation reproduces the same total exchange-revaluation entry the two-transaction path produces today.

## Verification

`yarn install` could not complete in the authoring environment (the `xlsx`/SheetJS dependency is served only from `cdn.sheetjs.com`, which is blocked by egress policy), so build/lint/tests were **not** run here. Please run in CI:

- `yarn workspace @accounter/server build`
- `yarn lint`
- `yarn test` (includes the new helper unit test)

Manual check against the issue example: a charge with two positive ILS credits, one negative USD debit, and one ILS fee should generate ledger records without the "two main transactions" error, producing N main records + the fee + a single balanced exchange-revaluation entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SeCQbUGiQVBgckQxGrBsEK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeCQbUGiQVBgckQxGrBsEK)_