### PR TITLE
Add Deel documents fetch functionality to user nav

### DIFF
--- a/.changeset/deel-documents-fetch-button.md
+++ b/.changeset/deel-documents-fetch-button.md
@@ -1,0 +1,17 @@
+---
+'@accounter/server': patch
+'@accounter/client': patch
+---
+
+Add a "Pull Deel Documents" button to the user nav menu, next to "Add Balance Charge", that triggers
+the `fetchDeelDocuments` mutation on demand.
+
+Also improves the underlying Deel invoice fetch/matching logic:
+
+- Distinguishes newly-seen invoices from previously-fetched invoices that are still unmatched, so a
+  later run can pick up a payment match for an invoice it already recorded (via a new
+  `updateDeelInvoiceRecords` update path) instead of only ever inserting.
+- Reuses an already-matched charge for a given receipt when creating charges from payment
+  breakdowns, avoiding duplicate charges for invoices that share a receipt.
+- Extends the Deel invoice schema/table with `billing_type` and `document_type`, and refines several
+  payment-receipt and payment-breakdown Zod schemas to match the Deel API more closely.

--- a/packages/client/src/components/__tests__/user-menu.test.tsx
+++ b/packages/client/src/components/__tests__/user-menu.test.tsx
@@ -8,9 +8,10 @@ import { UserNav } from '../layout/user-nav.js';
 import { UserContext, type UserInfo } from '../../providers/index.js';
 import { ROUTES } from '../../router/routes.js';
 
-const { useAuth0Mock, executeJobsMock, logoutMock } = vi.hoisted(() => ({
+const { useAuth0Mock, executeJobsMock, fetchDeelDocumentsMock, logoutMock } = vi.hoisted(() => ({
   useAuth0Mock: vi.fn(),
   executeJobsMock: vi.fn(),
+  fetchDeelDocumentsMock: vi.fn(),
   logoutMock: vi.fn(),
 }));
 
@@ -20,6 +21,10 @@ vi.mock('@auth0/auth0-react', () => ({
 
 vi.mock('../../hooks/use-corn-jobs.js', () => ({
   useCornJobs: () => ({ executeJobs: executeJobsMock }),
+}));
+
+vi.mock('../../hooks/use-fetch-deel-documents.js', () => ({
+  useFetchDeelDocuments: () => ({ fetching: false, fetchDocuments: fetchDeelDocumentsMock }),
 }));
 
 vi.mock('../common/modals/balance-charge-modal.js', () => ({

--- a/packages/client/src/components/layout/user-nav.tsx
+++ b/packages/client/src/components/layout/user-nav.tsx
@@ -82,7 +82,7 @@ export function UserNav(): JSX.Element | null {
 
   return (
     <>
-      <DropdownMenu open>
+      <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" className="relative h-8 w-8 rounded-full">
             <Avatar className="h-8 w-8 items-center flex flex-row justify-center">
@@ -144,8 +144,8 @@ export function UserNav(): JSX.Element | null {
               Add Balance Charge
             </Button>
           </DropdownMenuItem>
-          <DropdownMenuItem asChild>
-            <Tooltip content="Pull Deel Documents">
+          <Tooltip content="Pull Deel Documents">
+            <DropdownMenuItem asChild>
               <Button
                 variant="ghost"
                 disabled={fetchingDeelDocuments}
@@ -154,8 +154,8 @@ export function UserNav(): JSX.Element | null {
                 <Banknote className="size-4" />
                 <span className="hidden sm:inline">Pull Deel Documents</span>
               </Button>
-            </Tooltip>
-          </DropdownMenuItem>
+            </DropdownMenuItem>
+          </Tooltip>
           <DropdownMenuItem>
             <Tooltip content="Pull Green Invoice Documents">
               <Button

--- a/packages/client/src/components/layout/user-nav.tsx
+++ b/packages/client/src/components/layout/user-nav.tsx
@@ -1,8 +1,9 @@
 import { useContext, useState, type JSX } from 'react';
-import { CircleCheckBig, FileDown, KeyRound, Shield, User2Icon } from 'lucide-react';
+import { Banknote, CircleCheckBig, FileDown, KeyRound, Shield, User2Icon } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { useCornJobs } from '../../hooks/use-corn-jobs.js';
+import { useFetchDeelDocuments } from '../../hooks/use-fetch-deel-documents.js';
 import { UserContext } from '../../providers/index.js';
 import { getBusinessScopeIds, setBusinessScope } from '../../providers/urql.js';
 import { ROUTES } from '../../router/routes.js';
@@ -27,6 +28,8 @@ export function UserNav(): JSX.Element | null {
   const [balanceChargeModalOpen, setBalanceChargeModalOpen] = useState(false);
   const [selectedBusinessIds, setSelectedBusinessIds] = useState<string[]>(getBusinessScopeIds);
   const { executeJobs } = useCornJobs();
+  const { fetching: fetchingDeelDocuments, fetchDocuments: fetchDeelDocuments } =
+    useFetchDeelDocuments();
 
   if (!isAuthenticated || !user) {
     return null;
@@ -140,6 +143,19 @@ export function UserNav(): JSX.Element | null {
             <Button variant="ghost" onClick={() => setBalanceChargeModalOpen(true)}>
               Add Balance Charge
             </Button>
+          </DropdownMenuItem>
+          <DropdownMenuItem>
+            <Tooltip content="Pull Deel Documents">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7.5"
+                disabled={fetchingDeelDocuments}
+                onClick={() => fetchDeelDocuments()}
+              >
+                <Banknote className="size-5" />
+              </Button>
+            </Tooltip>
           </DropdownMenuItem>
           <DropdownMenuItem>
             <Tooltip content="Pull Green Invoice Documents">

--- a/packages/client/src/components/layout/user-nav.tsx
+++ b/packages/client/src/components/layout/user-nav.tsx
@@ -82,7 +82,7 @@ export function UserNav(): JSX.Element | null {
 
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu open>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" className="relative h-8 w-8 rounded-full">
             <Avatar className="h-8 w-8 items-center flex flex-row justify-center">
@@ -139,21 +139,20 @@ export function UserNav(): JSX.Element | null {
               </DropdownMenuItem>
             </>
           )}
-          <DropdownMenuItem>
+          <DropdownMenuItem asChild>
             <Button variant="ghost" onClick={() => setBalanceChargeModalOpen(true)}>
               Add Balance Charge
             </Button>
           </DropdownMenuItem>
-          <DropdownMenuItem>
+          <DropdownMenuItem asChild>
             <Tooltip content="Pull Deel Documents">
               <Button
                 variant="ghost"
-                size="icon"
-                className="size-7.5"
                 disabled={fetchingDeelDocuments}
                 onClick={() => fetchDeelDocuments()}
               >
-                <Banknote className="size-5" />
+                <Banknote className="size-4" />
+                <span className="hidden sm:inline">Pull Deel Documents</span>
               </Button>
             </Tooltip>
           </DropdownMenuItem>

--- a/packages/client/src/hooks/use-fetch-deel-documents.ts
+++ b/packages/client/src/hooks/use-fetch-deel-documents.ts
@@ -1,0 +1,54 @@
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { useMutation } from 'urql';
+import { FetchDeelDocumentsDocument, type FetchDeelDocumentsMutation } from '../gql/graphql.js';
+import { handleCommonErrors } from '../helpers/error-handling.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  mutation FetchDeelDocuments {
+    fetchDeelDocuments {
+      id
+    }
+  }
+`;
+
+type FetchDeelDocumentsResult = FetchDeelDocumentsMutation['fetchDeelDocuments'];
+
+type UseFetchDeelDocuments = {
+  fetching: boolean;
+  fetchDocuments: () => Promise<FetchDeelDocumentsResult | void>;
+};
+
+const NOTIFICATION_ID = 'fetch-deel-documents';
+
+export const useFetchDeelDocuments = (): UseFetchDeelDocuments => {
+  const [{ fetching }, mutate] = useMutation(FetchDeelDocumentsDocument);
+
+  const fetchDocuments = useCallback(async () => {
+    const message = 'Failed to fetch Deel documents';
+    toast.loading('Fetching Deel documents', { id: NOTIFICATION_ID });
+    try {
+      const res = await mutate({});
+      const data = handleCommonErrors(res, message, NOTIFICATION_ID);
+      if (data) {
+        toast.success('Success', {
+          id: NOTIFICATION_ID,
+          description: `Fetched ${data.fetchDeelDocuments.length} Deel charge(s)`,
+        });
+        return data.fetchDeelDocuments;
+      }
+    } catch (e) {
+      console.error(`${message}: ${e}`);
+      toast.error('Error', {
+        id: NOTIFICATION_ID,
+        description: message,
+        duration: 100_000,
+        closeButton: true,
+      });
+    }
+    return void 0;
+  }, [mutate]);
+
+  return { fetching, fetchDocuments };
+};

--- a/packages/client/src/hooks/use-fetch-deel-documents.ts
+++ b/packages/client/src/hooks/use-fetch-deel-documents.ts
@@ -31,7 +31,7 @@ export const useFetchDeelDocuments = (): UseFetchDeelDocuments => {
     try {
       const res = await mutate({});
       const data = handleCommonErrors(res, message, NOTIFICATION_ID);
-      if (data) {
+      if (data?.fetchDeelDocuments) {
         toast.success('Success', {
           id: NOTIFICATION_ID,
           description: `Fetched ${data.fetchDeelDocuments.length} Deel charge(s)`,

--- a/packages/client/src/hooks/use-fetch-deel-documents.ts
+++ b/packages/client/src/hooks/use-fetch-deel-documents.ts
@@ -38,6 +38,9 @@ export const useFetchDeelDocuments = (): UseFetchDeelDocuments => {
         });
         return data.fetchDeelDocuments;
       }
+      // handleCommonErrors already surfaced any error toast; dismiss the loading toast so it
+      // doesn't linger as a permanent spinner when there's no data to report success on
+      toast.dismiss(NOTIFICATION_ID);
     } catch (e) {
       console.error(`${message}: ${e}`);
       toast.error('Error', {

--- a/packages/migrations/src/actions/2026-07-07T13-00-00.extend-deel-table.ts
+++ b/packages/migrations/src/actions/2026-07-07T13-00-00.extend-deel-table.ts
@@ -1,0 +1,10 @@
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+export default {
+  name: '2026-07-07T13-00-00.extend-deel-table.sql',
+  run: ({ sql }) => sql`
+    ALTER TABLE "accounter_schema"."deel_invoices"
+    ADD COLUMN "billing_type" VARCHAR(20) NULL,
+    ADD COLUMN "document_type" VARCHAR(20) NULL;
+  `,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -190,6 +190,7 @@ import migration_2026_06_10T12_00_00_add_email_ingestion_replay_nonces from './a
 import migration_2026_06_10T13_00_00_add_email_ingestion_quarantine from './actions/2026-06-10T13-00-00.add-email-ingestion-quarantine.js';
 import migration_2026_06_11T10_00_00_add_email_ingestion_idempotency from './actions/2026-06-11T10-00-00.add-email-ingestion-idempotency.js';
 import migration_2026_06_22T10_00_00_add_email_ingestion_grant_business_id from './actions/2026-06-22T10-00-00.add-email-ingestion-grant-business-id.js';
+import migration_2026_07_07T13_00_00_extend_deel_table from './actions/2026-07-07T13-00-00.extend-deel-table.js';
 import { runMigrations } from './pg-migrator.js';
 
 export const MIGRATIONS = [
@@ -384,6 +385,7 @@ export const MIGRATIONS = [
   migration_2026_06_10T13_00_00_add_email_ingestion_quarantine,
   migration_2026_06_11T10_00_00_add_email_ingestion_idempotency,
   migration_2026_06_22T10_00_00_add_email_ingestion_grant_business_id,
+  migration_2026_07_07T13_00_00_extend_deel_table,
 ] as const;
 
 export const LATEST_MIGRATION_NAME = MIGRATIONS[MIGRATIONS.length - 1]?.name;

--- a/packages/server/src/modules/app-providers/deel/schemas.ts
+++ b/packages/server/src/modules/app-providers/deel/schemas.ts
@@ -6,6 +6,7 @@ const invoiceSchema = z
     amount: z
       .string() // NOTE: by docs, optional
       .describe('Billed amount of the invoice.'),
+    billing_type: z.enum(['FEE', 'WORK', 'RESERVE', 'PREPAID_BILLING']),
     contract_id: z
       .string()
       .nullable() // NOTE: by docs, not nullable
@@ -17,6 +18,7 @@ const invoiceSchema = z
     deel_fee: z
       .literal('0.00') // NOTE: by docs, nullable & optional
       .describe('Fee charged by Deel.'),
+    document_type: z.enum(['INVOICE', 'FUNDING_STATEMENT']),
     due_date: z
       .union([z.literal(''), z.iso.datetime()]) // NOTE: by docs, nullable
       .describe('Date and time when the invoice is due (ISO-8601 format).'), // example: "2022-05-24T09:38:46.235Z",
@@ -163,6 +165,100 @@ export const workerSchema = z
 
 export type DeelWorker = z.infer<typeof workerSchema>;
 
+export const generalFundsUsedSchema = z
+  .object({
+    amount: z
+      .string()
+      .nullable()
+      .describe("Amount deducted from general funds, in the payment currency. '0.00' if not used"),
+    original_amount: z
+      .string()
+      .nullable()
+      .describe(
+        'Amount deducted from general funds, in the original currency it was held in. Null if not used',
+      ),
+    original_currency: z
+      .string()
+      .length(3)
+      .nullable()
+      .describe(
+        'Currency in which the general funds were held, following ISO 4217 (e.g., USD, USDC). Null if not used',
+      ),
+  })
+  .strict();
+
+export const deelGrantedCreditsUsedSchema = z
+  .object({
+    amount: z
+      .string()
+      .nullable()
+      .describe(
+        "Amount deducted from Deel-granted credits, in the payment currency. '0.00' if not used",
+      ),
+    original_amount: z
+      .string()
+      .nullable()
+      .describe(
+        'Amount deducted from Deel-granted credits, in the original currency they were held in. Null if not used',
+      ),
+    original_currency: z
+      .string()
+      .length(3)
+      .nullable()
+      .describe(
+        'Currency in which the Deel-granted credits were held, following ISO 4217 (e.g., USD, USDC). Null if not used',
+      ),
+  })
+  .strict();
+
+export const prepaidBillingCreditsUsedSchema = z
+  .object({
+    amount: z
+      .string()
+      .nullable()
+      .describe(
+        "Amount deducted from prepaid billing credits, in the payment currency. '0.00' if not used",
+      ),
+    original_amount: z
+      .string()
+      .nullable()
+      .describe(
+        'Amount deducted from prepaid billing credits, in the original currency they were held in. Null if not used',
+      ),
+    original_currency: z
+      .string()
+      .length(3)
+      .nullable()
+      .describe(
+        'Currency in which the prepaid billing credits were held, following ISO 4217 (e.g., USD, USDC). Null if not used',
+      ),
+  })
+  .strict();
+
+export const eorEarlyInvoicingFundsUsedSchema = z
+  .object({
+    amount: z
+      .string()
+      .nullable()
+      .describe(
+        "Amount deducted from EOR early invoicing funds, in the payment currency. '0.00' if not used",
+      ),
+    original_amount: z
+      .string()
+      .nullable()
+      .describe(
+        'Amount deducted from EOR early invoicing funds, in the original currency they were held in. Null if not used',
+      ),
+    original_currency: z
+      .string()
+      .length(3)
+      .nullable()
+      .describe(
+        'Currency in which the EOR early invoicing funds were held, following ISO 4217 (e.g., USD, USDC). Null if not used',
+      ),
+  })
+  .strict();
+
 export const paymentReceiptsSchema = z
   .object({
     id: z
@@ -171,6 +267,16 @@ export const paymentReceiptsSchema = z
     created_at: z.iso
       .datetime() // NOTE: by docs, optional
       .describe('Date and time when the payment was created, in ISO-8601 format.'),
+    deel_granted_credits_used: deelGrantedCreditsUsedSchema,
+    eor_early_invoicing_funds_used: eorEarlyInvoicingFundsUsedSchema,
+    general_funds_used: generalFundsUsedSchema,
+    invoices: z.array(
+      z
+        .object({
+          id: z.string().describe('Unique identifier for the invoice.'),
+        })
+        .strict(),
+    ),
     label: z
       .string() // NOTE: by docs, optional
       .describe('A descriptive label for the payment.'),
@@ -182,19 +288,47 @@ export const paymentReceiptsSchema = z
       .string()
       .length(3) // NOTE: by docs, optional
       .describe('Three-letter currency code for the payment, following ISO 4217.'),
-    payment_method: z.object({}).optional().describe('payment_method object'), // TODO: define
-    total: z.string(), // NOTE: by docs, not existing
+    payment_method: z
+      .object({
+        type: z
+          .enum([
+            'ach',
+            'alviere_ach',
+            'adyen_card',
+            'bank_transfer',
+            'bt_card',
+            'bt_pay_pal',
+            'brex',
+            'coinbase',
+            'client_balance',
+            'eor_funding_balance',
+            'fee_credits',
+            'go_cardless',
+            'go_cardless_becs',
+            'mercury_wire',
+            'pay_pal',
+            'stablecoin_transfer',
+            'stripe_ach',
+            'stripe_bacs_debit',
+            'stripe_card',
+            'stripe_sepa_debit',
+            'transferwise',
+          ])
+          .optional(),
+      })
+      .optional()
+      .describe('Payment method details for the transaction'),
+    prepaid_billing_credits_used: prepaidBillingCreditsUsedSchema,
+    total: z.string().describe('Original invoice total before any credits or balance were applied'),
+    total_due: z
+      .string()
+      .describe(
+        "Amount due for the payment after applying any credits or balance. Equals 'total' when no credits were used.",
+      ),
     status: z
       .enum(['paid']) // NOTE: by docs, optional
       .describe("Status of the payment. Either 'paid' or 'processing'."),
     workers: z.array(workerSchema).optional(),
-    invoices: z.array(
-      z
-        .object({
-          id: z.string().describe('Unique identifier for the invoice.'),
-        })
-        .strict(),
-    ),
     timezone: z
       .string()
       .nullable()
@@ -244,12 +378,14 @@ const paymentBreakdownRecordSchema = z
     contract_country: z
       .union([z.literal(''), z.string().length(2)])
       .describe('Country where the contract is associated.'),
+    contract_id: z.null(),
     contract_start_date: z
       .union([z.iso.datetime(), z.literal('')])
       .describe('Start date of the contract.'),
     contract_type: z.string(),
     contractor_email: z.union([z.literal(''), z.email()]).describe("Worker's email address."),
     contractor_employee_name: z.string().describe("Worker's name."),
+    contractor_pic_url: z.null(),
     contractor_unique_identifier: z
       .union([z.literal(''), z.uuid()])
       .describe("Worker's unique identifier as a UUID."),
@@ -258,26 +394,17 @@ const paymentBreakdownRecordSchema = z
     deductions: z.literal('0.00').describe('Deductions from the payment.'),
     expenses: z.string().describe('Expenses related to the payment.'),
     frequency: z
-      .enum(['', 'hourly', 'daily', 'monthly', 'custom'])
+      .enum(['', 'hourly', 'daily', 'weekly', 'biweekly', 'semimonthly', 'monthly', 'custom'])
       .describe('Frequency of payment (e.g., monthly, weekly).'),
     general_ledger_account: z.literal('').describe('General ledger account for the payment.'),
     group_id: z.string(),
     invoice_id: z.string().describe('Invoice number associated with the payment.'),
-    // invoice_number: z
-    //   .string()
-    //   .optional()
-    //   .describe('Invoice number associated with the payment.'),
     others: z.string().describe('Other payment amounts.'),
     overtime: z.literal('0.00').describe('Overtime payment amount.'),
     payment_currency: z.string().describe('Currency in which the payment was made.'),
     payment_date: z.iso.datetime().describe('The date the payment was made.'),
     pro_rata: z.string().describe('Pro-rated payment amount.'),
     processing_fee: z.string().describe('Processing fee applied to the payment.'),
-    // receipt_number: z.string().optional().describe('Receipt number for the payment.'),
-    // team: z
-    //   .string()
-    //   .optional()
-    //   .describe('The name of the team or company associated with the payment.'),
     work: z.string().describe('Amount associated with work payment.'),
     total: z.string().describe('Total payment due for this breakdown item.'),
     total_payment_currency: z.string().describe('Total payment in the payment currency.'),

--- a/packages/server/src/modules/deel/helpers/deel.helper.ts
+++ b/packages/server/src/modules/deel/helpers/deel.helper.ts
@@ -24,6 +24,7 @@ import { DeelInvoicesProvider } from '../providers/deel-invoices.provider.js';
 import type {
   IGetEmployeeIDsByContractIdsResult,
   IInsertDeelInvoiceRecordsParams,
+  IUpdateDeelInvoiceRecordsParams,
 } from '../types.js';
 
 const DEEL_BUSINESS_ID = '8d34f668-7233-4ce3-9c9c-82550b0839ff'; // TODO: replace with DB based business id
@@ -138,10 +139,12 @@ export const createDeelInvoiceMatchFromUnmatchedInvoice = (invoice: Invoice): De
   breakdown_bonus: '0.00',
   breakdown_commissions: '0.00',
   breakdown_contract_country: '',
+  breakdown_contract_id: null,
   breakdown_contract_start_date: '',
   breakdown_contract_type: '',
   breakdown_contractor_email: '',
   breakdown_contractor_employee_name: '',
+  breakdown_contractor_pic_url: null,
   breakdown_contractor_unique_identifier: '',
   breakdown_currency: '',
   breakdown_date: '',
@@ -245,6 +248,7 @@ export function convertMatchToDeelInvoiceRecord(
     amount: match.amount,
     approveDate: nullifyEmptyStrings(match.breakdown_approve_date),
     approvers: match.breakdown_approvers,
+    billingType: match.billing_type,
     bonus: match.breakdown_bonus,
     commissions: match.breakdown_commissions,
     contractCountry: nullifyEmptyStrings(match.breakdown_contract_country),
@@ -259,6 +263,7 @@ export function convertMatchToDeelInvoiceRecord(
     deductions: match.breakdown_deductions,
     deelFee: match.deel_fee,
     documentId,
+    documentType: match.document_type,
     dueDate: match.due_date,
     expenses: match.breakdown_expenses,
     frequency: nullifyEmptyStrings(match.breakdown_frequency),
@@ -284,6 +289,40 @@ export function convertMatchToDeelInvoiceRecord(
     work: match.breakdown_work,
     recipientLegalEntityId: match.recipient_legal_entity_id,
   };
+}
+
+export function convertMatchToPartialDeelInvoiceRecord(
+  match: DeelInvoiceMatch,
+): IUpdateDeelInvoiceRecordsParams {
+  const updateParams: IUpdateDeelInvoiceRecordsParams = {
+    id: match.id,
+    adjustment: match.breakdown_adjustment,
+    approveDate: nullifyEmptyStrings(match.breakdown_approve_date),
+    approvers: match.breakdown_approvers,
+    bonus: match.breakdown_bonus,
+    commissions: match.breakdown_commissions,
+    contractCountry: nullifyEmptyStrings(match.breakdown_contract_country),
+    contractId: nullifyFeeInvoices(match.breakdown_contract_type, match.contract_id),
+    contractStartDate: nullifyEmptyStrings(match.breakdown_contract_start_date),
+    contractType: nullifyEmptyStrings(match.breakdown_contract_type),
+    contractorEmail: nullifyEmptyStrings(match.breakdown_contractor_email),
+    contractorEmployeeName: match.breakdown_contractor_employee_name,
+    contractorUniqueIdentifier: nullifyEmptyStrings(match.breakdown_contractor_unique_identifier),
+    deductions: match.breakdown_deductions,
+    expenses: match.breakdown_expenses,
+    frequency: nullifyEmptyStrings(match.breakdown_frequency),
+    generalLedgerAccount: nullifyEmptyStrings(match.breakdown_general_ledger_account),
+    groupId: nullifyEmptyStrings(match.breakdown_group_id),
+    others: match.breakdown_others,
+    overtime: match.breakdown_overtime,
+    paymentCurrency: match.breakdown_payment_currency as Currency,
+    paymentId: match.breakdown_receipt_id,
+    processingFee: match.breakdown_processing_fee,
+    proRata: match.breakdown_pro_rata,
+    totalPaymentCurrency: match.breakdown_total_payment_currency,
+    work: match.breakdown_work,
+  };
+  return updateParams;
 }
 
 export async function getDeelChargeDescription(
@@ -320,8 +359,10 @@ export async function fetchAndFilterInvoices(injector: Injector) {
       ).map(c => c.contract_id),
     );
 
-    const filteredInvoices: Invoice[] = [];
+    const newInvoices: Invoice[] = [];
+    const unmatchedExistingInvoices: Invoice[] = [];
 
+    // validate contract sequentially to prevent Deel API rate limit issues
     for (const invoice of invoices) {
       if (invoice.contract_id && !existingContractIds.has(invoice.contract_id)) {
         const deelContract = await injector
@@ -335,20 +376,32 @@ export async function fetchAndFilterInvoices(injector: Injector) {
           contractor_name: ${deelContract.data.worker?.full_name}
           contract_start_date: ${deelContract.data.start_date}`);
       }
-      const dbInvoice = await injector
-        .get(DeelInvoicesProvider)
-        .getInvoicesByIdLoader.load(invoice.id)
-        .catch(e => {
-          const message = 'Error fetching invoice by ID';
-          console.error(`${message}: ${e}`);
-          throw new Error(message);
-        });
-      if (!dbInvoice) {
-        filteredInvoices.push(invoice);
-      }
     }
 
-    return filteredInvoices;
+    //
+    await Promise.all(
+      invoices.map(async invoice => {
+        const dbInvoice = await injector
+          .get(DeelInvoicesProvider)
+          .getInvoicesByIdLoader.load(invoice.id)
+          .catch(e => {
+            const message = 'Error fetching invoice by ID';
+            console.error(`${message}: ${e}`);
+            throw new Error(message);
+          });
+        if (!dbInvoice) {
+          newInvoices.push(invoice);
+          return;
+        }
+        if (!dbInvoice.payment_id) {
+          unmatchedExistingInvoices.push(invoice);
+          return;
+        }
+        return;
+      }),
+    );
+
+    return { newInvoices, unmatchedExistingInvoices };
   } catch (error) {
     const message = 'Error fetching Deel invoices';
     console.error(`${message}: ${error}`);
@@ -367,8 +420,13 @@ export async function fetchReceipts(injector: Injector) {
   }
 }
 
-export async function fetchPaymentBreakdowns(injector: Injector, receipts: PaymentReceipts[]) {
-  const receiptsBreakDown: Array<PaymentBreakdownRecord & { receipt_id: string }> = [];
+export type DecoratedPaymentBreakdown = PaymentBreakdownRecord & { receipt_id: string };
+
+export async function fetchPaymentBreakdowns(
+  injector: Injector,
+  receipts: PaymentReceipts[],
+): Promise<DecoratedPaymentBreakdown[]> {
+  const receiptsBreakDown: DecoratedPaymentBreakdown[] = [];
 
   for (const receipt of receipts) {
     if (receipt.id) {
@@ -459,7 +517,11 @@ export async function validateContracts(
   );
 }
 
-export async function getChargeMatchesForPayments(injector: Injector, receipts: PaymentReceipts[]) {
+export async function getChargeMatchesForPayments(
+  injector: Injector,
+  receipts: PaymentReceipts[],
+  paymentBreakdowns: DecoratedPaymentBreakdown[],
+) {
   const receiptChargeMap = await injector.get(DeelInvoicesProvider).getReceiptToCharge();
   const invoiceChargeMap = new Map<string, string>();
   const newReceipts: PaymentReceipts[] = [];
@@ -473,20 +535,37 @@ export async function getChargeMatchesForPayments(injector: Injector, receipts: 
     }
   });
 
+  paymentBreakdowns.map(breakdown => {
+    const chargeId = receiptChargeMap.get(breakdown.receipt_id);
+    if (chargeId) {
+      invoiceChargeMap.set(breakdown.invoice_id, chargeId);
+    }
+  });
+
   return { receiptChargeMap, invoiceChargeMap, newReceipts };
 }
 
 export async function matchInvoicesWithPayments(
-  injector: Injector,
   invoices: Invoice[],
-  receipts: PaymentReceipts[],
+  paymentBreakdowns: DecoratedPaymentBreakdown[],
 ) {
   const matches: DeelInvoiceMatch[] = [];
   const unmatched: Invoice[] = [];
 
-  const paymentBreakdowns = await fetchPaymentBreakdowns(injector, receipts);
-
   invoices.map(invoice => {
+    const optionalMatches = paymentBreakdowns.filter(receipt => invoice.id === receipt.invoice_id);
+    if (optionalMatches.length < 1) {
+      unmatched.push(invoice);
+      return;
+    }
+    if (optionalMatches.length === 1) {
+      const adjustedBreakdown: Record<string, unknown> = {};
+      Object.entries(optionalMatches[0]).map(([key, value]) => {
+        adjustedBreakdown[`breakdown_${key}`] = value;
+      });
+      matches.push({ ...(adjustedBreakdown as PrefixedBreakdown), ...invoice });
+      return;
+    }
     if (
       invoice.status === 'processed' ||
       invoice.total === '0.00' ||
@@ -495,20 +574,53 @@ export async function matchInvoicesWithPayments(
       unmatched.push(invoice);
       return;
     }
-
-    const optionalMatches = paymentBreakdowns.filter(receipt => invoice.id === receipt.invoice_id);
-    if (optionalMatches.length === 1) {
-      const adjustedBreakdown: Record<string, unknown> = {};
-      Object.entries(optionalMatches[0]).map(([key, value]) => {
-        adjustedBreakdown[`breakdown_${key}`] = value;
-      });
-      matches.push({ ...(adjustedBreakdown as PrefixedBreakdown), ...invoice });
-    } else {
-      throw new Error(`No payment match found for invoice ${invoice.id}`);
-    }
+    throw new Error(`Multiple matches found for invoice ${invoice.id}`);
   });
 
   return { matches, unmatched };
+}
+
+export async function updateDeelInvoiceRecord(
+  injector: Injector,
+  match: DeelInvoiceMatch,
+  chargeId: string,
+) {
+  try {
+    const deelInvoice = await injector
+      .get(DeelInvoicesProvider)
+      .getInvoicesByIdLoader.load(match.id);
+    if (!deelInvoice) {
+      throw new Error(`Deel invoice ${match.id} not found in DB`);
+    }
+    if (!deelInvoice.document_id) {
+      throw new Error(`Deel invoice ${match.id} has no associated document_id`);
+    }
+    const documentId = deelInvoice.document_id;
+    await injector
+      .get(DocumentsProvider)
+      .updateDocument({ documentId, chargeId })
+      .catch(error => {
+        const message = 'Error updating Deel invoice document';
+        console.error(`${message}: ${error}`);
+        throw new Error(message, { cause: error });
+      });
+
+    await injector
+      .get(DeelInvoicesProvider)
+      .updateDeelInvoiceRecords(convertMatchToPartialDeelInvoiceRecord(match))
+      .catch(error => {
+        const message = 'Error updating Deel invoice record';
+        console.error(`${message}: ${error}`);
+        throw new Error(message, { cause: error });
+      });
+  } catch (error) {
+    const message = 'Error updating Deel invoice record';
+    console.error(`${message}: ${error}`);
+    if (error instanceof GraphQLError) {
+      throw error;
+    }
+    throw new Error(message, { cause: error });
+  }
 }
 
 export async function insertDeelInvoiceRecord(
@@ -518,11 +630,20 @@ export async function insertDeelInvoiceRecord(
 ) {
   try {
     const { ownerId } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
-    const documentId = await uploadDeelInvoice(chargeId, match, injector, ownerId);
+    const documentId = await uploadDeelInvoice(chargeId, match, injector, ownerId).catch(error => {
+      const message = 'Error uploading Deel invoice';
+      console.error(`${message}: ${error}`);
+      throw new Error(message, { cause: error });
+    });
 
     await injector
       .get(DeelInvoicesProvider)
-      .insertDeelInvoiceRecords(convertMatchToDeelInvoiceRecord(match, documentId));
+      .insertDeelInvoiceRecords(convertMatchToDeelInvoiceRecord(match, documentId))
+      .catch(error => {
+        const message = 'Error inserting Deel invoice record';
+        console.error(`${message}: ${error}`);
+        throw new Error(message, { cause: error });
+      });
   } catch (error) {
     const message = 'Error uploading Deel invoice record';
     console.error(`${message}: ${error}`);

--- a/packages/server/src/modules/deel/helpers/deel.helper.ts
+++ b/packages/server/src/modules/deel/helpers/deel.helper.ts
@@ -555,6 +555,7 @@ export async function matchInvoicesWithPayments(
   invoices.map(invoice => {
     const optionalMatches = paymentBreakdowns.filter(receipt => invoice.id === receipt.invoice_id);
     if (optionalMatches.length < 1) {
+      console.warn(`No payment breakdown match found for invoice ${invoice.id}`);
       unmatched.push(invoice);
       return;
     }

--- a/packages/server/src/modules/deel/providers/deel-invoices.provider.ts
+++ b/packages/server/src/modules/deel/providers/deel-invoices.provider.ts
@@ -11,6 +11,8 @@ import type {
   IGetReceiptToChargeQuery,
   IInsertDeelInvoiceRecordsParams,
   IInsertDeelInvoiceRecordsQuery,
+  IUpdateDeelInvoiceRecordsParams,
+  IUpdateDeelInvoiceRecordsQuery,
 } from '../types.js';
 
 const getInvoicesByIssueDates = sql<IGetInvoicesByIssueDatesQuery>`
@@ -47,10 +49,12 @@ const insertDeelInvoiceRecords = sql<IInsertDeelInvoiceRecordsQuery>`
         id,
         document_id,
         amount,
+        billing_type,
         contract_id,
         created_at,
         currency,
         deel_fee,
+        document_type,
         due_date,
         is_overdue,
         issued_at,
@@ -90,10 +94,12 @@ const insertDeelInvoiceRecords = sql<IInsertDeelInvoiceRecordsQuery>`
       VALUES ($id,
         $documentId,
         $amount,
+        $billingType,
         $contractId,
         $createdAt,
         $currency,
         $deelFee,
+        $documentType,
         $dueDate,
         $isOverdue,
         $issuedAt,
@@ -131,6 +137,186 @@ const insertDeelInvoiceRecords = sql<IInsertDeelInvoiceRecordsQuery>`
         $recipientLegalEntityId,
         $ownerId)
       RETURNING *;`;
+
+const updateDeelInvoiceRecords = sql<IUpdateDeelInvoiceRecordsQuery>`
+  UPDATE accounter_schema.deel_invoices
+  SET
+  document_id = COALESCE(
+    $documentId,
+    document_id
+  ),
+  amount = COALESCE(
+    $amount,
+    amount
+  ),
+  billing_type = COALESCE(
+    $billingType,
+    billing_type
+  ),
+  contract_id = COALESCE(
+    $contractId,
+    contract_id
+  ),
+  created_at = COALESCE(
+    $createdAt,
+    created_at
+  ),
+  currency = COALESCE(
+    $currency,
+    currency
+  ),
+  deel_fee = COALESCE(
+    $deelFee,
+    deel_fee
+  ),
+  document_type = COALESCE(
+    $documentType,
+    document_type
+  ),
+  due_date = COALESCE(
+    $dueDate,
+    due_date
+  ),
+  is_overdue = COALESCE(
+    $isOverdue,
+    is_overdue
+  ),
+  issued_at = COALESCE(
+    $issuedAt,
+    issued_at
+  ),
+  label = COALESCE(
+    $label,
+    label
+  ),
+  paid_at = COALESCE(
+    $paidAt,
+    paid_at
+  ),
+  status = COALESCE(
+    $status,
+    status
+  ),
+  total = COALESCE(
+    $total,
+    total
+  ),
+  vat_id = COALESCE(
+    $vatId,
+    vat_id
+  ),
+  vat_percentage = COALESCE(
+    $vatPercentage,
+    vat_percentage
+  ),
+  vat_total = COALESCE(
+    $vatTotal,
+    vat_total
+  ),
+  adjustment = COALESCE(
+    $adjustment,
+    adjustment
+  ),
+  approve_date = COALESCE(
+    $approveDate,
+    approve_date
+  ),
+  approvers = COALESCE(
+    $approvers,
+    approvers
+  ),
+  bonus = COALESCE(
+    $bonus,
+    bonus
+  ),
+  commissions = COALESCE(
+    $commissions,
+    commissions
+  ),
+  contract_country = COALESCE(
+    $contractCountry,
+    contract_country
+  ),
+  contract_start_date = COALESCE(
+    $contractStartDate,
+    contract_start_date
+  ),
+  contract_type = COALESCE(
+    $contractType,
+    contract_type
+  ),
+  contractor_email = COALESCE(
+    $contractorEmail,
+    contractor_email
+  ),
+  contractor_employee_name = COALESCE(
+    $contractorEmployeeName,
+    contractor_employee_name
+  ),
+  contractor_unique_identifier = COALESCE(
+    $contractorUniqueIdentifier,
+    contractor_unique_identifier
+  ),
+  deductions = COALESCE(
+    $deductions,
+    deductions
+  ),
+  expenses = COALESCE(
+    $expenses,
+    expenses
+  ),
+  frequency = COALESCE(
+    $frequency,
+    frequency
+  ),
+  general_ledger_account = COALESCE(
+    $generalLedgerAccount,
+    general_ledger_account
+  ),
+  group_id = COALESCE(
+    $groupId,
+    group_id
+  ),
+  others = COALESCE(
+    $others,
+    others
+  ),
+  overtime = COALESCE(
+    $overtime,
+    overtime
+  ),
+  payment_currency = COALESCE(
+    $paymentCurrency,
+    payment_currency
+  ),
+  pro_rata = COALESCE(
+    $proRata,
+    pro_rata
+  ),
+  processing_fee = COALESCE(
+    $processingFee,
+    processing_fee
+  ),
+  "work" = COALESCE(
+    $work,
+    work
+  ),
+  total_payment_currency = COALESCE(
+    $totalPaymentCurrency,
+    total_payment_currency
+  ),
+  payment_id = COALESCE(
+    $paymentId,
+    payment_id
+  ),
+  recipient_legal_entity_id = COALESCE(
+    $recipientLegalEntityId,
+    recipient_legal_entity_id
+  )
+  WHERE
+    id = $id
+  RETURNING *;
+  `;
 
 @Injectable({
   scope: Scope.Operation,
@@ -211,6 +397,16 @@ export class DeelInvoicesProvider {
       return insertDeelInvoiceRecords.run(reassureOwnerIdExists(params, ownerId), this.db);
     } catch (e) {
       const message = `Error inserting Deel invoice`;
+      console.error(message, e);
+      throw new Error(message, { cause: e });
+    }
+  }
+
+  public async updateDeelInvoiceRecords(params: IUpdateDeelInvoiceRecordsParams) {
+    try {
+      return updateDeelInvoiceRecords.run(params, this.db);
+    } catch (e) {
+      const message = `Error updating Deel invoice`;
       console.error(message, e);
       throw new Error(message, { cause: e });
     }

--- a/packages/server/src/modules/deel/resolvers/deel.resolvers.ts
+++ b/packages/server/src/modules/deel/resolvers/deel.resolvers.ts
@@ -8,12 +8,14 @@ import { TransactionsProvider } from '../../transactions/providers/transactions.
 import {
   createDeelInvoiceMatchFromUnmatchedInvoice,
   fetchAndFilterInvoices,
+  fetchPaymentBreakdowns,
   fetchReceipts,
   getChargeMatchesForPayments,
   getContractsFromPaymentBreakdowns,
   getDeelChargeDescription,
   insertDeelInvoiceRecord,
   matchInvoicesWithPayments,
+  updateDeelInvoiceRecord,
   validateContracts,
 } from '../helpers/deel.helper.js';
 import { DeelContractsProvider } from '../providers/deel-contracts.provider.js';
@@ -43,17 +45,20 @@ export const deelResolvers: DeelModule.Resolvers = {
     },
     fetchDeelDocuments: async (_, __, { injector }) => {
       try {
-        const invoices = await fetchAndFilterInvoices(injector);
-        if (invoices.length === 0) {
-          return [];
+        const { newInvoices, unmatchedExistingInvoices } = await fetchAndFilterInvoices(injector);
+        if (newInvoices.length === 0) {
+          // return [];
         }
 
+        const unmatchedExistingInvoicesSet = new Set(unmatchedExistingInvoices.map(i => i.id));
+
+        // NOTE: avoiding fetching receipts and invoices in parallel to avoid hitting Deel API rate limits
         const receipts = await fetchReceipts(injector);
+        const paymentBreakdowns = await fetchPaymentBreakdowns(injector, receipts);
 
         const { matches, unmatched } = await matchInvoicesWithPayments(
-          injector,
-          invoices,
-          receipts,
+          [...newInvoices, ...unmatchedExistingInvoices],
+          paymentBreakdowns,
         );
 
         if (matches.length + unmatched.length <= 0) {
@@ -65,7 +70,7 @@ export const deelResolvers: DeelModule.Resolvers = {
         await validateContracts(contractsInfo, injector);
 
         const { receiptChargeMap, invoiceChargeMap, newReceipts } =
-          await getChargeMatchesForPayments(injector, receipts);
+          await getChargeMatchesForPayments(injector, receipts, paymentBreakdowns);
 
         const updatedChargeIdsSet = new Set<string>();
 
@@ -73,26 +78,28 @@ export const deelResolvers: DeelModule.Resolvers = {
 
         // insert/update unmatched Deel invoice records
         for (const invoice of unmatched) {
-          if (invoiceChargeMap.has(invoice.id)) {
+          let chargeId = invoiceChargeMap.get(invoice.id);
+          if (chargeId) {
             console.log('Found missing match for invoice via invoiceChargeMap:', invoice.id);
+          } else {
+            const charge = await injector.get(ChargesProvider).generateCharge({
+              ownerId,
+              userDescription: `Deel invoice ${invoice.label}`,
+            });
+            updatedChargeIdsSet.add(charge.id);
+            chargeId = charge.id;
           }
 
-          const charge = await injector.get(ChargesProvider).generateCharge({
-            ownerId,
-            userDescription: `Deel invoice ${invoice.label}`,
-          });
-
-          updatedChargeIdsSet.add(charge.id);
-
           const match = createDeelInvoiceMatchFromUnmatchedInvoice(invoice);
-
-          await insertDeelInvoiceRecord(injector, match, charge.id);
+          if (!unmatchedExistingInvoicesSet.has(match.id)) {
+            await insertDeelInvoiceRecord(injector, match, chargeId);
+          }
         }
 
         // insert/update matched Deel invoice records
         for (const match of matches) {
           let chargeId =
-            invoiceChargeMap.get(match.id) ?? receiptChargeMap.get(match.breakdown_receipt_id);
+            receiptChargeMap.get(match.breakdown_receipt_id) ?? invoiceChargeMap.get(match.id);
 
           // if no charge found, create one from receipt
           if (!chargeId) {
@@ -104,6 +111,7 @@ export const deelResolvers: DeelModule.Resolvers = {
                 userDescription: description,
               });
               chargeId = charge.id;
+              receiptChargeMap.set(match.breakdown_receipt_id, chargeId);
 
               // TODO: upload receipt file (currently not available from Deel API)
             }
@@ -115,7 +123,13 @@ export const deelResolvers: DeelModule.Resolvers = {
 
           updatedChargeIdsSet.add(chargeId);
 
-          await insertDeelInvoiceRecord(injector, match, chargeId);
+          if (unmatchedExistingInvoicesSet.has(match.id)) {
+            // update existing invoice record
+            await updateDeelInvoiceRecord(injector, match, chargeId);
+          } else {
+            // insert new invoice record
+            await insertDeelInvoiceRecord(injector, match, chargeId);
+          }
         }
 
         // fetch charges, clean empty ones

--- a/packages/server/src/modules/deel/resolvers/deel.resolvers.ts
+++ b/packages/server/src/modules/deel/resolvers/deel.resolvers.ts
@@ -77,8 +77,15 @@ export const deelResolvers: DeelModule.Resolvers = {
 
         const { ownerId } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
 
-        // insert/update unmatched Deel invoice records
+        // insert unmatched Deel invoice records
         for (const invoice of unmatched) {
+          // an already-recorded invoice that is still unmatched has nothing new to persist — skip
+          // it before generating a charge, which would otherwise be created and immediately cleaned
+          // up as empty
+          if (unmatchedExistingInvoicesSet.has(invoice.id)) {
+            continue;
+          }
+
           let chargeId = invoiceChargeMap.get(invoice.id);
           if (chargeId) {
             console.log('Found missing match for invoice via invoiceChargeMap:', invoice.id);
@@ -95,9 +102,7 @@ export const deelResolvers: DeelModule.Resolvers = {
           updatedChargeIdsSet.add(chargeId);
 
           const match = createDeelInvoiceMatchFromUnmatchedInvoice(invoice);
-          if (!unmatchedExistingInvoicesSet.has(match.id)) {
-            await insertDeelInvoiceRecord(injector, match, chargeId);
-          }
+          await insertDeelInvoiceRecord(injector, match, chargeId);
         }
 
         // insert/update matched Deel invoice records

--- a/packages/server/src/modules/deel/resolvers/deel.resolvers.ts
+++ b/packages/server/src/modules/deel/resolvers/deel.resolvers.ts
@@ -46,8 +46,9 @@ export const deelResolvers: DeelModule.Resolvers = {
     fetchDeelDocuments: async (_, __, { injector }) => {
       try {
         const { newInvoices, unmatchedExistingInvoices } = await fetchAndFilterInvoices(injector);
-        if (newInvoices.length === 0) {
-          // return [];
+        if (newInvoices.length === 0 && unmatchedExistingInvoices.length === 0) {
+          // nothing to fetch or reconcile — skip the Deel API calls below
+          return [];
         }
 
         const unmatchedExistingInvoicesSet = new Set(unmatchedExistingInvoices.map(i => i.id));
@@ -86,9 +87,12 @@ export const deelResolvers: DeelModule.Resolvers = {
               ownerId,
               userDescription: `Deel invoice ${invoice.label}`,
             });
-            updatedChargeIdsSet.add(charge.id);
             chargeId = charge.id;
           }
+
+          // track the charge regardless of whether it was reused or freshly generated, so it is
+          // included in the returned charges and the empty-charge cleanup below
+          updatedChargeIdsSet.add(chargeId);
 
           const match = createDeelInvoiceMatchFromUnmatchedInvoice(invoice);
           if (!unmatchedExistingInvoicesSet.has(match.id)) {
@@ -98,6 +102,8 @@ export const deelResolvers: DeelModule.Resolvers = {
 
         // insert/update matched Deel invoice records
         for (const match of matches) {
+          // prefer the receipt-level charge (the breakdown-centric grouping used across this run)
+          // and fall back to any invoice-level charge mapping
           let chargeId =
             receiptChargeMap.get(match.breakdown_receipt_id) ?? invoiceChargeMap.get(match.id);
 


### PR DESCRIPTION
## Summary
Adds a new hook and UI button to fetch Deel documents from the user navigation menu, enabling users to pull Deel charge data directly from the application.

## Key Changes
- **New hook**: `useFetchDeelDocuments` in `packages/client/src/hooks/use-fetch-deel-documents.ts`
  - Wraps the `FetchDeelDocuments` GraphQL mutation
  - Handles loading states, success/error notifications via toast
  - Returns fetching state and async `fetchDocuments` function
  
- **Updated user nav**: `packages/client/src/components/layout/user-nav.tsx`
  - Imports and integrates the new `useFetchDeelDocuments` hook
  - Adds a new dropdown menu item with a "Pull Deel Documents" button
  - Button displays a `Banknote` icon and is disabled during fetch operations
  - Positioned alongside existing document fetch functionality (Green Invoice)

## Implementation Details
- Uses `urql` mutation for GraphQL integration with auto-generated types
- Toast notifications provide user feedback: loading state, success count, and error handling
- Follows existing patterns in the codebase (similar to corn jobs functionality)
- Properly typed with TypeScript for the mutation result

https://claude.ai/code/session_01DKN6Yt57C5unKdngaq4gbR