### PR TITLE
Add charge accountant-status degrade function to AccountantApprovalProvider

### DIFF
--- a/packages/server/src/modules/accountant-approval/providers/accountant-approval.provider.ts
+++ b/packages/server/src/modules/accountant-approval/providers/accountant-approval.provider.ts
@@ -1,7 +1,11 @@
 import { Injectable, Scope } from 'graphql-modules';
 import { sql } from '@pgtyped/runtime';
 import { TenantAwareDBClient } from '../../app-providers/tenant-db-client.js';
-import type { IGetChargesApprovalStatusParams, IGetChargesApprovalStatusQuery } from '../types.js';
+import type {
+  IDegradeChargeAccountantApprovalQuery,
+  IGetChargesApprovalStatusParams,
+  IGetChargesApprovalStatusQuery,
+} from '../types.js';
 
 const getChargesApprovalStatus = sql<IGetChargesApprovalStatusQuery>`
   SELECT COUNT(*) AS total_charges,
@@ -13,6 +17,13 @@ const getChargesApprovalStatus = sql<IGetChargesApprovalStatusQuery>`
   AND GREATEST(documents_max_date, transactions_max_event_date, transactions_max_debit_date, ledger_max_invoice_date, ledger_max_value_date)::TEXT::DATE >= date_trunc('day', $fromDate ::DATE)
   AND LEAST(documents_min_date, transactions_min_event_date, transactions_min_debit_date, ledger_min_invoice_date, ledger_min_value_date)::TEXT::DATE <= date_trunc('day', $toDate ::DATE);`;
 
+const degradeChargeAccountantApproval = sql<IDegradeChargeAccountantApprovalQuery>`
+  UPDATE accounter_schema.charges
+  SET accountant_status = 'PENDING'
+  WHERE id = $chargeId
+    AND accountant_status = 'APPROVED'
+  RETURNING *;`;
+
 @Injectable({
   scope: Scope.Operation,
   global: true,
@@ -22,5 +33,15 @@ export class AccountantApprovalProvider {
 
   public getChargesApprovalStatus(params: IGetChargesApprovalStatusParams) {
     return getChargesApprovalStatus.run(params, this.db);
+  }
+
+  /**
+   * Degrades a charge's accountant status from APPROVED to PENDING.
+   * Meant to be called whenever a charge is modified, so an already-approved
+   * charge gets flagged for re-approval. Charges in any other status
+   * (UNAPPROVED / PENDING) are left untouched.
+   */
+  public degradeChargeAccountantApproval(chargeId: string) {
+    return degradeChargeAccountantApproval.run({ chargeId }, this.db);
   }
 }

--- a/packages/server/src/modules/accountant-approval/providers/accountant-approval.provider.ts
+++ b/packages/server/src/modules/accountant-approval/providers/accountant-approval.provider.ts
@@ -1,6 +1,8 @@
 import { Injectable, Scope } from 'graphql-modules';
 import { sql } from '@pgtyped/runtime';
 import { TenantAwareDBClient } from '../../app-providers/tenant-db-client.js';
+import { ChargesAuthorizationProvider } from '../../charges/providers/charges-authorization.provider.js';
+import { ChargesProvider } from '../../charges/providers/charges.provider.js';
 import type {
   IDegradeChargeAccountantApprovalQuery,
   IGetChargesApprovalStatusParams,
@@ -29,7 +31,11 @@ const degradeChargeAccountantApproval = sql<IDegradeChargeAccountantApprovalQuer
   global: true,
 })
 export class AccountantApprovalProvider {
-  constructor(private db: TenantAwareDBClient) {}
+  constructor(
+    private db: TenantAwareDBClient,
+    private auth: ChargesAuthorizationProvider,
+    private charges: ChargesProvider,
+  ) {}
 
   public getChargesApprovalStatus(params: IGetChargesApprovalStatusParams) {
     return getChargesApprovalStatus.run(params, this.db);
@@ -41,7 +47,13 @@ export class AccountantApprovalProvider {
    * charge gets flagged for re-approval. Charges in any other status
    * (UNAPPROVED / PENDING) are left untouched.
    */
-  public degradeChargeAccountantApproval(chargeId: string) {
-    return degradeChargeAccountantApproval.run({ chargeId }, this.db);
+  public async degradeChargeAccountantApproval(chargeId: string) {
+    await this.auth.canWriteCharge();
+
+    const [newCharge] = await degradeChargeAccountantApproval.run({ chargeId }, this.db);
+    if (newCharge) {
+      this.charges.getChargeByIdLoader.prime(newCharge.id, newCharge);
+    }
+    return newCharge;
   }
 }


### PR DESCRIPTION
## What

Adds a new `degradeChargeAccountantApproval(chargeId)` function to `AccountantApprovalProvider` that resets a charge's `accountant_status` from `APPROVED` back to `PENDING`.

## Why

When a charge is modified after an accountant already approved it, the approval is stale and the charge should be re-reviewed. This provider function gives other providers a single call to flag such charges for re-approval whenever they mutate a charge.

## How

- New pgtyped query on `accounter_schema.charges` that sets `accountant_status = 'PENDING'` guarded by `WHERE ... accountant_status = 'APPROVED'`, so charges in any other status (`UNAPPROVED` / `PENDING`) are left untouched — callers can invoke it unconditionally after a change.
- The query returns the updated row (`RETURNING *`); when the charge wasn't `APPROVED` (or doesn't exist), no row is returned and nothing is written.
- Query types (`IDegradeChargeAccountantApprovalQuery`) are emitted by the existing pgtyped codegen (`yarn generate`) into the module's gitignored `__generated__/accountant-approval.types.ts`, re-exported via the module's `types.ts` — matching the existing `getChargesApprovalStatus` pattern in this provider.

## Notes

No behavior change on its own — nothing calls the new function yet; follow-up changes can wire it into charge-mutation flows. Codegen/lint could not be run in this sandbox (dependency install was blocked by the egress policy), so CI should confirm the generated types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T68N3AJK8TyYkeGttQUBvb

---
_Generated by [Claude Code](https://claude.ai/code/session_01T68N3AJK8TyYkeGttQUBvb)_