### PR TITLE
Default OCR VAT to 0 for recognized foreign counterparties

### DIFF
--- a/packages/server/src/modules/app-providers/anthropic.ts
+++ b/packages/server/src/modules/app-providers/anthropic.ts
@@ -162,7 +162,10 @@ export class AnthropicProvider {
       },
     ];
 
-    const { output, response } = await generateText({
+    const {
+      output,
+      finalStep: { response },
+    } = await generateText({
       model: anthropic('claude-sonnet-4-5'),
       output: Output.object({ schema: documentDataSchema }),
       messages: inputMessages,

--- a/packages/server/src/modules/app-providers/anthropic.ts
+++ b/packages/server/src/modules/app-providers/anthropic.ts
@@ -4,8 +4,11 @@ import stripIndent from 'strip-indent';
 import { z } from 'zod';
 import { anthropic } from '@ai-sdk/anthropic';
 import { Currency, DocumentType } from '../../shared/enums.js';
-import type { BusinessMatchData } from './helpers/business-matcher.helper.js';
-import { matchBusiness } from './helpers/business-matcher.helper.js';
+import type { BusinessMatchData, OwnerMatchInfo } from './helpers/business-matcher.helper.js';
+import {
+  applyForeignCounterpartyVatDefault,
+  matchBusiness,
+} from './helpers/business-matcher.helper.js';
 
 // NOTE: schema is kept as simple as possible to stay under Anthropic's constrained-decoding
 // grammar complexity budget. Two rules:
@@ -131,6 +134,7 @@ export class AnthropicProvider {
   async extractInvoiceDetails(
     fileOrBlob: File | Blob,
     businesses?: BusinessMatchData[],
+    owner?: OwnerMatchInfo,
   ): Promise<DocumentDataWithMatches> {
     const fileType = fileOrBlob.type.toLowerCase();
     if (!isSupportedFileType(fileType)) {
@@ -244,6 +248,14 @@ export class AnthropicProvider {
       }
     }
 
+    const vatAmount = applyForeignCounterpartyVatDefault(
+      draft.vatAmount,
+      owner,
+      suggestedIssuer,
+      suggestedRecipient,
+      businessList,
+    );
+
     const validatedType = (Object.values(DocumentType) as string[]).includes(draft.type ?? '')
       ? (draft.type as DocumentType)
       : undefined;
@@ -253,6 +265,7 @@ export class AnthropicProvider {
 
     return {
       ...draft,
+      vatAmount,
       type: validatedType,
       currency: validatedCurrency,
       suggestedIssuer,

--- a/packages/server/src/modules/app-providers/helpers/business-matcher.helper.test.ts
+++ b/packages/server/src/modules/app-providers/helpers/business-matcher.helper.test.ts
@@ -102,6 +102,31 @@ describe('applyForeignCounterpartyVatDefault', () => {
     ).toBeNull();
   });
 
+  it('treats localities differing only by case/whitespace as equal', () => {
+    const casedOwner: OwnerMatchInfo = { id: OWNER_ID, locality: ' ISRAEL ' };
+    expect(
+      applyForeignCounterpartyVatDefault(null, casedOwner, LOCAL_BIZ_ID, OWNER_ID, businesses),
+    ).toBeNull();
+    expect(
+      applyForeignCounterpartyVatDefault(null, casedOwner, FOREIGN_BIZ_ID, OWNER_ID, businesses),
+    ).toBe(0);
+  });
+
+  it('treats a whitespace-only locality as missing', () => {
+    const blankOwner: OwnerMatchInfo = { id: OWNER_ID, locality: '   ' };
+    expect(
+      applyForeignCounterpartyVatDefault(null, blankOwner, FOREIGN_BIZ_ID, OWNER_ID, businesses),
+    ).toBeNull();
+
+    const blankLocalityBiz = business('00000000-0000-0000-0000-000000000005', '   ');
+    expect(
+      applyForeignCounterpartyVatDefault(null, owner, blankLocalityBiz.id, OWNER_ID, [
+        ...businesses,
+        blankLocalityBiz,
+      ]),
+    ).toBeNull();
+  });
+
   it('keeps NULL when owner info is missing or has no locality', () => {
     expect(
       applyForeignCounterpartyVatDefault(null, undefined, OWNER_ID, FOREIGN_BIZ_ID, businesses),

--- a/packages/server/src/modules/app-providers/helpers/business-matcher.helper.test.ts
+++ b/packages/server/src/modules/app-providers/helpers/business-matcher.helper.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import type { BusinessMatchData, OwnerMatchInfo } from './business-matcher.helper.js';
+import { applyForeignCounterpartyVatDefault } from './business-matcher.helper.js';
+
+const OWNER_ID = '00000000-0000-0000-0000-000000000001';
+const LOCAL_BIZ_ID = '00000000-0000-0000-0000-000000000002';
+const FOREIGN_BIZ_ID = '00000000-0000-0000-0000-000000000003';
+const NO_LOCALITY_BIZ_ID = '00000000-0000-0000-0000-000000000004';
+
+const owner: OwnerMatchInfo = { id: OWNER_ID, locality: 'Israel' };
+
+function business(id: string, locality: string | null): BusinessMatchData {
+  return {
+    id,
+    name: `business-${id}`,
+    hebrew_name: null,
+    vat_number: null,
+    suggestion_data: null,
+    locality,
+  };
+}
+
+const businesses: BusinessMatchData[] = [
+  business(OWNER_ID, 'Israel'),
+  business(LOCAL_BIZ_ID, 'Israel'),
+  business(FOREIGN_BIZ_ID, 'United States'),
+  business(NO_LOCALITY_BIZ_ID, null),
+];
+
+describe('applyForeignCounterpartyVatDefault', () => {
+  it('keeps an extracted VAT amount untouched, even for a foreign counterparty', () => {
+    expect(
+      applyForeignCounterpartyVatDefault(17, owner, OWNER_ID, FOREIGN_BIZ_ID, businesses),
+    ).toBe(17);
+  });
+
+  it('keeps an extracted VAT amount of 0 untouched', () => {
+    expect(applyForeignCounterpartyVatDefault(0, owner, OWNER_ID, FOREIGN_BIZ_ID, businesses)).toBe(
+      0,
+    );
+  });
+
+  it('sets VAT to 0 when the recipient counterparty is foreign', () => {
+    expect(
+      applyForeignCounterpartyVatDefault(null, owner, OWNER_ID, FOREIGN_BIZ_ID, businesses),
+    ).toBe(0);
+  });
+
+  it('sets VAT to 0 when the issuer counterparty is foreign', () => {
+    expect(
+      applyForeignCounterpartyVatDefault(null, owner, FOREIGN_BIZ_ID, OWNER_ID, businesses),
+    ).toBe(0);
+  });
+
+  it('sets VAT to 0 when only a foreign non-owner side matched', () => {
+    expect(applyForeignCounterpartyVatDefault(null, owner, FOREIGN_BIZ_ID, null, businesses)).toBe(
+      0,
+    );
+    expect(applyForeignCounterpartyVatDefault(null, owner, null, FOREIGN_BIZ_ID, businesses)).toBe(
+      0,
+    );
+  });
+
+  it('keeps NULL when the counterparty shares the owner locality', () => {
+    expect(
+      applyForeignCounterpartyVatDefault(null, owner, LOCAL_BIZ_ID, OWNER_ID, businesses),
+    ).toBeNull();
+  });
+
+  it('keeps NULL when the counterparty has no locality', () => {
+    expect(
+      applyForeignCounterpartyVatDefault(null, owner, NO_LOCALITY_BIZ_ID, OWNER_ID, businesses),
+    ).toBeNull();
+  });
+
+  it('keeps NULL when no side matched', () => {
+    expect(applyForeignCounterpartyVatDefault(null, owner, null, null, businesses)).toBeNull();
+  });
+
+  it('keeps NULL when the only match is the owner itself', () => {
+    expect(applyForeignCounterpartyVatDefault(null, owner, OWNER_ID, null, businesses)).toBeNull();
+    expect(
+      applyForeignCounterpartyVatDefault(null, owner, OWNER_ID, OWNER_ID, businesses),
+    ).toBeNull();
+  });
+
+  it('keeps NULL when both sides matched non-owner businesses (ambiguous counterparty)', () => {
+    expect(
+      applyForeignCounterpartyVatDefault(null, owner, LOCAL_BIZ_ID, FOREIGN_BIZ_ID, businesses),
+    ).toBeNull();
+  });
+
+  it('keeps NULL when the counterparty is unknown to the businesses list', () => {
+    expect(
+      applyForeignCounterpartyVatDefault(
+        null,
+        owner,
+        OWNER_ID,
+        '00000000-0000-0000-0000-00000000dead',
+        businesses,
+      ),
+    ).toBeNull();
+  });
+
+  it('keeps NULL when owner info is missing or has no locality', () => {
+    expect(
+      applyForeignCounterpartyVatDefault(null, undefined, OWNER_ID, FOREIGN_BIZ_ID, businesses),
+    ).toBeNull();
+    expect(
+      applyForeignCounterpartyVatDefault(
+        null,
+        { id: OWNER_ID, locality: null },
+        OWNER_ID,
+        FOREIGN_BIZ_ID,
+        businesses,
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts
+++ b/packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts
@@ -7,6 +7,68 @@ export type BusinessMatchData = {
   locality: string | null;
 };
 
+export type OwnerMatchInfo = {
+  id: string;
+  locality: string | null;
+};
+
+/**
+ * Deduce the counterparty (the matched business that is not the owner) from
+ * the issuer/recipient match results.
+ *
+ * Returns null when neither side matched, when the only match is the owner
+ * itself, or when both sides matched non-owner businesses (ambiguous).
+ */
+function deduceCounterpartyId(
+  ownerId: string,
+  issuerId: string | null,
+  recipientId: string | null,
+): string | null {
+  if (issuerId === ownerId) {
+    return recipientId === ownerId ? null : recipientId;
+  }
+  if (recipientId === ownerId) {
+    return issuerId;
+  }
+  // Neither side is the owner: a single match is the counterparty; two
+  // non-owner matches leave the counterparty ambiguous.
+  if (issuerId && recipientId) {
+    return null;
+  }
+  return issuerId ?? recipientId;
+}
+
+/**
+ * A NULL extracted VAT amount is ambiguous: "not stated" vs "no VAT". When the
+ * counterparty is recognized and located in a different locality than the
+ * owner, the document carries no local VAT — resolve the amount to 0.
+ *
+ * In every other case (VAT already extracted, owner/counterparty unknown,
+ * locality missing or identical) the original value is returned unchanged.
+ */
+export function applyForeignCounterpartyVatDefault(
+  vatAmount: number | null,
+  owner: OwnerMatchInfo | undefined,
+  suggestedIssuer: string | null,
+  suggestedRecipient: string | null,
+  businesses: BusinessMatchData[],
+): number | null {
+  if (vatAmount !== null || !owner?.locality) {
+    return vatAmount;
+  }
+
+  const counterpartyId = deduceCounterpartyId(owner.id, suggestedIssuer, suggestedRecipient);
+  if (!counterpartyId) {
+    return vatAmount;
+  }
+
+  const counterparty = businesses.find(b => b.id === counterpartyId);
+  if (counterparty?.locality && counterparty.locality !== owner.locality) {
+    return 0;
+  }
+  return vatAmount;
+}
+
 function normalizeVat(vat: string): string {
   return vat.replace(/[\s-]/g, '');
 }

--- a/packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts
+++ b/packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts
@@ -38,6 +38,11 @@ function deduceCounterpartyId(
   return issuerId ?? recipientId;
 }
 
+function normalizeLocality(locality: string | null | undefined): string | null {
+  const normalized = locality?.trim().toLowerCase();
+  return normalized || null;
+}
+
 /**
  * A NULL extracted VAT amount is ambiguous: "not stated" vs "no VAT". When the
  * counterparty is recognized and located in a different locality than the
@@ -53,7 +58,8 @@ export function applyForeignCounterpartyVatDefault(
   suggestedRecipient: string | null,
   businesses: BusinessMatchData[],
 ): number | null {
-  if (vatAmount !== null || !owner?.locality) {
+  const ownerLocality = owner ? normalizeLocality(owner.locality) : null;
+  if (vatAmount !== null || !owner || !ownerLocality) {
     return vatAmount;
   }
 
@@ -63,7 +69,8 @@ export function applyForeignCounterpartyVatDefault(
   }
 
   const counterparty = businesses.find(b => b.id === counterpartyId);
-  if (counterparty?.locality && counterparty.locality !== owner.locality) {
+  const counterpartyLocality = normalizeLocality(counterparty?.locality);
+  if (counterpartyLocality && counterpartyLocality !== ownerLocality) {
     return 0;
   }
   return vatAmount;

--- a/packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts
+++ b/packages/server/src/modules/app-providers/helpers/business-matcher.helper.ts
@@ -4,6 +4,7 @@ export type BusinessMatchData = {
   hebrew_name: string | null;
   vat_number: string | null;
   suggestion_data: { phrases?: string[]; priority?: number } | null;
+  locality: string | null;
 };
 
 function normalizeVat(vat: string): string {

--- a/packages/server/src/modules/documents/helpers/upload.helper.ts
+++ b/packages/server/src/modules/documents/helpers/upload.helper.ts
@@ -53,6 +53,7 @@ async function fetchBusinessesForMatching(injector: Injector): Promise<BusinessM
       hebrew_name: b.hebrew_name ?? null,
       vat_number: b.vat_number ?? null,
       suggestion_data: suggestionDataSchema.safeParse(b.suggestion_data).data ?? null,
+      locality: b.country ?? null,
     }));
   } catch {
     return [];

--- a/packages/server/src/modules/documents/helpers/upload.helper.ts
+++ b/packages/server/src/modules/documents/helpers/upload.helper.ts
@@ -4,7 +4,10 @@ import { hashStringToInt } from '../../../shared/helpers/index.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
 import { AnthropicProvider } from '../../app-providers/anthropic.js';
 import { CloudinaryProvider } from '../../app-providers/cloudinary.js';
-import type { BusinessMatchData } from '../../app-providers/helpers/business-matcher.helper.js';
+import type {
+  BusinessMatchData,
+  OwnerMatchInfo,
+} from '../../app-providers/helpers/business-matcher.helper.js';
 import { suggestionDataSchema } from '../../financial-entities/helpers/business-suggestion-data-schema.helper.js';
 import { BusinessesProvider } from '../../financial-entities/providers/businesses.provider.js';
 import type { IInsertDocumentsParams } from '../types.js';
@@ -44,6 +47,17 @@ export type OcrData = {
   suggestedRecipient?: string;
 };
 
+async function fetchOwnerForMatching(injector: Injector): Promise<OwnerMatchInfo | undefined> {
+  try {
+    const { ownerId, locality } = await injector
+      .get(AdminContextProvider)
+      .getVerifiedAdminContext();
+    return { id: ownerId, locality: locality ?? null };
+  } catch {
+    return undefined;
+  }
+}
+
 async function fetchBusinessesForMatching(injector: Injector): Promise<BusinessMatchData[]> {
   try {
     const rawBusinesses = await injector.get(BusinessesProvider).getAllBusinesses();
@@ -81,8 +95,13 @@ export async function getOcrData(
     };
   }
 
-  const businesses = await fetchBusinessesForMatching(injector);
-  const draft = await injector.get(AnthropicProvider).extractInvoiceDetails(file, businesses);
+  const [businesses, owner] = await Promise.all([
+    fetchBusinessesForMatching(injector),
+    fetchOwnerForMatching(injector),
+  ]);
+  const draft = await injector
+    .get(AnthropicProvider)
+    .extractInvoiceDetails(file, businesses, owner);
 
   if (!draft) {
     throw new Error('No data returned from Anthropic OCR');


### PR DESCRIPTION
Closes #3861

## What

When the OCR extraction returns a `NULL` VAT amount, the value is ambiguous — the document may simply not state VAT, or it may carry none at all. This PR resolves that ambiguity for cross-locality documents: when the counterparty is a recognized business located in a different locality than the owner, no local VAT applies, so the amount is set to `0` instead of staying `NULL`.

## How

- **`business-matcher.helper.ts`**: new `applyForeignCounterpartyVatDefault()` pure helper. It deduces the counterparty from the issuer/recipient business matches (the matched side that is not the owner) and returns `0` only when the counterparty's locality is known and differs from the owner's locality. In every other case the original VAT value is returned unchanged:
  - VAT already extracted (including an explicit `0`)
  - owner info or owner locality missing
  - no side matched, the only match is the owner itself, or both sides matched non-owner businesses (ambiguous counterparty)
  - counterparty not found in the businesses list or has no locality
  - localities are equal
- **`anthropic.ts`**: `extractInvoiceDetails()` accepts an optional `owner` (`{ id, locality }`) and applies the helper to `vatAmount` after issuer/recipient matching (including the LLM fallback matches).
- **`upload.helper.ts`**: `getOcrData()` fetches the owner via `AdminContextProvider.getVerifiedAdminContext()` (defensively — OCR keeps working if context resolution fails, mirroring the existing `fetchBusinessesForMatching` pattern) and passes it to the extraction. This covers both the document-upload and email-ingestion paths.

Builds on the locality wiring commit that added `locality` (business `country`) to `BusinessMatchData`.

## Testing

- Added unit tests for `applyForeignCounterpartyVatDefault` covering all the keep-as-is branches and the zero-out cases (28 tests pass, including the existing email-ingestion suite).
- ESLint clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gTqYEiURTyAFjGW7oatru

---
_Generated by [Claude Code](https://claude.ai/code/session_019gTqYEiURTyAFjGW7oatru)_