### PR TITLE
Refine charge matching queue: cap BY_SCORE to 100, add mode filter

### DIFF
--- a/docs/matching-screen/prompt_plan.md
+++ b/docs/matching-screen/prompt_plan.md
@@ -10,9 +10,10 @@ without massive complexity leaps at any stage.
 2. **On-the-fly Scoring Service:** Create an internal helper/service that takes an array of
    unmatched charges and calculates their matches on the fly (reusing the existing algorithm).
 3. **Query Resolver Implementation:**
-   - Implement the `BY_DATE` path: Fetch `limit` charges, map to the scoring service.
-   - Implement the `BY_SCORE` path: Fetch `300` charges, map to the scoring service, sort by score
-     descending, slice to `limit`.
+   - Implement the `BY_DATE` path: Fetch `limit` charges at the requested `offset`, map to the
+     scoring service.
+   - Implement the `BY_SCORE` path: Fetch `100` charges (the evaluation cap), map to the scoring
+     service, sort by score descending, slice by `limit`/`offset`.
 4. **Merge Validation:** Ensure the existing merge mutation provides the correct responses
    (success/errors) expected by the client.
 
@@ -58,7 +59,7 @@ Target package: `packages/server/src/modules/charges-matcher` (or the appropriat
 
 Task:
 1. Extend the `charges-matcher.graphql.ts` schema to include a new query: `chargesAwaitingMatchQueue`.
-2. It should accept inputs for: `limit` (Int), `offset` (Int), `businessId` (UUID), `fromDate` (String), `toDate` (String), and `sortBy` (Enum: 'BY_DATE' | 'BY_SCORE').
+2. It should accept inputs for: `limit` (Int), `offset` (Int), `businessId` (UUID), `fromDate` (String), `toDate` (String), `mode` (Enum: 'DOC_BASE' | 'TRANSACTION_BASE' — filters the queue by base-charge type), and `sortBy` (Enum: 'BY_DATE' | 'BY_SCORE').
 3. It should return a paginated response type `ChargesAwaitingMatchResult` containing:
    - `baseCharges`: Array of a new type `ChargeWithSuggestions`.
    - `totalCount`: Int.
@@ -94,8 +95,8 @@ Implement the GraphQL resolver for the schema defined in Step 1, using the logic
 
 Instructions:
 1. Write Unit Tests for the resolver isolating the two sorting paths.
-   - Path A (`BY_DATE`): Verify it fetches `limit` unused charges from the DB and passes them to the scoring helper.
-   - Path B (`BY_SCORE`): Verify it forces a DB fetch limit of 300 recent unused charges, passes them to the scoring helper, sorts the entire 300-item array descending by the top suggestion's score, and THEN applies the `limit`/`offset` slice to return the page.
+   - Path A (`BY_DATE`): Verify it fetches `limit` unused charges from the DB at the requested `offset` (i.e., the DB query applies both `limit` and `offset`, so subsequent pages return different rows) and passes them to the scoring helper.
+   - Path B (`BY_SCORE`): Verify it forces a DB fetch limit of 100 recent unused charges (the evaluation cap), passes them to the scoring helper with bounded concurrency, sorts the entire 100-item array descending by the top suggestion's score, and THEN applies the `limit`/`offset` slice to return the page.
 2. Implement the resolver securely, ensuring authentication and authorization (e.g., matching the user's access to the requested `businessId`).
 3. Wire the resolver into the module's provider/index.
 ```
@@ -110,7 +111,7 @@ Task:
 We need to handle the queue state locally before building the UI.
 
 Instructions:
-1. Write a `.graphql` file in the client package defining the `ChargesAwaitingMatchQueue` query and the `MergeCharges` mutation to trigger `graphql-codegen`.
+1. Define the new `ChargesAwaitingMatchQueue` query operation in the client package to trigger `graphql-codegen`. Do NOT define a `MergeCharges` mutation — it already exists in `packages/client/src/hooks/use-merge-charges.ts` (exposed via the `useMergeCharges` hook), and redefining it would cause duplicate-operation errors during codegen. Reuse the existing hook.
 2. Write a Unit Test for a custom React Hook called `useChargeMatchQueue`.
 3. The hook test should assert:
    - It maintains an array of items.
@@ -129,7 +130,9 @@ Task:
 Create the visual shell, the filtering header, and the sidebar utilizing `shadcn/ui` and Tailwind in the React client.
 
 Instructions:
-1. Build `ChargeMatchingHeader`: Includes basic dropdowns/inputs for Business, Date Range, and Mode ("Date" vs "Score"). Include a conditional alert banner if "Score" is selected: "Note: Score-based sorting currently evaluates only the 300 most recent unmatched charges."
+1. Build `ChargeMatchingHeader` with two distinct groups of controls:
+   - Filters: a Mode/Type selector ("Doc Base" vs "Transaction Base"), a Date Range (timeframe) picker, and a Business select.
+   - Sort toggle: "Date" vs "Match Score" (separate from the Mode/Type filter). Include a conditional alert banner if "Match Score" is selected: "Note: Score-based sorting currently evaluates only the 100 most recent unmatched charges."
 2. Build `ChargeMatchingSidebar`: Accepts an array of charges and the state dictionary from our `useChargeMatchQueue` hook. It renders a vertical list. Items show a default icon, a "green check" for matched, and a "ghosted/gray" state for skipped.
 3. Build the main page container `ChargeMatchingReviewScreen` importing the Header, Sidebar, and the GraphQL queries. Wire it so that selecting filters in the Header triggers a refetch of the GraphQL query.
 ```
@@ -163,7 +166,7 @@ Instructions:
 2. In the main Screen component, maintain a local state for `selectedSuggestionOverride`. By default, it's null (meaning use Rank 1). Clicking an item in the Footer updates this override, passing a different suggestion to the right-side `ChargeDetailCard`.
 3. Implement the `handleSkip` function: Call the hook's skip method to advance the queue.
 4. Implement the `handleAccept` function:
-   - Call the `urql` GraphQL mutation to merge the charges.
+   - Call the existing `useMergeCharges` hook (`packages/client/src/hooks/use-merge-charges.ts`) to merge the charges.
    - Await the response.
    - If success: Fire a success Toast, and call the hook's success method to update the sidebar icon and advance the queue.
    - If error: Fire a descriptive error Toast. Do NOT advance the queue.

--- a/docs/matching-screen/spec.md
+++ b/docs/matching-screen/spec.md
@@ -32,9 +32,16 @@ allowing the user to rapidly accept or skip suggestions one-by-one.
   - The match scores should be calculated _on the fly_ to ensure fresh data.
   - **When sorting `BY_DATE`:** Fetch the requested page of unmatched base charges, then calculate
     their matches on the fly.
-  - **When sorting `BY_SCORE`:** Fetch the 300 most recent unmatched base charges that match the
-    filters. Calculate match scores for all 300 on the fly, sort them by top confidence score
+  - **When sorting `BY_SCORE`:** Fetch the 100 most recent unmatched base charges that match the
+    filters. Calculate match scores for all 100 on the fly, sort them by top confidence score
     descending, and paginate _that_ derived list.
+  - **Score-evaluation cap & guardrails:** The `BY_SCORE` evaluation window is deliberately capped
+    at 100 charges to bound request latency, CPU usage, and DB connection pool pressure (each
+    scoring pass loads candidate charges, transactions, and documents). The implementation must
+    batch/reuse data loading across the evaluated charges where possible and run the per-charge
+    scoring with bounded concurrency (not one unbounded parallel burst, nor 100 strictly sequential
+    full passes). If this proves too slow in practice, prefer caching or asynchronous
+    pre-calculation of scores over raising the cap.
 - **Data Contract:** Must return the base charge details (date, exact amount + currency symbol,
   counterparty, description, document `image_url` if applicable, additional nested
   transactions/docs), and an array of `suggestions` ordered by match score.
@@ -56,7 +63,7 @@ allowing the user to rapidly accept or skip suggestions one-by-one.
 - **Filters:** Mode/Type selector, Timeframe picker, Business select.
 - **Sort Toggle:** "Date" vs. "Match Score".
 - **Warning Note:** If "Sort by Score" is selected, dynamically render a text note/alert: _"Note:
-  Score-based sorting currently evaluates only the 300 most recent unmatched charges."_
+  Score-based sorting currently evaluates only the 100 most recent unmatched charges."_
 
 **2. Awaiting Matches Sidebar (Collapsible):**
 
@@ -107,7 +114,7 @@ allowing the user to rapidly accept or skip suggestions one-by-one.
 
 - **Unit Tests for Query Resolution:**
   - Verify `BY_DATE` pagination correctly lazy-loads scores only for the requested page limit.
-  - Verify `BY_SCORE` pagination restricts initial fetch to the capped limit of 300, correctly sorts
+  - Verify `BY_SCORE` pagination restricts initial fetch to the capped limit of 100, correctly sorts
     the highest scoring outputs, and handles pagination cleanly.
 - **Integration Tests for Merging:**
   - Verify the mutation cleanly collapses two charges and properly assigns existing documents and


### PR DESCRIPTION
## Summary

Updates the charge matching queue specification and implementation plan to clarify evaluation constraints, introduce a mode/type filter for base-charge selection, and correct the BY_SCORE evaluation cap from 300 to 100 charges with explicit guardrails on concurrency and performance.

## Key Changes

- **Evaluation cap adjustment:** Changed `BY_SCORE` fetch limit from 300 to 100 charges, with documented rationale for bounding latency, CPU, and DB connection pool pressure.
- **Mode filter addition:** Added `mode` parameter (Enum: `DOC_BASE` | `TRANSACTION_BASE`) to the `chargesAwaitingMatchQueue` query to allow filtering base charges by type.
- **Pagination clarification:** Explicitly documented that `BY_DATE` path applies both `limit` and `offset` at the DB query level for proper pagination, while `BY_SCORE` evaluates the capped 100-item set then applies pagination to the sorted results.
- **Concurrency guardrails:** Added specification requirement for bounded concurrency in per-charge scoring (not unbounded parallel, not strictly sequential) with preference for caching/async pre-calculation if performance becomes problematic.
- **UI refinement:** Separated filter controls (Mode/Type, Date Range, Business) from sort toggle ("Date" vs "Match Score") in the `ChargeMatchingHeader` component, with updated alert banner text reflecting the new 100-charge cap.
- **Client hook clarification:** Documented that the `MergeCharges` mutation already exists in `use-merge-charges.ts` hook and should be reused rather than redefined to avoid duplicate-operation codegen errors.
- **Test expectations:** Updated unit test specifications to reflect the 100-charge cap and clarify offset behavior in `BY_DATE` pagination tests.

## Implementation Notes

- The 100-charge cap is a deliberate performance boundary; if evaluation proves too slow, the preference is to implement caching or asynchronous pre-calculation rather than raise the cap.
- The `BY_DATE` and `BY_SCORE` paths have fundamentally different pagination semantics: `BY_DATE` paginates at the DB level, while `BY_SCORE` evaluates a fixed window then paginates the results.
- Client-side reuse of the existing `useMergeCharges` hook prevents codegen conflicts and maintains a single source of truth for the merge mutation.

https://claude.ai/code/session_01JBQoeDJraws6oq8cyxPri3