### PR TITLE
Enhance Profit & Loss report: PDF export + per-entity ledger record details

### DIFF
--- a/.changeset/eighty-adults-arrive.md
+++ b/.changeset/eighty-adults-arrive.md
@@ -1,0 +1,9 @@
+---
+'@accounter/client': patch
+---
+
+- **GraphQL schema**: `ReportCommentarySubRecord` gains a `ledgerRecords: [LedgerRecord!]!` field,
+  so the details are delegated to the client. This applies to both the Profit & Loss and Tax
+  reports, which share these commentary types.
+- **Client**: `ReportSubCommentaryRow` gains a per-entity `ToggleExpansionButton` that expands into
+  the existing `LedgerTable` component (no ledger diff view in this report).

--- a/.changeset/loose-beans-refuse.md
+++ b/.changeset/loose-beans-refuse.md
@@ -1,0 +1,10 @@
+---
+'@accounter/server': patch
+---
+
+- **Server**: `recordsByFinancialEntityIdAndSortCodeValidations`
+  (`packages/server/src/modules/reports/helpers/misc.helper.ts`) now collects the contributing
+  ledger records (deduplicated by record ID) alongside the per-entity amount aggregation.
+- **GraphQL schema**: `ReportCommentarySubRecord` gains a `ledgerRecords: [LedgerRecord!]!` field,
+  so the details are delegated to the client. This applies to both the Profit & Loss and Tax
+  reports, which share these commentary types.

--- a/packages/client/src/components/reports/profit-and-loss-report/index.tsx
+++ b/packages/client/src/components/reports/profit-and-loss-report/index.tsx
@@ -3,6 +3,7 @@ import { Loader2 } from 'lucide-react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from 'urql';
 import { Table } from '@mantine/core';
+import { PrintToPdfButton } from '@/components/common/index.js';
 import { ProfitAndLossReportDocument } from '../../../gql/graphql.js';
 import { dedupeFragments } from '../../../helpers/index.js';
 import { FiltersContext } from '../../../providers/filters-context.js';
@@ -169,7 +170,10 @@ export const ProfitAndLossReport = (): ReactElement => {
   const referenceYearsData = yearlyReports?.reference ?? [];
 
   return (
-    <PageLayout title="Profit and Loss Report">
+    <PageLayout
+      title="Profit and Loss Report"
+      headerActions={<PrintToPdfButton filename={`profit_and_loss_${year}`} />}
+    >
       {fetching ? (
         <Loader2 className="h-10 w-10 animate-spin mr-2 self-center" />
       ) : (

--- a/packages/client/src/components/reports/shared/report-sub-commentary-row.tsx
+++ b/packages/client/src/components/reports/shared/report-sub-commentary-row.tsx
@@ -37,12 +37,12 @@ const SubCommentaryEntityRow = ({ record }: EntityRowProps): ReactElement => {
         <td>{record.financialEntity.name}</td>
         <td>{record.amount.formatted}</td>
         <td>
-          {record.ledgerRecords.length > 0 && (
+          {record.ledgerRecords?.length > 0 && (
             <ToggleExpansionButton toggleExpansion={setOpened} isExpanded={opened} />
           )}
         </td>
       </tr>
-      {opened && (
+      {opened && record.ledgerRecords && (
         <tr>
           <td colSpan={99}>
             <div className="ml-8">

--- a/packages/client/src/components/reports/shared/report-sub-commentary-row.tsx
+++ b/packages/client/src/components/reports/shared/report-sub-commentary-row.tsx
@@ -1,8 +1,12 @@
 import { useState, type ReactElement } from 'react';
 import { Table } from '@mantine/core';
-import { ReportSubCommentaryTableFieldsFragmentDoc } from '../../../gql/graphql.js';
+import {
+  ReportSubCommentaryTableFieldsFragmentDoc,
+  type ReportSubCommentaryTableFieldsFragment,
+} from '../../../gql/graphql.js';
 import { getFragmentData, type FragmentType } from '../../../gql/index.js';
 import { ToggleExpansionButton } from '../../common/index.js';
+import { LedgerTable } from '../../ledger-table/index.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -14,8 +18,42 @@ import { ToggleExpansionButton } from '../../common/index.js';
     amount {
       formatted
     }
+    ledgerRecords {
+      ...LedgerRecordsTableFields
+    }
   }
 `;
+
+type EntityRowProps = {
+  record: ReportSubCommentaryTableFieldsFragment;
+};
+
+const SubCommentaryEntityRow = ({ record }: EntityRowProps): ReactElement => {
+  const [opened, setOpened] = useState(false);
+
+  return (
+    <>
+      <tr>
+        <td>{record.financialEntity.name}</td>
+        <td>{record.amount.formatted}</td>
+        <td>
+          {record.ledgerRecords.length > 0 && (
+            <ToggleExpansionButton toggleExpansion={setOpened} isExpanded={opened} />
+          )}
+        </td>
+      </tr>
+      {opened && (
+        <tr>
+          <td colSpan={99}>
+            <div className="ml-8">
+              <LedgerTable ledgerRecordsData={record.ledgerRecords} />
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+};
 
 type Props = {
   dataRow: (extendButton: ReactElement) => ReactElement;
@@ -41,16 +79,14 @@ export const ReportSubCommentaryRow = ({ subCommentaryData, dataRow }: Props): R
                 <tr>
                   <th>Entity</th>
                   <th>Amount</th>
+                  <th />
                 </tr>
               </thead>
               <tbody>
                 {records
                   ?.sort((a, b) => a.financialEntity.name.localeCompare(b.financialEntity.name))
                   .map(record => (
-                    <tr key={record.financialEntity.id}>
-                      <td>{record.financialEntity.name}</td>
-                      <td>{record.amount.formatted}</td>
-                    </tr>
+                    <SubCommentaryEntityRow key={record.financialEntity.id} record={record} />
                   ))}
                 <tr>
                   <td colSpan={8} />

--- a/packages/server/src/modules/reports/helpers/misc.helper.ts
+++ b/packages/server/src/modules/reports/helpers/misc.helper.ts
@@ -1,23 +1,44 @@
 import { CommentaryProto } from '../types.js';
 import { DecoratedLedgerRecord } from './profit-and-loss.helper.js';
 
+type EntityAmountAccumulator = {
+  amount: number;
+  // ledger records are keyed by ID, so a record hitting the same entity on multiple sides is listed once
+  ledgerRecords: Map<string, DecoratedLedgerRecord>;
+};
+
+type AmountsBySortCode = Map<
+  number,
+  { amount: number; records: Map<string, EntityAmountAccumulator> }
+>;
+
 export function updateRecords(
-  amountsByEntity: Map<number, { amount: number; records: Map<string, number> }>,
+  amountsByEntity: AmountsBySortCode,
   amount: number,
   sortCode: number,
   financialEntityId: string,
+  ledgerRecord: DecoratedLedgerRecord,
 ) {
   const currentRecord = amountsByEntity.get(sortCode);
   if (currentRecord) {
     currentRecord.amount += amount;
     const record = currentRecord.records.get(financialEntityId);
     if (record) {
-      currentRecord.records.set(financialEntityId, record + amount);
+      record.amount += amount;
+      record.ledgerRecords.set(ledgerRecord.id, ledgerRecord);
     } else {
-      currentRecord.records.set(financialEntityId, amount);
+      currentRecord.records.set(financialEntityId, {
+        amount,
+        ledgerRecords: new Map([[ledgerRecord.id, ledgerRecord]]),
+      });
     }
   } else {
-    amountsByEntity.set(sortCode, { amount, records: new Map([[financialEntityId, amount]]) });
+    amountsByEntity.set(sortCode, {
+      amount,
+      records: new Map([
+        [financialEntityId, { amount, ledgerRecords: new Map([[ledgerRecord.id, ledgerRecord]]) }],
+      ]),
+    });
   }
 }
 
@@ -72,13 +93,7 @@ export function recordsByFinancialEntityIdAndSortCodeValidations<
 >(unfilteredRecords: DecoratedLedgerRecord[], filteringRules: T): R {
   const commentaryProtos = filteringRules.map(() => ({
     amount: 0,
-    amountsByEntity: new Map<
-      number,
-      {
-        amount: number;
-        records: Map<string, number>;
-      }
-    >(),
+    amountsByEntity: new Map() as AmountsBySortCode,
   }));
   unfilteredRecords.map(record => {
     if (record.credit_entity1) {
@@ -91,6 +106,7 @@ export function recordsByFinancialEntityIdAndSortCodeValidations<
             recordAmount,
             record.credit_entity_sort_code1!,
             record.credit_entity1,
+            record,
           );
           commentaryProtos[i].amount += recordAmount;
         }
@@ -106,6 +122,7 @@ export function recordsByFinancialEntityIdAndSortCodeValidations<
             recordAmount,
             record.credit_entity_sort_code2!,
             record.credit_entity2,
+            record,
           );
           commentaryProtos[i].amount += recordAmount;
         }
@@ -121,6 +138,7 @@ export function recordsByFinancialEntityIdAndSortCodeValidations<
             recordAmount,
             record.debit_entity_sort_code1!,
             record.debit_entity1,
+            record,
           );
           commentaryProtos[i].amount += recordAmount;
         }
@@ -136,6 +154,7 @@ export function recordsByFinancialEntityIdAndSortCodeValidations<
             recordAmount,
             record.debit_entity_sort_code2!,
             record.debit_entity2,
+            record,
           );
           commentaryProtos[i].amount += recordAmount;
         }
@@ -148,9 +167,10 @@ export function recordsByFinancialEntityIdAndSortCodeValidations<
     records: Array.from(proto.amountsByEntity.entries()).map(([sortCode, data]) => ({
       sortCode,
       amount: data.amount,
-      records: Array.from(data.records.entries()).map(([financialEntityId, amount]) => ({
+      records: Array.from(data.records.entries()).map(([financialEntityId, entityData]) => ({
         financialEntityId,
-        amount,
+        amount: entityData.amount,
+        ledgerRecords: Array.from(entityData.ledgerRecords.values()),
       })),
     })),
   })) as R;

--- a/packages/server/src/modules/reports/resolvers/reports/profit-and-loss-report.resolver.ts
+++ b/packages/server/src/modules/reports/resolvers/reports/profit-and-loss-report.resolver.ts
@@ -254,5 +254,5 @@ export const reportCommentarySubRecordMapper: ReportCommentarySubRecordResolvers
       .getVerifiedAdminContext();
     return formatFinancialAmount(parent.amount, defaultLocalCurrency);
   },
-  ledgerRecords: parent => parent.ledgerRecords,
+  ledgerRecords: parent => parent.ledgerRecords ?? [],
 };

--- a/packages/server/src/modules/reports/resolvers/reports/profit-and-loss-report.resolver.ts
+++ b/packages/server/src/modules/reports/resolvers/reports/profit-and-loss-report.resolver.ts
@@ -254,4 +254,5 @@ export const reportCommentarySubRecordMapper: ReportCommentarySubRecordResolvers
       .getVerifiedAdminContext();
     return formatFinancialAmount(parent.amount, defaultLocalCurrency);
   },
+  ledgerRecords: parent => parent.ledgerRecords,
 };

--- a/packages/server/src/modules/reports/typeDefs/tax-report.graphql.ts
+++ b/packages/server/src/modules/reports/typeDefs/tax-report.graphql.ts
@@ -53,5 +53,7 @@ export default gql`
   type ReportCommentarySubRecord {
     financialEntity: FinancialEntity!
     amount: FinancialAmount!
+    " ledger records formulating the financial entity sum "
+    ledgerRecords: [LedgerRecord!]!
   }
 `;

--- a/packages/server/src/modules/reports/types.ts
+++ b/packages/server/src/modules/reports/types.ts
@@ -1,4 +1,5 @@
 import type { Shaam6111Data } from '../../__generated__/types.js';
+import type { IGetLedgerRecordsByDatesResult } from '../ledger/types.js';
 
 export type { DateOrString, currency } from './__generated__/balance-report.types.js';
 export type * from './__generated__/types.js';
@@ -21,6 +22,7 @@ export type CommentaryRecordProto = {
 export type CommentarySubRecordProto = {
   financialEntityId: string;
   amount: number;
+  ledgerRecords: IGetLedgerRecordsByDatesResult[];
 };
 
 export type ProfitAndLossReportYearProto = {


### PR DESCRIPTION
This PR enhances the Profit & Loss report with two improvements:

## PDF export (closes #3888)

Adds a `PrintToPdfButton` to the Profit & Loss report page header, enabling exporting the report as PDF.

## Per-entity ledger record details (closes #3887)

Each `ReportCommentarySubRecord` (the financial-entity rows shown when expanding a sort-code row in the report commentary tables) now exposes the ledger records that formulate the entity's sum, and the client renders them in a new expandable sub-row.

- **Server**: `recordsByFinancialEntityIdAndSortCodeValidations` (`packages/server/src/modules/reports/helpers/misc.helper.ts`) now collects the contributing ledger records (deduplicated by record ID) alongside the per-entity amount aggregation.
- **GraphQL schema**: `ReportCommentarySubRecord` gains a `ledgerRecords: [LedgerRecord!]!` field, so the details are delegated to the client. This applies to both the Profit & Loss and Tax reports, which share these commentary types.
- **Client**: `ReportSubCommentaryRow` gains a per-entity `ToggleExpansionButton` that expands into the existing `LedgerTable` component (no ledger diff view in this report).

## Verification

- `yarn generate` (GraphQL + SQL codegen) passes
- `yarn workspace @accounter/server build` and `yarn workspace @accounter/client build` pass
- `yarn lint` — 0 errors
- `yarn test` — all unit tests pass

Closes #3887
Closes #3888

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018T5G2JR2tqApsgwnTCF7Gb

---
_Generated by [Claude Code](https://claude.ai/code/session_018T5G2JR2tqApsgwnTCF7Gb)_