### PR TITLE
feat(charges-matcher): matching screen step 3 — chargesAwaitingMatchQueue resolver

### DIFF
--- a/packages/server/src/modules/charges-matcher/__tests__/charges-awaiting-match-queue.test.ts
+++ b/packages/server/src/modules/charges-matcher/__tests__/charges-awaiting-match-queue.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Injector } from 'graphql-modules';
+import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { ChargesProvider } from '../../charges/providers/charges.provider.js';
+import { BY_SCORE_EVALUATION_CAP } from '../helpers/awaiting-match-queue.helper.js';
+import { QueueMatchEvaluatorProvider } from '../providers/queue-match-evaluator.provider.js';
+import { chargesAwaitingMatchQueueResolver } from '../resolvers/charges-awaiting-match-queue.resolver.js';
+import type { ChargeMatchProto } from '../types.js';
+
+const OWNER_ID = 'owner-1';
+
+/**
+ * Minimal enriched charge row, as returned by ChargesProvider.getChargesByFilters.
+ * Count aggregates are int8 columns, surfaced as strings.
+ */
+function makeCharge(
+  id: string,
+  {
+    transactions = 0,
+    invoices = 0,
+    receipts = 0,
+  }: { transactions?: number; invoices?: number; receipts?: number } = {},
+) {
+  return {
+    id,
+    owner_id: OWNER_ID,
+    transactions_count: transactions ? String(transactions) : null,
+    invoices_count: invoices ? String(invoices) : null,
+    receipts_count: receipts ? String(receipts) : null,
+    documents_count: invoices + receipts ? String(invoices + receipts) : null,
+  };
+}
+
+const txCharge = (id: string) => makeCharge(id, { transactions: 1 });
+const docCharge = (id: string) => makeCharge(id, { invoices: 1 });
+
+type ResolverFn = (
+  parent: unknown,
+  args: Record<string, unknown>,
+  context: { injector: Injector },
+  info: unknown,
+) => Promise<{ baseCharges: { baseCharge: { id: string }; suggestions: ChargeMatchProto[] }[]; totalCount: number }>;
+
+const resolve = chargesAwaitingMatchQueueResolver.Query!
+  .chargesAwaitingMatchQueue as unknown as ResolverFn;
+
+function createTestContext({
+  charges,
+  suggestionsById = {},
+}: {
+  charges: ReturnType<typeof makeCharge>[];
+  suggestionsById?: Record<string, ChargeMatchProto[]>;
+}) {
+  const getChargesByFilters = vi.fn(async () => charges);
+  const evaluateMatchesForCharges = vi.fn(async (baseCharges: { id: string }[]) =>
+    baseCharges.map(baseCharge => ({
+      baseCharge,
+      suggestions: suggestionsById[baseCharge.id] ?? [],
+    })),
+  );
+
+  const injector = {
+    get: vi.fn((token: unknown) => {
+      if (token === AdminContextProvider) {
+        return { getVerifiedAdminContext: async () => ({ ownerId: OWNER_ID }) };
+      }
+      if (token === ChargesProvider) {
+        return { getChargesByFilters };
+      }
+      if (token === QueueMatchEvaluatorProvider) {
+        return { evaluateMatchesForCharges };
+      }
+      throw new Error(`Unexpected token requested from injector`);
+    }),
+  } as unknown as Injector;
+
+  return { injector, getChargesByFilters, evaluateMatchesForCharges };
+}
+
+const baseArgs = {
+  limit: 20,
+  offset: 0,
+  businessId: null,
+  fromDate: null,
+  toDate: null,
+  mode: null,
+  sortBy: 'BY_DATE',
+};
+
+describe('chargesAwaitingMatchQueue resolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('shared filtering', () => {
+    it('should scope the DB fetch to the verified admin owner and pass filters through', async () => {
+      const { injector, getChargesByFilters } = createTestContext({ charges: [] });
+
+      await resolve(
+        null,
+        {
+          ...baseArgs,
+          businessId: 'business-7',
+          fromDate: '2024-01-01',
+          toDate: '2024-12-31',
+        },
+        { injector },
+        null,
+      );
+
+      expect(getChargesByFilters).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownerIds: [OWNER_ID],
+          businessIds: ['business-7'],
+          fromDate: '2024-01-01',
+          toDate: '2024-12-31',
+        }),
+      );
+    });
+
+    it('should include only unmatched charges (tx-only or doc-only) in the queue', async () => {
+      const { injector } = createTestContext({
+        charges: [
+          txCharge('tx-1'),
+          makeCharge('matched-1', { transactions: 1, receipts: 1 }),
+          docCharge('doc-1'),
+          makeCharge('empty-1'),
+        ],
+      });
+
+      const result = await resolve(null, baseArgs, { injector }, null);
+
+      expect(result.baseCharges.map(c => c.baseCharge.id)).toEqual(['tx-1', 'doc-1']);
+      expect(result.totalCount).toBe(2);
+    });
+
+    it('should treat a transaction charge with invoice-only documents as unmatched', async () => {
+      const { injector } = createTestContext({
+        charges: [makeCharge('tx-with-invoice', { transactions: 1, invoices: 1 })],
+      });
+
+      const result = await resolve(null, baseArgs, { injector }, null);
+
+      expect(result.baseCharges.map(c => c.baseCharge.id)).toEqual(['tx-with-invoice']);
+    });
+
+    it('should filter by DOC_BASE mode', async () => {
+      const { injector } = createTestContext({
+        charges: [txCharge('tx-1'), docCharge('doc-1'), docCharge('doc-2')],
+      });
+
+      const result = await resolve(null, { ...baseArgs, mode: 'DOC_BASE' }, { injector }, null);
+
+      expect(result.baseCharges.map(c => c.baseCharge.id)).toEqual(['doc-1', 'doc-2']);
+      expect(result.totalCount).toBe(2);
+    });
+
+    it('should filter by TRANSACTION_BASE mode', async () => {
+      const { injector } = createTestContext({
+        charges: [txCharge('tx-1'), docCharge('doc-1'), txCharge('tx-2')],
+      });
+
+      const result = await resolve(
+        null,
+        { ...baseArgs, mode: 'TRANSACTION_BASE' },
+        { injector },
+        null,
+      );
+
+      expect(result.baseCharges.map(c => c.baseCharge.id)).toEqual(['tx-1', 'tx-2']);
+    });
+  });
+
+  describe('BY_DATE path', () => {
+    it('should evaluate scores only for the requested page (limit + offset applied before scoring)', async () => {
+      const charges = Array.from({ length: 10 }, (_, i) => txCharge(`charge-${i}`));
+      const { injector, evaluateMatchesForCharges } = createTestContext({ charges });
+
+      const result = await resolve(null, { ...baseArgs, limit: 3, offset: 4 }, { injector }, null);
+
+      expect(evaluateMatchesForCharges).toHaveBeenCalledTimes(1);
+      expect(
+        (evaluateMatchesForCharges.mock.calls[0][0] as { id: string }[]).map(c => c.id),
+      ).toEqual(['charge-4', 'charge-5', 'charge-6']);
+      expect(result.baseCharges.map(c => c.baseCharge.id)).toEqual([
+        'charge-4',
+        'charge-5',
+        'charge-6',
+      ]);
+      expect(result.totalCount).toBe(10);
+    });
+
+    it('should return different rows for subsequent pages', async () => {
+      const charges = Array.from({ length: 6 }, (_, i) => txCharge(`charge-${i}`));
+      const { injector } = createTestContext({ charges });
+
+      const page1 = await resolve(null, { ...baseArgs, limit: 2, offset: 0 }, { injector }, null);
+      const page2 = await resolve(null, { ...baseArgs, limit: 2, offset: 2 }, { injector }, null);
+
+      expect(page1.baseCharges.map(c => c.baseCharge.id)).toEqual(['charge-0', 'charge-1']);
+      expect(page2.baseCharges.map(c => c.baseCharge.id)).toEqual(['charge-2', 'charge-3']);
+    });
+
+    it('should return an empty page when offset exceeds the queue length', async () => {
+      const { injector, evaluateMatchesForCharges } = createTestContext({
+        charges: [txCharge('charge-0')],
+      });
+
+      const result = await resolve(null, { ...baseArgs, limit: 5, offset: 10 }, { injector }, null);
+
+      expect(result.baseCharges).toEqual([]);
+      expect(result.totalCount).toBe(1);
+      expect(evaluateMatchesForCharges).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('BY_SCORE path', () => {
+    it('should cap the evaluated window, sort by top suggestion score desc, then slice the page', async () => {
+      const charges = Array.from({ length: BY_SCORE_EVALUATION_CAP + 50 }, (_, i) =>
+        txCharge(`charge-${i}`),
+      );
+      const suggestionsById: Record<string, ChargeMatchProto[]> = {
+        'charge-0': [{ chargeId: 'm-0', confidenceScore: 0.5 }],
+        'charge-1': [{ chargeId: 'm-1', confidenceScore: 0.99 }],
+        'charge-2': [{ chargeId: 'm-2', confidenceScore: 0.75 }],
+      };
+      const { injector, evaluateMatchesForCharges } = createTestContext({
+        charges,
+        suggestionsById,
+      });
+
+      const result = await resolve(
+        null,
+        { ...baseArgs, sortBy: 'BY_SCORE', limit: 3, offset: 0 },
+        { injector },
+        null,
+      );
+
+      // Evaluated exactly the capped window, in one call
+      expect(evaluateMatchesForCharges).toHaveBeenCalledTimes(1);
+      expect(evaluateMatchesForCharges.mock.calls[0][0]).toHaveLength(BY_SCORE_EVALUATION_CAP);
+      // Highest scoring first
+      expect(result.baseCharges.map(c => c.baseCharge.id)).toEqual([
+        'charge-1',
+        'charge-2',
+        'charge-0',
+      ]);
+      // Pagination happens over the derived (capped) list
+      expect(result.totalCount).toBe(BY_SCORE_EVALUATION_CAP);
+    });
+
+    it('should apply limit/offset AFTER sorting the whole evaluated window', async () => {
+      const charges = Array.from({ length: 5 }, (_, i) => txCharge(`charge-${i}`));
+      const suggestionsById: Record<string, ChargeMatchProto[]> = {
+        'charge-0': [{ chargeId: 'm', confidenceScore: 0.1 }],
+        'charge-1': [{ chargeId: 'm', confidenceScore: 0.9 }],
+        'charge-2': [{ chargeId: 'm', confidenceScore: 0.5 }],
+        'charge-3': [{ chargeId: 'm', confidenceScore: 0.7 }],
+        'charge-4': [{ chargeId: 'm', confidenceScore: 0.3 }],
+      };
+      const { injector } = createTestContext({ charges, suggestionsById });
+
+      const result = await resolve(
+        null,
+        { ...baseArgs, sortBy: 'BY_SCORE', limit: 2, offset: 2 },
+        { injector },
+        null,
+      );
+
+      // Sorted order: charge-1 (0.9), charge-3 (0.7), charge-2 (0.5), charge-4 (0.3), charge-0 (0.1)
+      expect(result.baseCharges.map(c => c.baseCharge.id)).toEqual(['charge-2', 'charge-4']);
+      expect(result.totalCount).toBe(5);
+    });
+
+    it('should rank charges without suggestions last, preserving recency order between them', async () => {
+      const charges = [txCharge('charge-0'), txCharge('charge-1'), txCharge('charge-2')];
+      const suggestionsById: Record<string, ChargeMatchProto[]> = {
+        'charge-1': [{ chargeId: 'm', confidenceScore: 0.4 }],
+      };
+      const { injector } = createTestContext({ charges, suggestionsById });
+
+      const result = await resolve(null, { ...baseArgs, sortBy: 'BY_SCORE' }, { injector }, null);
+
+      expect(result.baseCharges.map(c => c.baseCharge.id)).toEqual([
+        'charge-1',
+        'charge-0',
+        'charge-2',
+      ]);
+    });
+  });
+});

--- a/packages/server/src/modules/charges-matcher/helpers/awaiting-match-queue.helper.ts
+++ b/packages/server/src/modules/charges-matcher/helpers/awaiting-match-queue.helper.ts
@@ -1,0 +1,75 @@
+import type { ChargesMatcherModule } from '../types.js';
+
+type ChargeMatchQueueMode = ChargesMatcherModule.ChargeMatchQueueMode;
+
+/**
+ * Max number of charges evaluated when sorting the queue BY_SCORE. Scoring is
+ * calculated on the fly and each pass loads candidates, transactions and
+ * documents, so the evaluation window is deliberately capped to bound request
+ * latency and DB load.
+ */
+export const BY_SCORE_EVALUATION_CAP = 100;
+
+/**
+ * The subset of enriched charge fields the queue filtering relies on.
+ * Counts are int8 aggregates, surfaced by pgtyped as strings.
+ */
+export interface QueueChargeCounts {
+  transactions_count: string | null;
+  invoices_count: string | null;
+  receipts_count: string | null;
+}
+
+function hasTransactions(charge: QueueChargeCounts): boolean {
+  return Number(charge.transactions_count ?? 0) > 0;
+}
+
+function hasReceiptDocuments(charge: QueueChargeCounts): boolean {
+  return Number(charge.receipts_count ?? 0) > 0;
+}
+
+function hasAccountingDocuments(charge: QueueChargeCounts): boolean {
+  return Number(charge.invoices_count ?? 0) > 0 || hasReceiptDocuments(charge);
+}
+
+/**
+ * A charge is transaction-based when it has transactions but no receipt
+ * documents (mirrors the auto-match unmatched-charge semantics)
+ */
+export function isTransactionBaseCharge(charge: QueueChargeCounts): boolean {
+  return hasTransactions(charge) && !hasReceiptDocuments(charge);
+}
+
+/**
+ * A charge is document-based when it has accounting documents but no
+ * transactions
+ */
+export function isDocumentBaseCharge(charge: QueueChargeCounts): boolean {
+  return !hasTransactions(charge) && hasAccountingDocuments(charge);
+}
+
+/**
+ * A charge belongs in the awaiting-match queue when it is unmatched:
+ * transaction-based XOR document-based. Charges with both sides (matched) or
+ * neither (empty) are excluded.
+ */
+export function isUnmatchedBaseCharge(charge: QueueChargeCounts): boolean {
+  return isTransactionBaseCharge(charge) || isDocumentBaseCharge(charge);
+}
+
+/**
+ * Apply the optional queue mode filter on top of the unmatched check
+ */
+export function matchesQueueMode(
+  charge: QueueChargeCounts,
+  mode?: ChargeMatchQueueMode | null,
+): boolean {
+  switch (mode) {
+    case 'DOC_BASE':
+      return isDocumentBaseCharge(charge);
+    case 'TRANSACTION_BASE':
+      return isTransactionBaseCharge(charge);
+    default:
+      return isUnmatchedBaseCharge(charge);
+  }
+}

--- a/packages/server/src/modules/charges-matcher/resolvers/charges-awaiting-match-queue.resolver.ts
+++ b/packages/server/src/modules/charges-matcher/resolvers/charges-awaiting-match-queue.resolver.ts
@@ -1,0 +1,70 @@
+import { GraphQLError } from 'graphql';
+import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { ChargesProvider } from '../../charges/providers/charges.provider.js';
+import {
+  BY_SCORE_EVALUATION_CAP,
+  matchesQueueMode,
+} from '../helpers/awaiting-match-queue.helper.js';
+import { QueueMatchEvaluatorProvider } from '../providers/queue-match-evaluator.provider.js';
+import type { ChargesMatcherModule } from '../types.js';
+
+export const chargesAwaitingMatchQueueResolver: ChargesMatcherModule.Resolvers = {
+  Query: {
+    chargesAwaitingMatchQueue: async (
+      _,
+      { limit, offset, businessId, fromDate, toDate, mode, sortBy },
+      { injector },
+    ) => {
+      try {
+        // Tenant scoping: only ever fetch charges of the verified admin owner,
+        // so a requested businessId can't leak other tenants' data
+        const { ownerId } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+
+        // Most recent first (default sort of getChargesByFilters)
+        const charges = await injector.get(ChargesProvider).getChargesByFilters({
+          ownerIds: [ownerId],
+          businessIds: businessId ? [businessId] : undefined,
+          fromDate,
+          toDate,
+        });
+
+        const queue = charges.filter(charge => matchesQueueMode(charge, mode));
+
+        const safeLimit = Math.max(0, limit ?? 20);
+        const safeOffset = Math.max(0, offset ?? 0);
+        const evaluator = injector.get(QueueMatchEvaluatorProvider);
+
+        if (sortBy === 'BY_SCORE') {
+          // Evaluate the capped window of most recent charges, sort the whole
+          // derived list by top confidence score, and paginate that list
+          const window = queue.slice(0, BY_SCORE_EVALUATION_CAP);
+          const evaluated = await evaluator.evaluateMatchesForCharges(window);
+          const topScore = (suggestions: { confidenceScore: number }[]): number =>
+            suggestions[0]?.confidenceScore ?? 0;
+          const sorted = evaluated.toSorted(
+            (a, b) => topScore(b.suggestions) - topScore(a.suggestions),
+          );
+          return {
+            baseCharges: sorted.slice(safeOffset, safeOffset + safeLimit),
+            totalCount: window.length,
+          };
+        }
+
+        // BY_DATE (default): paginate first, then lazily evaluate scores for
+        // the requested page only
+        const page = queue.slice(safeOffset, safeOffset + safeLimit);
+        const baseCharges = await evaluator.evaluateMatchesForCharges(page);
+        return {
+          baseCharges,
+          totalCount: queue.length,
+        };
+      } catch (e) {
+        if (e instanceof GraphQLError) {
+          throw e;
+        }
+        const message = (e as Error)?.message ?? 'Unknown error';
+        throw new GraphQLError(`Failed to fetch charges awaiting match: ${message}`);
+      }
+    },
+  },
+};

--- a/packages/server/src/modules/charges-matcher/resolvers/index.ts
+++ b/packages/server/src/modules/charges-matcher/resolvers/index.ts
@@ -1,11 +1,13 @@
 import { ChargesProvider } from '../../charges/providers/charges.provider.js';
 import type { ChargesMatcherModule } from '../types.js';
 import { autoMatchChargesResolver } from './auto-match-charges.resolver.js';
+import { chargesAwaitingMatchQueueResolver } from './charges-awaiting-match-queue.resolver.js';
 import { findChargeMatchesResolver } from './find-charge-matches.resolver.js';
 
 export const chargesMatcherResolvers: ChargesMatcherModule.Resolvers = {
   Query: {
     ...findChargeMatchesResolver.Query,
+    ...chargesAwaitingMatchQueueResolver.Query,
   },
   Mutation: {
     ...autoMatchChargesResolver.Mutation,

--- a/packages/server/src/modules/charges-matcher/typeDefs/charges-matcher.graphql.ts
+++ b/packages/server/src/modules/charges-matcher/typeDefs/charges-matcher.graphql.ts
@@ -52,7 +52,7 @@ export default gql`
   type ChargesAwaitingMatchResult {
     " The requested page of unmatched base charges, each with its match suggestions "
     baseCharges: [ChargeWithSuggestions!]!
-    " Total number of unmatched base charges that satisfy the filters "
+    " Total number of unmatched base charges available for pagination. When sorting BY_SCORE, capped at the 100-charge evaluation window "
     totalCount: Int!
   }
 


### PR DESCRIPTION
Step 3 of the [matching-screen plan](https://github.com/Urigo/accounter-fullstack/blob/matching-screen/docs/matching-screen/prompt_plan.md) (Prompt 3: Backend Resolver Implementation). Stacked on #3897.

## What

Implements the `chargesAwaitingMatchQueue` resolver on top of the step-2 `QueueMatchEvaluatorProvider`:

- **Auth/tenancy**: verified admin context scopes the DB fetch to the owner's charges (`ownerIds: [ownerId]`), so a requested `businessId` can only filter within the caller's own tenant; `@requiresAuth` already guards the field at the schema level
- **Filters**: `businessId`, `fromDate`/`toDate` passed to `ChargesProvider.getChargesByFilters` (the same enriched query `allCharges` uses); unmatched detection (tx-only XOR doc-only, mirroring auto-match semantics) and `DOC_BASE`/`TRANSACTION_BASE` mode filtering applied on the enriched counts in a dedicated helper
- **`BY_DATE` path**: applies `limit` **and `offset`** first, then lazily scores only the requested page
- **`BY_SCORE` path**: evaluates the 100 most recent unmatched charges (`BY_SCORE_EVALUATION_CAP`), sorts the whole derived list by top suggestion confidence descending, and only then applies the `limit`/`offset` slice; charges without suggestions rank last
- `totalCount` reflects the paginable set (full filtered count for `BY_DATE`, capped window for `BY_SCORE`) — schema doc updated accordingly
- Resolver wired into the module's resolver index

## Tests (TDD)

`charges-awaiting-match-queue.test.ts` — 11 unit tests isolating the two sorting paths with mocked injector/providers: filter passthrough + tenant scoping, unmatched/mode filtering, page-only scoring and offset paging for `BY_DATE` (subsequent pages return different rows), cap + sort-then-slice + capped `totalCount` for `BY_SCORE`.

## Verification

- `yarn vitest run --project unit` on the module — 515/515 pass
- `yarn workspace @accounter/server build` (tsc) passes
- `yarn generate`, `yarn lint`, `yarn prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBQoeDJraws6oq8cyxPri3

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBQoeDJraws6oq8cyxPri3)_