### PR TITLE
feat(client): matching screen step 4 — queue query + useChargeMatchQueue hook

### DIFF
--- a/packages/client/src/components/charge-matching/queue-query.graphql.ts
+++ b/packages/client/src/components/charge-matching/queue-query.graphql.ts
@@ -67,6 +67,7 @@
     ) {
       totalCount
       baseCharges {
+        id
         baseCharge {
           ...ChargeMatchCardFields
         }

--- a/packages/client/src/components/charge-matching/queue-query.graphql.ts
+++ b/packages/client/src/components/charge-matching/queue-query.graphql.ts
@@ -1,0 +1,83 @@
+// GraphQL operations for the charge matching review screen.
+// The MergeCharges mutation is NOT defined here on purpose — it already exists
+// in `src/hooks/use-merge-charges.ts` and is reused via the useMergeCharges hook.
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  fragment ChargeMatchCardFields on Charge {
+    __typename
+    id
+    minEventDate
+    minDebitDate
+    minDocumentsDate
+    totalAmount {
+      raw
+      formatted
+      currency
+    }
+    counterparty {
+      id
+      name
+    }
+    userDescription
+    additionalDocuments {
+      id
+      documentType
+      image
+      file
+    }
+    transactions {
+      id
+      eventDate
+      sourceDescription
+      amount {
+        raw
+        formatted
+      }
+    }
+    miscExpenses {
+      id
+      description
+      amount {
+        formatted
+      }
+    }
+  }
+`;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  query ChargesAwaitingMatchQueue(
+    $limit: Int
+    $offset: Int
+    $businessId: UUID
+    $fromDate: TimelessDate
+    $toDate: TimelessDate
+    $mode: ChargeMatchQueueMode
+    $sortBy: ChargeMatchQueueSortBy
+  ) {
+    chargesAwaitingMatchQueue(
+      limit: $limit
+      offset: $offset
+      businessId: $businessId
+      fromDate: $fromDate
+      toDate: $toDate
+      mode: $mode
+      sortBy: $sortBy
+    ) {
+      totalCount
+      baseCharges {
+        baseCharge {
+          ...ChargeMatchCardFields
+        }
+        suggestions {
+          chargeId
+          confidenceScore
+          charge {
+            ...ChargeMatchCardFields
+          }
+        }
+      }
+    }
+  }
+`;

--- a/packages/client/src/hooks/__tests__/use-charge-match-queue.test.ts
+++ b/packages/client/src/hooks/__tests__/use-charge-match-queue.test.ts
@@ -155,4 +155,22 @@ describe('useChargeMatchQueue', () => {
 
     await cleanup();
   });
+
+  it('does not reset state when a new array reference holds the same items (parent re-render)', async () => {
+    const { current, rerender, cleanup } = await renderQueueHarness(ITEMS);
+
+    await act(async () => {
+      current().skipItem('a');
+    });
+    expect(current().activeIndex).toBe(1);
+
+    const sameItemsNewRef: Item[] = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+    await rerender(sameItemsNewRef);
+
+    expect(current().activeIndex).toBe(1);
+    expect(current().activeItem).toEqual({ id: 'b' });
+    expect(current().statusById.a).toBe('skipped');
+
+    await cleanup();
+  });
 });

--- a/packages/client/src/hooks/__tests__/use-charge-match-queue.test.ts
+++ b/packages/client/src/hooks/__tests__/use-charge-match-queue.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { describe, expect, it } from 'vitest';
+import {
+  useChargeMatchQueue,
+  type UseChargeMatchQueue,
+} from '../use-charge-match-queue.js';
+
+type Item = { id: string; label?: string };
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function renderQueueHarness(initialItems: Item[]) {
+  const container = document.createElement('div');
+  document.body.append(container);
+
+  let latest: UseChargeMatchQueue<Item> | null = null;
+
+  function Harness({ items }: { items: Item[] }): null {
+    latest = useChargeMatchQueue(items);
+    return null;
+  }
+
+  let root: Root | null = null;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(React.createElement(Harness, { items: initialItems }));
+    await Promise.resolve();
+  });
+
+  const rerender = async (items: Item[]) => {
+    await act(async () => {
+      root?.render(React.createElement(Harness, { items }));
+      await Promise.resolve();
+    });
+  };
+
+  const cleanup = async () => {
+    await act(async () => {
+      root?.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+  };
+
+  const current = () => {
+    if (!latest) {
+      throw new Error('Hook value not captured');
+    }
+    return latest;
+  };
+
+  return { current, rerender, cleanup };
+}
+
+const ITEMS: Item[] = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+describe('useChargeMatchQueue', () => {
+  it('maintains the items array with the first item active and all statuses pending', async () => {
+    const { current, cleanup } = await renderQueueHarness(ITEMS);
+
+    expect(current().items).toEqual(ITEMS);
+    expect(current().activeIndex).toBe(0);
+    expect(current().activeItem).toEqual({ id: 'a' });
+    expect(current().isDone).toBe(false);
+    expect(current().statusById).toEqual({ a: 'pending', b: 'pending', c: 'pending' });
+
+    await cleanup();
+  });
+
+  it('skipItem flags the id as skipped and increments activeIndex', async () => {
+    const { current, cleanup } = await renderQueueHarness(ITEMS);
+
+    await act(async () => {
+      current().skipItem('a');
+    });
+
+    expect(current().statusById.a).toBe('skipped');
+    expect(current().activeIndex).toBe(1);
+    expect(current().activeItem).toEqual({ id: 'b' });
+
+    await cleanup();
+  });
+
+  it('acceptItemStatus with success flags the id as matched and increments activeIndex', async () => {
+    const { current, cleanup } = await renderQueueHarness(ITEMS);
+
+    await act(async () => {
+      current().acceptItemStatus('a', true);
+    });
+
+    expect(current().statusById.a).toBe('matched');
+    expect(current().activeIndex).toBe(1);
+    expect(current().activeItem).toEqual({ id: 'b' });
+
+    await cleanup();
+  });
+
+  it('acceptItemStatus with failure keeps the active item and status untouched', async () => {
+    const { current, cleanup } = await renderQueueHarness(ITEMS);
+
+    await act(async () => {
+      current().acceptItemStatus('a', false);
+    });
+
+    expect(current().statusById.a).toBe('pending');
+    expect(current().activeIndex).toBe(0);
+    expect(current().activeItem).toEqual({ id: 'a' });
+
+    await cleanup();
+  });
+
+  it('marks the queue as done once every item was resolved', async () => {
+    const { current, cleanup } = await renderQueueHarness(ITEMS);
+
+    await act(async () => {
+      current().skipItem('a');
+    });
+    await act(async () => {
+      current().acceptItemStatus('b', true);
+    });
+    await act(async () => {
+      current().skipItem('c');
+    });
+
+    expect(current().isDone).toBe(true);
+    expect(current().activeItem).toBeNull();
+    expect(current().statusById).toEqual({ a: 'skipped', b: 'matched', c: 'skipped' });
+
+    await cleanup();
+  });
+
+  it('resets index and statuses when a new items array arrives (e.g. filters changed)', async () => {
+    const { current, rerender, cleanup } = await renderQueueHarness(ITEMS);
+
+    await act(async () => {
+      current().skipItem('a');
+    });
+    expect(current().activeIndex).toBe(1);
+
+    const nextItems: Item[] = [{ id: 'x' }, { id: 'y' }];
+    await rerender(nextItems);
+
+    expect(current().items).toEqual(nextItems);
+    expect(current().activeIndex).toBe(0);
+    expect(current().activeItem).toEqual({ id: 'x' });
+    expect(current().statusById).toEqual({ x: 'pending', y: 'pending' });
+
+    await cleanup();
+  });
+});

--- a/packages/client/src/hooks/use-charge-match-queue.ts
+++ b/packages/client/src/hooks/use-charge-match-queue.ts
@@ -1,0 +1,87 @@
+import { useCallback, useMemo, useState } from 'react';
+
+export type ChargeMatchItemStatus = 'pending' | 'matched' | 'skipped';
+
+export type UseChargeMatchQueue<TItem extends { id: string }> = {
+  /** The queue of base charges under review, in queue order */
+  items: TItem[];
+  /** Index of the currently viewed base charge */
+  activeIndex: number;
+  /** The currently viewed base charge, or null once the queue is exhausted */
+  activeItem: TItem | null;
+  /** True when the user stepped past the last item */
+  isDone: boolean;
+  /** Session-only status per item id (no backend persistence) */
+  statusById: Record<string, ChargeMatchItemStatus>;
+  /** Flag an item as skipped and advance to the next one */
+  skipItem: (id: string) => void;
+  /**
+   * Report the merge outcome for an item: on success it is flagged as matched
+   * and the queue advances; on failure nothing changes so the user can retry
+   */
+  acceptItemStatus: (id: string, success: boolean) => void;
+};
+
+/**
+ * Local (session-only) state management for the charge matching review queue:
+ * tracks the active item and each item's pending/matched/skipped status.
+ *
+ * State resets whenever a new `items` array arrives (new page or filters).
+ */
+export function useChargeMatchQueue<TItem extends { id: string }>(
+  items: TItem[],
+): UseChargeMatchQueue<TItem> {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [overrides, setOverrides] = useState<Record<string, ChargeMatchItemStatus>>({});
+
+  // Reset session state when the queue itself is replaced (render-phase
+  // adjustment, per React's "storing information from previous renders")
+  const [prevItems, setPrevItems] = useState(items);
+  if (items !== prevItems) {
+    setPrevItems(items);
+    setActiveIndex(0);
+    setOverrides({});
+  }
+
+  const statusById = useMemo(() => {
+    const statuses: Record<string, ChargeMatchItemStatus> = {};
+    for (const item of items) {
+      statuses[item.id] = overrides[item.id] ?? 'pending';
+    }
+    return statuses;
+  }, [items, overrides]);
+
+  const advance = useCallback(() => {
+    setActiveIndex(index => Math.min(index + 1, items.length));
+  }, [items.length]);
+
+  const skipItem = useCallback(
+    (id: string) => {
+      setOverrides(prev => ({ ...prev, [id]: 'skipped' }));
+      advance();
+    },
+    [advance],
+  );
+
+  const acceptItemStatus = useCallback(
+    (id: string, success: boolean) => {
+      if (!success) {
+        // Merge failed: stay on the same charge so the user can retry or skip
+        return;
+      }
+      setOverrides(prev => ({ ...prev, [id]: 'matched' }));
+      advance();
+    },
+    [advance],
+  );
+
+  return {
+    items,
+    activeIndex,
+    activeItem: items[activeIndex] ?? null,
+    isDone: activeIndex >= items.length,
+    statusById,
+    skipItem,
+    acceptItemStatus,
+  };
+}

--- a/packages/client/src/hooks/use-charge-match-queue.ts
+++ b/packages/client/src/hooks/use-charge-match-queue.ts
@@ -35,9 +35,14 @@ export function useChargeMatchQueue<TItem extends { id: string }>(
   const [overrides, setOverrides] = useState<Record<string, ChargeMatchItemStatus>>({});
 
   // Reset session state when the queue itself is replaced (render-phase
-  // adjustment, per React's "storing information from previous renders")
+  // adjustment, per React's "storing information from previous renders").
+  // Items are compared by id rather than reference, so a parent re-render
+  // that rebuilds an identical array doesn't wipe the user's progress
   const [prevItems, setPrevItems] = useState(items);
-  if (items !== prevItems) {
+  const itemsChanged =
+    items.length !== prevItems.length ||
+    items.some((item, index) => item.id !== prevItems[index]?.id);
+  if (itemsChanged) {
     setPrevItems(items);
     setActiveIndex(0);
     setOverrides({});


### PR DESCRIPTION
Step 4 of the [matching-screen plan](https://github.com/Urigo/accounter-fullstack/blob/matching-screen/docs/matching-screen/prompt_plan.md) (Prompt 4: Client CodeGen & State Management Hook). Stacked on #3898.

## What

- **GraphQL operations** (`components/charge-matching/queue-query.graphql.ts`, matching the repo's `**/*.graphql.ts` codegen glob): `ChargesAwaitingMatchQueue` query with a shared `ChargeMatchCardFields` fragment covering the spec's data contract — dates, amount + currency, counterparty, description, document `image`/`file`/type, nested transactions, and misc expenses (for the extension panel). Per the plan, the `MergeCharges` mutation is **not** redefined — the existing `useMergeCharges` hook will be reused in step 7
- **`useChargeMatchQueue` hook** (`hooks/use-charge-match-queue.ts`): session-only queue state — `items`, `activeIndex`/`activeItem`, `statusById` (`pending`/`matched`/`skipped`), `isDone`; `skipItem(id)` flags + advances; `acceptItemStatus(id, success)` flags matched + advances only on success (failure keeps the user on the same charge, per the spec's error-handling rules); state resets when a new `items` array arrives (page/filter change)

## Tests (TDD)

`hooks/__tests__/use-charge-match-queue.test.ts` — 6 unit tests (happy-dom, same harness style as `use-logout.test.ts`): initial state, skip advance, accept-success advance, accept-failure no-op, queue completion, reset on new items.

## Verification

- `yarn vitest run --project unit` on the hook test — 6/6 pass
- `yarn generate` picks the operation up (document present in `src/gql/`); `yarn graphql:validate` — all documents valid
- `yarn workspace @accounter/client build` passes; lint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBQoeDJraws6oq8cyxPri3

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBQoeDJraws6oq8cyxPri3)_