### PR TITLE
feat(client): matching screen step 5 — UI scaffold, header & sidebar

### DIFF
--- a/packages/client/src/components/charge-matching/charge-matching-header.tsx
+++ b/packages/client/src/components/charge-matching/charge-matching-header.tsx
@@ -68,6 +68,7 @@ export const ChargeMatchingHeader = ({ filters, onFiltersChange }: Props): React
             id="charge-matching-from-date"
             type="date"
             className="w-40"
+            max={filters.toDate ?? undefined}
             value={filters.fromDate ?? ''}
             onChange={event =>
               update({ fromDate: (event.target.value as TimelessDateString) || null })
@@ -80,6 +81,7 @@ export const ChargeMatchingHeader = ({ filters, onFiltersChange }: Props): React
             id="charge-matching-to-date"
             type="date"
             className="w-40"
+            min={filters.fromDate ?? undefined}
             value={filters.toDate ?? ''}
             onChange={event =>
               update({ toDate: (event.target.value as TimelessDateString) || null })

--- a/packages/client/src/components/charge-matching/charge-matching-header.tsx
+++ b/packages/client/src/components/charge-matching/charge-matching-header.tsx
@@ -1,0 +1,126 @@
+import { type ReactElement } from 'react';
+import { Info } from 'lucide-react';
+import { ChargeMatchQueueMode, ChargeMatchQueueSortBy } from '../../gql/graphql.js';
+import type { TimelessDateString } from '../../helpers/dates.js';
+import { useGetBusinesses } from '../../hooks/use-get-businesses.js';
+import { ComboBox } from '../common/index.js';
+import { Alert, AlertDescription } from '../ui/alert.js';
+import { Input } from '../ui/input.js';
+import { Label } from '../ui/label.js';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select.js';
+import { Tabs, TabsList, TabsTrigger } from '../ui/tabs.js';
+
+export type ChargeMatchingFilters = {
+  businessId: string | null;
+  fromDate: TimelessDateString | null;
+  toDate: TimelessDateString | null;
+  mode: ChargeMatchQueueMode | null;
+  sortBy: ChargeMatchQueueSortBy;
+};
+
+export const DEFAULT_CHARGE_MATCHING_FILTERS: ChargeMatchingFilters = {
+  businessId: null,
+  fromDate: null,
+  toDate: null,
+  mode: null,
+  sortBy: ChargeMatchQueueSortBy.ByDate,
+};
+
+const MODE_ALL = 'ALL';
+
+type Props = {
+  filters: ChargeMatchingFilters;
+  onFiltersChange: (filters: ChargeMatchingFilters) => void;
+};
+
+export const ChargeMatchingHeader = ({ filters, onFiltersChange }: Props): ReactElement => {
+  const { selectableBusinesses, fetching: fetchingBusinesses } = useGetBusinesses();
+
+  const update = (patch: Partial<ChargeMatchingFilters>): void => {
+    onFiltersChange({ ...filters, ...patch });
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-end gap-4">
+        {/* Filters group */}
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="charge-matching-mode">Mode</Label>
+          <Select
+            value={filters.mode ?? MODE_ALL}
+            onValueChange={value =>
+              update({ mode: value === MODE_ALL ? null : (value as ChargeMatchQueueMode) })
+            }
+          >
+            <SelectTrigger id="charge-matching-mode" className="w-44">
+              <SelectValue placeholder="All" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={MODE_ALL}>All</SelectItem>
+              <SelectItem value={ChargeMatchQueueMode.DocBase}>Doc Base</SelectItem>
+              <SelectItem value={ChargeMatchQueueMode.TransactionBase}>Transaction Base</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="charge-matching-from-date">From</Label>
+          <Input
+            id="charge-matching-from-date"
+            type="date"
+            className="w-40"
+            value={filters.fromDate ?? ''}
+            onChange={event =>
+              update({ fromDate: (event.target.value as TimelessDateString) || null })
+            }
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="charge-matching-to-date">To</Label>
+          <Input
+            id="charge-matching-to-date"
+            type="date"
+            className="w-40"
+            value={filters.toDate ?? ''}
+            onChange={event =>
+              update({ toDate: (event.target.value as TimelessDateString) || null })
+            }
+          />
+        </div>
+        <div className="flex flex-col gap-1 min-w-52">
+          <Label>Business</Label>
+          <ComboBox
+            data={selectableBusinesses}
+            disabled={fetchingBusinesses}
+            placeholder="All businesses"
+            value={filters.businessId}
+            onChange={businessId => update({ businessId })}
+          />
+        </div>
+
+        {/* Sort toggle group (separate from the mode filter) */}
+        <div className="flex flex-col gap-1 ml-auto">
+          <Label>Sort by</Label>
+          <Tabs
+            value={filters.sortBy}
+            onValueChange={value => update({ sortBy: value as ChargeMatchQueueSortBy })}
+          >
+            <TabsList>
+              <TabsTrigger value={ChargeMatchQueueSortBy.ByDate}>Date</TabsTrigger>
+              <TabsTrigger value={ChargeMatchQueueSortBy.ByScore}>Match Score</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+      </div>
+
+      {filters.sortBy === ChargeMatchQueueSortBy.ByScore && (
+        <Alert>
+          <Info className="size-4" />
+          <AlertDescription>
+            Note: Score-based sorting currently evaluates only the 100 most recent unmatched
+            charges.
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+};

--- a/packages/client/src/components/charge-matching/charge-matching-sidebar.tsx
+++ b/packages/client/src/components/charge-matching/charge-matching-sidebar.tsx
@@ -1,0 +1,91 @@
+import { type ReactElement } from 'react';
+import { CheckCircle2, Circle, CircleSlash, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import type { ChargeMatchItemStatus } from '../../hooks/use-charge-match-queue.js';
+import { cn } from '../../lib/utils.js';
+import { Button } from '../ui/button.js';
+import { ScrollArea } from '../ui/scroll-area.js';
+
+export type ChargeMatchingSidebarItem = {
+  id: string;
+  title: string;
+  subtitle?: string;
+  amount?: string;
+};
+
+type Props = {
+  items: ChargeMatchingSidebarItem[];
+  statusById: Record<string, ChargeMatchItemStatus>;
+  activeId: string | null;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+};
+
+function StatusIcon({ status }: { status: ChargeMatchItemStatus }): ReactElement {
+  switch (status) {
+    case 'matched':
+      return <CheckCircle2 className="size-4 shrink-0 text-green-600" aria-label="Matched" />;
+    case 'skipped':
+      return <CircleSlash className="size-4 shrink-0 text-gray-400" aria-label="Skipped" />;
+    default:
+      return <Circle className="size-4 shrink-0 text-gray-300" aria-label="Pending" />;
+  }
+}
+
+export const ChargeMatchingSidebar = ({
+  items,
+  statusById,
+  activeId,
+  collapsed,
+  onToggleCollapsed,
+}: Props): ReactElement => {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-2 border-r pr-3 transition-all',
+        collapsed ? 'w-10' : 'w-72 shrink-0',
+      )}
+    >
+      <div className="flex items-center justify-between">
+        {!collapsed && <h3 className="text-sm font-semibold">Awaiting Matches</h3>}
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onToggleCollapsed}
+          aria-label={collapsed ? 'Show sidebar' : 'Hide sidebar'}
+        >
+          {collapsed ? <PanelLeftOpen className="size-4" /> : <PanelLeftClose className="size-4" />}
+        </Button>
+      </div>
+      {!collapsed && (
+        <ScrollArea className="h-[calc(100vh-20rem)]">
+          <ul className="flex flex-col gap-1">
+            {items.map(item => {
+              const status = statusById[item.id] ?? 'pending';
+              return (
+                <li
+                  key={item.id}
+                  className={cn(
+                    'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm',
+                    item.id === activeId && 'bg-accent',
+                    status === 'skipped' && 'opacity-50',
+                  )}
+                >
+                  <StatusIcon status={status} />
+                  <div className="flex min-w-0 flex-col">
+                    <span className="truncate font-medium">{item.title}</span>
+                    <span className="truncate text-xs text-gray-500">
+                      {[item.subtitle, item.amount].filter(Boolean).join(' · ')}
+                    </span>
+                  </div>
+                </li>
+              );
+            })}
+            {items.length === 0 && (
+              <li className="px-2 py-1.5 text-sm text-gray-500">No charges awaiting match</li>
+            )}
+          </ul>
+        </ScrollArea>
+      )}
+    </div>
+  );
+};

--- a/packages/client/src/components/charge-matching/index.tsx
+++ b/packages/client/src/components/charge-matching/index.tsx
@@ -1,0 +1,173 @@
+import { useMemo, useState, type ReactElement } from 'react';
+import { useQuery } from 'urql';
+import {
+  ChargeMatchCardFieldsFragmentDoc,
+  ChargesAwaitingMatchQueueDocument,
+  type ChargeMatchCardFieldsFragment,
+  type ChargesAwaitingMatchQueueQuery,
+} from '../../gql/graphql.js';
+import { getFragmentData } from '../../gql/index.js';
+import { useChargeMatchQueue } from '../../hooks/use-charge-match-queue.js';
+import { PageLayout } from '../layout/page-layout.js';
+import { Alert, AlertDescription, AlertTitle } from '../ui/alert.js';
+import { Skeleton } from '../ui/skeleton.js';
+import {
+  ChargeMatchingHeader,
+  DEFAULT_CHARGE_MATCHING_FILTERS,
+  type ChargeMatchingFilters,
+} from './charge-matching-header.js';
+import {
+  ChargeMatchingSidebar,
+  type ChargeMatchingSidebarItem,
+} from './charge-matching-sidebar.js';
+
+export const QUEUE_PAGE_SIZE = 20;
+
+type QueueEntry =
+  ChargesAwaitingMatchQueueQuery['chargesAwaitingMatchQueue']['baseCharges'][number];
+
+export type ChargeMatchQueueItem = {
+  id: string;
+  baseCharge: ChargeMatchCardFieldsFragment;
+  suggestions: QueueEntry['suggestions'];
+};
+
+function chargeDate(charge: ChargeMatchCardFieldsFragment): string | undefined {
+  const raw = charge.minDocumentsDate ?? charge.minEventDate ?? charge.minDebitDate;
+  return raw ? new Date(raw).toLocaleDateString() : undefined;
+}
+
+function chargeTitle(charge: ChargeMatchCardFieldsFragment): string {
+  return charge.counterparty?.name ?? charge.userDescription ?? 'Unknown charge';
+}
+
+export const ChargeMatchingReviewScreen = (): ReactElement => {
+  const [filters, setFilters] = useState<ChargeMatchingFilters>(DEFAULT_CHARGE_MATCHING_FILTERS);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+
+  // Changing any filter updates the variables, which triggers a refetch
+  const [{ data, fetching, error }] = useQuery({
+    query: ChargesAwaitingMatchQueueDocument,
+    variables: {
+      limit: QUEUE_PAGE_SIZE,
+      offset: 0,
+      businessId: filters.businessId,
+      fromDate: filters.fromDate,
+      toDate: filters.toDate,
+      mode: filters.mode,
+      sortBy: filters.sortBy,
+    },
+  });
+
+  const items: ChargeMatchQueueItem[] = useMemo(
+    () =>
+      (data?.chargesAwaitingMatchQueue.baseCharges ?? []).map(entry => {
+        const baseCharge = getFragmentData(ChargeMatchCardFieldsFragmentDoc, entry.baseCharge);
+        return { id: baseCharge.id, baseCharge, suggestions: entry.suggestions };
+      }),
+    [data],
+  );
+
+  const queue = useChargeMatchQueue(items);
+
+  const sidebarItems: ChargeMatchingSidebarItem[] = useMemo(
+    () =>
+      items.map(item => ({
+        id: item.id,
+        title: chargeTitle(item.baseCharge),
+        subtitle: chargeDate(item.baseCharge),
+        amount: item.baseCharge.totalAmount?.formatted,
+      })),
+    [items],
+  );
+
+  const totalCount = data?.chargesAwaitingMatchQueue.totalCount ?? 0;
+  const { activeItem } = queue;
+  const topSuggestion = activeItem?.suggestions[0];
+  const topSuggestionCharge = topSuggestion
+    ? getFragmentData(ChargeMatchCardFieldsFragmentDoc, topSuggestion.charge)
+    : null;
+
+  return (
+    <PageLayout
+      title="Charge Matching"
+      description="Review and merge suggested charge matches, one by one."
+    >
+      <ChargeMatchingHeader filters={filters} onFiltersChange={setFilters} />
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertTitle>Failed to load the matching queue</AlertTitle>
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {fetching ? (
+        <div className="flex gap-4">
+          <Skeleton className="h-96 w-72" />
+          <Skeleton className="h-96 flex-1" />
+        </div>
+      ) : (
+        <div className="flex gap-4">
+          <ChargeMatchingSidebar
+            items={sidebarItems}
+            statusById={queue.statusById}
+            activeId={activeItem?.id ?? null}
+            collapsed={sidebarCollapsed}
+            onToggleCollapsed={() => setSidebarCollapsed(collapsed => !collapsed)}
+          />
+
+          <div className="flex min-w-0 flex-1 flex-col gap-4">
+            <p className="text-sm text-gray-500">
+              Showing {items.length} of {totalCount} charges awaiting match
+            </p>
+
+            {/* Split comparison view — detailed cards land in the next step */}
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+              <section className="rounded-lg border p-4">
+                <h3 className="mb-2 text-sm font-semibold text-gray-500">Base Charge</h3>
+                {activeItem ? (
+                  <div className="flex flex-col gap-1">
+                    <span className="font-medium">{chargeTitle(activeItem.baseCharge)}</span>
+                    <span className="text-sm text-gray-500">
+                      {[
+                        chargeDate(activeItem.baseCharge),
+                        activeItem.baseCharge.totalAmount?.formatted,
+                      ]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </span>
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">
+                    {items.length === 0 ? 'No charges awaiting match.' : 'Queue completed 🎉'}
+                  </p>
+                )}
+              </section>
+              <section className="rounded-lg border p-4">
+                <h3 className="mb-2 text-sm font-semibold text-gray-500">Suggested Match</h3>
+                {topSuggestionCharge ? (
+                  <div className="flex flex-col gap-1">
+                    <span className="font-medium">{chargeTitle(topSuggestionCharge)}</span>
+                    <span className="text-sm text-gray-500">
+                      {[chargeDate(topSuggestionCharge), topSuggestionCharge.totalAmount?.formatted]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </span>
+                    <span className="text-sm text-gray-500">
+                      Confidence: {Math.round((topSuggestion?.confidenceScore ?? 0) * 100)}%
+                    </span>
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">
+                    {activeItem ? 'No suggestions for this charge.' : '—'}
+                  </p>
+                )}
+              </section>
+            </div>
+          </div>
+        </div>
+      )}
+    </PageLayout>
+  );
+};

--- a/packages/client/src/components/charge-matching/index.tsx
+++ b/packages/client/src/components/charge-matching/index.tsx
@@ -34,7 +34,9 @@ export type ChargeMatchQueueItem = {
 
 function chargeDate(charge: ChargeMatchCardFieldsFragment): string | undefined {
   const raw = charge.minDocumentsDate ?? charge.minEventDate ?? charge.minDebitDate;
-  return raw ? new Date(raw).toLocaleDateString() : undefined;
+  // Date-only strings parse as UTC midnight; format in UTC so users in
+  // negative offsets don't see the previous day
+  return raw ? new Date(raw).toLocaleDateString(undefined, { timeZone: 'UTC' }) : undefined;
 }
 
 function chargeTitle(charge: ChargeMatchCardFieldsFragment): string {
@@ -107,7 +109,7 @@ export const ChargeMatchingReviewScreen = (): ReactElement => {
           <Skeleton className="h-96 w-72" />
           <Skeleton className="h-96 flex-1" />
         </div>
-      ) : (
+      ) : error ? null : (
         <div className="flex gap-4">
           <ChargeMatchingSidebar
             items={sidebarItems}

--- a/packages/client/src/components/layout/sidelinks.tsx
+++ b/packages/client/src/components/layout/sidelinks.tsx
@@ -68,6 +68,12 @@ export const sidelinks: SideLink[] = [
         href: ROUTES.CHARGES.LEDGER_VALIDATION,
         icon: <BookOpenCheck size={18} />,
       },
+      {
+        title: 'Charge Matching',
+        label: '',
+        href: ROUTES.CHARGES.MATCHING,
+        icon: <Puzzle size={18} />,
+      },
     ],
   },
   {

--- a/packages/client/src/hooks/__tests__/use-charge-match-queue.test.ts
+++ b/packages/client/src/hooks/__tests__/use-charge-match-queue.test.ts
@@ -156,6 +156,28 @@ describe('useChargeMatchQueue', () => {
     await cleanup();
   });
 
+  it('preserves progress when the item set changes, e.g. a merged charge drops out on refetch', async () => {
+    const { current, rerender, cleanup } = await renderQueueHarness(ITEMS);
+
+    await act(async () => {
+      current().skipItem('a');
+    });
+    await act(async () => {
+      current().acceptItemStatus('b', true);
+    });
+    expect(current().activeItem).toEqual({ id: 'c' });
+
+    // Refetch after the merge: charge "b" no longer exists in the queue
+    const refetchedItems: Item[] = [{ id: 'a' }, { id: 'c' }];
+    await rerender(refetchedItems);
+
+    expect(current().statusById).toEqual({ a: 'skipped', c: 'pending' });
+    expect(current().activeItem).toEqual({ id: 'c' });
+    expect(current().isDone).toBe(false);
+
+    await cleanup();
+  });
+
   it('does not reset state when a new array reference holds the same items (parent re-render)', async () => {
     const { current, rerender, cleanup } = await renderQueueHarness(ITEMS);
 

--- a/packages/client/src/hooks/use-charge-match-queue.ts
+++ b/packages/client/src/hooks/use-charge-match-queue.ts
@@ -9,7 +9,7 @@ export type UseChargeMatchQueue<TItem extends { id: string }> = {
   activeIndex: number;
   /** The currently viewed base charge, or null once the queue is exhausted */
   activeItem: TItem | null;
-  /** True when the user stepped past the last item */
+  /** True when every item in the queue was matched or skipped */
   isDone: boolean;
   /** Session-only status per item id (no backend persistence) */
   statusById: Record<string, ChargeMatchItemStatus>;
@@ -26,27 +26,15 @@ export type UseChargeMatchQueue<TItem extends { id: string }> = {
  * Local (session-only) state management for the charge matching review queue:
  * tracks the active item and each item's pending/matched/skipped status.
  *
- * State resets whenever a new `items` array arrives (new page or filters).
+ * The active item is derived as the first still-pending item rather than a
+ * stored index, so the user's position and session statuses survive query
+ * refetches — including refetches where the item set changes (e.g. a merged
+ * charge dropping out of the queue, or filters changing the page).
  */
 export function useChargeMatchQueue<TItem extends { id: string }>(
   items: TItem[],
 ): UseChargeMatchQueue<TItem> {
-  const [activeIndex, setActiveIndex] = useState(0);
   const [overrides, setOverrides] = useState<Record<string, ChargeMatchItemStatus>>({});
-
-  // Reset session state when the queue itself is replaced (render-phase
-  // adjustment, per React's "storing information from previous renders").
-  // Items are compared by id rather than reference, so a parent re-render
-  // that rebuilds an identical array doesn't wipe the user's progress
-  const [prevItems, setPrevItems] = useState(items);
-  const itemsChanged =
-    items.length !== prevItems.length ||
-    items.some((item, index) => item.id !== prevItems[index]?.id);
-  if (itemsChanged) {
-    setPrevItems(items);
-    setActiveIndex(0);
-    setOverrides({});
-  }
 
   const statusById = useMemo(() => {
     const statuses: Record<string, ChargeMatchItemStatus> = {};
@@ -56,29 +44,23 @@ export function useChargeMatchQueue<TItem extends { id: string }>(
     return statuses;
   }, [items, overrides]);
 
-  const advance = useCallback(() => {
-    setActiveIndex(index => Math.min(index + 1, items.length));
-  }, [items.length]);
-
-  const skipItem = useCallback(
-    (id: string) => {
-      setOverrides(prev => ({ ...prev, [id]: 'skipped' }));
-      advance();
-    },
-    [advance],
+  const firstPendingIndex = useMemo(
+    () => items.findIndex(item => (overrides[item.id] ?? 'pending') === 'pending'),
+    [items, overrides],
   );
+  const activeIndex = firstPendingIndex === -1 ? items.length : firstPendingIndex;
 
-  const acceptItemStatus = useCallback(
-    (id: string, success: boolean) => {
-      if (!success) {
-        // Merge failed: stay on the same charge so the user can retry or skip
-        return;
-      }
-      setOverrides(prev => ({ ...prev, [id]: 'matched' }));
-      advance();
-    },
-    [advance],
-  );
+  const skipItem = useCallback((id: string) => {
+    setOverrides(prev => ({ ...prev, [id]: 'skipped' }));
+  }, []);
+
+  const acceptItemStatus = useCallback((id: string, success: boolean) => {
+    if (!success) {
+      // Merge failed: stay on the same charge so the user can retry or skip
+      return;
+    }
+    setOverrides(prev => ({ ...prev, [id]: 'matched' }));
+  }, []);
 
   return {
     items,

--- a/packages/client/src/router/config.tsx
+++ b/packages/client/src/router/config.tsx
@@ -30,6 +30,11 @@ const ChargesLedgerValidation = lazy(() =>
     default: m.ChargesLedgerValidation,
   })),
 );
+const ChargeMatchingReviewScreen = lazy(() =>
+  import('../components/charge-matching/index.js').then(m => ({
+    default: m.ChargeMatchingReviewScreen,
+  })),
+);
 
 // Businesses
 const Businesses = lazy(() =>
@@ -294,6 +299,14 @@ export const routes: RouteObject[] = [
                 handle: {
                   title: 'Ledger Validation',
                   breadcrumb: 'Ledger Validation',
+                },
+              },
+              {
+                path: 'matching',
+                element: withSuspense(ChargeMatchingReviewScreen, <PageSkeleton />),
+                handle: {
+                  title: 'Charge Matching',
+                  breadcrumb: 'Matching',
                 },
               },
               {

--- a/packages/client/src/router/routes.ts
+++ b/packages/client/src/router/routes.ts
@@ -77,6 +77,7 @@ export const ROUTES = {
       `/charges${getAllChargesParams(filter, page)}`,
     MISSING_INFO: '/charges/missing-info',
     LEDGER_VALIDATION: '/charges/ledger-validation',
+    MATCHING: '/charges/matching',
     DETAIL: (chargeId: string) => `/charges/${chargeId}`,
   },
 


### PR DESCRIPTION
Step 5 of the [matching-screen plan](https://github.com/Urigo/accounter-fullstack/blob/matching-screen/docs/matching-screen/prompt_plan.md) (Prompt 5: UI Scaffold, Header & Sidebar). Stacked on #3899.

## What

- **`ChargeMatchingHeader`** — two distinct control groups per the spec:
  - Filters: Mode selector (All / Doc Base / Transaction Base), From/To date pickers, Business combo-box (`useGetBusinesses`)
  - Sort toggle (separate from the mode filter): Date vs Match Score tabs, with the conditional alert *"Note: Score-based sorting currently evaluates only the 100 most recent unmatched charges."* when Match Score is selected
- **`ChargeMatchingSidebar`** — collapsible "Awaiting Matches" list fed by the queue items + `statusById` from `useChargeMatchQueue`: pending (neutral circle), matched (green check), skipped (ghosted/gray), active item highlighted; hide/show toggle to maximize the matching view
- **`ChargeMatchingReviewScreen`** — page container wiring the `ChargesAwaitingMatchQueue` urql query (filter changes update variables → refetch), the queue state hook, loading skeletons, error alert, and a placeholder split comparison view (Base Charge / Suggested Match with confidence %) that step 6 replaces with the detailed `ChargeDetailCard`s
- **Routing**: `/charges/matching` route (`ROUTES.CHARGES.MATCHING`), lazy-loaded screen, breadcrumb, and a "Charge Matching" entry in the Charges sidebar navigation

## Verification

- `yarn workspace @accounter/client build` passes
- `yarn lint` / `yarn prettier --check` clean on changed files
- `yarn graphql:validate` — all documents valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBQoeDJraws6oq8cyxPri3

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBQoeDJraws6oq8cyxPri3)_