### PR TITLE
feat(client): matching screen step 6 — comparison detail cards

### DIFF
--- a/packages/client/src/components/charge-matching/__tests__/charge-detail-card.test.tsx
+++ b/packages/client/src/components/charge-matching/__tests__/charge-detail-card.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { describe, expect, it } from 'vitest';
+import type { ChargeMatchCardFieldsFragment } from '../../../gql/graphql.js';
+import { ChargeDetailCard } from '../charge-detail-card.js';
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function makeCharge(
+  overrides: Partial<ChargeMatchCardFieldsFragment> = {},
+): ChargeMatchCardFieldsFragment {
+  return {
+    __typename: 'CommonCharge',
+    id: 'charge-1',
+    minEventDate: '2024-03-15',
+    minDebitDate: null,
+    minDocumentsDate: null,
+    totalAmount: {
+      raw: 1234.56,
+      // deliberately NOT a plain number rendering — the exact string must be shown as-is
+      formatted: '₪1,234.56',
+      currency: 'ILS',
+    },
+    counterparty: { id: 'business-1', name: 'Acme Ltd' },
+    userDescription: 'Office supplies',
+    additionalDocuments: [],
+    transactions: [],
+    miscExpenses: [],
+    ...overrides,
+  } as ChargeMatchCardFieldsFragment;
+}
+
+async function renderCard(props: React.ComponentProps<typeof ChargeDetailCard>) {
+  const container = document.createElement('div');
+  document.body.append(container);
+
+  let root: Root | null = null;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(React.createElement(ChargeDetailCard, props));
+    await Promise.resolve();
+  });
+
+  const cleanup = async () => {
+    await act(async () => {
+      root?.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+  };
+
+  return { container, cleanup };
+}
+
+describe('ChargeDetailCard', () => {
+  it('renders the exact formatted amount string with its currency symbol', async () => {
+    const { container, cleanup } = await renderCard({
+      charge: makeCharge(),
+      title: 'Base Charge',
+    });
+
+    expect(container.textContent).toContain('₪1,234.56');
+    expect(container.textContent).toContain('Acme Ltd');
+    expect(container.textContent).toContain('Office supplies');
+
+    await cleanup();
+  });
+
+  it('handles a missing document image gracefully without crashing', async () => {
+    const { container, cleanup } = await renderCard({
+      charge: makeCharge({ additionalDocuments: [] }),
+      title: 'Base Charge',
+    });
+
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain('No document preview');
+
+    await cleanup();
+  });
+
+  it('renders a document image thumbnail when available', async () => {
+    const { container, cleanup } = await renderCard({
+      charge: makeCharge({
+        additionalDocuments: [
+          {
+            id: 'doc-1',
+            documentType: 'INVOICE',
+            image: 'https://example.com/preview.png',
+            file: null,
+          },
+        ],
+      } as Partial<ChargeMatchCardFieldsFragment>),
+      title: 'Base Charge',
+    });
+
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('https://example.com/preview.png');
+
+    await cleanup();
+  });
+
+  it('renders a confidence score badge only when a score is provided', async () => {
+    const withScore = await renderCard({
+      charge: makeCharge(),
+      title: 'Suggested Match',
+      confidenceScore: 0.94,
+    });
+    expect(withScore.container.textContent).toContain('94');
+    expect(
+      withScore.container.querySelector('[aria-label="Match confidence score: 94%"]'),
+    ).not.toBeNull();
+    await withScore.cleanup();
+
+    const withoutScore = await renderCard({ charge: makeCharge(), title: 'Base Charge' });
+    expect(
+      withoutScore.container.querySelector('[aria-label^="Match confidence score"]'),
+    ).toBeNull();
+    await withoutScore.cleanup();
+  });
+});

--- a/packages/client/src/components/charge-matching/charge-detail-card.tsx
+++ b/packages/client/src/components/charge-matching/charge-detail-card.tsx
@@ -1,0 +1,115 @@
+import { type ReactElement } from 'react';
+import type { ChargeMatchCardFieldsFragment } from '../../gql/graphql.js';
+import { Score } from '../common/index.js';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '../ui/accordion.js';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card.js';
+import { chargeDate } from './utils.js';
+
+type Props = {
+  charge: ChargeMatchCardFieldsFragment;
+  /** Match confidence (0..1). When provided, a score badge is rendered */
+  confidenceScore?: number;
+  title: string;
+};
+
+function Field({ label, value }: { label: string; value?: string | null }): ReactElement | null {
+  if (!value) {
+    return null;
+  }
+  return (
+    <div className="flex flex-col">
+      <span className="text-xs text-gray-500">{label}</span>
+      <span className="text-sm font-medium">{value}</span>
+    </div>
+  );
+}
+
+export const ChargeDetailCard = ({ charge, confidenceScore, title }: Props): ReactElement => {
+  const documentWithImage = charge.additionalDocuments.find(doc => doc.image);
+  const documentTypes = [
+    ...new Set(charge.additionalDocuments.map(doc => doc.documentType).filter(Boolean)),
+  ].join(', ');
+  const hasExtensions = charge.transactions.length > 0 || charge.miscExpenses.length > 0;
+
+  return (
+    <Card data-testid="charge-detail-card">
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-base">{title}</CardTitle>
+        {confidenceScore != null && (
+          <div
+            className="flex items-center gap-2"
+            aria-label={`Match confidence score: ${Math.round(confidenceScore * 100)}%`}
+          >
+            <Score value={Math.round(confidenceScore * 100)} size="sm" />
+          </div>
+        )}
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="grid grid-cols-2 gap-3">
+          <Field label="Date" value={chargeDate(charge)} />
+          {/* Exact server-formatted amount with its currency symbol, no conversion */}
+          <Field label="Amount" value={charge.totalAmount?.formatted} />
+          <Field label="Counterparty" value={charge.counterparty?.name} />
+          <Field label="Document type" value={documentTypes} />
+        </div>
+        <Field label="Description" value={charge.userDescription} />
+
+        {documentWithImage?.image ? (
+          <a
+            href={documentWithImage.file?.toString() ?? documentWithImage.image.toString()}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <img
+              src={documentWithImage.image.toString()}
+              alt="Document preview"
+              className="max-h-56 w-auto rounded-md border object-contain"
+            />
+          </a>
+        ) : (
+          <p className="text-xs text-gray-400">No document preview</p>
+        )}
+
+        {hasExtensions && (
+          <Accordion type="single" collapsible>
+            <AccordionItem value="more-details">
+              <AccordionTrigger className="text-sm">More Details</AccordionTrigger>
+              <AccordionContent className="flex flex-col gap-3">
+                {charge.transactions.length > 0 && (
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs font-semibold text-gray-500">Transactions</span>
+                    <ul className="flex flex-col gap-1">
+                      {charge.transactions.map(transaction => (
+                        <li key={transaction.id} className="flex justify-between gap-2 text-sm">
+                          <span className="truncate">
+                            {transaction.eventDate} · {transaction.sourceDescription}
+                          </span>
+                          <span className="shrink-0 font-medium">
+                            {transaction.amount.formatted}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {charge.miscExpenses.length > 0 && (
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs font-semibold text-gray-500">Misc Expenses</span>
+                    <ul className="flex flex-col gap-1">
+                      {charge.miscExpenses.map(expense => (
+                        <li key={expense.id} className="flex justify-between gap-2 text-sm">
+                          <span className="truncate">{expense.description ?? 'Misc expense'}</span>
+                          <span className="shrink-0 font-medium">{expense.amount.formatted}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/packages/client/src/components/charge-matching/index.tsx
+++ b/packages/client/src/components/charge-matching/index.tsx
@@ -11,6 +11,7 @@ import { useChargeMatchQueue } from '../../hooks/use-charge-match-queue.js';
 import { PageLayout } from '../layout/page-layout.js';
 import { Alert, AlertDescription, AlertTitle } from '../ui/alert.js';
 import { Skeleton } from '../ui/skeleton.js';
+import { ChargeDetailCard } from './charge-detail-card.js';
 import {
   ChargeMatchingHeader,
   DEFAULT_CHARGE_MATCHING_FILTERS,
@@ -20,6 +21,7 @@ import {
   ChargeMatchingSidebar,
   type ChargeMatchingSidebarItem,
 } from './charge-matching-sidebar.js';
+import { chargeDate, chargeTitle } from './utils.js';
 
 export const QUEUE_PAGE_SIZE = 20;
 
@@ -31,17 +33,6 @@ export type ChargeMatchQueueItem = {
   baseCharge: ChargeMatchCardFieldsFragment;
   suggestions: QueueEntry['suggestions'];
 };
-
-function chargeDate(charge: ChargeMatchCardFieldsFragment): string | undefined {
-  const raw = charge.minDocumentsDate ?? charge.minEventDate ?? charge.minDebitDate;
-  // Date-only strings parse as UTC midnight; format in UTC so users in
-  // negative offsets don't see the previous day
-  return raw ? new Date(raw).toLocaleDateString(undefined, { timeZone: 'UTC' }) : undefined;
-}
-
-function chargeTitle(charge: ChargeMatchCardFieldsFragment): string {
-  return charge.counterparty?.name ?? charge.userDescription ?? 'Unknown charge';
-}
 
 export const ChargeMatchingReviewScreen = (): ReactElement => {
   const [filters, setFilters] = useState<ChargeMatchingFilters>(DEFAULT_CHARGE_MATCHING_FILTERS);
@@ -124,48 +115,32 @@ export const ChargeMatchingReviewScreen = (): ReactElement => {
               Showing {items.length} of {totalCount} charges awaiting match
             </p>
 
-            {/* Split comparison view — detailed cards land in the next step */}
+            {/* Split comparison view: base charge on the left, top suggestion on the right */}
             <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-              <section className="rounded-lg border p-4">
-                <h3 className="mb-2 text-sm font-semibold text-gray-500">Base Charge</h3>
-                {activeItem ? (
-                  <div className="flex flex-col gap-1">
-                    <span className="font-medium">{chargeTitle(activeItem.baseCharge)}</span>
-                    <span className="text-sm text-gray-500">
-                      {[
-                        chargeDate(activeItem.baseCharge),
-                        activeItem.baseCharge.totalAmount?.formatted,
-                      ]
-                        .filter(Boolean)
-                        .join(' · ')}
-                    </span>
-                  </div>
-                ) : (
+              {activeItem ? (
+                <ChargeDetailCard charge={activeItem.baseCharge} title="Base Charge" />
+              ) : (
+                <section className="rounded-lg border p-4">
+                  <h3 className="mb-2 text-sm font-semibold text-gray-500">Base Charge</h3>
                   <p className="text-sm text-gray-500">
                     {items.length === 0 ? 'No charges awaiting match.' : 'Queue completed 🎉'}
                   </p>
-                )}
-              </section>
-              <section className="rounded-lg border p-4">
-                <h3 className="mb-2 text-sm font-semibold text-gray-500">Suggested Match</h3>
-                {topSuggestionCharge ? (
-                  <div className="flex flex-col gap-1">
-                    <span className="font-medium">{chargeTitle(topSuggestionCharge)}</span>
-                    <span className="text-sm text-gray-500">
-                      {[chargeDate(topSuggestionCharge), topSuggestionCharge.totalAmount?.formatted]
-                        .filter(Boolean)
-                        .join(' · ')}
-                    </span>
-                    <span className="text-sm text-gray-500">
-                      Confidence: {Math.round((topSuggestion?.confidenceScore ?? 0) * 100)}%
-                    </span>
-                  </div>
-                ) : (
+                </section>
+              )}
+              {topSuggestionCharge ? (
+                <ChargeDetailCard
+                  charge={topSuggestionCharge}
+                  title="Suggested Match"
+                  confidenceScore={topSuggestion?.confidenceScore}
+                />
+              ) : (
+                <section className="rounded-lg border p-4">
+                  <h3 className="mb-2 text-sm font-semibold text-gray-500">Suggested Match</h3>
                   <p className="text-sm text-gray-500">
                     {activeItem ? 'No suggestions for this charge.' : '—'}
                   </p>
-                )}
-              </section>
+                </section>
+              )}
             </div>
           </div>
         </div>

--- a/packages/client/src/components/charge-matching/utils.ts
+++ b/packages/client/src/components/charge-matching/utils.ts
@@ -1,0 +1,12 @@
+import type { ChargeMatchCardFieldsFragment } from '../../gql/graphql.js';
+
+export function chargeDate(charge: ChargeMatchCardFieldsFragment): string | undefined {
+  const raw = charge.minDocumentsDate ?? charge.minEventDate ?? charge.minDebitDate;
+  // Date-only strings parse as UTC midnight; format in UTC so users in
+  // negative offsets don't see the previous day
+  return raw ? new Date(raw).toLocaleDateString(undefined, { timeZone: 'UTC' }) : undefined;
+}
+
+export function chargeTitle(charge: ChargeMatchCardFieldsFragment): string {
+  return charge.counterparty?.name ?? charge.userDescription ?? 'Unknown charge';
+}


### PR DESCRIPTION
Step 6 of the [matching-screen plan](https://github.com/Urigo/accounter-fullstack/blob/matching-screen/docs/matching-screen/prompt_plan.md) (Prompt 6: Comparison Cards). Stacked on #3900.

## What

- **`ChargeDetailCard`** — the shared visual card for 1:1 side-by-side comparison:
  - Core metadata: date, **exact server-formatted amount with currency symbol** (rendered as-is, no client-side conversion, per the spec's render rules), counterparty, document type(s), description
  - Document image thumbnail (links to the original file) with a graceful "No document preview" fallback when `image` is null
  - Expandable **"More Details"** accordion revealing secondary transactions and misc expenses
  - Optional match-confidence gauge (reuses the existing shared `Score` component) rendered only when `confidenceScore` is provided
- **Screen split view** now renders two `ChargeDetailCard` instances: the active base charge from `useChargeMatchQueue` on the left and the top-scoring suggestion (with confidence badge) on the right; empty/completed states preserved
- Shared `chargeDate`/`chargeTitle` helpers extracted to `utils.ts`

## Tests

`__tests__/charge-detail-card.test.tsx` — 4 component tests: exact amount string rendering, missing-image null fallback (no crash), thumbnail rendering, conditional score badge — covering the spec's §5.2 "Render Core" requirements.

## Verification

- `yarn vitest run --project unit` — 4/4 pass
- `yarn workspace @accounter/client build` passes; lint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBQoeDJraws6oq8cyxPri3

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBQoeDJraws6oq8cyxPri3)_