### PR TITLE
Add sortCode field support to sort-code-branch nodes

### DIFF
--- a/.changeset/upset-eggs-show.md
+++ b/.changeset/upset-eggs-show.md
@@ -1,0 +1,8 @@
+---
+'@accounter/client': patch
+'@accounter/server': patch
+---
+
+- **Schema updates**: Added `sortCode: Int` field to the `DynamicReportNodeData` GraphQL type and Zod validation schema
+- **GraphQL query**: Updated the dynamic report query to fetch the `sortCode` field from template data
+- **Tests**: Added comprehensive test coverage for parsing and validating sort-code-branch nodes with sortCode fields, plus a test verifying sortCode is read from template data (not derived from UUID IDs)

--- a/packages/client/src/components/reports/dynamic-report/__tests__/report-tree.test.ts
+++ b/packages/client/src/components/reports/dynamic-report/__tests__/report-tree.test.ts
@@ -109,6 +109,24 @@ describe('buildReportTree', () => {
     });
   });
 
+  describe('sort-code-branch node with UUID id and sortCode from the query', () => {
+    it('data.sortCode is read straight from the template data, not derived from the id', () => {
+      const template: TemplateNode[] = [
+        {
+          id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+          parent: 'report',
+          text: 'Sort Code 42',
+          droppable: true,
+          data: { nodeType: 'sort-code-branch', isOpen: false, sortCode: 42 },
+        },
+      ];
+      const { reportTree } = buildReportTree(template, []);
+      const branch = reportTree.find(n => n.id === 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+      expect(branch).toBeDefined();
+      expect(branch!.data.sortCode).toBe(42);
+    });
+  });
+
   describe('parent: 0 is replaced with REPORT_ROOT', () => {
     it('branch node with parent 0 gets parent = REPORT_ROOT', () => {
       const template: TemplateNode[] = [tmplBranch('br-1', 0)];

--- a/packages/client/src/components/reports/dynamic-report/index.tsx
+++ b/packages/client/src/components/reports/dynamic-report/index.tsx
@@ -120,6 +120,7 @@ import { buildNodeStats, type CustomData, type FlatNode, type Template } from '.
           nodeType
           isOpen
           hebrewText
+          sortCode
         }
       }
     }

--- a/packages/server/src/modules/reports/helpers/__tests__/dynamic-report.helper.test.ts
+++ b/packages/server/src/modules/reports/helpers/__tests__/dynamic-report.helper.test.ts
@@ -58,6 +58,20 @@ describe('parseTemplate', () => {
     expect(result[0].data.nodeType).toBe('sort-code-branch');
     expect(result[0].data.sortCode).toBe(100);
   });
+
+  it('succeeds with an explicit sortCode: null', () => {
+    const nodes = [
+      {
+        id: 'synth-1',
+        parent: '0',
+        text: 'Synthetic Category',
+        droppable: true,
+        data: { nodeType: 'synthetic-branch', isOpen: false, sortCode: null },
+      },
+    ];
+    const result = parseTemplate(JSON.stringify(nodes));
+    expect(result[0].data.sortCode).toBeNull();
+  });
 });
 
 describe('validateTemplate', () => {

--- a/packages/server/src/modules/reports/helpers/__tests__/dynamic-report.helper.test.ts
+++ b/packages/server/src/modules/reports/helpers/__tests__/dynamic-report.helper.test.ts
@@ -3,6 +3,7 @@ import {
   isLegacyTemplate,
   migrateLegacyTemplate,
   parseTemplate,
+  validateTemplate,
 } from '../dynamic-report.helper.js';
 
 describe('parseTemplate', () => {
@@ -40,6 +41,37 @@ describe('parseTemplate', () => {
       },
     ];
     expect(() => parseTemplate(JSON.stringify(nodes))).toThrow();
+  });
+
+  it('succeeds with a sort-code-branch node carrying a sortCode field', () => {
+    const nodes = [
+      {
+        id: 'sc-branch-1',
+        parent: '0',
+        text: 'Sort Code 100',
+        droppable: true,
+        data: { nodeType: 'sort-code-branch', isOpen: false, sortCode: 100 },
+      },
+    ];
+    const result = parseTemplate(JSON.stringify(nodes));
+    expect(result).toHaveLength(1);
+    expect(result[0].data.nodeType).toBe('sort-code-branch');
+    expect(result[0].data.sortCode).toBe(100);
+  });
+});
+
+describe('validateTemplate', () => {
+  it('does not throw for a sort-code-branch node carrying a sortCode field', () => {
+    const nodes = [
+      {
+        id: 'sc-branch-1',
+        parent: '0',
+        text: 'Sort Code 100',
+        droppable: true,
+        data: { nodeType: 'sort-code-branch', isOpen: false, sortCode: 100 },
+      },
+    ];
+    expect(() => validateTemplate(JSON.stringify(nodes))).not.toThrow();
   });
 });
 

--- a/packages/server/src/modules/reports/helpers/dynamic-report.helper.ts
+++ b/packages/server/src/modules/reports/helpers/dynamic-report.helper.ts
@@ -5,6 +5,7 @@ const dynamicReportNodeData = z
     nodeType: z.enum(['synthetic-branch', 'sort-code-branch', 'financial-entity']),
     isOpen: z.boolean(),
     hebrewText: z.string().optional(),
+    sortCode: z.number().optional(),
   })
   .strict();
 

--- a/packages/server/src/modules/reports/helpers/dynamic-report.helper.ts
+++ b/packages/server/src/modules/reports/helpers/dynamic-report.helper.ts
@@ -5,7 +5,7 @@ const dynamicReportNodeData = z
     nodeType: z.enum(['synthetic-branch', 'sort-code-branch', 'financial-entity']),
     isOpen: z.boolean(),
     hebrewText: z.string().optional(),
-    sortCode: z.number().optional(),
+    sortCode: z.number().nullable().optional(),
   })
   .strict();
 

--- a/packages/server/src/modules/reports/typeDefs/dynamic-report.graphql.ts
+++ b/packages/server/src/modules/reports/typeDefs/dynamic-report.graphql.ts
@@ -55,5 +55,6 @@ export default gql`
     nodeType: String!
     isOpen: Boolean!
     hebrewText: String
+    sortCode: Int
   }
 `;


### PR DESCRIPTION
## Summary
Adds support for an optional `sortCode` field in sort-code-branch template nodes, allowing sort codes to be stored directly in the template data rather than derived from node IDs.

## Key Changes
- **Schema updates**: Added `sortCode: Int` field to the `DynamicReportNodeData` GraphQL type and Zod validation schema
- **GraphQL query**: Updated the dynamic report query to fetch the `sortCode` field from template data
- **Tests**: Added comprehensive test coverage for parsing and validating sort-code-branch nodes with sortCode fields, plus a test verifying sortCode is read from template data (not derived from UUID IDs)

## Implementation Details
- The `sortCode` field is optional in the Zod schema to maintain backward compatibility with existing templates
- Client-side tests confirm that `sortCode` is read directly from template data, not computed from node IDs
- Changes span server schema/validation, client GraphQL operations, and test coverage across both packages

https://claude.ai/code/session_01Hsj3U2uahEN6dQVxFakSsA