### PR TITLE
Fix Accountant Approvals report always returning empty charges

### DIFF
--- a/packages/client/src/components/reports/accountant-approvals.tsx
+++ b/packages/client/src/components/reports/accountant-approvals.tsx
@@ -49,7 +49,7 @@ export const AccountantApprovals = (): ReactElement => {
     query: AccountantApprovalsChargesTableDocument,
     variables: {
       filters: filter,
-      page: 1,
+      page: 0,
       limit: 999_999,
     },
   });


### PR DESCRIPTION
## Summary
- Fixes #3890 — the Accountant Approvals report always showed 0 charges because `allCharges` returned an empty `nodes` array.
- Root cause: `allCharges` pagination on the server is 0-indexed (`packages/server/src/modules/charges/resolvers/charges.resolver.ts`: `filteredCharges.slice(page * limit, (page + 1) * limit)`), but `AccountantApprovals` requested `page: 1` with `limit: 999_999`. That sliced `[999999, 1999998]`, past every real record, so the query always returned an empty array — regardless of filters or actual data.
- Other components that page through `allCharges` (`all-charges.tsx`, `charges-section.tsx`) correctly start at `page: 0`. Changed `accountant-approvals.tsx` to match.

## Test plan
- [x] Manually traced the pagination math in `charges.resolver.ts` confirming `page: 1` skips all results for any realistic charge count.
- [x] Could not run `yarn lint` / `yarn generate` / `yarn build` in this environment — dependency install failed with a `403` from the package registry (network policy). The change is a single-line, type-correct numeric literal swap (`1` → `0`), both valid for the existing `Int` `page` argument.
- [ ] Recommend a manual smoke test in a dev environment: open the Accountant Approvals report and confirm charge counts now populate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EqSur1Gd7xQhk2hVm4SyP7)_