### PR TITLE
Improve multi-select UX with ordered options and overflow tooltip

### DIFF
--- a/.changeset/@accounter_scraper-app-3923-dependencies.md
+++ b/.changeset/@accounter_scraper-app-3923-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/scraper-app": patch
+---
+dependencies updates:
+  - Updated dependency [`@fastify/websocket@11.3.0` ↗︎](https://www.npmjs.com/package/@fastify/websocket/v/11.3.0) (from `11.2.0`, in `dependencies`)

--- a/.changeset/spotty-badges-listen.md
+++ b/.changeset/spotty-badges-listen.md
@@ -1,0 +1,8 @@
+---
+'@accounter/client': patch
+---
+
+Improve `MultiSelect` readability for large selections (closes #3891). The
+collapsed "+N more" badge now shows the hidden selected labels in a tooltip on
+hover/focus, and the dropdown lists checked items at the top when opened (order
+is snapshotted on open so it does not reshuffle while toggling).

--- a/packages/client/src/components/common/inputs/multi-select.tsx
+++ b/packages/client/src/components/common/inputs/multi-select.tsx
@@ -243,38 +243,43 @@ export const MultiSelect = React.forwardRef<HTMLButtonElement, MultiSelectProps>
                     );
                   })}
                   {selectedValues.length > maxCount && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Badge
-                          className={cn(
-                            'bg-transparent text-gray-950 border-gray-950/1 hover:bg-transparent',
-                            isAnimating ? 'animate-bounce' : '',
-                            multiSelectVariants({ variant }),
-                          )}
-                          style={{ animationDuration: `${animation}s` }}
+                    <Badge
+                      className={cn(
+                        'bg-transparent text-gray-950 border-gray-950/1 hover:bg-transparent p-0 gap-0',
+                        isAnimating ? 'animate-bounce' : '',
+                        multiSelectVariants({ variant }),
+                      )}
+                      style={{ animationDuration: `${animation}s` }}
+                    >
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span
+                            tabIndex={0}
+                            className="pl-2 pr-1 py-0.5 cursor-help outline-none focus-visible:underline"
+                          >
+                            {`+ ${selectedValues.length - maxCount} more`}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent className="flex flex-col gap-0.5">
+                          {selectedValues.slice(maxCount).map(value => {
+                            const option = options.find(o => o.value === value);
+                            return <span key={value}>{option?.label ?? value}</span>;
+                          })}
+                        </TooltipContent>
+                      </Tooltip>
+                      {removeButton && (
+                        <Button
+                          className="h-4 w-4 p-0 mr-1"
+                          variant="link"
+                          onClick={event => {
+                            event.stopPropagation();
+                            clearExtraOptions();
+                          }}
                         >
-                          {`+ ${selectedValues.length - maxCount} more`}
-                          {removeButton && (
-                            <Button
-                              className="h-4 w-4 p-0"
-                              variant="link"
-                              onClick={event => {
-                                event.stopPropagation();
-                                clearExtraOptions();
-                              }}
-                            >
-                              <XCircle className="h-4 w-4 cursor-pointer" />
-                            </Button>
-                          )}
-                        </Badge>
-                      </TooltipTrigger>
-                      <TooltipContent className="flex flex-col gap-0.5">
-                        {selectedValues.slice(maxCount).map(value => {
-                          const option = options.find(o => o.value === value);
-                          return <span key={value}>{option?.label ?? value}</span>;
-                        })}
-                      </TooltipContent>
-                    </Tooltip>
+                          <XCircle className="h-4 w-4 cursor-pointer" />
+                        </Button>
+                      )}
+                    </Badge>
                   )}
                 </div>
                 <div className="flex items-center justify-between">

--- a/packages/client/src/components/common/inputs/multi-select.tsx
+++ b/packages/client/src/components/common/inputs/multi-select.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../ui/command.js';
 import { Popover, PopoverContent, PopoverTrigger } from '../../ui/popover.js';
 import { Separator } from '../../ui/separator.js';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../ui/tooltip.js';
 
 /**
  * Variants for the multi-select component to handle different styles.
@@ -132,6 +133,17 @@ export const MultiSelect = React.forwardRef<HTMLButtonElement, MultiSelectProps>
     const [selectedValues, setSelectedValues] = React.useState<string[]>(defaultValue);
     const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
     const [isAnimating, setIsAnimating] = React.useState(false);
+    // Snapshot of the selection taken when the popover opens, used to order the
+    // option list (selected first) without reshuffling while the user toggles items.
+    const [orderSnapshot, setOrderSnapshot] = React.useState<string[]>(defaultValue);
+
+    const orderedOptions = React.useMemo(() => {
+      const selected = new Set(orderSnapshot);
+      return [
+        ...options.filter(option => selected.has(option.value)),
+        ...options.filter(option => !selected.has(option.value)),
+      ];
+    }, [options, orderSnapshot]);
 
     const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
       if (event.key === 'Enter') {
@@ -178,7 +190,16 @@ export const MultiSelect = React.forwardRef<HTMLButtonElement, MultiSelectProps>
     };
 
     return (
-      <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen} modal={modalPopover}>
+      <Popover
+        open={isPopoverOpen}
+        onOpenChange={open => {
+          if (open) {
+            setOrderSnapshot(selectedValues);
+          }
+          setIsPopoverOpen(open);
+        }}
+        modal={modalPopover}
+      >
         <PopoverTrigger asChild={asChild}>
           <Button
             ref={ref}
@@ -222,28 +243,38 @@ export const MultiSelect = React.forwardRef<HTMLButtonElement, MultiSelectProps>
                     );
                   })}
                   {selectedValues.length > maxCount && (
-                    <Badge
-                      className={cn(
-                        'bg-transparent text-gray-950 border-gray-950/1 hover:bg-transparent',
-                        isAnimating ? 'animate-bounce' : '',
-                        multiSelectVariants({ variant }),
-                      )}
-                      style={{ animationDuration: `${animation}s` }}
-                    >
-                      {`+ ${selectedValues.length - maxCount} more`}
-                      {removeButton && (
-                        <Button
-                          className="h-4 w-4 p-0"
-                          variant="link"
-                          onClick={event => {
-                            event.stopPropagation();
-                            clearExtraOptions();
-                          }}
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Badge
+                          className={cn(
+                            'bg-transparent text-gray-950 border-gray-950/1 hover:bg-transparent',
+                            isAnimating ? 'animate-bounce' : '',
+                            multiSelectVariants({ variant }),
+                          )}
+                          style={{ animationDuration: `${animation}s` }}
                         >
-                          <XCircle className="h-4 w-4 cursor-pointer" />
-                        </Button>
-                      )}
-                    </Badge>
+                          {`+ ${selectedValues.length - maxCount} more`}
+                          {removeButton && (
+                            <Button
+                              className="h-4 w-4 p-0"
+                              variant="link"
+                              onClick={event => {
+                                event.stopPropagation();
+                                clearExtraOptions();
+                              }}
+                            >
+                              <XCircle className="h-4 w-4 cursor-pointer" />
+                            </Button>
+                          )}
+                        </Badge>
+                      </TooltipTrigger>
+                      <TooltipContent className="flex flex-col gap-0.5">
+                        {selectedValues.slice(maxCount).map(value => {
+                          const option = options.find(o => o.value === value);
+                          return <span key={value}>{option?.label ?? value}</span>;
+                        })}
+                      </TooltipContent>
+                    </Tooltip>
                   )}
                 </div>
                 <div className="flex items-center justify-between">
@@ -289,7 +320,7 @@ export const MultiSelect = React.forwardRef<HTMLButtonElement, MultiSelectProps>
                   </div>
                   <span>(Select All)</span>
                 </CommandItem>
-                {options.map(option => {
+                {orderedOptions.map(option => {
                   const isSelected = selectedValues.includes(option.value);
                   return (
                     <CommandItem

--- a/packages/client/src/components/common/inputs/multi-select.tsx
+++ b/packages/client/src/components/common/inputs/multi-select.tsx
@@ -254,6 +254,7 @@ export const MultiSelect = React.forwardRef<HTMLButtonElement, MultiSelectProps>
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span
+                            role="button"
                             tabIndex={0}
                             className="pl-2 pr-1 py-0.5 cursor-help outline-none focus-visible:underline"
                           >


### PR DESCRIPTION
## Summary
Enhanced the multi-select component to provide better UX when managing selections, particularly when the number of selected items exceeds the display limit.

## Key Changes
- **Ordered option list**: Selected items now appear first in the dropdown menu, maintaining their order from when the popover opened. This prevents the list from reshuffling as users toggle selections, making it easier to find and deselect items.
- **Overflow tooltip**: When selected items exceed `maxCount`, the "+X more" badge now displays a tooltip showing the labels of all hidden items, allowing users to see what's selected without opening the dropdown.
- **Order snapshot**: Captures the current selection state when the popover opens via `orderSnapshot` state, used to compute `orderedOptions` via `useMemo`.

## Implementation Details
- Added `Tooltip` and `TooltipContent` imports from the UI component library
- New state: `orderSnapshot` tracks selections at popover open time
- New computed value: `orderedOptions` memoized to avoid unnecessary recalculations
- Updated `Popover` `onOpenChange` handler to capture snapshot when opening
- Wrapped the "+X more" badge with `Tooltip` component to display hidden selections

closes #3891

https://claude.ai/code/session_014TbCneWBvMRVDwgma5tkB1