### PR TITLE
feat(client): general shadcn sort code selector with key + name labels

### DIFF
--- a/.changeset/@accounter_scraper-app-3927-dependencies.md
+++ b/.changeset/@accounter_scraper-app-3927-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/scraper-app": patch
+---
+dependencies updates:
+  - Updated dependency [`@fastify/websocket@11.3.0` ↗︎](https://www.npmjs.com/package/@fastify/websocket/v/11.3.0) (from `11.2.0`, in `dependencies`)

--- a/.changeset/sort-code-select.md
+++ b/.changeset/sort-code-select.md
@@ -1,0 +1,8 @@
+---
+'@accounter/client': patch
+---
+
+Migrate the tax category sort code selector from Mantine to a reusable shadcn-based
+`SortCodeSelect`. Each option now shows both the sort code key and its name (e.g. `100 - Cash`), and
+the selector is extracted into a general component (`components/common/inputs/sort-code-select.tsx`)
+so it can be reused across forms — it is now also used in the business configurations section.

--- a/packages/client/src/components/business/configurations-section.tsx
+++ b/packages/client/src/components/business/configurations-section.tsx
@@ -492,7 +492,7 @@ function DefaultSettingsSubSection({
                   ownerId={business.ownerId}
                   value={field.value}
                   onChange={(sortCode, sortCodeObj) => {
-                    field.onChange(sortCode);
+                    field.onChange(sortCode?.toString() ?? '');
                     onSortCodeChangeUpdateIrsCode(sortCodeObj);
                   }}
                   formPart

--- a/packages/client/src/components/business/configurations-section.tsx
+++ b/packages/client/src/components/business/configurations-section.tsx
@@ -44,7 +44,6 @@ import {
   relevantDataPicker,
   type MakeBoolean,
 } from '@/helpers/index.js';
-import { useGetSortCodes } from '@/hooks/use-get-sort-codes.js';
 import { useGetTags } from '@/hooks/use-get-tags.js';
 import { useGetTaxCategories } from '@/hooks/use-get-tax-categories.js';
 import { useUpdateBusiness } from '@/hooks/use-update-business.js';
@@ -55,6 +54,8 @@ import {
   MultiSelect,
   NumberInput,
   SimilarChargesByBusinessModal,
+  SortCodeSelect,
+  type SortCode as SortCodeOption,
 } from '../common/index.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
@@ -464,29 +465,16 @@ function DefaultSettingsSubSection({
   business,
 }: SubSectionProps & { business: BusinessConfigurationSectionFragment }) {
   const { selectableTaxCategories, fetching: fetchingTaxCategories } = useGetTaxCategories();
-  const {
-    selectableSortCodes,
-    fetching: fetchingSortCodes,
-    sortCodes,
-  } = useGetSortCodes({ ownerId: business.ownerId });
   const { selectableTags, fetching: fetchingTags } = useGetTags();
 
   // When sort code changes, update IRS code if sort code has a default IRS code
   const onSortCodeChangeUpdateIrsCode = useCallback(
-    (sortCode: string | null) => {
+    (sortCode?: SortCodeOption | null) => {
       if (sortCode) {
-        const sortCodeObj = sortCodes.find(sc => Number(sc.key) === Number(sortCode));
-
-        if (sortCodeObj) {
-          if (sortCodeObj.defaultIrsCode) {
-            form.setValue('irsCode', sortCodeObj.defaultIrsCode, { shouldDirty: true });
-          } else {
-            form.setValue('irsCode', null, { shouldDirty: true });
-          }
-        }
+        form.setValue('irsCode', sortCode.defaultIrsCode ?? null, { shouldDirty: true });
       }
     },
-    [form, sortCodes],
+    [form],
   );
 
   return (
@@ -500,19 +488,15 @@ function DefaultSettingsSubSection({
             <FormItem>
               <FormLabel>Sort Code</FormLabel>
               <FormControl>
-                <ComboBox
-                  onChange={sortCode => {
-                    onSortCodeChangeUpdateIrsCode(sortCode);
-                    field.onChange(sortCode);
-                  }}
-                  data={selectableSortCodes}
+                <SortCodeSelect
+                  ownerId={business.ownerId}
                   value={field.value}
-                  disabled={fetchingSortCodes}
-                  placeholder="Scroll to see all options"
-                  formPart
-                  triggerProps={{
-                    className: dirtyFieldMarker(fieldState),
+                  onChange={(sortCode, sortCodeObj) => {
+                    field.onChange(sortCode);
+                    onSortCodeChangeUpdateIrsCode(sortCodeObj);
                   }}
+                  formPart
+                  triggerClassName={dirtyFieldMarker(fieldState)}
                 />
               </FormControl>
               <FormMessage />

--- a/packages/client/src/components/common/forms/modify-tax-category-fields.tsx
+++ b/packages/client/src/components/common/forms/modify-tax-category-fields.tsx
@@ -2,11 +2,11 @@ import { type ReactElement } from 'react';
 import { type UseFormReturn } from 'react-hook-form';
 import type { InsertTaxCategoryInput, UpdateTaxCategoryInput } from '../../../gql/graphql.js';
 import { dirtyFieldMarker } from '../../../helpers/index.js';
-import { SortCodeSelect } from '../inputs/sort-code-select.js';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { Input } from '../../ui/input.js';
 import { Switch } from '../../ui/switch.js';
 import { NumberInput } from '../index.js';
+import { SortCodeSelect } from '../inputs/sort-code-select.js';
 
 type ModalProps<T extends boolean> = {
   isInsert: T;

--- a/packages/client/src/components/common/forms/modify-tax-category-fields.tsx
+++ b/packages/client/src/components/common/forms/modify-tax-category-fields.tsx
@@ -1,9 +1,8 @@
-import { useEffect, type ReactElement } from 'react';
-import { Controller, type UseFormReturn } from 'react-hook-form';
-import { Select } from '@mantine/core';
+import { type ReactElement } from 'react';
+import { type UseFormReturn } from 'react-hook-form';
 import type { InsertTaxCategoryInput, UpdateTaxCategoryInput } from '../../../gql/graphql.js';
 import { dirtyFieldMarker } from '../../../helpers/index.js';
-import { useGetSortCodes } from '../../../hooks/use-get-sort-codes.js';
+import { SortCodeSelect } from '../inputs/sort-code-select.js';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { Input } from '../../ui/input.js';
 import { Switch } from '../../ui/switch.js';
@@ -26,29 +25,7 @@ export function ModifyTaxCategoryFields({
   isInsert,
   ownerId,
 }: ModalProps<boolean>): ReactElement {
-  const { control, watch, setValue } = formManager;
-
-  // Sort codes array handle
-  const {
-    selectableSortCodes: sortCodes,
-    fetching: fetchingSortCodes,
-    sortCodes: rawSortCodes,
-  } = useGetSortCodes({ ownerId });
-
-  useEffect(() => {
-    setFetching(fetchingSortCodes);
-  }, [setFetching, fetchingSortCodes]);
-
-  // on sort code change, update IRS code
-  const sortCode = watch('sortCode');
-  useEffect(() => {
-    if (sortCode) {
-      const sortCodeObj = rawSortCodes.find(sc => sc.key === sortCode);
-      if (sortCodeObj?.defaultIrsCode) {
-        setValue('irsCode', sortCodeObj.defaultIrsCode, { shouldDirty: true });
-      }
-    }
-  }, [sortCode, rawSortCodes, setValue]);
+  const { control, setValue } = formManager;
 
   return (
     <>
@@ -75,27 +52,31 @@ export function ModifyTaxCategoryFields({
         )}
       />
 
-      <Controller
+      <FormField
         name="sortCode"
         control={control}
-        render={({ field, fieldState }): ReactElement => {
-          return (
-            <Select
-              {...field}
-              onChange={val => {
-                field.onChange(Number(val));
-              }}
-              data={sortCodes}
-              value={field.value?.toString()}
-              disabled={fetchingSortCodes}
-              label="Sort Code"
-              placeholder="Scroll to see all options"
-              maxDropdownHeight={160}
-              searchable
-              className={isInsert ? '' : dirtyFieldMarker(fieldState)}
-            />
-          );
-        }}
+        render={({ field, fieldState }): ReactElement => (
+          <FormItem>
+            <FormLabel>Sort Code</FormLabel>
+            <FormControl>
+              <SortCodeSelect
+                ownerId={ownerId}
+                value={field.value}
+                onChange={(value, sortCode) => {
+                  field.onChange(value);
+                  // on sort code change, update IRS code with its default (if any)
+                  if (sortCode?.defaultIrsCode) {
+                    setValue('irsCode', sortCode.defaultIrsCode, { shouldDirty: true });
+                  }
+                }}
+                onFetchingChange={setFetching}
+                formPart
+                triggerClassName={isInsert ? undefined : dirtyFieldMarker(fieldState)}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
       />
 
       <FormField

--- a/packages/client/src/components/common/inputs/index.ts
+++ b/packages/client/src/components/common/inputs/index.ts
@@ -8,6 +8,7 @@ export * from './input.js';
 export * from './multi-select.js';
 export * from './number-input.js';
 export * from './select-with-search.js';
+export * from './sort-code-select.js';
 export * from './string-array-input.js';
 export * from './tag-input.js';
 export * from './update-accountant-status.js';

--- a/packages/client/src/components/common/inputs/sort-code-select.tsx
+++ b/packages/client/src/components/common/inputs/sort-code-select.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useMemo, type ReactElement } from 'react';
+import type { AllSortCodesQuery } from '../../../gql/graphql.js';
+import { useGetSortCodes } from '../../../hooks/use-get-sort-codes.js';
+import { ComboBox } from './combo-box.js';
+
+export type SortCode = NonNullable<AllSortCodesQuery['allSortCodesByBusiness']>[number];
+
+type SortCodeSelectProps = {
+  /** Business owner id used to fetch the relevant sort codes. */
+  ownerId?: string | null;
+  /** Currently selected sort code key. */
+  value?: number | string | null;
+  /**
+   * Called when the selection changes.
+   * Provides the numeric sort code key (or null) and the full sort code object when available.
+   */
+  onChange: (value: number | null, sortCode?: SortCode | null) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  /** Render inside a shadcn `FormControl` (forwards form styling). */
+  formPart?: boolean;
+  error?: string;
+  triggerClassName?: string;
+  /** Notifies the parent about the sort codes fetching state. */
+  onFetchingChange?: (fetching: boolean) => void;
+};
+
+/**
+ * General, reusable sort code selector.
+ *
+ * Fetches the sort codes for the given business owner and renders a searchable
+ * shadcn combo box. Each option displays both the sort code key and its name.
+ */
+export function SortCodeSelect({
+  ownerId,
+  value,
+  onChange,
+  disabled,
+  placeholder = 'Scroll to see all options',
+  formPart,
+  error,
+  triggerClassName,
+  onFetchingChange,
+}: SortCodeSelectProps): ReactElement {
+  const { sortCodes, fetching } = useGetSortCodes({ ownerId });
+
+  useEffect(() => {
+    onFetchingChange?.(fetching);
+  }, [onFetchingChange, fetching]);
+
+  const options = useMemo(
+    () =>
+      sortCodes.map(sortCode => ({
+        value: sortCode.key.toString(),
+        label: sortCode.name ? `${sortCode.key} - ${sortCode.name}` : sortCode.key.toString(),
+      })),
+    [sortCodes],
+  );
+
+  return (
+    <ComboBox
+      data={options}
+      value={value?.toString() ?? null}
+      onChange={selected => {
+        if (!selected) {
+          onChange(null, null);
+          return;
+        }
+        const numericValue = Number(selected);
+        const sortCode = sortCodes.find(sc => Number(sc.key) === numericValue) ?? null;
+        onChange(numericValue, sortCode);
+      }}
+      disabled={disabled || fetching}
+      placeholder={placeholder}
+      formPart={formPart}
+      error={error}
+      triggerProps={triggerClassName ? { className: triggerClassName } : undefined}
+    />
+  );
+}

--- a/packages/client/src/components/common/inputs/sort-code-select.tsx
+++ b/packages/client/src/components/common/inputs/sort-code-select.tsx
@@ -48,14 +48,21 @@ export function SortCodeSelect({
     onFetchingChange?.(fetching);
   }, [onFetchingChange, fetching]);
 
-  const options = useMemo(
-    () =>
-      sortCodes.map(sortCode => ({
-        value: sortCode.key.toString(),
-        label: sortCode.name ? `${sortCode.key} - ${sortCode.name}` : sortCode.key.toString(),
-      })),
-    [sortCodes],
-  );
+  const options = useMemo(() => {
+    const list = sortCodes.map(sortCode => ({
+      value: sortCode.key.toString(),
+      label: sortCode.name ? `${sortCode.key} - ${sortCode.name}` : sortCode.key.toString(),
+    }));
+    // Keep the currently selected value visible even while the list is still
+    // loading or if it no longer exists among the fetched sort codes.
+    if (value !== undefined && value !== null) {
+      const stringValue = value.toString();
+      if (!list.some(option => option.value === stringValue)) {
+        list.push({ value: stringValue, label: stringValue });
+      }
+    }
+    return list;
+  }, [sortCodes, value]);
 
   return (
     <ComboBox

--- a/packages/client/src/components/common/modals/edit-tax-category.tsx
+++ b/packages/client/src/components/common/modals/edit-tax-category.tsx
@@ -1,8 +1,9 @@
-import { useState, type ReactElement } from 'react';
+import { useContext, useState, type ReactElement } from 'react';
 import { Edit, Loader2 } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { toast } from 'sonner';
 import { useQuery } from 'urql';
+import { UserContext } from '@/providers/index.js';
 import {
   TaxCategoryToUpdateDocument,
   type TaxCategoryToUpdateQuery,
@@ -113,6 +114,8 @@ function EditTaxCategoryForm({
   const { handleSubmit } = useFormManager;
   const [fetching, setFetching] = useState(false);
 
+  const { userContext } = useContext(UserContext);
+
   const { updateTaxCategory, fetching: updatingInProcess } = useUpdateTaxCategory();
 
   const onSubmit: SubmitHandler<UpdateTaxCategoryInput> = data => {
@@ -133,7 +136,7 @@ function EditTaxCategoryForm({
             isInsert={false}
             formManager={useFormManager}
             setFetching={setFetching}
-            ownerId={taxCategory.ownerId ?? undefined}
+            ownerId={taxCategory.ownerId ?? userContext?.context.adminBusinessId}
           />
         </div>
 


### PR DESCRIPTION
## What & why

Closes #3575.

The sort code select on the **Edit Tax Category** modal still used Mantine and only showed the sort code *name*. This PR migrates it to shadcn and shows both the key and the name, and extracts the selector into a reusable component so other forms can use it.

## Changes

- **Migrate Mantine → shadcn**: the sort code input in the tax category form (`modify-tax-category-fields.tsx`) no longer uses `@mantine/core`'s `Select`. It now uses a shadcn-based, searchable selector wired into the react-hook-form `FormField`.
- **Show both key & name**: each option is rendered as `"<key> - <name>"` (e.g. `100 - Cash`) in both the dropdown and the trigger, instead of name only.
- **General, reusable `SortCodeSelect`** (`components/common/inputs/sort-code-select.tsx`): fetches sort codes for a given business owner, renders the searchable `ComboBox`, and exposes both the numeric key and the full sort code object on change (so callers can react — e.g. auto-filling the default IRS code).
- **Reuse in business configurations**: `configurations-section.tsx` now consumes `SortCodeSelect`, removing duplicated sort-code fetching and label wiring, and gaining the key + name display for free.

Each form keeps its original IRS-code side-effect semantics.

## Notes

`yarn install` could not complete in the sandbox because the `xlsx` dependency is fetched from `cdn.sheetjs.com`, which is blocked by the environment's egress policy. As a result `yarn generate`, `yarn lint`, and `tsc` could not be run here; the changes were verified by inspection against existing patterns (the `ComboBox` + `useGetSortCodes` usage already in `configurations-section.tsx`). Please let CI run the type/lint checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015BMy7oGK6oTPjMXo6UcFD6)_