### PR TITLE
fix(client): handle crypto currencies in balance report formatter (#3869)

### DIFF
--- a/.changeset/balance-report-crypto-currency-formatter.md
+++ b/.changeset/balance-report-crypto-currency-formatter.md
@@ -1,0 +1,10 @@
+---
+'@accounter/client': patch
+---
+
+Fix a crash in the transactions balance report when a period's per-currency breakdown includes a
+crypto currency. Crypto currencies (`USDC`, `ETH`, `GRT`) are not valid ISO 4217 codes, so
+`getCurrencyFormatter` threw `RangeError: Invalid currency code` when building an
+`Intl.NumberFormat` with `style: 'currency'`. The formatter now falls back to decimal formatting
+with the currency symbol as a prefix for non-fiat currencies (placing the minus sign before the
+symbol for negatives, matching fiat notation), leaving fiat currency formatting unchanged.

--- a/packages/client/src/helpers/currency.ts
+++ b/packages/client/src/helpers/currency.ts
@@ -1,6 +1,17 @@
 import { Currency } from '../gql/graphql.js';
 import { formatStringifyAmount } from './index.js';
 
+export const FIAT_CURRENCIES: Currency[] = [
+  Currency.Ils,
+  Currency.Eur,
+  Currency.Usd,
+  Currency.Gbp,
+  Currency.Cad,
+  Currency.Jpy,
+  Currency.Aud,
+  Currency.Sek,
+] as const;
+
 export type CurrencyFormatter = Pick<Intl.NumberFormat, 'format'>;
 
 export function getCurrencyFormatter(
@@ -18,8 +29,13 @@ export function getCurrencyFormatter(
       style: 'decimal',
     });
     return {
-      format: (value: number): string =>
-        `${currencyCodeToSymbol(currency)} ${decimalFormatter.format(value)}`,
+      format: (value: number): string => {
+        // Place the minus sign before the symbol (e.g. `-USDC 1,234.50`) to
+        // match the standard financial notation used for fiat currencies.
+        const symbol = currencyCodeToSymbol(currency);
+        const formatted = decimalFormatter.format(Math.abs(value));
+        return value < 0 ? `-${symbol} ${formatted}` : `${symbol} ${formatted}`;
+      },
     };
   }
   return new Intl.NumberFormat('en-US', {
@@ -75,17 +91,6 @@ export function currencyCodeToSymbol(currency_code: Currency): string {
   }
   return currencySymbol;
 }
-
-export const FIAT_CURRENCIES: Currency[] = [
-  Currency.Ils,
-  Currency.Eur,
-  Currency.Usd,
-  Currency.Gbp,
-  Currency.Cad,
-  Currency.Jpy,
-  Currency.Aud,
-  Currency.Sek,
-] as const;
 
 export function formatAmountWithCurrency(amount: number, currency: Currency, digits = 2): string {
   return `${currencyCodeToSymbol(currency)} ${formatStringifyAmount(amount, digits)}`;

--- a/packages/client/src/helpers/currency.ts
+++ b/packages/client/src/helpers/currency.ts
@@ -1,10 +1,27 @@
 import { Currency } from '../gql/graphql.js';
 import { formatStringifyAmount } from './index.js';
 
+export type CurrencyFormatter = Pick<Intl.NumberFormat, 'format'>;
+
 export function getCurrencyFormatter(
   currency: Currency,
   options?: Omit<Intl.NumberFormatOptions, 'currency'>,
-): Intl.NumberFormat {
+): CurrencyFormatter {
+  // Crypto currencies (e.g. USDC, ETH, GRT) are not valid ISO 4217 codes, so
+  // `Intl.NumberFormat` with `style: 'currency'` throws a RangeError. Fall back
+  // to decimal formatting and prepend the currency symbol for those.
+  if (!FIAT_CURRENCIES.includes(currency)) {
+    const decimalFormatter = new Intl.NumberFormat('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+      ...options,
+      style: 'decimal',
+    });
+    return {
+      format: (value: number): string =>
+        `${currencyCodeToSymbol(currency)} ${decimalFormatter.format(value)}`,
+    };
+  }
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
     ...options,


### PR DESCRIPTION
## Problem

Fixes #3869.

Opening the transactions balance report, selecting a wide date range with a **MONTHLY** period, then clicking a period on the chart (which sets `extendedPeriod` and renders `PeriodSummary`) could crash the app with:

```
RangeError: Invalid currency code : USDC
    at new NumberFormat (<anonymous>)
    at getCurrencyFormatter ...
```

## Root cause

`PeriodSummary` (`packages/client/src/components/screens/reports/balance-report/period-summary.tsx`) renders a per-currency breakdown of income/expense/delta and calls `getCurrencyFormatter(currency)` for each currency found in the period's transactions.

`getCurrencyFormatter` used `Intl.NumberFormat('en-US', { style: 'currency', currency })`. The `Currency` enum includes crypto currencies (`ETH`, `GRT`, `USDC`) that are **not** valid ISO 4217 codes. In particular `USDC` is 4 characters, which is not a well-formed currency code, so `Intl.NumberFormat` throws a `RangeError` and the whole report tree crashes. This only surfaced once a period whose breakdown contained a crypto currency was clicked — hence the intermittent "sometimes fails".

## Fix

`getCurrencyFormatter` now falls back to decimal formatting with a symbol prefix (via the existing `currencyCodeToSymbol`) for non-FIAT currencies, leaving fiat behavior unchanged. The return type is narrowed to `Pick<Intl.NumberFormat, 'format'>` (a `CurrencyFormatter` alias); all call sites only use `.format(...)`, so they are unaffected.

Example output after the fix:

| currency | before | after |
| --- | --- | --- |
| `USD` | `$1,234.50` | `$1,234.50` |
| `ILS` | `₪1,234.50` | `₪1,234.50` |
| `USDC` | **throws RangeError** | `USDC 1,234.50` |
| `ETH` | `ETH 1,234.50` | `ETH 1,234.50` |
| `GRT` | `GRT 1,234.50` | `GRT 1,234.50` |

## Testing

Dependencies could not be fully installed in this environment (`xlsx` is fetched from `cdn.sheetjs.com`, which is blocked by the egress policy), so the repo's typecheck/lint could not be run here. The fix logic was verified with a standalone Node script that reproduces the original `RangeError` on `USDC` and confirms the fallback produces correct output for both fiat and crypto currencies, including options pass-through (`minimumFractionDigits`). All `getCurrencyFormatter` call sites use only `.format`, so the narrowed return type is compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T29T7SCykKRNAB3qLpFnx1)_