### PR TITLE
fix(client): show deposit name in reassign transaction dialog

### DIFF
--- a/.changeset/deposit-reassign-name-display.md
+++ b/.changeset/deposit-reassign-name-display.md
@@ -1,0 +1,7 @@
+---
+'@accounter/client': patch
+---
+
+Show the deposit name instead of its ID in the Reassign Transaction dialog's target deposit
+selection. The currency is now rendered conditionally so no empty parentheses appear when a deposit
+has no currency.

--- a/packages/client/src/components/bank-deposits/deposit-reassign-dialog.tsx
+++ b/packages/client/src/components/bank-deposits/deposit-reassign-dialog.tsx
@@ -78,7 +78,7 @@ export function DepositReassignDialog({ depositId, chargeId, refetch }: Props): 
               <SelectContent>
                 {openDeposits.map(d => (
                   <SelectItem key={d.id} value={d.id}>
-                    {d.id} ({d.currency})
+                    {d.name} ({d.currency})
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/packages/client/src/components/bank-deposits/deposit-reassign-dialog.tsx
+++ b/packages/client/src/components/bank-deposits/deposit-reassign-dialog.tsx
@@ -78,7 +78,8 @@ export function DepositReassignDialog({ depositId, chargeId, refetch }: Props): 
               <SelectContent>
                 {openDeposits.map(d => (
                   <SelectItem key={d.id} value={d.id}>
-                    {d.name} ({d.currency})
+                    {d.name}
+                    {d.currency ? ` (${d.currency})` : ''}
                   </SelectItem>
                 ))}
               </SelectContent>


### PR DESCRIPTION
## Summary

The Target Deposit selection in the **Reassign Transaction** dialog displayed each deposit's raw `id` instead of its human-readable `name`, making it hard to identify the right deposit.

This changes the `SelectItem` label to render `{d.name} ({d.currency})` instead of `{d.id} ({d.currency})`.

## Details

- File: `packages/client/src/components/bank-deposits/deposit-reassign-dialog.tsx`
- The `AllDeposits` query already fetches the `name` field, so no GraphQL/query changes were needed.
- The `value` of each option remains `d.id`, so the reassign mutation continues to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNN8mfSD7zoovkW7sQuXmn)_