### PR TITLE
fix(client): prevent bank deposits screen blink on transaction reassign

### DIFF
--- a/.changeset/bank-deposits-reassign-blink.md
+++ b/.changeset/bank-deposits-reassign-blink.md
@@ -2,8 +2,16 @@
 "@accounter/client": patch
 ---
 
-Fix the Bank Deposits screen "blinking" when reassigning a transaction. The reassign still triggers
-the required `AllDeposits` refetch, but the view no longer blanks out and fully re-renders: loading
-gates now only replace the table on the initial load (`fetching && !data`) instead of on every
-background refetch, and derived rows are wrapped in a new `useStableValue` hook so the table updates
-only when the deposits data actually changes.
+Fix the Bank Deposits screen "blinking" when reassigning a transaction, without losing the update.
+
+Previously, reassigning a transaction refetched `AllDeposits`, and the loading gate replaced the
+whole table on every refetch — unmounting and remounting the expanded transaction sub-tables, which
+is what actually refreshed their data (the urql client has no cache exchange, so mutations don't
+invalidate queries). This caused a jarring full-screen blink.
+
+Now the loading gates only replace the table on the initial load (`fetching && !data`), and derived
+rows are wrapped in a new `useStableValue` hook so the view updates only when data actually changes.
+To keep the data correct without the remount, a reassign bumps a token that every mounted deposit
+transaction table observes and re-executes its own query for — so the reassigned row leaves the
+source deposit and appears under the target deposit, and both deposits' balances refresh, with no
+blink.

--- a/.changeset/bank-deposits-reassign-blink.md
+++ b/.changeset/bank-deposits-reassign-blink.md
@@ -1,0 +1,9 @@
+---
+"@accounter/client": patch
+---
+
+Fix the Bank Deposits screen "blinking" when reassigning a transaction. The reassign still triggers
+the required `AllDeposits` refetch, but the view no longer blanks out and fully re-renders: loading
+gates now only replace the table on the initial load (`fetching && !data`) instead of on every
+background refetch, and derived rows are wrapped in a new `useStableValue` hook so the table updates
+only when the deposits data actually changes.

--- a/packages/client/src/components/bank-deposits/deposits-transactions-table.tsx
+++ b/packages/client/src/components/bank-deposits/deposits-transactions-table.tsx
@@ -10,6 +10,7 @@ import {
   type SortingState,
 } from '@tanstack/react-table';
 import { getFragmentData } from '@/gql/fragment-masking.js';
+import { useStableValue } from '@/hooks/use-stable-value.js';
 import { UserContext } from '@/providers/user-provider.js';
 import {
   Currency,
@@ -69,7 +70,7 @@ export function DepositsTransactionsTable({
     variables: { depositId },
   });
 
-  const tableData: DepositTransactionRowType[] = useMemo(() => {
+  const computedTableData: DepositTransactionRowType[] = useMemo(() => {
     if (!data?.deposit?.metadata.transactions) {
       return [];
     }
@@ -127,6 +128,10 @@ export function DepositsTransactionsTable({
     });
   }, [data?.deposit, userContext]);
 
+  // Keep a stable reference across refetches so the table only re-renders when
+  // the transactions actually changed, avoiding a "blink" on background refetch.
+  const tableData = useStableValue(computedTableData);
+
   const columnsWithActions: ColumnDef<DepositTransactionRowType>[] = useMemo(() => {
     const defaultLocalCurrency =
       (userContext?.context.defaultLocalCurrency as Currency) ?? Currency.Ils;
@@ -172,7 +177,7 @@ export function DepositsTransactionsTable({
     state: { sorting },
   });
 
-  if (fetching) {
+  if (fetching && !data) {
     return (
       <div className="flex h-64 w-full items-center justify-center">
         <Loader2 className="size-10 animate-spin" />

--- a/packages/client/src/components/bank-deposits/deposits-transactions-table.tsx
+++ b/packages/client/src/components/bank-deposits/deposits-transactions-table.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState, type ReactElement } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useQuery } from 'urql';
 import {
@@ -55,20 +55,39 @@ type Props = {
   depositId: string;
   enableReassign?: boolean;
   refetch?: () => void;
+  /**
+   * Bumped by the parent whenever any transaction is reassigned. Because the
+   * urql client has no cache exchange, mutations don't invalidate queries on
+   * their own; each mounted table re-executes its own transactions query when
+   * this token changes so both the source and the target deposit refresh.
+   */
+  reassignToken?: number;
 };
 
 export function DepositsTransactionsTable({
   depositId,
   enableReassign = false,
   refetch,
+  reassignToken,
 }: Props): ReactElement {
   const { userContext } = useContext(UserContext);
   const [sorting, setSorting] = useState<SortingState>([{ id: 'date', desc: false }]);
 
-  const [{ data, fetching }] = useQuery({
+  const [{ data, fetching }, reexecuteQuery] = useQuery({
     query: SharedDepositTransactionsDocument,
     variables: { depositId },
   });
+
+  // Re-execute this deposit's transactions query when a reassign happens
+  // elsewhere. Skip the initial render — the query already fetches on mount.
+  const previousReassignToken = useRef(reassignToken);
+  useEffect(() => {
+    if (previousReassignToken.current === reassignToken) {
+      return;
+    }
+    previousReassignToken.current = reassignToken;
+    reexecuteQuery({ requestPolicy: 'network-only' });
+  }, [reassignToken, reexecuteQuery]);
 
   const computedTableData: DepositTransactionRowType[] = useMemo(() => {
     if (!data?.deposit?.metadata.transactions) {

--- a/packages/client/src/components/screens/bank-deposits/index.tsx
+++ b/packages/client/src/components/screens/bank-deposits/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, type ReactElement } from 'react';
+import { Fragment, useMemo, useRef, useState, type ReactElement } from 'react';
 import { ChevronDown, ChevronRight, Pencil, Plus } from 'lucide-react';
 import { useQuery } from 'urql';
 import {
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/table.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip.js';
 import { AllDepositsDocument } from '@/gql/graphql.js';
+import { useStableValue } from '@/hooks/use-stable-value.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -76,7 +77,7 @@ export function DepositsScreen(): ReactElement {
   const [createOpen, setCreateOpen] = useState(false);
   const [editingDeposit, setEditingDeposit] = useState<DepositRow | null>(null);
 
-  const rows: DepositRow[] = useMemo(() => {
+  const computedRows: DepositRow[] = useMemo(() => {
     const deposits = data?.allDeposits ?? [];
     return deposits.map(d => ({
       id: d.id,
@@ -93,6 +94,10 @@ export function DepositsScreen(): ReactElement {
       totalInterestFormatted: d.metadata.totalInterest?.formatted ?? '',
     }));
   }, [data]);
+
+  // Keep a stable reference across refetches so the table (and its expanded
+  // sub-rows) only re-render when the deposits actually changed.
+  const rows = useStableValue(computedRows);
 
   const columnsRef = useRef<ColumnDef<DepositRow>[]>([
     {
@@ -235,7 +240,7 @@ export function DepositsScreen(): ReactElement {
             ))}
           </TableHeader>
           <TableBody>
-            {fetching ? (
+            {fetching && !data ? (
               <TableRow>
                 <TableCell colSpan={columns.length} className="h-24 text-center">
                   Loading...
@@ -243,8 +248,8 @@ export function DepositsScreen(): ReactElement {
               </TableRow>
             ) : table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map(row => (
-                <>
-                  <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+                <Fragment key={row.id}>
+                  <TableRow data-state={row.getIsSelected() && 'selected'}>
                     {row.getVisibleCells().map(cell => (
                       <TableCell key={cell.id}>
                         {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -262,7 +267,7 @@ export function DepositsScreen(): ReactElement {
                       </TableCell>
                     </TableRow>
                   ) : null}
-                </>
+                </Fragment>
               ))
             ) : (
               <TableRow>

--- a/packages/client/src/components/screens/bank-deposits/index.tsx
+++ b/packages/client/src/components/screens/bank-deposits/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useRef, useState, type ReactElement } from 'react';
+import { Fragment, useCallback, useMemo, useRef, useState, type ReactElement } from 'react';
 import { ChevronDown, ChevronRight, Pencil, Plus } from 'lucide-react';
 import { useQuery } from 'urql';
 import {
@@ -76,6 +76,15 @@ export function DepositsScreen(): ReactElement {
   const [sorting, setSorting] = useState<SortingState>([{ id: 'openDate', desc: false }]);
   const [createOpen, setCreateOpen] = useState(false);
   const [editingDeposit, setEditingDeposit] = useState<DepositRow | null>(null);
+  const [reassignToken, setReassignToken] = useState(0);
+
+  // A reassign changes both deposits' balances (this list) and moves a
+  // transaction between two deposit tables. Refetch the list and bump the token
+  // so every mounted transaction table re-executes its own query.
+  const handleTransactionReassigned = useCallback(() => {
+    setReassignToken(token => token + 1);
+    refetch({ requestPolicy: 'network-only' });
+  }, [refetch]);
 
   const computedRows: DepositRow[] = useMemo(() => {
     const deposits = data?.allDeposits ?? [];
@@ -262,7 +271,8 @@ export function DepositsScreen(): ReactElement {
                         <DepositsTransactionsTable
                           depositId={row.original.id}
                           enableReassign
-                          refetch={refetch}
+                          refetch={handleTransactionReassigned}
+                          reassignToken={reassignToken}
                         />
                       </TableCell>
                     </TableRow>

--- a/packages/client/src/hooks/__tests__/use-stable-value.test.ts
+++ b/packages/client/src/hooks/__tests__/use-stable-value.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useStableValue } from '../use-stable-value.js';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function renderStableValue<T>(): { render: (value: T) => T } {
+  const seen: T[] = [];
+
+  function Harness({ value }: { value: T }): null {
+    seen.push(useStableValue(value));
+    return null;
+  }
+
+  return {
+    render(value: T): T {
+      act(() => root.render(React.createElement(Harness, { value })));
+      return seen[seen.length - 1] as T;
+    },
+  };
+}
+
+describe('useStableValue', () => {
+  it('returns the same reference when a deeply-equal value is passed', () => {
+    const harness = renderStableValue<{ id: string }[]>();
+
+    const first = harness.render([{ id: 'a' }]);
+    // New array + object identity, same content (simulating a urql refetch).
+    const second = harness.render([{ id: 'a' }]);
+
+    expect(second).toBe(first);
+  });
+
+  it('returns a new reference when the value actually changes', () => {
+    const harness = renderStableValue<{ id: string }[]>();
+
+    const first = harness.render([{ id: 'a' }]);
+    const second = harness.render([{ id: 'b' }]);
+
+    expect(second).not.toBe(first);
+    expect(second).toEqual([{ id: 'b' }]);
+  });
+
+  it('tracks the latest value across a stable then changed sequence', () => {
+    const harness = renderStableValue<number[]>();
+
+    const first = harness.render([1, 2, 3]);
+    const stable = harness.render([1, 2, 3]);
+    const changed = harness.render([1, 2, 3, 4]);
+
+    expect(stable).toBe(first);
+    expect(changed).not.toBe(first);
+    expect(changed).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/packages/client/src/hooks/use-stable-value.ts
+++ b/packages/client/src/hooks/use-stable-value.ts
@@ -1,0 +1,21 @@
+import { useRef } from 'react';
+import equal from 'deep-equal';
+
+/**
+ * Returns a referentially-stable version of `value` that only changes identity
+ * when the value changes by deep equality.
+ *
+ * Useful for values derived from GraphQL query results: urql returns a fresh
+ * `data` object on every (re)fetch, even when the underlying content is
+ * identical. Feeding that straight into `useReactTable`/`useMemo` dependencies
+ * forces the consumer to re-render on every background refetch, causing a
+ * visible "blink". Wrapping the derived value here keeps the reference stable
+ * so downstream renders only happen when the data actually changed.
+ */
+export function useStableValue<T>(value: T): T {
+  const ref = useRef<T>(value);
+  if (!equal(ref.current, value)) {
+    ref.current = value;
+  }
+  return ref.current;
+}

--- a/packages/client/src/hooks/use-stable-value.ts
+++ b/packages/client/src/hooks/use-stable-value.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useState } from 'react';
 import equal from 'deep-equal';
 
 /**
@@ -13,9 +13,18 @@ import equal from 'deep-equal';
  * so downstream renders only happen when the data actually changed.
  */
 export function useStableValue<T>(value: T): T {
-  const ref = useRef<T>(value);
-  if (!equal(ref.current, value)) {
-    ref.current = value;
+  const [stable, setStable] = useState<T>(value);
+
+  // Fast path: an identical reference (e.g. an unrelated local state update such
+  // as sorting or expanding a row) skips the potentially expensive deep
+  // comparison. Only when the reference changed — e.g. a urql refetch returned a
+  // fresh object — do we fall back to deep equality, and adopt the new reference
+  // solely when the content genuinely differs. Updating state during render is
+  // React's supported pattern for deriving state from arguments.
+  if (stable !== value && !equal(stable, value)) {
+    setStable(value);
+    return value;
   }
-  return ref.current;
+
+  return stable;
 }


### PR DESCRIPTION
## Problem

On the Bank Deposits screen (`packages/client/src/components/screens/bank-deposits/index.tsx`), reassigning a transaction triggers a refetch of `AllDeposits`. While the refetch itself is necessary, the whole screen visibly "blinks": the entire deposits table (and any expanded transaction sub-tables) blanks out and re-renders, even when nothing actually changed.

## Root causes

1. **Loading gates blank the view on every refetch.** Both the parent table and the nested `DepositsTransactionsTable` replaced their content with a `Loading...`/spinner whenever `fetching` was true. urql sets `fetching: true` on background refetches too, so the existing view disappeared and reappeared.
2. **Fresh object identity from urql forces re-renders.** urql returns a brand-new `data` object on every refetch. The derived row arrays (`useMemo` on `data`) therefore changed identity even when the content was byte-for-byte identical, causing TanStack Table to re-render.
3. **Keyless fragment in the row map.** Each deposit row mapped to a keyless `<>...</>`, making React fall back to index-based reconciliation.

## Changes

- **`use-stable-value.ts` (new hook):** returns a referentially-stable value that only changes identity when the value changes by deep equality (`deep-equal`, already a dependency). Wraps the derived rows in both tables so the view updates only when the data actually changed.
- **Loading gates:** changed `fetching` → `fetching && !data` in both the parent screen and `DepositsTransactionsTable`, so existing data stays on screen during background refetches (spinner only on the initial load).
- **Keyed `Fragment`:** replaced the keyless fragment with `<Fragment key={row.id}>` to keep reconciliation and expanded state stable.

Net effect: the refetch still happens after a reassign, but the view only updates when the new data differs — no more blinking.

## Testing

- Added a unit test for `useStableValue` (`src/hooks/__tests__/use-stable-value.test.ts`) covering stable-reference on deeply-equal input, new reference on change, and mixed sequences.
- Note: `yarn install`, lint, and tests could not be run in this environment because the org network policy blocks `cdn.sheetjs.com` (the registry host for the `xlsx` dependency), which fails the install. The changes are small and self-contained; please run `yarn lint` / `yarn test` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017fXR4gpNLwkT5Zpb45zjuM)_