### PR TITLE
feat(client): collapse charge row when accountant approval set to APPROVED

### DIFF
--- a/.changeset/charges-approval-collapse-row.md
+++ b/.changeset/charges-approval-collapse-row.md
@@ -1,0 +1,6 @@
+---
+'@accounter/client': patch
+---
+
+Collapse an expanded charge row automatically when its accountant approval status is set to
+`APPROVED` from the charges table.

--- a/packages/client/src/components/charges/cells/accountant-approval.tsx
+++ b/packages/client/src/components/charges/cells/accountant-approval.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState, type ReactElement } from 'react';
-import { ChargesTableAccountantApprovalFieldsFragmentDoc } from '../../../gql/graphql.js';
+import {
+  ChargesTableAccountantApprovalFieldsFragmentDoc,
+  type AccountantStatus,
+} from '../../../gql/graphql.js';
 import { getFragmentData, type FragmentType } from '../../../gql/index.js';
 import { UpdateAccountantStatus } from '../../common/index.js';
 
@@ -14,9 +17,10 @@ import { UpdateAccountantStatus } from '../../common/index.js';
 interface Props {
   data: FragmentType<typeof ChargesTableAccountantApprovalFieldsFragmentDoc>;
   onChange: () => void;
+  onStatusChange?: (status: AccountantStatus) => void;
 }
 
-export function AccountantApproval({ data, onChange }: Props): ReactElement {
+export function AccountantApproval({ data, onChange, onStatusChange }: Props): ReactElement {
   const charge = getFragmentData(ChargesTableAccountantApprovalFieldsFragmentDoc, data);
   const [status, setStatus] = useState(charge.accountantApproval);
 
@@ -28,7 +32,12 @@ export function AccountantApproval({ data, onChange }: Props): ReactElement {
 
   return (
     <td>
-      <UpdateAccountantStatus chargeId={charge.id} value={status} onChange={onChange} />
+      <UpdateAccountantStatus
+        chargeId={charge.id}
+        value={status}
+        onChange={onChange}
+        onStatusChange={onStatusChange}
+      />
     </td>
   );
 }

--- a/packages/client/src/components/charges/charges-row.tsx
+++ b/packages/client/src/components/charges/charges-row.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { useQuery } from 'urql';
 import { Paper } from '@mantine/core';
 import {
+  AccountantStatus,
   ChargeForRowDocument,
   ChargesTableBusinessTripFieldsFragmentDoc,
   ChargesTableEntityFieldsFragmentDoc,
@@ -130,6 +131,12 @@ export const ChargesTableRow = ({
 
   const isIncomeCharge = (charge?.totalAmount?.raw ?? 0) > 0;
 
+  const onAccountantStatusChange = useCallback((status: AccountantStatus): void => {
+    if (status === AccountantStatus.Approved) {
+      setOpened(false);
+    }
+  }, []);
+
   return (
     <>
       <tr>
@@ -181,7 +188,11 @@ export const ChargesTableRow = ({
         )}
 
         <MoreInfo data={charge} />
-        <AccountantApproval data={charge} onChange={onChange} />
+        <AccountantApproval
+          data={charge}
+          onChange={onChange}
+          onStatusChange={onAccountantStatusChange}
+        />
 
         <td>
           <div className="flex flex-col gap-2">

--- a/packages/client/src/components/common/inputs/update-accountant-status.tsx
+++ b/packages/client/src/components/common/inputs/update-accountant-status.tsx
@@ -47,7 +47,7 @@ export function UpdateAccountantStatus(props: {
   businessTripId?: string;
   value?: AccountantStatus;
 }): ReactNode {
-  const { onChange, onStatusChange, value } = props;
+  const { onChange, onStatusChange: onStatusChangeProp, value } = props;
   const [status, setStatus] = useState(value ?? AccountantStatus.Unapproved);
   const { updateChargeAccountantApproval } = useUpdateChargeAccountantApproval();
   const { updateBusinessTripAccountantApproval } = useUpdateBusinessTripAccountantApproval();
@@ -74,7 +74,7 @@ export function UpdateAccountantStatus(props: {
       if (!result) {
         setStatus(oldStatus);
       } else {
-        onStatusChange?.(newStatus);
+        onStatusChangeProp?.(newStatus);
       }
       onChange?.();
     },
@@ -85,7 +85,7 @@ export function UpdateAccountantStatus(props: {
       updateBusinessTripAccountantApproval,
       status,
       onChange,
-      onStatusChange,
+      onStatusChangeProp,
     ],
   );
 

--- a/packages/client/src/components/common/inputs/update-accountant-status.tsx
+++ b/packages/client/src/components/common/inputs/update-accountant-status.tsx
@@ -71,10 +71,10 @@ export function UpdateAccountantStatus(props: {
           status: newStatus,
         });
       }
-      if (!result) {
-        setStatus(oldStatus);
-      } else {
+      if (result) {
         onStatusChangeProp?.(newStatus);
+      } else {
+        setStatus(oldStatus);
       }
       onChange?.();
     },

--- a/packages/client/src/components/common/inputs/update-accountant-status.tsx
+++ b/packages/client/src/components/common/inputs/update-accountant-status.tsx
@@ -42,11 +42,12 @@ const getApprovalStatusConfig = (status: AccountantStatus) => accountantApproval
 
 export function UpdateAccountantStatus(props: {
   onChange?: () => void;
+  onStatusChange?: (status: AccountantStatus) => void;
   chargeId?: string;
   businessTripId?: string;
   value?: AccountantStatus;
 }): ReactNode {
-  const { onChange, value } = props;
+  const { onChange, onStatusChange, value } = props;
   const [status, setStatus] = useState(value ?? AccountantStatus.Unapproved);
   const { updateChargeAccountantApproval } = useUpdateChargeAccountantApproval();
   const { updateBusinessTripAccountantApproval } = useUpdateBusinessTripAccountantApproval();
@@ -72,6 +73,8 @@ export function UpdateAccountantStatus(props: {
       }
       if (!result) {
         setStatus(oldStatus);
+      } else {
+        onStatusChange?.(newStatus);
       }
       onChange?.();
     },
@@ -82,6 +85,7 @@ export function UpdateAccountantStatus(props: {
       updateBusinessTripAccountantApproval,
       status,
       onChange,
+      onStatusChange,
     ],
   );
 


### PR DESCRIPTION
## Summary

Closes #3732

On the charges table, every row has an "accountant approval" button and can be expanded to show extended info. This PR makes an expanded charge row **collapse automatically when its accountant status is changed to `APPROVED`**.

## Changes

- **`UpdateAccountantStatus`** (`common/inputs/update-accountant-status.tsx`): added an optional `onStatusChange?: (status: AccountantStatus) => void` callback, fired with the new status after a successful update.
- **`AccountantApproval`** cell (`charges/cells/accountant-approval.tsx`): threads the optional `onStatusChange` prop through to `UpdateAccountantStatus`.
- **`ChargesTableRow`** (`charges/charges-row.tsx`): passes an `onAccountantStatusChange` handler that sets `opened` to `false` when the new status is `AccountantStatus.Approved`.

The callback is optional, so existing consumers of `UpdateAccountantStatus` (VAT monthly report, business trip report) are unaffected.

## Notes

Dependency install could not complete in the sandbox (an egress-policy–blocked host during `yarn install`), so `yarn generate`/`yarn lint` were not run here. The changes are type-safe and follow existing patterns — `AccountantStatus` is already imported as a runtime enum value in sibling files. Please let CI verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtimgNcwA3j3e8AjKG4V2t

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtimgNcwA3j3e8AjKG4V2t)_