### PR TITLE
fix(server): restore tsc-alias path resolution broken by 1.9.1

### DIFF
--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -5,6 +5,14 @@
     "rootDir": "..",
     "noUnusedLocals": false,
 
+    // `baseUrl` anchors the relative `paths` below (which point at sibling
+    // packages via `../`) so `tsc-alias` rewrites them to the correct output
+    // location. tsc-alias 1.9.1 stopped implicitly defaulting `baseUrl` to
+    // `rootDir`, which previously made this work by accident. Deprecated in
+    // TS 6, hence `ignoreDeprecations` — revisit when migrating off `paths`.
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+
     "paths": {
       "@accounter/green-invoice-graphql": ["../green-invoice-graphql/src/index.js"],
       "@accounter/pcn874-generator": ["../pcn874-generator/src/index.js"],


### PR DESCRIPTION
## Problem

`yarn server:dev` crashes at runtime with:

```
file:///.../packages/server/dist/server/src/modules/app-providers/green-invoice-client.js:5
import { init, } from '../../index.js';
         ^^^^
SyntaxError: The requested module '../../index.js' does not provide an export named 'init'
```

This started when `tsc-alias` was bumped **1.9.0 → 1.9.1** (#3928).

## Root cause

`tsc-alias` 1.9.1 shipped one change — *"do not activate baseurl mode"* ([tsc-alias#262](https://github.com/justkey007/tsc-alias/pull/262)): it stopped implicitly defaulting `baseUrl = rootDir`.

`packages/server/tsconfig.json` defines `paths` that point at **sibling packages** via relative `../` values (e.g. `../green-invoice-graphql/src/index.js`) together with `rootDir: ".."`, but had **no explicit `baseUrl`** — so it was silently depending on that old auto-default. Without the anchor, tsc-alias rewrote `@accounter/green-invoice-graphql` to `../../index.js` (the server's own `dist/server/src/index.js`, which has no `init` export) instead of `../../../../green-invoice-graphql/src/index.js`.

Only `packages/server` uses `tsc-alias`.

## Fix

Two lines in `packages/server/tsconfig.json`:

- `"baseUrl": "."` — explicitly anchors the relative path aliases so tsc-alias resolves them to the correct sibling-package output.
- `"ignoreDeprecations": "6.0"` — `baseUrl` is deprecated in TS 6.0.3 (TS5101); without this, `tsc && tsc-alias` would abort before tsc-alias runs.

This keeps `tsc-alias` at 1.9.1 (the version Renovate wants) and fixes the underlying config rather than reverting the bump. It's a tsconfig-only change — no dependency or lockfile changes.

## Verification

Reproduced in an isolated toolchain mirroring the real root + server tsconfigs (TypeScript 6.0.3, tsc-alias 1.9.1):

- **Before:** emitted `import { init, } from '../../index.js';` (the reported bug).
- **After:** all four workspace aliases rewrite to correct, on-disk paths (`../../../../green-invoice-graphql/src/index.js`, `../../../../pcn874-generator/src/index.js`, `../../../../shaam6111-generator/src/index.js`, `../../../../shaam-uniform-format-generator/src/index.js`); `graphql-modules` correctly stays a bare import; and TS5101 no longer fires, so the build no longer aborts.

> Note: a full `yarn install` / `yarn build` could not be run in the authoring environment (egress proxy blocks some Yarn hosts). A CI run or local `yarn server:dev` is worth a confirming glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013a3kTC8JGUJzhx2wGtBaug)_