### PR TITLE
fix(documents): pre-fill financial fields when switching an "other" document to a financial type

### DIFF
--- a/.changeset/document-type-switch-financial-fields.md
+++ b/.changeset/document-type-switch-financial-fields.md
@@ -1,0 +1,21 @@
+---
+'@accounter/server': patch
+'@accounter/client': patch
+---
+
+Pre-fill financial fields when switching an "other"/"unprocessed" document to a financial type in
+the edit-document modal.
+
+A document can be inserted carrying full financial data (date, amount, VAT, serial number,
+debtor/creditor, etc.) while still categorized as `OTHER`/`UNPROCESSED`. Previously, editing such a
+document and switching its type to a financial one (e.g. invoice) showed all extended attribute
+fields empty — the stored values only appeared after saving and reopening the modal, once the
+document re-resolved as a `FinancialDocument`.
+
+The financial fields were only exposed on the `FinancialDocument` GraphQL types, so the edit query
+could never fetch the already-stored values for `Unprocessed`/`OtherDocument`. These fields (`vat`,
+`serialNumber`, `date`, `amount`, `vatReportDateOverride`, `noVatAmount`, `allocationNumber`,
+`exchangeRateOverride`, `debtor`, `creditor`) are now exposed on the `Unprocessed` and
+`OtherDocument` types and fetched by the client, and the edit form reads its financial defaults from
+the document regardless of its current type — so switching to a financial type immediately
+pre-fills the stored values.

--- a/packages/client/src/components/common/forms/edit-document.tsx
+++ b/packages/client/src/components/common/forms/edit-document.tsx
@@ -47,6 +47,54 @@ import { ModifyDocumentFields } from './modify-document-fields.js';
         allocationNumber
         exchangeRateOverride
       }
+      ... on Unprocessed {
+        vat {
+          raw
+          currency
+        }
+        serialNumber
+        date
+        amount {
+          raw
+          currency
+        }
+        debtor {
+          id
+          name
+        }
+        creditor {
+          id
+          name
+        }
+        vatReportDateOverride
+        noVatAmount
+        allocationNumber
+        exchangeRateOverride
+      }
+      ... on OtherDocument {
+        vat {
+          raw
+          currency
+        }
+        serialNumber
+        date
+        amount {
+          raw
+          currency
+        }
+        debtor {
+          id
+          name
+        }
+        creditor {
+          id
+          name
+        }
+        vatReportDateOverride
+        noVatAmount
+        allocationNumber
+        exchangeRateOverride
+      }
     }
   }
 `;

--- a/packages/client/src/components/common/forms/modify-document-fields.tsx
+++ b/packages/client/src/components/common/forms/modify-document-fields.tsx
@@ -39,11 +39,10 @@ export const ModifyDocumentFields = ({
 
   // Financial metadata may already be stored on the document row even when it is currently
   // classified as "Unprocessed"/"Other" (e.g. a document inserted carrying full data but
-  // categorized as "other"). Read it regardless of the current document type so that switching
-  // to a financial type immediately pre-fills the stored values instead of showing empty fields.
-  const processedDoc = document
-    ? (document as Extract<NonNullable<EditDocumentQuery['documentById']>, { date: unknown }>)
-    : undefined;
+  // categorized as "other"). The edit query now selects these fields on every document type, so
+  // read them regardless of the current type to immediately pre-fill the stored values when
+  // switching to a financial type instead of showing empty fields.
+  const processedDoc = document ?? undefined;
 
   const type = watch('documentType');
 

--- a/packages/client/src/components/common/forms/modify-document-fields.tsx
+++ b/packages/client/src/components/common/forms/modify-document-fields.tsx
@@ -10,13 +10,6 @@ import {
   type UpdateDocumentFieldsInput,
 } from '../../../gql/graphql.js';
 import { TIMELESS_DATE_REGEX } from '../../../helpers/consts.js';
-import {
-  isDocumentCreditInvoice,
-  isDocumentInvoice,
-  isDocumentInvoiceReceipt,
-  isDocumentProforma,
-  isDocumentReceipt,
-} from '../../../helpers/documents.js';
 import { useGetFinancialEntities } from '../../../hooks/use-get-financial-entities.js';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { Input } from '../../ui/input.js';
@@ -44,14 +37,11 @@ export const ModifyDocumentFields = ({
   const { selectableFinancialEntities: financialEntities, fetching: fetchingFinancialEntities } =
     useGetFinancialEntities();
 
-  const isDocumentProcessed =
-    isDocumentInvoice(document) ||
-    isDocumentReceipt(document) ||
-    isDocumentInvoiceReceipt(document) ||
-    isDocumentProforma(document) ||
-    isDocumentCreditInvoice(document);
-
-  const processedDoc = isDocumentProcessed
+  // Financial metadata may already be stored on the document row even when it is currently
+  // classified as "Unprocessed"/"Other" (e.g. a document inserted carrying full data but
+  // categorized as "other"). Read it regardless of the current document type so that switching
+  // to a financial type immediately pre-fills the stored values instead of showing empty fields.
+  const processedDoc = document
     ? (document as Extract<NonNullable<EditDocumentQuery['documentById']>, { date: unknown }>)
     : undefined;
 

--- a/packages/server/src/modules/documents/resolvers/common.ts
+++ b/packages/server/src/modules/documents/resolvers/common.ts
@@ -59,7 +59,9 @@ export const commonFinancialDocumentsFields:
   serialNumber: documentRoot => documentRoot.serial_number ?? '',
   date: documentRoot => optionalDateToTimelessDateString(documentRoot.date),
   amount: documentRoot =>
-    formatFinancialAmount(documentRoot.total_amount, documentRoot.currency_code),
+    documentRoot.total_amount == null
+      ? null
+      : formatFinancialAmount(documentRoot.total_amount, documentRoot.currency_code),
   vat: documentRoot =>
     documentRoot.vat_amount == null
       ? null

--- a/packages/server/src/modules/documents/resolvers/common.ts
+++ b/packages/server/src/modules/documents/resolvers/common.ts
@@ -53,7 +53,9 @@ export const commonFinancialDocumentsFields:
   | DocumentsModule.InvoiceResolvers
   | DocumentsModule.ReceiptResolvers
   | DocumentsModule.InvoiceReceiptResolvers
-  | DocumentsModule.ProformaResolvers = {
+  | DocumentsModule.ProformaResolvers
+  | DocumentsModule.UnprocessedResolvers
+  | DocumentsModule.OtherDocumentResolvers = {
   serialNumber: documentRoot => documentRoot.serial_number ?? '',
   date: documentRoot => optionalDateToTimelessDateString(documentRoot.date),
   amount: documentRoot =>

--- a/packages/server/src/modules/documents/resolvers/documents.resolver.ts
+++ b/packages/server/src/modules/documents/resolvers/documents.resolver.ts
@@ -571,9 +571,11 @@ export const documentsResolvers: DocumentsModule.Resolvers &
   },
   Unprocessed: {
     ...commonDocumentsFields,
+    ...commonFinancialDocumentsFields,
   },
   OtherDocument: {
     ...commonDocumentsFields,
+    ...commonFinancialDocumentsFields,
   },
   Receipt: {
     ...commonDocumentsFields,

--- a/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
+++ b/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
@@ -97,6 +97,16 @@ export default gql`
     isReviewed: Boolean
     description: String
     remarks: String
+
+    " financial metadata that may already be stored on the document even before it is classified as a financial document "
+    vat: FinancialAmount
+    serialNumber: String
+    date: TimelessDate
+    amount: FinancialAmount
+    vatReportDateOverride: TimelessDate
+    noVatAmount: Float
+    allocationNumber: String
+    exchangeRateOverride: Float
   }
 
   " processed non-financial document "
@@ -108,6 +118,16 @@ export default gql`
     isReviewed: Boolean
     description: String
     remarks: String
+
+    " financial metadata that may already be stored on the document even though it is classified as a non-financial document "
+    vat: FinancialAmount
+    serialNumber: String
+    date: TimelessDate
+    amount: FinancialAmount
+    vatReportDateOverride: TimelessDate
+    noVatAmount: Float
+    allocationNumber: String
+    exchangeRateOverride: Float
   }
 
   " represent a financial document "

--- a/packages/server/src/modules/financial-entities/resolvers/common.ts
+++ b/packages/server/src/modules/financial-entities/resolvers/common.ts
@@ -80,7 +80,10 @@ export const commonTransactionFields:
   },
 };
 
-export const commonDocumentsFields: FinancialEntitiesModule.FinancialDocumentResolvers = {
+export const commonDocumentsFields:
+  | FinancialEntitiesModule.FinancialDocumentResolvers
+  | FinancialEntitiesModule.UnprocessedResolvers
+  | FinancialEntitiesModule.OtherDocumentResolvers = {
   creditor: (documentRoot, _, { injector }) =>
     documentRoot.creditor_id
       ? injector

--- a/packages/server/src/modules/financial-entities/resolvers/financial-entities.resolver.ts
+++ b/packages/server/src/modules/financial-entities/resolvers/financial-entities.resolver.ts
@@ -97,6 +97,12 @@ export const financialEntitiesResolvers: FinancialEntitiesModule.Resolvers &
   Receipt: {
     ...commonDocumentsFields,
   },
+  Unprocessed: {
+    ...commonDocumentsFields,
+  },
+  OtherDocument: {
+    ...commonDocumentsFields,
+  },
   LedgerRecord: {
     creditAccount1: ledgerCounterparty('CreditAccount1'),
     creditAccount2: ledgerCounterparty('CreditAccount2'),

--- a/packages/server/src/modules/financial-entities/typeDefs/financial-entities.graphql.ts
+++ b/packages/server/src/modules/financial-entities/typeDefs/financial-entities.graphql.ts
@@ -119,6 +119,16 @@ export default gql`
     debtor: FinancialEntity
   }
 
+  extend type Unprocessed {
+    creditor: FinancialEntity
+    debtor: FinancialEntity
+  }
+
+  extend type OtherDocument {
+    creditor: FinancialEntity
+    debtor: FinancialEntity
+  }
+
   extend type LedgerRecord {
     debitAccount1: FinancialEntity
     debitAccount2: FinancialEntity


### PR DESCRIPTION
## Problem

When editing a document via the edit-document modal, a document that was inserted **carrying full financial data** (date, amount, VAT, serial number, debtor/creditor, etc.) but **categorized as `OTHER` / `UNPROCESSED`** shows all extended attribute fields **empty** the moment the user switches its type to a financial one (e.g. Invoice).

The data was there all along — it only appeared after saving and reopening the modal, once the document re-resolved as a `FinancialDocument`. This is confusing UX: the info should appear immediately as the user switches the document type.

## Root cause

The financial metadata fields were only exposed on the `FinancialDocument` GraphQL types. So the `EditDocument` query's `... on FinancialDocument` fragment never matched an `Unprocessed`/`OtherDocument`, and the already-stored values could not be fetched into the form. Switching the type in the form therefore had nothing to pre-fill from.

## Fix

**Server**
- Expose the financial metadata fields (`vat`, `serialNumber`, `date`, `amount`, `vatReportDateOverride`, `noVatAmount`, `allocationNumber`, `exchangeRateOverride`) plus `debtor`/`creditor` on the `Unprocessed` and `OtherDocument` types. The values already exist on the document row, so the resolvers simply reuse the existing `commonFinancialDocumentsFields` and the financial-entities `commonDocumentsFields` (debtor/creditor) resolvers.

**Client**
- Fetch these fields in the `EditDocument` query for `Unprocessed` and `OtherDocument`.
- Populate the edit form's financial defaults from the document regardless of its current type, so switching to a financial type immediately pre-fills the stored values instead of showing empty fields.

## Behavior change

- Additive schema change only — existing queries are unaffected.
- The insert-document flow is unchanged (`document` is not passed there, so the derived defaults stay `undefined`).

## Note on validation

`yarn generate` / `yarn lint` / `yarn build` could not be run in this environment: `yarn install` is blocked by the egress policy on `cdn.sheetjs.com` (the pre-existing `xlsx` dependency of `node-xlsx`), which returns 403. All other packages are cached. **Please run `yarn generate && yarn lint && yarn build` in CI / locally to regenerate the GraphQL types and confirm.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019cLCwisvfhJ6wrZMKBiUVw)_