### PR TITLE
fix(scraper-app): surface Poalim schema validation failures instead of silently swallowing them

### DIFF
--- a/.changeset/poalim-scraper-validation-errors.md
+++ b/.changeset/poalim-scraper-validation-errors.md
@@ -1,0 +1,12 @@
+---
+'@accounter/scraper-app': patch
+---
+
+Surface Poalim schema validation failures instead of silently swallowing them. The
+modern-poalim-scraper runs Zod validation internally (`validateSchema: true`) and returns
+`{ data, isValid, errors }`, setting `data` to `null` and `isValid` to `false` on a failed
+validation. `scrapePoalim` only read `data`, so a failed `getAccountsData` validation looked like
+"no accounts" and the run reported success with no data; the same silent swallow applied to the
+per-account ILS, foreign, and SWIFT requests. Each Poalim request now checks `isValid` and throws a
+descriptive error (including the validation issues), which propagates to the run runner and is
+emitted as a `task-error` so the user is notified.

--- a/packages/scraper-app/src/server/scrapers/__tests__/poalim.test.ts
+++ b/packages/scraper-app/src/server/scrapers/__tests__/poalim.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
 import { OtpManager } from '../../otp-manager.js';
-import { PayloadValidationError } from '../../validate-payload.js';
 import { scrapePoalim } from '../poalim.js';
 
 const VALID_ACCOUNTS = [{ bankNumber: 12, branchNumber: 600, accountNumber: 100_000 }];
@@ -145,12 +144,16 @@ describe('scrapePoalim — Unknown Error', () => {
   });
 });
 
-describe('scrapePoalim — invalid payload', () => {
-  it('throws PayloadValidationError when ILS data fails schema validation', async () => {
+describe('scrapePoalim — schema validation failures are surfaced', () => {
+  it('throws (not silently returns empty) when accounts data fails schema validation', async () => {
+    // Regression: the scraper reports isValid:false with data:null on a failed validation.
+    // Previously only `data` was read, so this looked like "no accounts" and the run reported
+    // success with no data. It must now surface as an error instead.
     const scraper = makeScraper({
-      getILSTransactions: vi.fn().mockResolvedValue({
-        data: { transactions: 'not-an-array', retrievalTransactionData: {} },
+      getAccountsData: vi.fn().mockResolvedValue({
+        data: null,
         isValid: false,
+        errors: [{ message: 'expected array, received object' }],
       }),
     });
     const initMock = await getInitMock();
@@ -161,6 +164,80 @@ describe('scrapePoalim — invalid payload', () => {
 
     await expect(
       scrapePoalim(CREDS, new Date(), new Date(), true, new OtpManager(), noop),
-    ).rejects.toBeInstanceOf(PayloadValidationError);
+    ).rejects.toThrow('accounts data failed schema validation');
+  });
+
+  it('throws when ILS data fails schema validation', async () => {
+    const scraper = makeScraper({
+      getILSTransactions: vi.fn().mockResolvedValue({
+        data: null,
+        isValid: false,
+        errors: [{ message: 'transactions: expected array' }],
+      }),
+    });
+    const initMock = await getInitMock();
+    initMock.mockResolvedValue({
+      hapoalim: vi.fn().mockResolvedValue(scraper),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await expect(
+      scrapePoalim(CREDS, new Date(), new Date(), true, new OtpManager(), noop),
+    ).rejects.toThrow('ILS transactions failed schema validation');
+  });
+
+  it('throws when foreign data is unreachable / fails schema validation', async () => {
+    const scraper = makeScraper({
+      getForeignTransactions: vi.fn().mockResolvedValue({
+        data: null,
+        isValid: false,
+        errors: 'Data seems unreachable. Is the account active?',
+      }),
+    });
+    const initMock = await getInitMock();
+    initMock.mockResolvedValue({
+      hapoalim: vi.fn().mockResolvedValue(scraper),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await expect(
+      scrapePoalim(CREDS, new Date(), new Date(), true, new OtpManager(), noop),
+    ).rejects.toThrow('foreign transactions failed schema validation');
+  });
+
+  it('throws when SWIFT data fails schema validation', async () => {
+    const scraper = makeScraper({
+      getForeignSwiftTransactions: vi.fn().mockResolvedValue({
+        data: null,
+        isValid: false,
+        errors: [{ message: 'swiftsList: expected array' }],
+      }),
+    });
+    const initMock = await getInitMock();
+    initMock.mockResolvedValue({
+      hapoalim: vi.fn().mockResolvedValue(scraper),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await expect(
+      scrapePoalim(CREDS, new Date(), new Date(), true, new OtpManager(), noop),
+    ).rejects.toThrow('SWIFT transactions failed schema validation');
+  });
+
+  it('calls close() when a schema validation error is thrown', async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const scraper = makeScraper({
+      getAccountsData: vi.fn().mockResolvedValue({ data: null, isValid: false, errors: [] }),
+    });
+    const initMock = await getInitMock();
+    initMock.mockResolvedValue({
+      hapoalim: vi.fn().mockResolvedValue(scraper),
+      close,
+    });
+
+    await expect(
+      scrapePoalim(CREDS, new Date(), new Date(), true, new OtpManager(), noop),
+    ).rejects.toThrow();
+    expect(close).toHaveBeenCalledOnce();
   });
 });

--- a/packages/scraper-app/src/server/scrapers/poalim.ts
+++ b/packages/scraper-app/src/server/scrapers/poalim.ts
@@ -37,7 +37,27 @@ const OTP_TIMEOUT_MS = 5 * 60 * 1000;
 function describeValidationError(errors: unknown): string {
   if (errors == null) return 'unknown validation error';
   if (typeof errors === 'string') return errors;
-  if (errors instanceof Error) return errors.message;
+  if (errors instanceof Error) {
+    // ZodError carries the individual issues on `.issues`; prefer those over the noisy message.
+    if ('issues' in errors && Array.isArray(errors.issues)) {
+      return describeValidationError(errors.issues);
+    }
+    return errors.message;
+  }
+  if (Array.isArray(errors)) {
+    return errors
+      .map(err => {
+        if (err && typeof err === 'object' && 'message' in err) {
+          const pathStr =
+            'path' in err && Array.isArray(err.path) && err.path.length > 0
+              ? ` at ${err.path.join('.')}`
+              : '';
+          return `${(err as { message: unknown }).message}${pathStr}`;
+        }
+        return String(err);
+      })
+      .join(', ');
+  }
   try {
     return JSON.stringify(errors);
   } catch {
@@ -89,8 +109,11 @@ export async function scrapePoalim(
       throw new Error('Hapoalim login failed: Unknown Error');
     }
 
-    const { data: accounts, isValid: accountsValid, errors: accountsErrors } =
-      await scraper.getAccountsData();
+    const {
+      data: accounts,
+      isValid: accountsValid,
+      errors: accountsErrors,
+    } = await scraper.getAccountsData();
     if (accountsValid === false) {
       throw new Error(
         `Poalim accounts data failed schema validation: ${describeValidationError(accountsErrors)}`,
@@ -184,8 +207,11 @@ export async function scrapePoalim(
       };
 
       emit({ type: 'task-account-txns-fetching', sourceId: creds.id, accountId, txnType: 'ils' });
-      const { data: ilsData, isValid: ilsValid, errors: ilsErrors } =
-        await scraper.getILSTransactions(accountRef);
+      const {
+        data: ilsData,
+        isValid: ilsValid,
+        errors: ilsErrors,
+      } = await scraper.getILSTransactions(accountRef);
       if (ilsValid === false) {
         throw new Error(
           `Poalim ILS transactions failed schema validation for account ${accountId}: ${describeValidationError(ilsErrors)}`,
@@ -201,8 +227,11 @@ export async function scrapePoalim(
         accountId,
         txnType: 'foreign',
       });
-      const { data: foreignData, isValid: foreignValid, errors: foreignErrors } =
-        await scraper.getForeignTransactions(accountRef, isBusiness);
+      const {
+        data: foreignData,
+        isValid: foreignValid,
+        errors: foreignErrors,
+      } = await scraper.getForeignTransactions(accountRef, isBusiness);
       if (foreignValid === false) {
         throw new Error(
           `Poalim foreign transactions failed schema validation for account ${accountId}: ${describeValidationError(foreignErrors)}`,
@@ -213,8 +242,11 @@ export async function scrapePoalim(
       }
 
       emit({ type: 'task-account-txns-fetching', sourceId: creds.id, accountId, txnType: 'swift' });
-      const { data: swiftData, isValid: swiftValid, errors: swiftErrors } =
-        await scraper.getForeignSwiftTransactions(accountRef);
+      const {
+        data: swiftData,
+        isValid: swiftValid,
+        errors: swiftErrors,
+      } = await scraper.getForeignSwiftTransactions(accountRef);
       if (swiftValid === false) {
         throw new Error(
           `Poalim SWIFT transactions failed schema validation for account ${accountId}: ${describeValidationError(swiftErrors)}`,

--- a/packages/scraper-app/src/server/scrapers/poalim.ts
+++ b/packages/scraper-app/src/server/scrapers/poalim.ts
@@ -27,6 +27,24 @@ export type DecoratedSwiftTransactions = Omit<SwiftTransactions, 'swiftsList'> &
 
 const OTP_TIMEOUT_MS = 5 * 60 * 1000;
 
+/**
+ * The modern-poalim-scraper runs Zod schema validation internally (validateSchema: true) and
+ * returns `{ data, isValid, errors }`. On a validation failure `data` is `null` and `isValid` is
+ * `false`. If we only read `data` we silently treat a failed validation as "no data", which makes a
+ * broken run look successful. This turns the validation error into a readable message so the caller
+ * can surface it to the user.
+ */
+function describeValidationError(errors: unknown): string {
+  if (errors == null) return 'unknown validation error';
+  if (typeof errors === 'string') return errors;
+  if (errors instanceof Error) return errors.message;
+  try {
+    return JSON.stringify(errors);
+  } catch {
+    return String(errors);
+  }
+}
+
 export async function scrapePoalim(
   creds: PoalimCreds,
   dateFrom: Date,
@@ -71,7 +89,13 @@ export async function scrapePoalim(
       throw new Error('Hapoalim login failed: Unknown Error');
     }
 
-    const { data: accounts } = await scraper.getAccountsData();
+    const { data: accounts, isValid: accountsValid, errors: accountsErrors } =
+      await scraper.getAccountsData();
+    if (accountsValid === false) {
+      throw new Error(
+        `Poalim accounts data failed schema validation: ${describeValidationError(accountsErrors)}`,
+      );
+    }
     if (!accounts || accounts.length === 0) {
       return [];
     }
@@ -160,7 +184,13 @@ export async function scrapePoalim(
       };
 
       emit({ type: 'task-account-txns-fetching', sourceId: creds.id, accountId, txnType: 'ils' });
-      const { data: ilsData } = await scraper.getILSTransactions(accountRef);
+      const { data: ilsData, isValid: ilsValid, errors: ilsErrors } =
+        await scraper.getILSTransactions(accountRef);
+      if (ilsValid === false) {
+        throw new Error(
+          `Poalim ILS transactions failed schema validation for account ${accountId}: ${describeValidationError(ilsErrors)}`,
+        );
+      }
       if (ilsData) {
         ils = validatePayload('poalim-ils', ilsData);
       }
@@ -171,13 +201,25 @@ export async function scrapePoalim(
         accountId,
         txnType: 'foreign',
       });
-      const { data: foreignData } = await scraper.getForeignTransactions(accountRef, isBusiness);
+      const { data: foreignData, isValid: foreignValid, errors: foreignErrors } =
+        await scraper.getForeignTransactions(accountRef, isBusiness);
+      if (foreignValid === false) {
+        throw new Error(
+          `Poalim foreign transactions failed schema validation for account ${accountId}: ${describeValidationError(foreignErrors)}`,
+        );
+      }
       if (foreignData) {
         foreign = validatePayload('poalim-foreign', foreignData);
       }
 
       emit({ type: 'task-account-txns-fetching', sourceId: creds.id, accountId, txnType: 'swift' });
-      const { data: swiftData } = await scraper.getForeignSwiftTransactions(accountRef);
+      const { data: swiftData, isValid: swiftValid, errors: swiftErrors } =
+        await scraper.getForeignSwiftTransactions(accountRef);
+      if (swiftValid === false) {
+        throw new Error(
+          `Poalim SWIFT transactions failed schema validation for account ${accountId}: ${describeValidationError(swiftErrors)}`,
+        );
+      }
       if (swiftData) {
         const validated = validatePayload('poalim-swift', swiftData);
         const decoratedSwiftsList: DecoratedSwiftTransactions['swiftsList'] = [];


### PR DESCRIPTION
## Problem

When scraping Poalim, `scrapePoalim` calls `scraper.getAccountsData()` (and the per-account `getILSTransactions` / `getForeignTransactions` / `getForeignSwiftTransactions`). Because the scraper is initialized with `validateSchema: true`, each of these runs Zod validation internally and returns `{ data, isValid, errors }`. **On a validation failure, `data` is `null` and `isValid` is `false`.**

`scrapePoalim` only destructured `data` and ignored `isValid`/`errors`. So when `getAccountsData` failed schema validation, `data` was `null`, the code hit `if (!accounts || accounts.length === 0) return []`, and the run reported **success with no data** — masking a real scraper/schema breakage. The same silent-swallow applied to the parallel ILS, foreign, and SWIFT requests (`if (data) …` skipped when `data` was `null`).

## Fix

`packages/scraper-app/src/server/scrapers/poalim.ts`:

- Read `isValid`/`errors` from every Poalim request and throw a descriptive error when `isValid === false`, including the validation issues via a small `describeValidationError` helper (handles Zod issue arrays, `ZodError`, plain strings, and unknown shapes).
- The thrown error propagates through the existing `try/catch` and the run runner emits a `task-error`, so **the user is notified** instead of seeing a phantom successful, empty run.

This mirrors how `amex.ts` / `isracard.ts` already handle `isValid`.

## Scope check (other sources)

- **amex / isracard** — already check `isValid` and throw. ✅
- **cal / discount / max** — don't use the scraper's internal validation; they validate app-side with `validatePayload`, which already throws on failure. ✅
- **otsar-hahayal** — doesn't enable `validateSchema` (defaults to `false`), so `isValid` is always `null` and there's no silent-validation path. ✅
- **poalim** — the only affected source. Fixed here.

An empty-but-well-formed SWIFT response still validates (`isValid: true`, empty `swiftsList`), so surfacing `isValid === false` does not produce false positives for accounts with no transactions.

## Tests

`packages/scraper-app/src/server/scrapers/__tests__/poalim.test.ts`:

- Added a regression test asserting that `getAccountsData` returning `{ data: null, isValid: false }` **throws** rather than silently returning `[]`.
- Added tests that ILS, foreign, and SWIFT validation failures each throw a descriptive error.
- Added a test that `close()` is still called when a validation error is thrown.
- Updated the existing invalid-payload test's mock to match real scraper behavior (`data: null` on failure).

> Note: `yarn install` could not complete in this environment because a transitive dependency (`xlsx`) fetches from `cdn.sheetjs.com`, which is blocked by the sandbox egress policy — so the vitest suite could not be executed here. The changes are localized and follow the existing `amex.ts` pattern; CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S5gMRPeaDBx7JnEKGHUvpH)_