### PR TITLE
feat(mcp-server): scaffold package skeleton (MCP Prompt 01)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,0 +1,25 @@
+# @accounter/mcp-server
+
+Remote MCP (Model Context Protocol) server that exposes a curated, **read-only** subset of Accounter
+capabilities to Claude clients (Claude.ai / Claude Desktop).
+
+See the design docs:
+
+- [`docs/mcp/spec.md`](../../docs/mcp/spec.md) — connector specification
+- [`docs/mcp/implementation-blueprint.md`](../../docs/mcp/implementation-blueprint.md) — incremental
+  implementation plan
+
+## Status
+
+Early scaffolding. This package is being built incrementally following the prompt pack in the
+implementation blueprint. It currently contains only the package skeleton (no runtime behavior yet).
+
+## Scripts
+
+```bash
+yarn workspace @accounter/mcp-server build     # tsc → dist/
+yarn workspace @accounter/mcp-server dev       # run entrypoint with tsx (watch)
+yarn workspace @accounter/mcp-server lint      # eslint
+yarn workspace @accounter/mcp-server test      # vitest (package-scoped)
+yarn workspace @accounter/mcp-server typecheck # tsc --noEmit
+```

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@accounter/mcp-server",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Remote MCP (Model Context Protocol) server exposing a curated, read-only subset of Accounter capabilities to Claude clients",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Urigo/accounter-fullstack.git",
+    "directory": "packages/mcp-server"
+  },
+  "homepage": "https://github.com/Urigo/accounter-fullstack/tree/main/packages/mcp-server#readme",
+  "bugs": {
+    "url": "https://github.com/Urigo/accounter-fullstack/issues"
+  },
+  "author": "Gil Gardosh <gilgardosh@gmail.com>",
+  "license": "MIT",
+  "private": true,
+  "engines": {
+    "node": "26.5.0"
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "connector",
+    "accounter"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts",
+    "lint": "eslint './src/**/*.{js,ts,tsx}' --quiet",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "25.9.5",
+    "tsx": "4.23.1",
+    "typescript": "6.0.3",
+    "vitest": "4.1.10"
+  }
+}

--- a/packages/mcp-server/src/__tests__/index.test.ts
+++ b/packages/mcp-server/src/__tests__/index.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { main, PACKAGE_NAME } from '../index.js';
+
+describe('mcp-server scaffold', () => {
+  it('exposes the package name', () => {
+    expect(PACKAGE_NAME).toBe('@accounter/mcp-server');
+  });
+
+  it('main() is a no-op and does not throw', () => {
+    expect(() => main()).not.toThrow();
+  });
+});

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -11,6 +11,8 @@
  * package compilable and importable without locking in a runtime framework.
  */
 
+import { fileURLToPath } from 'node:url';
+
 export const PACKAGE_NAME = '@accounter/mcp-server';
 
 /**
@@ -22,7 +24,8 @@ export function main(): void {
 }
 
 // Only auto-run when executed directly (e.g. `node dist/index.js`), never when
-// imported by tests or other modules.
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+// imported by tests or other modules. Compare via fileURLToPath so paths with
+// spaces or other special characters (URL-encoded in import.meta.url) match.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   main();
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Accounter MCP server entrypoint.
+ *
+ * Phase 1 (see docs/mcp/spec.md) exposes a curated, read-only subset of
+ * Accounter capabilities to Claude clients over a remote MCP (Model Context
+ * Protocol) endpoint.
+ *
+ * This is the scaffolding entrypoint (Prompt 01). It intentionally performs no
+ * runtime work yet — HTTP transport, OAuth discovery, and the tool registry are
+ * added in subsequent, incremental steps. Keeping this a no-op keeps the
+ * package compilable and importable without locking in a runtime framework.
+ */
+
+export const PACKAGE_NAME = '@accounter/mcp-server';
+
+/**
+ * Placeholder startup entrypoint. Later prompts replace this with the HTTP
+ * server bootstrap, health route, and MCP transport wiring.
+ */
+export function main(): void {
+  // No-op for now.
+}
+
+// Only auto-run when executed directly (e.g. `node dist/index.js`), never when
+// imported by tests or other modules.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "module": "ES2022",
+    "target": "ES2022",
+    "strict": true,
+    "sourceMap": true,
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/mcp-server/vitest.config.ts
+++ b/packages/mcp-server/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+// Package-local Vitest config so `yarn workspace @accounter/mcp-server test`
+// runs only this package's tests in isolation. The repo-root config still
+// discovers these files via its `unit` project glob when running `yarn test`.
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -264,6 +264,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@accounter/mcp-server@workspace:packages/mcp-server":
+  version: 0.0.0-use.local
+  resolution: "@accounter/mcp-server@workspace:packages/mcp-server"
+  dependencies:
+    "@types/node": "npm:25.9.5"
+    tsx: "npm:4.23.1"
+    typescript: "npm:6.0.3"
+    vitest: "npm:4.1.10"
+  languageName: unknown
+  linkType: soft
+
 "@accounter/modern-poalim-scraper@workspace:^, @accounter/modern-poalim-scraper@workspace:packages/modern-poalim-scraper":
   version: 0.0.0-use.local
   resolution: "@accounter/modern-poalim-scraper@workspace:packages/modern-poalim-scraper"


### PR DESCRIPTION
## Summary

First step of the incremental MCP connector build described in
[`docs/mcp/spec.md`](../blob/main/docs/mcp/spec.md) and
[`docs/mcp/implementation-blueprint.md`](../blob/main/docs/mcp/implementation-blueprint.md).

Implements **Prompt 01 – Scaffold package and scripts**: creates a new
`packages/mcp-server` workspace with minimal, compilable TypeScript scaffolding
and yarn workspace scripts. No runtime behavior yet (HTTP transport, OAuth, and
the tool registry come in later prompts).

## Changes

- `packages/mcp-server/package.json` — `build` / `dev` / `lint` / `test` / `typecheck` scripts, private workspace `@accounter/mcp-server`, mirrors the `email-ingestion-gateway` package conventions.
- `packages/mcp-server/tsconfig.json` — extends the monorepo base `tsconfig.json` (same pattern as the gateway package).
- `packages/mcp-server/vitest.config.ts` — package-local Vitest config so `yarn workspace @accounter/mcp-server test` runs this package's tests in isolation. The repo-root config still discovers these files via its `unit` project glob.
- `packages/mcp-server/src/index.ts` — no-op startup entrypoint.
- `packages/mcp-server/src/__tests__/index.test.ts` — placeholder scaffold test (under `src/__tests__/` per the repo's eslint convention).
- `packages/mcp-server/README.md` — package overview and script reference.
- `yarn.lock` — new workspace entry only.

## Validation

- `yarn workspace @accounter/mcp-server build` → passes (emits `dist/`, tests excluded)
- `yarn workspace @accounter/mcp-server test` → 2 passed
- `yarn workspace @accounter/mcp-server lint` → clean
- `yarn prettier --check 'packages/mcp-server/**/*'` → clean

## Notes / open decisions

- **Package-local `vitest.config.ts`**: not strictly required by the prompt, but added so the package's `test` script runs in isolation (the gateway package relies solely on the root config). Happy to drop it if the team prefers a single root config.
- No changes to any unrelated package. The only cross-cutting edit is the new `yarn.lock` workspace entry.

Part of the MCP connector series — Prompts 02–04 follow, each stacked on the previous PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_