### PR TITLE
feat(mcp-server): MCP transport route with list-tools stub (MCP Prompt 04)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -13,8 +13,9 @@ See the design docs:
 
 Early scaffolding. This package is being built incrementally following the prompt pack in the
 implementation blueprint. It currently contains the package skeleton, strict environment
-configuration, and a minimal HTTP server with a `/health` endpoint and graceful shutdown (no MCP
-protocol logic yet).
+configuration, a minimal HTTP server with a `/health` endpoint and graceful shutdown, and an MCP
+transport route (`POST /mcp`) that speaks JSON-RPC 2.0 and lists an internal smoke tool.
+Authentication, authorization, and production tools are not implemented yet.
 
 ## Running locally
 
@@ -27,6 +28,18 @@ curl http://localhost:3100/health
 
 The server handles `SIGINT`/`SIGTERM` by closing connections and exiting cleanly (forcing exit after
 a grace period).
+
+### MCP endpoint
+
+The transport lives at `POST /mcp` and accepts JSON-RPC 2.0. It is currently **auth-agnostic** (the
+OAuth challenge is added in a later step). Supported methods: `initialize`, `ping`, `tools/list`,
+and `tools/call` (for the internal `accounter_smoke_ping` tool). Unknown methods return a
+deterministic JSON-RPC `-32601` error; notifications receive `202 Accepted` with no body.
+
+```bash
+curl -sX POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
 
 ## Configuration
 

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -1,0 +1,125 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import type { JsonRpcErrorResponse, JsonRpcSuccess } from '../jsonrpc.js';
+import { JsonRpcErrorCode } from '../jsonrpc.js';
+import {
+  handleMcpBody,
+  MCP_PROTOCOL_VERSION,
+  mcpHttpHandler,
+} from '../handler.js';
+import { SMOKE_TOOL_NAME } from '../tools.js';
+
+function rpc(method: string, params?: unknown, id: string | number | null = 1) {
+  return JSON.stringify({ jsonrpc: '2.0', id, method, ...(params !== undefined && { params }) });
+}
+
+describe('handleMcpBody — method dispatch', () => {
+  it('handles initialize', () => {
+    const res = handleMcpBody(rpc('initialize')) as JsonRpcSuccess;
+    const result = res.result as Record<string, unknown>;
+    expect(result.protocolVersion).toBe(MCP_PROTOCOL_VERSION);
+    expect(result.capabilities).toEqual({ tools: { listChanged: false } });
+    expect(result.serverInfo).toMatchObject({ name: '@accounter/mcp-server' });
+  });
+
+  it('handles ping', () => {
+    const res = handleMcpBody(rpc('ping')) as JsonRpcSuccess;
+    expect(res.result).toEqual({});
+  });
+
+  it('lists the smoke tool', () => {
+    const res = handleMcpBody(rpc('tools/list')) as JsonRpcSuccess;
+    const result = res.result as { tools: Array<{ name: string }> };
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0].name).toBe(SMOKE_TOOL_NAME);
+  });
+
+  it('calls the smoke tool and echoes the message', () => {
+    const res = handleMcpBody(
+      rpc('tools/call', { name: SMOKE_TOOL_NAME, arguments: { message: 'hi' } }),
+    ) as JsonRpcSuccess;
+    expect(res.result).toEqual({ content: [{ type: 'text', text: 'pong: hi' }], isError: false });
+  });
+
+  it('returns MethodNotFound for an unknown tool', () => {
+    const res = handleMcpBody(rpc('tools/call', { name: 'nope' })) as JsonRpcErrorResponse;
+    expect(res.error.code).toBe(JsonRpcErrorCode.MethodNotFound);
+  });
+
+  it('returns MethodNotFound for an unsupported method', () => {
+    const res = handleMcpBody(rpc('resources/list')) as JsonRpcErrorResponse;
+    expect(res.error.code).toBe(JsonRpcErrorCode.MethodNotFound);
+    expect(res.error.message).toContain('resources/list');
+  });
+
+  it('returns null for a notification (no id)', () => {
+    expect(handleMcpBody(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }))).toBeNull();
+  });
+});
+
+describe('handleMcpBody — malformed input', () => {
+  it('maps invalid JSON to ParseError with null id', () => {
+    const res = handleMcpBody('{ not json') as JsonRpcErrorResponse;
+    expect(res.id).toBeNull();
+    expect(res.error.code).toBe(JsonRpcErrorCode.ParseError);
+  });
+
+  it('rejects JSON-RPC batches', () => {
+    const res = handleMcpBody('[{"jsonrpc":"2.0","id":1,"method":"ping"}]') as JsonRpcErrorResponse;
+    expect(res.error.code).toBe(JsonRpcErrorCode.InvalidRequest);
+  });
+
+  it('rejects a malformed request shape', () => {
+    const res = handleMcpBody('{"jsonrpc":"1.0","method":"ping"}') as JsonRpcErrorResponse;
+    expect(res.error.code).toBe(JsonRpcErrorCode.InvalidRequest);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP adapter
+// ---------------------------------------------------------------------------
+
+function mockReq(body: string): IncomingMessage {
+  return Readable.from([Buffer.from(body, 'utf8')]) as unknown as IncomingMessage;
+}
+
+function mockRes() {
+  const res = {
+    writeHead: vi.fn(() => res),
+    end: vi.fn(() => res),
+  };
+  return res as unknown as ServerResponse & {
+    writeHead: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('mcpHttpHandler', () => {
+  it('responds 200 with the JSON-RPC result for a request', async () => {
+    const res = mockRes();
+    await mcpHttpHandler(mockReq(rpc('tools/list')), res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
+    const body = JSON.parse(res.end.mock.calls[0][0] as string);
+    expect(body.result.tools[0].name).toBe(SMOKE_TOOL_NAME);
+  });
+
+  it('responds 202 with no body for a notification', async () => {
+    const res = mockRes();
+    await mcpHttpHandler(
+      mockReq(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })),
+      res,
+    );
+    expect(res.writeHead).toHaveBeenCalledWith(202);
+    expect(res.end).toHaveBeenCalledWith();
+  });
+
+  it('responds 413 when the body exceeds the size cap', async () => {
+    const res = mockRes();
+    // Build a body larger than MAX_MCP_BODY_BYTES (1,000,000).
+    const huge = `{"jsonrpc":"2.0","id":1,"method":"ping","params":"${'x'.repeat(1_000_001)}"}`;
+    await mcpHttpHandler(mockReq(huge), res);
+    expect(res.writeHead).toHaveBeenCalledWith(413, { 'Content-Type': 'application/json' });
+  });
+});

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -42,9 +42,9 @@ describe('handleMcpBody — method dispatch', () => {
     expect(res.result).toEqual({ content: [{ type: 'text', text: 'pong: hi' }], isError: false });
   });
 
-  it('returns MethodNotFound for an unknown tool', () => {
+  it('returns InvalidParams for an unknown tool', () => {
     const res = handleMcpBody(rpc('tools/call', { name: 'nope' })) as JsonRpcErrorResponse;
-    expect(res.error.code).toBe(JsonRpcErrorCode.MethodNotFound);
+    expect(res.error.code).toBe(JsonRpcErrorCode.InvalidParams);
   });
 
   it('returns MethodNotFound for an unsupported method', () => {
@@ -88,10 +88,14 @@ function mockRes() {
   const res = {
     writeHead: vi.fn(() => res),
     end: vi.fn(() => res),
+    setHeader: vi.fn(() => res),
+    on: vi.fn(() => res),
   };
   return res as unknown as ServerResponse & {
     writeHead: ReturnType<typeof vi.fn>;
     end: ReturnType<typeof vi.fn>;
+    setHeader: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
   };
 }
 

--- a/packages/mcp-server/src/mcp/__tests__/jsonrpc.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/jsonrpc.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  asJsonRpcRequest,
+  failure,
+  isNotification,
+  JSON_RPC_VERSION,
+  JsonRpcErrorCode,
+  success,
+} from '../jsonrpc.js';
+
+describe('success / failure builders', () => {
+  it('builds a success envelope', () => {
+    expect(success(1, { ok: true })).toEqual({
+      jsonrpc: JSON_RPC_VERSION,
+      id: 1,
+      result: { ok: true },
+    });
+  });
+
+  it('builds an error envelope and omits absent data', () => {
+    const err = failure('x', JsonRpcErrorCode.MethodNotFound, 'nope');
+    expect(err).toEqual({
+      jsonrpc: JSON_RPC_VERSION,
+      id: 'x',
+      error: { code: -32_601, message: 'nope' },
+    });
+    expect('data' in err.error).toBe(false);
+  });
+
+  it('includes data when provided', () => {
+    const err = failure(null, JsonRpcErrorCode.InvalidParams, 'bad', { field: 'name' });
+    expect(err.error.data).toEqual({ field: 'name' });
+  });
+});
+
+describe('asJsonRpcRequest', () => {
+  it('accepts a valid request', () => {
+    expect(asJsonRpcRequest({ jsonrpc: '2.0', id: 1, method: 'ping' })).not.toBeNull();
+  });
+
+  it('accepts a notification (no id)', () => {
+    const req = asJsonRpcRequest({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    expect(req).not.toBeNull();
+    expect(isNotification(req!)).toBe(true);
+  });
+
+  it.each([
+    ['null', null],
+    ['a string', 'hello'],
+    ['wrong version', { jsonrpc: '1.0', method: 'ping' }],
+    ['missing method', { jsonrpc: '2.0', id: 1 }],
+    ['non-string method', { jsonrpc: '2.0', method: 42 }],
+    ['object id', { jsonrpc: '2.0', id: {}, method: 'ping' }],
+  ])('rejects %s', (_label, value) => {
+    expect(asJsonRpcRequest(value)).toBeNull();
+  });
+});
+
+describe('isNotification', () => {
+  it('is true only when id is absent', () => {
+    expect(isNotification({ jsonrpc: '2.0', method: 'x' })).toBe(true);
+    expect(isNotification({ jsonrpc: '2.0', id: null, method: 'x' })).toBe(false);
+    expect(isNotification({ jsonrpc: '2.0', id: 0, method: 'x' })).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/mcp/__tests__/jsonrpc.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/jsonrpc.test.ts
@@ -51,8 +51,14 @@ describe('asJsonRpcRequest', () => {
     ['missing method', { jsonrpc: '2.0', id: 1 }],
     ['non-string method', { jsonrpc: '2.0', method: 42 }],
     ['object id', { jsonrpc: '2.0', id: {}, method: 'ping' }],
+    ['primitive params', { jsonrpc: '2.0', id: 1, method: 'ping', params: 'oops' }],
   ])('rejects %s', (_label, value) => {
     expect(asJsonRpcRequest(value)).toBeNull();
+  });
+
+  it('accepts object and array params', () => {
+    expect(asJsonRpcRequest({ jsonrpc: '2.0', id: 1, method: 'x', params: { a: 1 } })).not.toBeNull();
+    expect(asJsonRpcRequest({ jsonrpc: '2.0', id: 1, method: 'x', params: [1, 2] })).not.toBeNull();
   });
 });
 

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -1,0 +1,155 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { log } from '../logger.js';
+import { getServiceVersion, SERVICE_NAME } from '../version.js';
+import {
+  asJsonRpcRequest,
+  failure,
+  isNotification,
+  JsonRpcErrorCode,
+  success,
+  type JsonRpcRequest,
+  type JsonRpcResponse,
+} from './jsonrpc.js';
+import { listedTools, runSmokeTool, SMOKE_TOOL_NAME } from './tools.js';
+
+/**
+ * MCP transport route (Streamable HTTP) — request dispatch skeleton.
+ *
+ * Handles the JSON-RPC methods needed to establish a session and list tools.
+ * It is intentionally auth-agnostic for now (authentication and per-tool
+ * authorization are layered on in later steps) and performs NO upstream
+ * GraphQL calls. Unknown methods get a deterministic JSON-RPC "method not
+ * found" error.
+ */
+
+/** MCP protocol revision this server implements. */
+export const MCP_PROTOCOL_VERSION = '2025-06-18';
+
+export const MCP_SERVER_INFO = {
+  name: SERVICE_NAME,
+  version: getServiceVersion(),
+};
+
+/** Max accepted request body size (bounded input, per spec §9.1). */
+export const MAX_MCP_BODY_BYTES = 1_000_000;
+
+/**
+ * Dispatch a single JSON-RPC request to its MCP method handler. Returns the
+ * response, or `null` for notifications (which must not be answered).
+ */
+export function handleRpcRequest(request: JsonRpcRequest): JsonRpcResponse | null {
+  const { method } = request;
+
+  // Notifications carry no id and expect no reply (e.g. notifications/initialized).
+  if (isNotification(request)) {
+    return null;
+  }
+
+  const id = request.id ?? null;
+
+  switch (method) {
+    case 'initialize':
+      return success(id, {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: { tools: { listChanged: false } },
+        serverInfo: MCP_SERVER_INFO,
+      });
+
+    case 'ping':
+      return success(id, {});
+
+    case 'tools/list':
+      return success(id, { tools: listedTools });
+
+    case 'tools/call': {
+      const params = (request.params ?? {}) as { name?: unknown; arguments?: unknown };
+      if (params.name === SMOKE_TOOL_NAME) {
+        return success(id, runSmokeTool(params.arguments));
+      }
+      return failure(id, JsonRpcErrorCode.MethodNotFound, `Unknown tool: ${String(params.name)}`);
+    }
+
+    default:
+      return failure(id, JsonRpcErrorCode.MethodNotFound, `Unsupported method: ${method}`);
+  }
+}
+
+/**
+ * Process a raw (already string-decoded) request body into a JSON-RPC response.
+ * Returns `null` for notifications. Never throws for malformed input — it maps
+ * to the appropriate JSON-RPC error instead.
+ */
+export function handleMcpBody(raw: string): JsonRpcResponse | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return failure(null, JsonRpcErrorCode.ParseError, 'Parse error: body is not valid JSON');
+  }
+
+  // JSON-RPC batching is not supported by MCP 2025-06-18.
+  if (Array.isArray(parsed)) {
+    return failure(null, JsonRpcErrorCode.InvalidRequest, 'Batch requests are not supported');
+  }
+
+  const request = asJsonRpcRequest(parsed);
+  if (!request) {
+    return failure(null, JsonRpcErrorCode.InvalidRequest, 'Invalid JSON-RPC 2.0 request');
+  }
+
+  return handleRpcRequest(request);
+}
+
+function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > maxBytes) {
+        reject(new Error('PAYLOAD_TOO_LARGE'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res: ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+/**
+ * HTTP handler for `POST /mcp`. Reads the JSON-RPC body, dispatches it, and
+ * writes the response as `application/json`. Notifications get `202 Accepted`
+ * with no body.
+ */
+export async function mcpHttpHandler(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  let raw: string;
+  try {
+    raw = await readBody(req, MAX_MCP_BODY_BYTES);
+  } catch (error) {
+    if (error instanceof Error && error.message === 'PAYLOAD_TOO_LARGE') {
+      sendJson(res, 413, failure(null, JsonRpcErrorCode.InvalidRequest, 'Request body too large'));
+      return;
+    }
+    log('error', 'failed to read MCP request body', { error: String(error) });
+    sendJson(res, 400, failure(null, JsonRpcErrorCode.ParseError, 'Failed to read request body'));
+    return;
+  }
+
+  const response = handleMcpBody(raw);
+
+  if (response === null) {
+    // Notification: acknowledge without a JSON-RPC response body.
+    res.writeHead(202);
+    res.end();
+    return;
+  }
+
+  sendJson(res, 200, response);
+}

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -66,7 +66,9 @@ export function handleRpcRequest(request: JsonRpcRequest): JsonRpcResponse | nul
       if (params.name === SMOKE_TOOL_NAME) {
         return success(id, runSmokeTool(params.arguments));
       }
-      return failure(id, JsonRpcErrorCode.MethodNotFound, `Unknown tool: ${String(params.name)}`);
+      // The `tools/call` method itself is supported; an unrecognized tool name
+      // is an invalid parameter, not an unsupported method.
+      return failure(id, JsonRpcErrorCode.InvalidParams, `Unknown tool: ${String(params.name)}`);
     }
 
     default:
@@ -107,8 +109,10 @@ function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
     req.on('data', (chunk: Buffer) => {
       size += chunk.length;
       if (size > maxBytes) {
+        // Pause (don't destroy) the stream so the caller can still write the
+        // 413 response before the socket is closed.
+        req.pause();
         reject(new Error('PAYLOAD_TOO_LARGE'));
-        req.destroy();
         return;
       }
       chunks.push(chunk);
@@ -134,7 +138,11 @@ export async function mcpHttpHandler(req: IncomingMessage, res: ServerResponse):
     raw = await readBody(req, MAX_MCP_BODY_BYTES);
   } catch (error) {
     if (error instanceof Error && error.message === 'PAYLOAD_TOO_LARGE') {
+      // Close the connection cleanly after the 413 is flushed — the request
+      // body was only partially consumed, so the socket cannot be reused.
+      res.setHeader('Connection', 'close');
       sendJson(res, 413, failure(null, JsonRpcErrorCode.InvalidRequest, 'Request body too large'));
+      res.on('finish', () => req.destroy());
       return;
     }
     log('error', 'failed to read MCP request body', { error: String(error) });

--- a/packages/mcp-server/src/mcp/jsonrpc.ts
+++ b/packages/mcp-server/src/mcp/jsonrpc.ts
@@ -1,0 +1,90 @@
+/**
+ * Minimal JSON-RPC 2.0 primitives used by the MCP transport.
+ *
+ * MCP speaks JSON-RPC 2.0. This module intentionally implements only the small
+ * subset the connector needs, avoiding a heavyweight framework dependency while
+ * the protocol surface is still small. It can be swapped for the official MCP
+ * SDK later without changing tool handlers.
+ */
+
+export const JSON_RPC_VERSION = '2.0';
+
+/** Standard JSON-RPC 2.0 error codes plus the range reserved for the server. */
+export const JsonRpcErrorCode = {
+  ParseError: -32_700,
+  InvalidRequest: -32_600,
+  MethodNotFound: -32_601,
+  InvalidParams: -32_602,
+  InternalError: -32_603,
+} as const;
+
+export type JsonRpcId = string | number | null;
+
+export interface JsonRpcRequest {
+  jsonrpc: typeof JSON_RPC_VERSION;
+  id?: JsonRpcId;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcSuccess {
+  jsonrpc: typeof JSON_RPC_VERSION;
+  id: JsonRpcId;
+  result: unknown;
+}
+
+export interface JsonRpcErrorResponse {
+  jsonrpc: typeof JSON_RPC_VERSION;
+  id: JsonRpcId;
+  error: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+export type JsonRpcResponse = JsonRpcSuccess | JsonRpcErrorResponse;
+
+export function success(id: JsonRpcId, result: unknown): JsonRpcSuccess {
+  return { jsonrpc: JSON_RPC_VERSION, id, result };
+}
+
+export function failure(
+  id: JsonRpcId,
+  code: number,
+  message: string,
+  data?: unknown,
+): JsonRpcErrorResponse {
+  return {
+    jsonrpc: JSON_RPC_VERSION,
+    id,
+    error: { code, message, ...(data !== undefined && { data }) },
+  };
+}
+
+/**
+ * Validate that an arbitrary parsed value is a well-formed JSON-RPC request.
+ * Returns the narrowed request or `null` when the shape is invalid.
+ */
+export function asJsonRpcRequest(value: unknown): JsonRpcRequest | null {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (candidate.jsonrpc !== JSON_RPC_VERSION) {
+    return null;
+  }
+  if (typeof candidate.method !== 'string') {
+    return null;
+  }
+  const id = candidate.id;
+  if (id !== undefined && id !== null && typeof id !== 'string' && typeof id !== 'number') {
+    return null;
+  }
+  return candidate as unknown as JsonRpcRequest;
+}
+
+/** A request with no `id` is a notification: the server must not reply. */
+export function isNotification(request: JsonRpcRequest): boolean {
+  return request.id === undefined;
+}

--- a/packages/mcp-server/src/mcp/jsonrpc.ts
+++ b/packages/mcp-server/src/mcp/jsonrpc.ts
@@ -81,6 +81,12 @@ export function asJsonRpcRequest(value: unknown): JsonRpcRequest | null {
   if (id !== undefined && id !== null && typeof id !== 'string' && typeof id !== 'number') {
     return null;
   }
+  // Per JSON-RPC 2.0, `params` (when present) must be a structured value —
+  // an object or an array — never a primitive.
+  const params = candidate.params;
+  if (params !== undefined && (typeof params !== 'object' || params === null)) {
+    return null;
+  }
   return candidate as unknown as JsonRpcRequest;
 }
 

--- a/packages/mcp-server/src/mcp/tools.ts
+++ b/packages/mcp-server/src/mcp/tools.ts
@@ -1,0 +1,70 @@
+/**
+ * Placeholder tool surface for the MCP transport skeleton.
+ *
+ * This file exists only to prove the list-tools / dispatch path end-to-end. It
+ * exposes a single, clearly-marked internal smoke tool and NO production
+ * capabilities. The curated, authorization-gated tool registry (with strict
+ * input/output schemas) replaces this in later steps; the smoke tool is removed
+ * or folded into that registry at wiring time.
+ */
+
+/** JSON Schema (draft-07 subset) describing a tool's input. */
+export interface ToolInputSchema {
+  type: 'object';
+  properties?: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+/** MCP tool descriptor as returned by `tools/list`. */
+export interface ToolDescriptor {
+  name: string;
+  description: string;
+  inputSchema: ToolInputSchema;
+}
+
+/** MCP `tools/call` result content block. */
+export interface ToolTextContent {
+  type: 'text';
+  text: string;
+}
+
+export interface ToolCallResult {
+  content: ToolTextContent[];
+  isError?: boolean;
+}
+
+export const SMOKE_TOOL_NAME = 'accounter_smoke_ping';
+
+export const smokeTool: ToolDescriptor = {
+  name: SMOKE_TOOL_NAME,
+  description:
+    'Internal connectivity smoke test. Echoes the provided message back. Not a production capability — used only to verify the MCP transport is reachable.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      message: {
+        type: 'string',
+        description: 'Text to echo back.',
+      },
+    },
+    additionalProperties: false,
+  },
+};
+
+/** Tools advertised by `tools/list` in the current (skeleton) phase. */
+export const listedTools: readonly ToolDescriptor[] = [smokeTool];
+
+/** Execute the smoke tool. Pure and side-effect free — no upstream calls. */
+export function runSmokeTool(args: unknown): ToolCallResult {
+  const message =
+    typeof args === 'object' &&
+    args !== null &&
+    typeof (args as { message?: unknown }).message === 'string'
+      ? (args as { message: string }).message
+      : '';
+  return {
+    content: [{ type: 'text', text: `pong: ${message}` }],
+    isError: false,
+  };
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,41 +1,18 @@
-import { readFileSync } from 'node:fs';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { env } from './config/env.js';
 import { log } from './logger.js';
+import { mcpHttpHandler } from './mcp/handler.js';
+import { getServiceVersion, SERVICE_NAME } from './version.js';
 
 /**
  * HTTP server bootstrap for the MCP server.
  *
- * Provides a plain `node:http` server with a `/health` endpoint and graceful
- * shutdown. No MCP protocol logic lives here yet — the MCP transport route is
- * added in a later step. Kept dependency-free (stdlib only) to avoid runtime
- * framework lock-in.
+ * Provides a plain `node:http` server with a `/health` endpoint, the MCP
+ * transport route (`POST /mcp`), and graceful shutdown. Kept dependency-free
+ * (stdlib only) to avoid runtime framework lock-in.
  */
 
-export const SERVICE_NAME = '@accounter/mcp-server';
-
-let cachedVersion: string | undefined;
-
-/**
- * Resolve the package version at runtime without importing outside `rootDir`.
- * The result is cached: the version cannot change while the process runs, so
- * we avoid a synchronous disk read on every `/health` request.
- */
-export function getServiceVersion(): string {
-  if (cachedVersion !== undefined) {
-    return cachedVersion;
-  }
-  try {
-    const packageJsonPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
-    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { version?: string };
-    cachedVersion = parsed.version ?? '0.0.0';
-  } catch {
-    cachedVersion = '0.0.0';
-  }
-  return cachedVersion;
-}
+export { getServiceVersion, SERVICE_NAME } from './version.js';
 
 export interface HealthBody {
   status: 'ok';
@@ -51,6 +28,8 @@ export function sendJson(res: ServerResponse, statusCode: number, body: unknown)
 
 type RouteHandler = (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
 
+export const MCP_ROUTE_PATH = '/mcp';
+
 export const routes: Record<string, Record<string, RouteHandler>> = {
   GET: {
     '/health': (_req, res) => {
@@ -62,6 +41,15 @@ export const routes: Record<string, Record<string, RouteHandler>> = {
       };
       sendJson(res, 200, body);
     },
+    // Streamable HTTP's optional GET (server-initiated SSE stream) is not
+    // supported in this phase — respond deterministically.
+    [MCP_ROUTE_PATH]: (_req, res) => {
+      res.writeHead(405, { 'Content-Type': 'application/json', Allow: 'POST' });
+      res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+    },
+  },
+  POST: {
+    [MCP_ROUTE_PATH]: mcpHttpHandler,
   },
 };
 

--- a/packages/mcp-server/src/version.ts
+++ b/packages/mcp-server/src/version.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Canonical service name used in logs, health, and MCP server info. */
+export const SERVICE_NAME = '@accounter/mcp-server';
+
+/**
+ * Resolve the package version at runtime without importing outside `rootDir`.
+ * Works from both `src/` (dev via tsx) and `dist/` (built), since each is one
+ * level below the package root.
+ */
+export function getServiceVersion(): string {
+  try {
+    const packageJsonPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
+    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { version?: string };
+    return parsed.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}

--- a/packages/mcp-server/src/version.ts
+++ b/packages/mcp-server/src/version.ts
@@ -5,17 +5,25 @@ import { fileURLToPath } from 'node:url';
 /** Canonical service name used in logs, health, and MCP server info. */
 export const SERVICE_NAME = '@accounter/mcp-server';
 
+let cachedVersion: string | undefined;
+
 /**
  * Resolve the package version at runtime without importing outside `rootDir`.
  * Works from both `src/` (dev via tsx) and `dist/` (built), since each is one
- * level below the package root.
+ * level below the package root. The result is cached — the version cannot
+ * change while the process runs, so we avoid a synchronous disk read on every
+ * `/health` request.
  */
 export function getServiceVersion(): string {
+  if (cachedVersion !== undefined) {
+    return cachedVersion;
+  }
   try {
     const packageJsonPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
     const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { version?: string };
-    return parsed.version ?? '0.0.0';
+    cachedVersion = parsed.version ?? '0.0.0';
   } catch {
-    return '0.0.0';
+    cachedVersion = '0.0.0';
   }
+  return cachedVersion;
 }


### PR DESCRIPTION
## Summary

Implements **Prompt 04 – MCP route shell and list-tools stub** of the
incremental MCP build. Adds the Streamable HTTP MCP endpoint (`POST /mcp`)
speaking JSON-RPC 2.0, with a request-dispatch skeleton and one internal smoke
tool. Auth-agnostic, and performs no upstream GraphQL calls yet.

> **Stacked PR:** targets `claude/mcp-prompt-03-http-health` (Prompt 03, #3953).
> Review/merge Prompts 01→02→03 first; this diff shows only the Prompt 04 changes.

## Changes

- **`src/mcp/jsonrpc.ts`** — minimal JSON-RPC 2.0 primitives: standard error codes, `success`/`failure` envelope builders, request-shape validation (`asJsonRpcRequest`), notification detection.
- **`src/mcp/tools.ts`** — a single, clearly-marked internal smoke tool (`accounter_smoke_ping`) with its input schema and a pure runner. No production capabilities.
- **`src/mcp/handler.ts`** — method dispatch for `initialize`, `ping`, `tools/list`, and `tools/call` (smoke tool only). Unknown methods/tools → deterministic JSON-RPC `-32601`. Includes a size-bounded body reader (`MAX_MCP_BODY_BYTES = 1_000_000`, per spec §9.1) and the HTTP adapter: `200` for responses, `202` for notifications, `413` over the cap, and JSON-RPC-shaped parse/invalid-request errors.
- **`src/version.ts`** — shared `SERVICE_NAME` / `getServiceVersion()` helper (extracted from `server.ts` to avoid a `server` ↔ `handler` import cycle).
- **`src/server.ts`** — registers `POST /mcp` and a deterministic `405` for `GET /mcp`.
- **Tests** — dispatch (all methods), malformed input (parse error, batch rejection, bad shape), and the HTTP adapter (200/202/413). 50 tests total across the package.
- **`README.md`** — MCP endpoint usage.

## Validation

- `yarn workspace @accounter/mcp-server test` → 50 passed
- `yarn workspace @accounter/mcp-server lint` / `typecheck` / `build` → pass
- **End-to-end smoke test** (server started via `tsx`):
  - `initialize` → `protocolVersion: 2025-06-18`, `capabilities.tools`, `serverInfo`
  - `tools/list` → the smoke tool
  - `tools/call` (smoke) → `pong: hello`
  - unknown method → `{"error":{"code":-32601,…}}`
  - `notifications/initialized` → `202`
  - `GET /mcp` → `405`

## Notes / open decisions

- **Hand-rolled JSON-RPC vs. the official MCP SDK.** Per Prompt 01's "no runtime framework lock-in" and Prompt 04's "minimal skeleton" constraints, I implemented a small JSON-RPC layer instead of pulling in `@modelcontextprotocol/sdk`. The handler surface (`handleRpcRequest` / tool descriptors) is isolated so it can be swapped for the SDK later. **Flagging for a decision:** if the team would rather adopt the SDK's `StreamableHTTPServerTransport` now, that's a reasonable alternative — I kept the seam clean either way.
- **`tools/call` for the smoke tool is implemented.** The prompt only strictly requires `tools/list`, but wiring a minimal `tools/call` makes the dispatch skeleton demonstrable end-to-end (and MCP Inspector exercises it). It's clearly marked temporary — the curated registry + input validation + authorization in Prompts 10/11/13+ replace it, and Prompt 24 removes the smoke stub.
- **Protocol version pinned to `2025-06-18`** and echoed on `initialize` (the server does not yet negotiate down to a client-requested version). Batching is rejected, matching that revision.
- **Still auth-agnostic:** `POST /mcp` currently accepts any caller. The `401` + `WWW-Authenticate` challenge and Auth0 token validation arrive in Prompts 06–08; `MCP_ENABLED`/allowlist gating attaches once auth/registry land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_