### PR TITLE
feat(mcp-server): request context & structured logging (MCP Prompt 05)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -13,9 +13,18 @@ See the design docs:
 
 Early scaffolding. This package is being built incrementally following the prompt pack in the
 implementation blueprint. It currently contains the package skeleton, strict environment
-configuration, a minimal HTTP server with a `/health` endpoint and graceful shutdown, and an MCP
-transport route (`POST /mcp`) that speaks JSON-RPC 2.0 and lists an internal smoke tool.
-Authentication, authorization, and production tools are not implemented yet.
+configuration, a minimal HTTP server with a `/health` endpoint and graceful shutdown, an MCP
+transport route (`POST /mcp`) that speaks JSON-RPC 2.0 and lists an internal smoke tool, and
+per-request structured logging with request/correlation ids. Authentication, authorization, and
+production tools are not implemented yet.
+
+## Observability
+
+Every request is assigned a `requestId` and a `correlationId` (the latter inherited from an inbound
+`X-Correlation-Id` header when present, otherwise generated). The correlation id is echoed back on
+the response. Structured JSON logs are emitted at request start and completion, carrying
+`requestId`, `correlationId`, `method`, `route`, and — on completion — `status` and `latencyMs`.
+Secrets and authorization headers are never logged.
 
 ## Running locally
 

--- a/packages/mcp-server/src/__tests__/context.test.ts
+++ b/packages/mcp-server/src/__tests__/context.test.ts
@@ -1,0 +1,51 @@
+import type { IncomingMessage } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import {
+  createRequestContext,
+  elapsedMs,
+  getRequestContext,
+  setRequestContext,
+} from '../context.js';
+
+function req(overrides: Partial<IncomingMessage> = {}): IncomingMessage {
+  return { headers: {}, method: 'GET', url: '/health', ...overrides } as unknown as IncomingMessage;
+}
+
+describe('createRequestContext', () => {
+  it('mints a request id and a correlation id', () => {
+    const ctx = createRequestContext(req());
+    expect(ctx.requestId).toMatch(/[0-9a-f-]{36}/);
+    expect(ctx.correlationId).toMatch(/[0-9a-f-]{36}/);
+    expect(ctx.requestId).not.toBe(ctx.correlationId);
+  });
+
+  it('inherits the correlation id from the inbound header', () => {
+    const ctx = createRequestContext(req({ headers: { 'x-correlation-id': 'trace-abc' } }));
+    expect(ctx.correlationId).toBe('trace-abc');
+  });
+
+  it('captures method and route without the query string', () => {
+    const ctx = createRequestContext(req({ method: 'POST', url: '/mcp?token=secret' }));
+    expect(ctx.method).toBe('POST');
+    expect(ctx.route).toBe('/mcp');
+  });
+
+  it('measures elapsed time as a non-negative integer', () => {
+    const ctx = createRequestContext(req());
+    expect(elapsedMs(ctx)).toBeGreaterThanOrEqual(0);
+    expect(Number.isInteger(elapsedMs(ctx))).toBe(true);
+  });
+});
+
+describe('request context store', () => {
+  it('associates and retrieves a context per request', () => {
+    const request = req();
+    const ctx = createRequestContext(request);
+    setRequestContext(request, ctx);
+    expect(getRequestContext(request)).toBe(ctx);
+  });
+
+  it('returns undefined for a request with no stored context', () => {
+    expect(getRequestContext(req())).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/src/__tests__/context.test.ts
+++ b/packages/mcp-server/src/__tests__/context.test.ts
@@ -30,6 +30,13 @@ describe('createRequestContext', () => {
     expect(ctx.route).toBe('/mcp');
   });
 
+  it('does not throw on a malformed URL, falling back to a path split', () => {
+    // `//` cannot be parsed relative to the placeholder host and throws in
+    // `new URL`; context creation must still succeed.
+    const ctx = createRequestContext(req({ url: '//?x=1' }));
+    expect(ctx.route).toBe('//');
+  });
+
   it('measures elapsed time as a non-negative integer', () => {
     const ctx = createRequestContext(req());
     expect(elapsedMs(ctx)).toBeGreaterThanOrEqual(0);

--- a/packages/mcp-server/src/__tests__/logger.test.ts
+++ b/packages/mcp-server/src/__tests__/logger.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { log } from '../logger.js';
+import type { RequestContext } from '../context.js';
+import { completionFields, contextFields, createRequestLogger, log } from '../logger.js';
+
+const ctx: RequestContext = {
+  requestId: 'req-1',
+  correlationId: 'corr-1',
+  method: 'POST',
+  route: '/mcp',
+  startTimeMs: performance.now(),
+};
 
 describe('log', () => {
   afterEach(() => {
@@ -31,5 +40,49 @@ describe('log', () => {
     const fallback = JSON.parse(errorSpy.mock.calls[0][0] as string);
     expect(fallback.message).toBe('failed to serialize log entry');
     expect(fallback.originalMessage).toBe('with circular');
+  });
+});
+
+describe('createRequestLogger', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('merges context fields into every entry', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logger = createRequestLogger(ctx);
+    logger.info('hello', { extra: true });
+
+    const entry = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(entry).toMatchObject({
+      requestId: 'req-1',
+      correlationId: 'corr-1',
+      method: 'POST',
+      route: '/mcp',
+      extra: true,
+      message: 'hello',
+      level: 'info',
+    });
+  });
+
+  it('routes error entries to console.error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    createRequestLogger(ctx).error('boom');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('field helpers', () => {
+  it('contextFields excludes timing internals', () => {
+    expect(contextFields(ctx)).toEqual({
+      requestId: 'req-1',
+      correlationId: 'corr-1',
+      method: 'POST',
+      route: '/mcp',
+    });
+  });
+
+  it('completionFields includes status and latency', () => {
+    const fields = completionFields(ctx, 200);
+    expect(fields.status).toBe(200);
+    expect(fields.latencyMs).toBeGreaterThanOrEqual(0);
   });
 });

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -22,10 +22,14 @@ function mockRes(): ServerResponse & {
     writeHead: vi.fn(),
     end: vi.fn(),
     setHeader: vi.fn(),
+    once: vi.fn(),
+    statusCode: 200,
     headersSent: false,
   } as unknown as ServerResponse & {
     writeHead: ReturnType<typeof vi.fn>;
     end: ReturnType<typeof vi.fn>;
+    setHeader: ReturnType<typeof vi.fn>;
+    once: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -72,6 +76,23 @@ describe('requestHandler routing', () => {
     await requestHandler(mockReq({ method: 'GET', url: '/nope' }), res);
     expect(res.writeHead).toHaveBeenCalledWith(404, { 'Content-Type': 'application/json' });
     expect(res.end).toHaveBeenCalledWith('{"error":"Not found"}');
+  });
+
+  it('sets an X-Correlation-Id response header', async () => {
+    const res = mockRes();
+    await requestHandler(mockReq({ method: 'GET', url: '/health' }), res);
+    const call = res.setHeader.mock.calls.find(([name]) => name === 'X-Correlation-Id');
+    expect(call).toBeDefined();
+    expect(typeof call?.[1]).toBe('string');
+  });
+
+  it('reuses an inbound correlation id', async () => {
+    const res = mockRes();
+    await requestHandler(
+      mockReq({ method: 'GET', url: '/health', headers: { 'x-correlation-id': 'trace-123' } }),
+      res,
+    );
+    expect(res.setHeader).toHaveBeenCalledWith('X-Correlation-Id', 'trace-123');
   });
 
   it('returns 404 for unsupported methods on a known path', async () => {

--- a/packages/mcp-server/src/context.ts
+++ b/packages/mcp-server/src/context.ts
@@ -34,12 +34,26 @@ function headerValue(req: IncomingMessage, name: string): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
 
+/**
+ * Extract the pathname from a request URL, dropping the query string. Falls back
+ * to a manual split if the URL is malformed (so a bad `req.url` can never throw
+ * out of context creation and hang the request).
+ */
+function extractRoute(rawUrl: string | undefined): string {
+  const url = rawUrl ?? '/';
+  try {
+    // Only the pathname is retained; the host is a placeholder and the query
+    // string is dropped so we never log sensitive query params.
+    return new URL(url, 'http://localhost').pathname;
+  } catch {
+    return url.split('?')[0];
+  }
+}
+
 /** Build a fresh {@link RequestContext} from an incoming request. */
 export function createRequestContext(req: IncomingMessage): RequestContext {
   const inboundCorrelationId = headerValue(req, CORRELATION_ID_HEADER)?.trim();
-  // Only the pathname is retained; the host is a placeholder and the query
-  // string is dropped so we never log sensitive query params.
-  const route = new URL(req.url ?? '/', 'http://localhost').pathname;
+  const route = extractRoute(req.url);
   return {
     requestId: generateId(),
     correlationId: inboundCorrelationId || generateId(),

--- a/packages/mcp-server/src/context.ts
+++ b/packages/mcp-server/src/context.ts
@@ -1,0 +1,66 @@
+import { randomUUID } from 'node:crypto';
+import type { IncomingMessage } from 'node:http';
+
+/**
+ * Per-request context for observability.
+ *
+ * A `requestId` is minted fresh for every request. A `correlationId` is taken
+ * from the inbound `x-correlation-id` header when present (so a trace can span
+ * multiple hops) and otherwise generated. The correlation id is echoed back on
+ * the response and propagated to upstream calls in later steps.
+ */
+export interface RequestContext {
+  /** Unique id for this single request. */
+  requestId: string;
+  /** Trace id spanning hops; inherited from the inbound header when present. */
+  correlationId: string;
+  /** HTTP method (e.g. GET, POST). */
+  method: string;
+  /** Request path (pathname only — never the query string). */
+  route: string;
+  /** High-resolution start timestamp (ms) for latency measurement. */
+  startTimeMs: number;
+}
+
+/** Header used to inherit/propagate the correlation id. */
+export const CORRELATION_ID_HEADER = 'x-correlation-id';
+
+export function generateId(): string {
+  return randomUUID();
+}
+
+function headerValue(req: IncomingMessage, name: string): string | undefined {
+  const value = req.headers[name];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/** Build a fresh {@link RequestContext} from an incoming request. */
+export function createRequestContext(req: IncomingMessage): RequestContext {
+  const inboundCorrelationId = headerValue(req, CORRELATION_ID_HEADER)?.trim();
+  // Only the pathname is retained; the host is a placeholder and the query
+  // string is dropped so we never log sensitive query params.
+  const route = new URL(req.url ?? '/', 'http://localhost').pathname;
+  return {
+    requestId: generateId(),
+    correlationId: inboundCorrelationId || generateId(),
+    method: req.method ?? 'UNKNOWN',
+    route,
+    startTimeMs: performance.now(),
+  };
+}
+
+/** Elapsed time since the context was created, in whole milliseconds. */
+export function elapsedMs(context: RequestContext): number {
+  return Math.round(performance.now() - context.startTimeMs);
+}
+
+// Associate a context with its request without mutating the request's type.
+const contextByRequest = new WeakMap<IncomingMessage, RequestContext>();
+
+export function setRequestContext(req: IncomingMessage, context: RequestContext): void {
+  contextByRequest.set(req, context);
+}
+
+export function getRequestContext(req: IncomingMessage): RequestContext | undefined {
+  return contextByRequest.get(req);
+}

--- a/packages/mcp-server/src/logger.ts
+++ b/packages/mcp-server/src/logger.ts
@@ -1,12 +1,12 @@
 /* eslint-disable no-console */
+import type { RequestContext } from './context.js';
+import { elapsedMs } from './context.js';
 
 /**
  * Minimal structured logger for the MCP server.
  *
- * Emits single-line JSON so logs are machine-parseable in production. This is a
- * deliberately small foundation; request-context propagation (correlation ids,
- * per-request child loggers) is layered on in a later step. Secrets and
- * authorization headers must never be passed as fields.
+ * Emits single-line JSON so logs are machine-parseable in production. Secrets
+ * and authorization headers must never be passed as fields.
  */
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
@@ -45,4 +45,42 @@ export function log(level: LogLevel, message: string, fields?: Record<string, un
       }),
     );
   }
+}
+
+/** Structured fields derived from a request context (no secrets/headers). */
+export function contextFields(context: RequestContext): Record<string, unknown> {
+  return {
+    requestId: context.requestId,
+    correlationId: context.correlationId,
+    method: context.method,
+    route: context.route,
+  };
+}
+
+export interface RequestLogger {
+  debug(message: string, fields?: Record<string, unknown>): void;
+  info(message: string, fields?: Record<string, unknown>): void;
+  warn(message: string, fields?: Record<string, unknown>): void;
+  error(message: string, fields?: Record<string, unknown>): void;
+}
+
+/**
+ * A logger bound to a request context. Every entry automatically carries the
+ * request id, correlation id, method, and route.
+ */
+export function createRequestLogger(context: RequestContext): RequestLogger {
+  const base = contextFields(context);
+  const emit = (level: LogLevel) => (message: string, fields?: Record<string, unknown>) =>
+    log(level, message, { ...base, ...fields });
+  return {
+    debug: emit('debug'),
+    info: emit('info'),
+    warn: emit('warn'),
+    error: emit('error'),
+  };
+}
+
+/** Log fields describing request completion, including latency. */
+export function completionFields(context: RequestContext, status: number): Record<string, unknown> {
+  return { status, latencyMs: elapsedMs(context) };
 }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,6 +1,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { env } from './config/env.js';
-import { log } from './logger.js';
+import { createRequestContext, elapsedMs, setRequestContext } from './context.js';
+import { completionFields, createRequestLogger, log } from './logger.js';
 import { mcpHttpHandler } from './mcp/handler.js';
 import { getServiceVersion, SERVICE_NAME } from './version.js';
 
@@ -54,18 +55,31 @@ export const routes: Record<string, Record<string, RouteHandler>> = {
 };
 
 export async function requestHandler(req: IncomingMessage, res: ServerResponse): Promise<void> {
-  // Only the pathname matters for routing; the host is a placeholder so we never
-  // need to read config here.
-  const url = new URL(req.url ?? '/', 'http://localhost');
+  const context = createRequestContext(req);
+  setRequestContext(req, context);
+  const logger = createRequestLogger(context);
+
+  // Echo the correlation id so callers can tie their logs to ours.
+  res.setHeader('X-Correlation-Id', context.correlationId);
+
+  logger.info('request started');
+  // Log completion (with status + latency) exactly once when the response ends.
+  res.once('finish', () => {
+    logger.info('request completed', completionFields(context, res.statusCode));
+  });
+
   try {
-    const handler = routes[req.method ?? '']?.[url.pathname];
+    const handler = routes[context.method]?.[context.route];
     if (handler) {
       await handler(req, res);
     } else {
       sendJson(res, 404, { error: 'Not found' });
     }
   } catch (error) {
-    log('error', 'unhandled request error', { error: String(error), path: url.pathname });
+    logger.error('request failed', {
+      error: String(error),
+      latencyMs: elapsedMs(context),
+    });
     if (!res.headersSent) {
       sendJson(res, 500, { error: 'Internal server error' });
     }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -63,8 +63,9 @@ export async function requestHandler(req: IncomingMessage, res: ServerResponse):
   res.setHeader('X-Correlation-Id', context.correlationId);
 
   logger.info('request started');
-  // Log completion (with status + latency) exactly once when the response ends.
-  res.once('finish', () => {
+  // Log completion on `close` (not `finish`) so an aborted/prematurely-closed
+  // connection still emits a completion log instead of a silent blind spot.
+  res.once('close', () => {
     logger.info('request completed', completionFields(context, res.statusCode));
   });
 


### PR DESCRIPTION
## Summary

Implements **Prompt 05 – Request context and structured logging foundation**
of the incremental MCP build (see [`docs/mcp/spec.md`](../blob/main/docs/mcp/spec.md) §11.1).
Adds per-request observability groundwork.

> **Stacked PR:** targets `claude/mcp-prompt-04-mcp-listtools` (Prompt 04, #3954).
> Review/merge Prompts 01→04 first; this diff shows only the Prompt 05 changes.

## Changes

- **`src/context.ts`** — `RequestContext` with a fresh `requestId` per request and a `correlationId` inherited from the inbound `X-Correlation-Id` header (or generated). Captures `method` and `route` (pathname only — the query string is dropped so sensitive params are never logged), plus a high-res start timer (`elapsedMs`). A `WeakMap`-backed store (`setRequestContext`/`getRequestContext`) associates a context with its request without mutating request types — later steps (upstream propagation, auth) read it.
- **`src/logger.ts`** — `createRequestLogger(context)` returns a level-bound logger that stamps `requestId`, `correlationId`, `method`, and `route` on every entry; `contextFields`/`completionFields` helpers (the latter adds `status` + `latencyMs`).
- **`src/server.ts`** — `requestHandler` now mints a context, echoes `X-Correlation-Id`, and logs `request started` / `request completed` (with status + latency) and `request failed`.
- **Tests** — context id generation/inheritance, route/query handling, the context store, the bound logger's field merging, and correlation-id propagation through `requestHandler`. 68 tests total.
- **`README.md`** — Observability section.

## Validation

- `yarn workspace @accounter/mcp-server test` → 68 passed
- `yarn workspace @accounter/mcp-server lint` / `typecheck` / `build` → pass
- **End-to-end:** logs at start/completion carry `requestId`, `correlationId`, `method`, `route`, `status`, `latencyMs`; an inbound `X-Correlation-Id: trace-xyz` is reused and echoed on the response.

## Notes

- **No secrets logged:** only method/route/status/latency and the ids are logged — never headers (Authorization) or query strings.
- The context store is intentionally added now (unused by current handlers) so Prompt 08's auth and Prompt 12's upstream client can propagate the correlation id without another refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_