### PR TITLE
feat(mcp-server): OAuth protected resource metadata route (MCP Prompt 06)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -14,9 +14,26 @@ See the design docs:
 Early scaffolding. This package is being built incrementally following the prompt pack in the
 implementation blueprint. It currently contains the package skeleton, strict environment
 configuration, a minimal HTTP server with a `/health` endpoint and graceful shutdown, an MCP
-transport route (`POST /mcp`) that speaks JSON-RPC 2.0 and lists an internal smoke tool, and
-per-request structured logging with request/correlation ids. Authentication, authorization, and
-production tools are not implemented yet.
+transport route (`POST /mcp`) that speaks JSON-RPC 2.0 and lists an internal smoke tool, per-request
+structured logging with request/correlation ids, and the OAuth protected-resource metadata endpoint.
+Token verification, authorization, and production tools are not implemented yet.
+
+## OAuth discovery
+
+`GET /.well-known/oauth-protected-resource` serves an
+[RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) protected-resource metadata document so Claude
+clients can discover the authorization server:
+
+```json
+{
+  "resource": "<MCP_PUBLIC_BASE_URL>",
+  "authorization_servers": ["<AUTH0_ISSUER_URL>"],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+The document is fully config-driven (no hardcoded URLs). `bearer_methods_supported: ["header"]`
+signals that tokens are accepted only via the `Authorization` header, never query params.
 
 ## Observability
 

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -73,10 +73,10 @@ describe('GET /health', () => {
 
 describe('GET /.well-known/oauth-protected-resource', () => {
   it('returns 200 with the config-driven metadata document', async () => {
-    process.env.MCP_PUBLIC_BASE_URL = 'https://mcp.example.com';
-    process.env.AUTH0_ISSUER_URL = 'https://tenant.auth0.com/';
-    process.env.AUTH0_AUDIENCE = 'aud';
-    process.env.GRAPHQL_UPSTREAM_URL = 'http://localhost:4000/graphql';
+    vi.stubEnv('MCP_PUBLIC_BASE_URL', 'https://mcp.example.com');
+    vi.stubEnv('AUTH0_ISSUER_URL', 'https://tenant.auth0.com/');
+    vi.stubEnv('AUTH0_AUDIENCE', 'aud');
+    vi.stubEnv('GRAPHQL_UPSTREAM_URL', 'http://localhost:4000/graphql');
     const { resetEnvCache } = await import('../config/env.js');
     resetEnvCache();
 
@@ -89,6 +89,7 @@ describe('GET /.well-known/oauth-protected-resource', () => {
     expect(body.authorization_servers).toEqual(['https://tenant.auth0.com/']);
     expect(body.bearer_methods_supported).toEqual(['header']);
 
+    vi.unstubAllEnvs();
     resetEnvCache();
   });
 });

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, Server, ServerResponse } from 'node:http';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PROTECTED_RESOURCE_METADATA_PATH } from '../oauth/metadata.js';
 
 // Silence structured log output during server tests.
 vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -67,6 +68,28 @@ describe('GET /health', () => {
 
   it('is registered under GET routes', () => {
     expect(typeof routes.GET['/health']).toBe('function');
+  });
+});
+
+describe('GET /.well-known/oauth-protected-resource', () => {
+  it('returns 200 with the config-driven metadata document', async () => {
+    process.env.MCP_PUBLIC_BASE_URL = 'https://mcp.example.com';
+    process.env.AUTH0_ISSUER_URL = 'https://tenant.auth0.com/';
+    process.env.AUTH0_AUDIENCE = 'aud';
+    process.env.GRAPHQL_UPSTREAM_URL = 'http://localhost:4000/graphql';
+    const { resetEnvCache } = await import('../config/env.js');
+    resetEnvCache();
+
+    const res = mockRes();
+    await requestHandler(mockReq({ method: 'GET', url: PROTECTED_RESOURCE_METADATA_PATH }), res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
+    const body = JSON.parse(res.end.mock.calls.at(-1)?.[0] as string);
+    expect(body.resource).toBe('https://mcp.example.com');
+    expect(body.authorization_servers).toEqual(['https://tenant.auth0.com/']);
+    expect(body.bearer_methods_supported).toEqual(['header']);
+
+    resetEnvCache();
   });
 });
 

--- a/packages/mcp-server/src/oauth/__tests__/metadata.test.ts
+++ b/packages/mcp-server/src/oauth/__tests__/metadata.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProtectedResourceMetadata,
+  PROTECTED_RESOURCE_METADATA_PATH,
+  protectedResourceMetadataUrl,
+} from '../metadata.js';
+
+describe('buildProtectedResourceMetadata', () => {
+  it('sets resource to the MCP public base URL exactly', () => {
+    const doc = buildProtectedResourceMetadata({
+      resource: 'https://mcp.example.com',
+      authorizationServers: ['https://tenant.auth0.com/'],
+    });
+    expect(doc.resource).toBe('https://mcp.example.com');
+  });
+
+  it('lists the authorization servers', () => {
+    const doc = buildProtectedResourceMetadata({
+      resource: 'https://mcp.example.com',
+      authorizationServers: ['https://tenant.auth0.com/'],
+    });
+    expect(doc.authorization_servers).toEqual(['https://tenant.auth0.com/']);
+  });
+
+  it('declares header-only bearer methods (no query-param tokens)', () => {
+    const doc = buildProtectedResourceMetadata({
+      resource: 'https://mcp.example.com',
+      authorizationServers: ['https://tenant.auth0.com/'],
+    });
+    expect(doc.bearer_methods_supported).toEqual(['header']);
+  });
+
+  it('produces a stable document shape', () => {
+    const doc = buildProtectedResourceMetadata({
+      resource: 'https://mcp.example.com',
+      authorizationServers: ['https://tenant.auth0.com/'],
+    });
+    expect(Object.keys(doc).sort()).toEqual([
+      'authorization_servers',
+      'bearer_methods_supported',
+      'resource',
+    ]);
+  });
+
+  it('copies the authorization servers (no shared reference)', () => {
+    const servers = ['https://tenant.auth0.com/'];
+    const doc = buildProtectedResourceMetadata({ resource: 'https://x', authorizationServers: servers });
+    expect(doc.authorization_servers).not.toBe(servers);
+  });
+});
+
+describe('protectedResourceMetadataUrl', () => {
+  it('joins the public base URL with the well-known path', () => {
+    expect(protectedResourceMetadataUrl('https://mcp.example.com')).toBe(
+      `https://mcp.example.com${PROTECTED_RESOURCE_METADATA_PATH}`,
+    );
+  });
+
+  it('normalizes a trailing slash on the base URL', () => {
+    expect(protectedResourceMetadataUrl('https://mcp.example.com/')).toBe(
+      `https://mcp.example.com${PROTECTED_RESOURCE_METADATA_PATH}`,
+    );
+  });
+});

--- a/packages/mcp-server/src/oauth/metadata.ts
+++ b/packages/mcp-server/src/oauth/metadata.ts
@@ -1,0 +1,46 @@
+/**
+ * OAuth 2.0 Protected Resource Metadata (RFC 9728).
+ *
+ * Claude clients discover how to authenticate to this MCP server by fetching
+ * the well-known document served here. The document points at the Auth0
+ * authorization server(s) and declares that bearer tokens are accepted via the
+ * `Authorization` header only (never query params — see spec §6.5).
+ */
+
+/** Well-known path for the protected resource metadata document. */
+export const PROTECTED_RESOURCE_METADATA_PATH = '/.well-known/oauth-protected-resource';
+
+/** Inputs for building the metadata document. Kept explicit for testability. */
+export interface ProtectedResourceMetadataConfig {
+  /** Canonical resource identifier — the MCP server's public base URL. */
+  resource: string;
+  /** Authorization server issuer URLs (Auth0). */
+  authorizationServers: readonly string[];
+}
+
+/** Shape of the served metadata document (RFC 9728 subset). */
+export interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  bearer_methods_supported: string[];
+}
+
+/**
+ * Build the protected resource metadata document. Pure and config-driven — no
+ * environment-specific values are hardcoded.
+ */
+export function buildProtectedResourceMetadata(
+  config: ProtectedResourceMetadataConfig,
+): ProtectedResourceMetadata {
+  return {
+    resource: config.resource,
+    authorization_servers: [...config.authorizationServers],
+    // Tokens are accepted only in the Authorization header, never query params.
+    bearer_methods_supported: ['header'],
+  };
+}
+
+/** Absolute URL of the metadata document, given the MCP public base URL. */
+export function protectedResourceMetadataUrl(publicBaseUrl: string): string {
+  return `${publicBaseUrl.replace(/\/+$/, '')}${PROTECTED_RESOURCE_METADATA_PATH}`;
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -3,6 +3,10 @@ import { env } from './config/env.js';
 import { createRequestContext, elapsedMs, setRequestContext } from './context.js';
 import { completionFields, createRequestLogger, log } from './logger.js';
 import { mcpHttpHandler } from './mcp/handler.js';
+import {
+  buildProtectedResourceMetadata,
+  PROTECTED_RESOURCE_METADATA_PATH,
+} from './oauth/metadata.js';
 import { getServiceVersion, SERVICE_NAME } from './version.js';
 
 /**
@@ -40,6 +44,15 @@ export const routes: Record<string, Record<string, RouteHandler>> = {
         version: getServiceVersion(),
         uptimeSeconds: Math.round(process.uptime()),
       };
+      sendJson(res, 200, body);
+    },
+    // OAuth 2.0 Protected Resource Metadata (RFC 9728) — lets Claude clients
+    // discover the Auth0 authorization server for this resource.
+    [PROTECTED_RESOURCE_METADATA_PATH]: (_req, res) => {
+      const body = buildProtectedResourceMetadata({
+        resource: env.server.publicBaseUrl,
+        authorizationServers: [env.auth0.issuerUrl],
+      });
       sendJson(res, 200, body);
     },
     // Streamable HTTP's optional GET (server-initiated SSE stream) is not


### PR DESCRIPTION
## Summary

Implements **Prompt 06 – Protected resource metadata route** (see
[`docs/mcp/spec.md`](../blob/main/docs/mcp/spec.md) §6.2). Serves the
[RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) OAuth protected-resource
metadata document so Claude clients can discover the Auth0 authorization server.

> **Stacked PR:** targets `claude/mcp-prompt-05-request-context` (Prompt 05, #3970).
> Review/merge Prompts 01→05 first; this diff shows only the Prompt 06 changes.

## Changes

- **`src/oauth/metadata.ts`** — pure, config-driven `buildProtectedResourceMetadata({ resource, authorizationServers })` returning `{ resource, authorization_servers, bearer_methods_supported: ["header"] }`; `protectedResourceMetadataUrl(baseUrl)` and the well-known path constant (both reused by the Prompt 07 challenge).
- **`src/server.ts`** — registers `GET /.well-known/oauth-protected-resource`, built from `env.server.publicBaseUrl` and `env.auth0.issuerUrl`. No hardcoded URLs.
- **Tests** — document shape/stability, `resource` exactness, header-only bearer methods, URL joining/normalization, plus a route-level test through `requestHandler`. 76 tests total.
- **`README.md`** — OAuth discovery section.

## Validation

- `yarn workspace @accounter/mcp-server test` → 76 passed
- `yarn workspace @accounter/mcp-server lint` / `typecheck` / `build` → pass
- **End-to-end:** `GET /.well-known/oauth-protected-resource` → `200`, `Content-Type: application/json`, and `resource` exactly matches `MCP_PUBLIC_BASE_URL`.

## Notes

- `bearer_methods_supported: ["header"]` encodes spec §6.5 (no query-param tokens).
- The document is served unauthenticated (as discovery must be); the `401` challenge that points clients here lands in Prompt 07, and token verification in Prompt 08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_