### PR TITLE
feat(mcp-server): 401 challenge helper for auth discovery (MCP Prompt 07)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -57,13 +57,16 @@ a grace period).
 
 ### MCP endpoint
 
-The transport lives at `POST /mcp` and accepts JSON-RPC 2.0. It is currently **auth-agnostic** (the
-OAuth challenge is added in a later step). Supported methods: `initialize`, `ping`, `tools/list`,
-and `tools/call` (for the internal `accounter_smoke_ping` tool). Unknown methods return a
-deterministic JSON-RPC `-32601` error; notifications receive `202 Accepted` with no body.
+The transport lives at `POST /mcp` and accepts JSON-RPC 2.0. Requests **must** carry a bearer token
+in the `Authorization` header — a request without one gets a `401` with a `WWW-Authenticate: Bearer`
+header pointing at the protected-resource metadata document (token _validity_ is verified in a later
+step). Supported methods: `initialize`, `ping`, `tools/list`, and `tools/call` (for the internal
+`accounter_smoke_ping` tool). Unknown methods return a deterministic JSON-RPC `-32601` error;
+notifications receive `202 Accepted` with no body.
 
 ```bash
 curl -sX POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <token>' \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -133,10 +133,10 @@ describe('mcpHttpHandler', () => {
   });
 
   it('challenges with 401 + WWW-Authenticate when no bearer token is present', async () => {
-    process.env.MCP_PUBLIC_BASE_URL = 'https://mcp.example.com';
-    process.env.AUTH0_ISSUER_URL = 'https://tenant.auth0.com/';
-    process.env.AUTH0_AUDIENCE = 'aud';
-    process.env.GRAPHQL_UPSTREAM_URL = 'http://localhost:4000/graphql';
+    vi.stubEnv('MCP_PUBLIC_BASE_URL', 'https://mcp.example.com');
+    vi.stubEnv('AUTH0_ISSUER_URL', 'https://tenant.auth0.com/');
+    vi.stubEnv('AUTH0_AUDIENCE', 'aud');
+    vi.stubEnv('GRAPHQL_UPSTREAM_URL', 'http://localhost:4000/graphql');
     const { resetEnvCache } = await import('../../config/env.js');
     resetEnvCache();
 
@@ -148,6 +148,7 @@ describe('mcpHttpHandler', () => {
     expect(wwwAuth?.[1]).toContain(
       'resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"',
     );
+    vi.unstubAllEnvs();
     resetEnvCache();
   });
 });

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -80,8 +80,13 @@ describe('handleMcpBody — malformed input', () => {
 // HTTP adapter
 // ---------------------------------------------------------------------------
 
-function mockReq(body: string): IncomingMessage {
-  return Readable.from([Buffer.from(body, 'utf8')]) as unknown as IncomingMessage;
+function mockReq(
+  body: string,
+  headers: Record<string, string> = { authorization: 'Bearer test-token' },
+): IncomingMessage {
+  const stream = Readable.from([Buffer.from(body, 'utf8')]) as unknown as IncomingMessage;
+  stream.headers = headers as IncomingMessage['headers'];
+  return stream;
 }
 
 function mockRes() {
@@ -125,5 +130,39 @@ describe('mcpHttpHandler', () => {
     const huge = `{"jsonrpc":"2.0","id":1,"method":"ping","params":"${'x'.repeat(1_000_001)}"}`;
     await mcpHttpHandler(mockReq(huge), res);
     expect(res.writeHead).toHaveBeenCalledWith(413, { 'Content-Type': 'application/json' });
+  });
+
+  it('challenges with 401 + WWW-Authenticate when no bearer token is present', async () => {
+    process.env.MCP_PUBLIC_BASE_URL = 'https://mcp.example.com';
+    process.env.AUTH0_ISSUER_URL = 'https://tenant.auth0.com/';
+    process.env.AUTH0_AUDIENCE = 'aud';
+    process.env.GRAPHQL_UPSTREAM_URL = 'http://localhost:4000/graphql';
+    const { resetEnvCache } = await import('../../config/env.js');
+    resetEnvCache();
+
+    const res = mockRes();
+    await mcpHttpHandler(mockReq(rpc('tools/list'), {}), res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+    const wwwAuth = res.setHeader.mock.calls.find(([name]) => name === 'WWW-Authenticate');
+    expect(wwwAuth?.[1]).toContain(
+      'resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"',
+    );
+    resetEnvCache();
+  });
+});
+
+describe('hasBearerToken', () => {
+  it('detects a bearer token (case-insensitive)', async () => {
+    const { hasBearerToken } = await import('../handler.js');
+    expect(hasBearerToken(mockReq('', { authorization: 'Bearer abc' }))).toBe(true);
+    expect(hasBearerToken(mockReq('', { authorization: 'bearer abc' }))).toBe(true);
+  });
+
+  it('rejects a missing, empty, or non-bearer header', async () => {
+    const { hasBearerToken } = await import('../handler.js');
+    expect(hasBearerToken(mockReq('', {}))).toBe(false);
+    expect(hasBearerToken(mockReq('', { authorization: 'Bearer ' }))).toBe(false);
+    expect(hasBearerToken(mockReq('', { authorization: 'Basic xyz' }))).toBe(false);
   });
 });

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -1,5 +1,8 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { env } from '../config/env.js';
 import { log } from '../logger.js';
+import { sendUnauthorized } from '../oauth/challenge.js';
+import { protectedResourceMetadataUrl } from '../oauth/metadata.js';
 import { getServiceVersion, SERVICE_NAME } from '../version.js';
 import {
   asJsonRpcRequest,
@@ -128,11 +131,33 @@ function sendJson(res: ServerResponse, statusCode: number, body: unknown): void 
 }
 
 /**
- * HTTP handler for `POST /mcp`. Reads the JSON-RPC body, dispatches it, and
- * writes the response as `application/json`. Notifications get `202 Accepted`
- * with no body.
+ * Whether the request carries a bearer token in the Authorization header.
+ * Token *validity* is verified in a later step; here we only detect presence
+ * so an unauthenticated call gets the standard 401 challenge (never a
+ * JSON-RPC/tool-level error). Query-param tokens are intentionally ignored.
+ */
+export function hasBearerToken(req: IncomingMessage): boolean {
+  const header = req.headers.authorization;
+  if (typeof header !== 'string') {
+    return false;
+  }
+  const match = /^Bearer[ ]+(.+)$/i.exec(header.trim());
+  return match !== null && match[1].trim().length > 0;
+}
+
+/**
+ * HTTP handler for `POST /mcp`. Enforces authentication (presence for now),
+ * reads the JSON-RPC body, dispatches it, and writes the response as
+ * `application/json`. Notifications get `202 Accepted` with no body.
  */
 export async function mcpHttpHandler(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (!hasBearerToken(req)) {
+    sendUnauthorized(res, {
+      resourceMetadataUrl: protectedResourceMetadataUrl(env.server.publicBaseUrl),
+    });
+    return;
+  }
+
   let raw: string;
   try {
     raw = await readBody(req, MAX_MCP_BODY_BYTES);

--- a/packages/mcp-server/src/oauth/__tests__/challenge.test.ts
+++ b/packages/mcp-server/src/oauth/__tests__/challenge.test.ts
@@ -1,0 +1,67 @@
+import type { ServerResponse } from 'node:http';
+import { describe, expect, it, vi } from 'vitest';
+import { buildWwwAuthenticateHeader, sendUnauthorized } from '../challenge.js';
+
+const RESOURCE_METADATA_URL =
+  'https://mcp.example.com/.well-known/oauth-protected-resource';
+
+describe('buildWwwAuthenticateHeader', () => {
+  it('includes the resource_metadata pointer', () => {
+    expect(buildWwwAuthenticateHeader({ resourceMetadataUrl: RESOURCE_METADATA_URL })).toBe(
+      `Bearer resource_metadata="${RESOURCE_METADATA_URL}"`,
+    );
+  });
+
+  it('appends error and error_description when provided', () => {
+    const header = buildWwwAuthenticateHeader({
+      resourceMetadataUrl: RESOURCE_METADATA_URL,
+      error: 'invalid_token',
+      errorDescription: 'The access token expired',
+    });
+    expect(header).toBe(
+      `Bearer resource_metadata="${RESOURCE_METADATA_URL}", error="invalid_token", error_description="The access token expired"`,
+    );
+  });
+});
+
+describe('sendUnauthorized', () => {
+  function mockRes() {
+    const res = {
+      setHeader: vi.fn(() => res),
+      writeHead: vi.fn(() => res),
+      end: vi.fn(() => res),
+    };
+    return res as unknown as ServerResponse & {
+      setHeader: ReturnType<typeof vi.fn>;
+      writeHead: ReturnType<typeof vi.fn>;
+      end: ReturnType<typeof vi.fn>;
+    };
+  }
+
+  it('sets WWW-Authenticate and writes a 401 JSON body', () => {
+    const res = mockRes();
+    sendUnauthorized(res, { resourceMetadataUrl: RESOURCE_METADATA_URL });
+
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'WWW-Authenticate',
+      `Bearer resource_metadata="${RESOURCE_METADATA_URL}"`,
+    );
+    expect(res.writeHead).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+    const body = JSON.parse(res.end.mock.calls[0][0] as string);
+    expect(body.error).toBe('unauthorized');
+    expect(typeof body.error_description).toBe('string');
+  });
+
+  it('propagates a specific error code into the body and header', () => {
+    const res = mockRes();
+    sendUnauthorized(res, {
+      resourceMetadataUrl: RESOURCE_METADATA_URL,
+      error: 'invalid_token',
+      errorDescription: 'expired',
+    });
+    expect((res.setHeader.mock.calls[0][1] as string)).toContain('error="invalid_token"');
+    const body = JSON.parse(res.end.mock.calls[0][0] as string);
+    expect(body.error).toBe('invalid_token');
+    expect(body.error_description).toBe('expired');
+  });
+});

--- a/packages/mcp-server/src/oauth/__tests__/challenge.test.ts
+++ b/packages/mcp-server/src/oauth/__tests__/challenge.test.ts
@@ -22,6 +22,24 @@ describe('buildWwwAuthenticateHeader', () => {
       `Bearer resource_metadata="${RESOURCE_METADATA_URL}", error="invalid_token", error_description="The access token expired"`,
     );
   });
+
+  it('omits error_description when error is absent (RFC 6750 §3)', () => {
+    const header = buildWwwAuthenticateHeader({
+      resourceMetadataUrl: RESOURCE_METADATA_URL,
+      errorDescription: 'orphaned description',
+    });
+    expect(header).toBe(`Bearer resource_metadata="${RESOURCE_METADATA_URL}"`);
+    expect(header).not.toContain('error_description');
+  });
+
+  it('escapes quotes and backslashes in quoted-string values', () => {
+    const header = buildWwwAuthenticateHeader({
+      resourceMetadataUrl: RESOURCE_METADATA_URL,
+      error: 'invalid_token',
+      errorDescription: 'has "quote" and \\ backslash',
+    });
+    expect(header).toContain('error_description="has \\"quote\\" and \\\\ backslash"');
+  });
 });
 
 describe('sendUnauthorized', () => {

--- a/packages/mcp-server/src/oauth/challenge.ts
+++ b/packages/mcp-server/src/oauth/challenge.ts
@@ -19,14 +19,20 @@ export interface UnauthorizedOptions {
   errorDescription?: string;
 }
 
+/** Escape `"` and `\` so a value is a valid RFC 7235 quoted-string. */
+function quote(value: string): string {
+  return value.replace(/["\\]/g, '\\$&');
+}
+
 /** Build the `WWW-Authenticate` header value for a bearer challenge. */
 export function buildWwwAuthenticateHeader(options: UnauthorizedOptions): string {
-  const params = [`resource_metadata="${options.resourceMetadataUrl}"`];
+  const params = [`resource_metadata="${quote(options.resourceMetadataUrl)}"`];
+  // Per RFC 6750 §3, error_description is only meaningful alongside error.
   if (options.error) {
-    params.push(`error="${options.error}"`);
-  }
-  if (options.errorDescription) {
-    params.push(`error_description="${options.errorDescription}"`);
+    params.push(`error="${quote(options.error)}"`);
+    if (options.errorDescription) {
+      params.push(`error_description="${quote(options.errorDescription)}"`);
+    }
   }
   return `Bearer ${params.join(', ')}`;
 }

--- a/packages/mcp-server/src/oauth/challenge.ts
+++ b/packages/mcp-server/src/oauth/challenge.ts
@@ -1,0 +1,47 @@
+import type { ServerResponse } from 'node:http';
+
+/**
+ * Standardized 401 challenge for MCP auth discovery.
+ *
+ * When a request is unauthenticated, the server must respond with `401` and a
+ * `WWW-Authenticate: Bearer` header carrying a `resource_metadata` pointer to
+ * the protected-resource metadata document (RFC 9728 §5.1 / spec §6.2). Claude
+ * follows that pointer to begin the OAuth flow.
+ *
+ * This is a transport-level challenge — never a JSON-RPC/tool-level error.
+ */
+export interface UnauthorizedOptions {
+  /** Absolute URL of the protected-resource metadata document. */
+  resourceMetadataUrl: string;
+  /** Optional RFC 6750 error code (e.g. `invalid_token`). */
+  error?: string;
+  /** Optional human-readable description (must be safe for end users). */
+  errorDescription?: string;
+}
+
+/** Build the `WWW-Authenticate` header value for a bearer challenge. */
+export function buildWwwAuthenticateHeader(options: UnauthorizedOptions): string {
+  const params = [`resource_metadata="${options.resourceMetadataUrl}"`];
+  if (options.error) {
+    params.push(`error="${options.error}"`);
+  }
+  if (options.errorDescription) {
+    params.push(`error_description="${options.errorDescription}"`);
+  }
+  return `Bearer ${params.join(', ')}`;
+}
+
+/**
+ * Write a standards-compliant 401 challenge to the response, including the
+ * `WWW-Authenticate` header with the `resource_metadata` pointer.
+ */
+export function sendUnauthorized(res: ServerResponse, options: UnauthorizedOptions): void {
+  res.setHeader('WWW-Authenticate', buildWwwAuthenticateHeader(options));
+  res.writeHead(401, { 'Content-Type': 'application/json' });
+  res.end(
+    JSON.stringify({
+      error: options.error ?? 'unauthorized',
+      error_description: options.errorDescription ?? 'Authentication required',
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

Implements **Prompt 07 – 401 challenge helper with resource_metadata pointer**
(see [`docs/mcp/spec.md`](../blob/main/docs/mcp/spec.md) §6.2 / §10.1). Adds the
standardized unauthenticated response for MCP OAuth discovery and gates the MCP
endpoint on token presence.

> **Stacked PR:** targets `claude/mcp-prompt-06-resource-metadata` (Prompt 06, #3971).
> Review/merge Prompts 01→06 first; this diff shows only the Prompt 07 changes.

## Changes

- **`src/oauth/challenge.ts`** — reusable helper:
  - `buildWwwAuthenticateHeader({ resourceMetadataUrl, error?, errorDescription? })` → `Bearer resource_metadata="…"` (plus optional RFC 6750 `error`/`error_description`).
  - `sendUnauthorized(res, opts)` → writes `401` with that `WWW-Authenticate` header and a small JSON body. Transport-level — **not** a JSON-RPC/tool error, per the prompt constraint.
- **`src/mcp/handler.ts`** — `hasBearerToken(req)` presence check (case-insensitive `Bearer`, non-empty token, query-param tokens ignored). `POST /mcp` without a bearer token now returns the 401 challenge pointing at `/.well-known/oauth-protected-resource` (built from `MCP_PUBLIC_BASE_URL`). Token **validity** is verified in Prompt 08.
- **Tests** — header builder, `sendUnauthorized`, `hasBearerToken` edge cases, and the 401 path through `mcpHttpHandler`; existing MCP tests updated to send a bearer token. 83 tests total.
- **`README.md`** — MCP endpoint now documents the auth requirement.

## Validation

- `yarn workspace @accounter/mcp-server test` → 83 passed
- `yarn workspace @accounter/mcp-server lint` / `typecheck` / `build` → pass
- **End-to-end:** `POST /mcp` with no token → `401` + `WWW-Authenticate: Bearer resource_metadata="https://…/.well-known/oauth-protected-resource"`; with a token → `200`.

## Notes / open decisions

- **This is where the MCP endpoint stops being auth-agnostic.** Prompt 07 only checks *presence* (the prompt says "use this helper for unauthenticated MCP calls"); Prompt 08 adds real JWT verification and will reuse `hasBearerToken`/the challenge to reject *invalid* tokens with `401` + `error="invalid_token"`.
- The smoke tool now requires a bearer token like any other call — consistent with the intended progression (it's removed/folded into the curated registry later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_