### PR TITLE
feat(mcp-server): bearer token extraction & Auth0 verification (MCP Prompt 08)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -15,8 +15,9 @@ Early scaffolding. This package is being built incrementally following the promp
 implementation blueprint. It currently contains the package skeleton, strict environment
 configuration, a minimal HTTP server with a `/health` endpoint and graceful shutdown, an MCP
 transport route (`POST /mcp`) that speaks JSON-RPC 2.0 and lists an internal smoke tool, per-request
-structured logging with request/correlation ids, and the OAuth protected-resource metadata endpoint.
-Token verification, authorization, and production tools are not implemented yet.
+structured logging with request/correlation ids, the OAuth protected-resource metadata endpoint, and
+Auth0 bearer-token verification on the MCP endpoint. Fine-grained authorization and production tools
+are not implemented yet.
 
 ## OAuth discovery
 
@@ -57,12 +58,13 @@ a grace period).
 
 ### MCP endpoint
 
-The transport lives at `POST /mcp` and accepts JSON-RPC 2.0. Requests **must** carry a bearer token
-in the `Authorization` header — a request without one gets a `401` with a `WWW-Authenticate: Bearer`
-header pointing at the protected-resource metadata document (token _validity_ is verified in a later
-step). Supported methods: `initialize`, `ping`, `tools/list`, and `tools/call` (for the internal
-`accounter_smoke_ping` tool). Unknown methods return a deterministic JSON-RPC `-32601` error;
-notifications receive `202 Accepted` with no body.
+The transport lives at `POST /mcp` and accepts JSON-RPC 2.0. Requests **must** carry a valid Auth0
+bearer token in the `Authorization` header. The token is verified (signature via the tenant JWKS,
+plus `issuer`, `audience`, and expiry). A request with no token gets a `401` pointing at the
+protected-resource metadata document; a request with an invalid/expired token gets a `401` with
+`error="invalid_token"`. Supported methods: `initialize`, `ping`, `tools/list`, and `tools/call`
+(for the internal `accounter_smoke_ping` tool). Unknown methods return a deterministic JSON-RPC
+`-32601` error; notifications receive `202 Accepted` with no body.
 
 ```bash
 curl -sX POST http://localhost:3100/mcp -H 'Content-Type: application/json' \

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "dotenv": "17.4.2",
+    "jose": "6.2.3",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/packages/mcp-server/src/auth/__tests__/token.test.ts
+++ b/packages/mcp-server/src/auth/__tests__/token.test.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage } from 'node:http';
-import { generateKeyPair, type KeyObject, SignJWT } from 'jose';
+import { generateKeyPair, type JWTVerifyGetKey, type KeyObject, SignJWT } from 'jose';
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
   extractBearerToken,
@@ -120,5 +120,16 @@ describe('verifyAccessTokenWithKey', () => {
     await expect(
       verifyAccessTokenWithKey(token, publicKey, { issuer: ISSUER, audience: AUDIENCE }),
     ).rejects.toBeInstanceOf(TokenVerificationError);
+  });
+
+  it('propagates infrastructure errors (e.g. JWKS timeout) instead of masking them as invalid', async () => {
+    const token = await sign({});
+    const infra = Object.assign(new Error('jwks unreachable'), { code: 'ERR_JWKS_TIMEOUT' });
+    const getKey: JWTVerifyGetKey = () => {
+      throw infra;
+    };
+    await expect(
+      verifyAccessTokenWithKey(token, getKey, { issuer: ISSUER, audience: AUDIENCE }),
+    ).rejects.toBe(infra);
   });
 });

--- a/packages/mcp-server/src/auth/__tests__/token.test.ts
+++ b/packages/mcp-server/src/auth/__tests__/token.test.ts
@@ -1,0 +1,124 @@
+import type { IncomingMessage } from 'node:http';
+import { generateKeyPair, type KeyObject, SignJWT } from 'jose';
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  extractBearerToken,
+  toPrincipal,
+  TokenVerificationError,
+  verifyAccessTokenWithKey,
+} from '../token.js';
+
+const ISSUER = 'https://tenant.auth0.com/';
+const AUDIENCE = 'https://api.accounter.example';
+
+function req(headers: Record<string, string> = {}): IncomingMessage {
+  return { headers } as unknown as IncomingMessage;
+}
+
+describe('extractBearerToken', () => {
+  it('extracts the token from a well-formed header (case-insensitive)', () => {
+    expect(extractBearerToken(req({ authorization: 'Bearer abc.def.ghi' }))).toBe('abc.def.ghi');
+    expect(extractBearerToken(req({ authorization: 'bearer abc' }))).toBe('abc');
+  });
+
+  it('returns null when absent, empty, or non-bearer', () => {
+    expect(extractBearerToken(req())).toBeNull();
+    expect(extractBearerToken(req({ authorization: 'Bearer ' }))).toBeNull();
+    expect(extractBearerToken(req({ authorization: 'Basic xyz' }))).toBeNull();
+  });
+});
+
+describe('toPrincipal', () => {
+  it('parses subject, email, and scopes from scope + permissions', () => {
+    const principal = toPrincipal({
+      sub: 'user-1',
+      iss: ISSUER,
+      aud: AUDIENCE,
+      email: 'a@b.com',
+      scope: 'read:charges read:tags',
+      permissions: ['read:reports', 'read:charges'],
+      exp: 123,
+    });
+    expect(principal.subject).toBe('user-1');
+    expect(principal.email).toBe('a@b.com');
+    expect(principal.expiresAt).toBe(123);
+    expect([...principal.scopes].sort()).toEqual(['read:charges', 'read:reports', 'read:tags']);
+  });
+
+  it('throws when the subject claim is missing', () => {
+    expect(() => toPrincipal({ iss: ISSUER })).toThrow(TokenVerificationError);
+  });
+});
+
+describe('verifyAccessTokenWithKey', () => {
+  let publicKey: KeyObject;
+  let privateKey: KeyObject;
+
+  beforeAll(async () => {
+    ({ publicKey, privateKey } = (await generateKeyPair('RS256')) as {
+      publicKey: KeyObject;
+      privateKey: KeyObject;
+    });
+  });
+
+  async function sign(overrides: {
+    issuer?: string;
+    audience?: string;
+    expiresIn?: string | number;
+    subject?: string;
+  }): Promise<string> {
+    return new SignJWT({ scope: 'read:charges', email: 'a@b.com' })
+      .setProtectedHeader({ alg: 'RS256' })
+      .setIssuer(overrides.issuer ?? ISSUER)
+      .setAudience(overrides.audience ?? AUDIENCE)
+      .setSubject(overrides.subject ?? 'user-1')
+      .setIssuedAt()
+      .setExpirationTime(overrides.expiresIn ?? '2h')
+      .sign(privateKey);
+  }
+
+  it('accepts a valid token and returns a principal', async () => {
+    const token = await sign({});
+    const principal = await verifyAccessTokenWithKey(token, publicKey, {
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    expect(principal.subject).toBe('user-1');
+    expect(principal.scopes).toContain('read:charges');
+  });
+
+  it('rejects a token with the wrong issuer', async () => {
+    const token = await sign({ issuer: 'https://evil.example/' });
+    await expect(
+      verifyAccessTokenWithKey(token, publicKey, { issuer: ISSUER, audience: AUDIENCE }),
+    ).rejects.toBeInstanceOf(TokenVerificationError);
+  });
+
+  it('rejects a token with the wrong audience', async () => {
+    const token = await sign({ audience: 'https://other.audience' });
+    await expect(
+      verifyAccessTokenWithKey(token, publicKey, { issuer: ISSUER, audience: AUDIENCE }),
+    ).rejects.toBeInstanceOf(TokenVerificationError);
+  });
+
+  it('rejects an expired token', async () => {
+    const token = await sign({ expiresIn: Math.floor(Date.now() / 1000) - 60 });
+    await expect(
+      verifyAccessTokenWithKey(token, publicKey, { issuer: ISSUER, audience: AUDIENCE }),
+    ).rejects.toBeInstanceOf(TokenVerificationError);
+  });
+
+  it('rejects a token signed by a different key', async () => {
+    const other = (await generateKeyPair('RS256')) as { privateKey: KeyObject };
+    const token = await new SignJWT({})
+      .setProtectedHeader({ alg: 'RS256' })
+      .setIssuer(ISSUER)
+      .setAudience(AUDIENCE)
+      .setSubject('user-1')
+      .setExpirationTime('2h')
+      .sign(other.privateKey);
+    await expect(
+      verifyAccessTokenWithKey(token, publicKey, { issuer: ISSUER, audience: AUDIENCE }),
+    ).rejects.toBeInstanceOf(TokenVerificationError);
+  });
+});

--- a/packages/mcp-server/src/auth/token.ts
+++ b/packages/mcp-server/src/auth/token.ts
@@ -97,10 +97,37 @@ export interface VerifyOptions {
 }
 
 /**
+ * jose error codes that mean the *token itself* is invalid (client error → 401)
+ * as opposed to an infrastructure problem such as a JWKS fetch timeout, which
+ * should surface as a 5xx and must NOT be masked as an auth failure.
+ */
+const TOKEN_VALIDATION_CODES = new Set([
+  'ERR_JWT_EXPIRED',
+  'ERR_JWT_NOT_ACTIVE',
+  'ERR_JWT_CLAIM_VALIDATION_FAILED',
+  'ERR_JWT_INVALID',
+  'ERR_JWS_INVALID',
+  'ERR_JWS_SIGNATURE_VERIFICATION_FAILED',
+  'ERR_JWKS_NO_MATCHING_KEY',
+  'ERR_JWKS_MULTIPLE_MATCHING_KEYS',
+  'ERR_JOSE_ALG_NOT_ALLOWED',
+  'ERR_JOSE_NOT_SUPPORTED',
+]);
+
+function isTokenValidationError(error: unknown): boolean {
+  const code = (error as { code?: unknown })?.code;
+  return typeof code === 'string' && TOKEN_VALIDATION_CODES.has(code);
+}
+
+/**
  * Verify an access token against the given key (a JWKS resolver or a public
- * key), enforcing issuer, audience, signature, and expiry. Throws
- * {@link TokenVerificationError} on any failure. Pure w.r.t. process env, so it
- * is directly unit-testable with a local key.
+ * key), enforcing issuer, audience, signature, and expiry. Pure w.r.t. process
+ * env, so it is directly unit-testable with a local key.
+ *
+ * Throws {@link TokenVerificationError} only when the token itself is invalid
+ * (→ 401). Infrastructure failures (e.g. a JWKS fetch timeout) propagate
+ * unchanged so the caller can surface a 5xx instead of masking an outage as an
+ * authentication failure.
  */
 export async function verifyAccessTokenWithKey(
   token: string,
@@ -120,9 +147,12 @@ export async function verifyAccessTokenWithKey(
     if (error instanceof TokenVerificationError) {
       throw error;
     }
-    // Normalize jose errors to a safe, token-free message.
-    const reason = error instanceof Error ? error.message : 'verification failed';
-    throw new TokenVerificationError(reason);
+    if (isTokenValidationError(error)) {
+      // Normalize to a safe, token-free message.
+      throw new TokenVerificationError(error instanceof Error ? error.message : 'invalid token');
+    }
+    // Infrastructure/unexpected error — let it propagate (becomes a 5xx).
+    throw error;
   }
 }
 

--- a/packages/mcp-server/src/auth/token.ts
+++ b/packages/mcp-server/src/auth/token.ts
@@ -1,0 +1,138 @@
+import type { IncomingMessage } from 'node:http';
+import { jwtVerify, type JWTPayload, type JWTVerifyGetKey, type KeyObject } from 'jose';
+
+/**
+ * Bearer token extraction and Auth0 access-token verification.
+ *
+ * Tokens are only ever read from the `Authorization: Bearer <token>` header —
+ * never from query params (spec §6.5). Raw token values are never logged.
+ */
+
+const BEARER_RE = /^Bearer[ ]+(.+)$/i;
+
+/** Extract the bearer token from the Authorization header, or `null`. */
+export function extractBearerToken(req: IncomingMessage): string | null {
+  const header = req.headers.authorization;
+  if (typeof header !== 'string') {
+    return null;
+  }
+  const match = BEARER_RE.exec(header.trim());
+  if (!match) {
+    return null;
+  }
+  const token = match[1].trim();
+  return token.length > 0 ? token : null;
+}
+
+/** Authenticated caller derived from a verified access token. */
+export interface AuthPrincipal {
+  /** Subject claim (`sub`) — the stable user identifier. */
+  subject: string;
+  /** Token issuer (`iss`). */
+  issuer: string;
+  /** Audience claim (`aud`). */
+  audience: string | string[] | undefined;
+  /** Granted scopes, parsed from the `scope` string and/or `permissions`. */
+  scopes: readonly string[];
+  /** Email claim, when present. */
+  email: string | null;
+  /** Expiry as a UNIX timestamp (seconds), when present. */
+  expiresAt: number | undefined;
+  /** Full verified claim set for downstream identity mapping. */
+  claims: JWTPayload;
+}
+
+/** Raised when an access token fails verification. Carries no token material. */
+export class TokenVerificationError extends Error {
+  /** RFC 6750 error code surfaced in the WWW-Authenticate challenge. */
+  public readonly code = 'invalid_token';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'TokenVerificationError';
+  }
+}
+
+/** Parse space-delimited `scope` and array `permissions` into a scope list. */
+function parseScopes(payload: JWTPayload): string[] {
+  const scopes = new Set<string>();
+  if (typeof payload.scope === 'string') {
+    for (const scope of payload.scope.split(' ')) {
+      if (scope.trim()) {
+        scopes.add(scope.trim());
+      }
+    }
+  }
+  const permissions = (payload as { permissions?: unknown }).permissions;
+  if (Array.isArray(permissions)) {
+    for (const permission of permissions) {
+      if (typeof permission === 'string' && permission.trim()) {
+        scopes.add(permission.trim());
+      }
+    }
+  }
+  return [...scopes];
+}
+
+/** Map a verified JWT payload to an {@link AuthPrincipal}. */
+export function toPrincipal(payload: JWTPayload): AuthPrincipal {
+  if (!payload.sub) {
+    throw new TokenVerificationError('token is missing the subject (sub) claim');
+  }
+  const email = payload['email'];
+  return {
+    subject: payload.sub,
+    issuer: payload.iss ?? '',
+    audience: payload.aud,
+    scopes: parseScopes(payload),
+    email: typeof email === 'string' ? email : null,
+    expiresAt: payload.exp,
+    claims: payload,
+  };
+}
+
+export interface VerifyOptions {
+  issuer: string;
+  audience: string;
+}
+
+/**
+ * Verify an access token against the given key (a JWKS resolver or a public
+ * key), enforcing issuer, audience, signature, and expiry. Throws
+ * {@link TokenVerificationError} on any failure. Pure w.r.t. process env, so it
+ * is directly unit-testable with a local key.
+ */
+export async function verifyAccessTokenWithKey(
+  token: string,
+  key: JWTVerifyGetKey | KeyObject | Uint8Array,
+  options: VerifyOptions,
+): Promise<AuthPrincipal> {
+  try {
+    const verifyOptions = { issuer: options.issuer, audience: options.audience };
+    // jose has separate overloads for a static key vs. a key-resolver function;
+    // branch so the correct one is selected.
+    const { payload } =
+      typeof key === 'function'
+        ? await jwtVerify(token, key, verifyOptions)
+        : await jwtVerify(token, key, verifyOptions);
+    return toPrincipal(payload);
+  } catch (error) {
+    if (error instanceof TokenVerificationError) {
+      throw error;
+    }
+    // Normalize jose errors to a safe, token-free message.
+    const reason = error instanceof Error ? error.message : 'verification failed';
+    throw new TokenVerificationError(reason);
+  }
+}
+
+// Associate a verified principal with its request for downstream steps.
+const principalByRequest = new WeakMap<IncomingMessage, AuthPrincipal>();
+
+export function setAuthPrincipal(req: IncomingMessage, principal: AuthPrincipal): void {
+  principalByRequest.set(req, principal);
+}
+
+export function getAuthPrincipal(req: IncomingMessage): AuthPrincipal | undefined {
+  return principalByRequest.get(req);
+}

--- a/packages/mcp-server/src/auth/verifier.ts
+++ b/packages/mcp-server/src/auth/verifier.ts
@@ -1,0 +1,38 @@
+import { createRemoteJWKSet, type JWTVerifyGetKey } from 'jose';
+import { env } from '../config/env.js';
+import { verifyAccessTokenWithKey, type AuthPrincipal } from './token.js';
+
+/**
+ * Default access-token verifier wired to the configured Auth0 tenant.
+ *
+ * The JWKS is fetched lazily and cached per JWKS URL (jose's
+ * `createRemoteJWKSet` also caches keys and handles rotation), mirroring the
+ * server package's auth setup.
+ */
+
+const jwksCache = new Map<string, JWTVerifyGetKey>();
+
+function getRemoteJwks(jwksUrl: string): JWTVerifyGetKey {
+  let jwks = jwksCache.get(jwksUrl);
+  if (!jwks) {
+    jwks = createRemoteJWKSet(new URL(jwksUrl));
+    jwksCache.set(jwksUrl, jwks);
+  }
+  return jwks;
+}
+
+/**
+ * Verify an Auth0 access token using the configured issuer, audience, and
+ * JWKS. Throws `TokenVerificationError` on any failure.
+ */
+export function verifyAccessToken(token: string): Promise<AuthPrincipal> {
+  return verifyAccessTokenWithKey(token, getRemoteJwks(env.auth0.jwksUrl), {
+    issuer: env.auth0.issuerUrl,
+    audience: env.auth0.audience,
+  });
+}
+
+/** Test-only: clear the memoized JWKS resolvers. */
+export function resetJwksCache(): void {
+  jwksCache.clear();
+}

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -190,6 +190,18 @@ describe('mcpHttpHandler', () => {
     vi.unstubAllEnvs();
     resetEnvCache();
   });
+
+  it('propagates infrastructure errors instead of returning a misleading 401', async () => {
+    // An error without a token-validation code (e.g. a JWKS outage) must bubble
+    // up so the request becomes a 5xx, not a 401.
+    mockVerify.mockRejectedValue(new Error('jwks endpoint unreachable'));
+
+    const res = mockRes();
+    await expect(mcpHttpHandler(mockReq(rpc('tools/list')), res)).rejects.toThrow(
+      'jwks endpoint unreachable',
+    );
+    expect(res.writeHead).not.toHaveBeenCalledWith(401, expect.anything());
+  });
 });
 
 describe('hasBearerToken', () => {

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -1,14 +1,27 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TokenVerificationError } from '../../auth/token.js';
+import { verifyAccessToken } from '../../auth/verifier.js';
+import { handleMcpBody, MCP_PROTOCOL_VERSION, mcpHttpHandler } from '../handler.js';
 import type { JsonRpcErrorResponse, JsonRpcSuccess } from '../jsonrpc.js';
 import { JsonRpcErrorCode } from '../jsonrpc.js';
-import {
-  handleMcpBody,
-  MCP_PROTOCOL_VERSION,
-  mcpHttpHandler,
-} from '../handler.js';
 import { SMOKE_TOOL_NAME } from '../tools.js';
+
+// The MCP handler verifies bearer tokens via the env-backed verifier, which
+// would otherwise fetch a remote JWKS. Mock it so tests stay hermetic.
+vi.mock('../../auth/verifier.js', () => ({ verifyAccessToken: vi.fn() }));
+const mockVerify = vi.mocked(verifyAccessToken);
+
+const PRINCIPAL = {
+  subject: 'user-1',
+  issuer: 'https://tenant.auth0.com/',
+  audience: 'aud',
+  scopes: [],
+  email: null,
+  expiresAt: undefined,
+  claims: { sub: 'user-1' },
+};
 
 function rpc(method: string, params?: unknown, id: string | number | null = 1) {
   return JSON.stringify({ jsonrpc: '2.0', id, method, ...(params !== undefined && { params }) });
@@ -105,6 +118,12 @@ function mockRes() {
 }
 
 describe('mcpHttpHandler', () => {
+  beforeEach(() => {
+    // A valid bearer token resolves to a principal by default.
+    mockVerify.mockReset();
+    mockVerify.mockResolvedValue(PRINCIPAL);
+  });
+
   it('responds 200 with the JSON-RPC result for a request', async () => {
     const res = mockRes();
     await mcpHttpHandler(mockReq(rpc('tools/list')), res);
@@ -148,6 +167,26 @@ describe('mcpHttpHandler', () => {
     expect(wwwAuth?.[1]).toContain(
       'resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource"',
     );
+    expect(mockVerify).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+    resetEnvCache();
+  });
+
+  it('challenges with 401 + error="invalid_token" when the token fails verification', async () => {
+    vi.stubEnv('MCP_PUBLIC_BASE_URL', 'https://mcp.example.com');
+    vi.stubEnv('AUTH0_ISSUER_URL', 'https://tenant.auth0.com/');
+    vi.stubEnv('AUTH0_AUDIENCE', 'aud');
+    vi.stubEnv('GRAPHQL_UPSTREAM_URL', 'http://localhost:4000/graphql');
+    const { resetEnvCache } = await import('../../config/env.js');
+    resetEnvCache();
+    mockVerify.mockRejectedValue(new TokenVerificationError('expired'));
+
+    const res = mockRes();
+    await mcpHttpHandler(mockReq(rpc('tools/list'), { authorization: 'Bearer bad' }), res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+    const wwwAuth = res.setHeader.mock.calls.find(([name]) => name === 'WWW-Authenticate');
+    expect(wwwAuth?.[1]).toContain('error="invalid_token"');
     vi.unstubAllEnvs();
     resetEnvCache();
   });

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -1,5 +1,10 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { extractBearerToken, setAuthPrincipal, TokenVerificationError } from '../auth/token.js';
+import {
+  type AuthPrincipal,
+  extractBearerToken,
+  setAuthPrincipal,
+  TokenVerificationError,
+} from '../auth/token.js';
 import { verifyAccessToken } from '../auth/verifier.js';
 import { env } from '../config/env.js';
 import { getRequestContext } from '../context.js';
@@ -151,7 +156,7 @@ export function hasBearerToken(req: IncomingMessage): boolean {
 async function authenticate(
   req: IncomingMessage,
   res: ServerResponse,
-): Promise<Awaited<ReturnType<typeof verifyAccessToken>> | null> {
+): Promise<AuthPrincipal | null> {
   const token = extractBearerToken(req);
   if (!token) {
     sendUnauthorized(res, {
@@ -165,13 +170,20 @@ async function authenticate(
     setAuthPrincipal(req, principal);
     return principal;
   } catch (error) {
-    const reason = error instanceof TokenVerificationError ? error.message : 'verification failed';
+    // Only an invalid token is a 401; infrastructure failures (e.g. a JWKS
+    // outage) propagate so the request surfaces as a 5xx rather than a
+    // misleading auth error.
+    if (!(error instanceof TokenVerificationError)) {
+      throw error;
+    }
     // Log the reason only — never the token.
     const context = getRequestContext(req);
     if (context) {
-      createRequestLogger(context).warn('access token verification failed', { reason });
+      createRequestLogger(context).warn('access token verification failed', {
+        reason: error.message,
+      });
     } else {
-      log('warn', 'access token verification failed', { reason });
+      log('warn', 'access token verification failed', { reason: error.message });
     }
     sendUnauthorized(res, {
       resourceMetadataUrl: protectedResourceMetadataUrl(env.server.publicBaseUrl),

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -1,9 +1,9 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import {
-  type AuthPrincipal,
   extractBearerToken,
   setAuthPrincipal,
   TokenVerificationError,
+  type AuthPrincipal,
 } from '../auth/token.js';
 import { verifyAccessToken } from '../auth/verifier.js';
 import { env } from '../config/env.js';

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -1,6 +1,9 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { extractBearerToken, setAuthPrincipal, TokenVerificationError } from '../auth/token.js';
+import { verifyAccessToken } from '../auth/verifier.js';
 import { env } from '../config/env.js';
-import { log } from '../logger.js';
+import { getRequestContext } from '../context.js';
+import { createRequestLogger, log } from '../logger.js';
 import { sendUnauthorized } from '../oauth/challenge.js';
 import { protectedResourceMetadataUrl } from '../oauth/metadata.js';
 import { getServiceVersion, SERVICE_NAME } from '../version.js';
@@ -132,29 +135,61 @@ function sendJson(res: ServerResponse, statusCode: number, body: unknown): void 
 
 /**
  * Whether the request carries a bearer token in the Authorization header.
- * Token *validity* is verified in a later step; here we only detect presence
- * so an unauthenticated call gets the standard 401 challenge (never a
- * JSON-RPC/tool-level error). Query-param tokens are intentionally ignored.
+ * Query-param tokens are intentionally ignored. Kept for callers that only
+ * need presence; the handler itself verifies the token.
  */
 export function hasBearerToken(req: IncomingMessage): boolean {
-  const header = req.headers.authorization;
-  if (typeof header !== 'string') {
-    return false;
-  }
-  const match = /^Bearer[ ]+(.+)$/i.exec(header.trim());
-  return match !== null && match[1].trim().length > 0;
+  return extractBearerToken(req) !== null;
 }
 
 /**
- * HTTP handler for `POST /mcp`. Enforces authentication (presence for now),
- * reads the JSON-RPC body, dispatches it, and writes the response as
- * `application/json`. Notifications get `202 Accepted` with no body.
+ * Authenticate the request: extract and verify the bearer token. On success
+ * returns the principal (and stores it on the request); on failure writes the
+ * appropriate 401 challenge and returns `null`. Never returns a JSON-RPC/tool
+ * error for auth problems, and never logs the token.
  */
-export async function mcpHttpHandler(req: IncomingMessage, res: ServerResponse): Promise<void> {
-  if (!hasBearerToken(req)) {
+async function authenticate(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<Awaited<ReturnType<typeof verifyAccessToken>> | null> {
+  const token = extractBearerToken(req);
+  if (!token) {
     sendUnauthorized(res, {
       resourceMetadataUrl: protectedResourceMetadataUrl(env.server.publicBaseUrl),
     });
+    return null;
+  }
+
+  try {
+    const principal = await verifyAccessToken(token);
+    setAuthPrincipal(req, principal);
+    return principal;
+  } catch (error) {
+    const reason = error instanceof TokenVerificationError ? error.message : 'verification failed';
+    // Log the reason only — never the token.
+    const context = getRequestContext(req);
+    if (context) {
+      createRequestLogger(context).warn('access token verification failed', { reason });
+    } else {
+      log('warn', 'access token verification failed', { reason });
+    }
+    sendUnauthorized(res, {
+      resourceMetadataUrl: protectedResourceMetadataUrl(env.server.publicBaseUrl),
+      error: 'invalid_token',
+      errorDescription: 'The access token is invalid or expired',
+    });
+    return null;
+  }
+}
+
+/**
+ * HTTP handler for `POST /mcp`. Authenticates the caller (extract + verify the
+ * bearer token), reads the JSON-RPC body, dispatches it, and writes the
+ * response as `application/json`. Notifications get `202 Accepted` with no body.
+ */
+export async function mcpHttpHandler(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const principal = await authenticate(req, res);
+  if (!principal) {
     return;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,6 +270,7 @@ __metadata:
   dependencies:
     "@types/node": "npm:25.9.5"
     dotenv: "npm:17.4.2"
+    jose: "npm:6.2.3"
     tsx: "npm:4.23.1"
     typescript: "npm:6.0.3"
     vitest: "npm:4.1.10"


### PR DESCRIPTION
## Summary

Implements **Prompt 08 – Token extraction and Auth0 verification module**
(see [`docs/mcp/spec.md`](../blob/main/docs/mcp/spec.md) §6.4, §10.1). Verifies
Auth0 access tokens on the MCP endpoint, reusing the server package's
`jose`/JWKS approach.

> **Stacked PR:** targets `claude/mcp-prompt-07-401-challenge` (Prompt 07, #3972).
> Review/merge Prompts 01→07 first; this diff shows only the Prompt 08 changes.

## Changes

- **`src/auth/token.ts`**
  - `extractBearerToken(req)` — parses `Authorization: Bearer <token>` (case-insensitive, non-empty); query-param tokens are ignored.
  - `verifyAccessTokenWithKey(token, key, { issuer, audience })` — verifies signature + `iss`/`aud`/`exp` via `jose.jwtVerify`, mapping the payload to a typed `AuthPrincipal` (`subject`, `scopes` from `scope` + `permissions`, `email`, `expiresAt`, raw `claims`). Pure w.r.t. env, so it's directly unit-testable with a local key.
  - `TokenVerificationError` (code `invalid_token`) — carries **no** token material; jose errors are normalized to safe messages.
  - Per-request principal store (`setAuthPrincipal`/`getAuthPrincipal`) for Prompt 09's identity mapping.
- **`src/auth/verifier.ts`** — env-backed `verifyAccessToken(token)` using a lazily-built, cached `createRemoteJWKSet` keyed by JWKS URL (mirrors `packages/server`'s auth provider).
- **`src/mcp/handler.ts`** — `POST /mcp` now extracts **and verifies** the token: missing → `401` challenge; invalid/expired → `401` with `error="invalid_token"`; on success the principal is stored on the request. Verification failures are logged by **reason only**, never the token.
- **`package.json`** — add `jose@6.2.3` (same version as `packages/server`).
- **Tests** — extraction edge cases, claim/scope mapping, and verification of valid / wrong-issuer / wrong-audience / expired / wrong-key tokens (signed with a locally generated key pair); handler tests mock the verifier and cover the invalid-token 401. 93 tests total.

## Validation

- `yarn workspace @accounter/mcp-server test` → 93 passed
- `yarn workspace @accounter/mcp-server lint` / `typecheck` / `build` → pass
- **End-to-end:** garbage token → `401` + `WWW-Authenticate: … error="invalid_token"`; no token → `401` challenge; the failure log records the reason (`"JWS Protected Header is invalid"`) with request/correlation ids and **no token**.

## Notes / open decisions

- **Reuse vs. duplication.** The blueprint says to reuse the server's shared auth utilities "where possible." Those live inside a `graphql-modules` DI provider (`AuthContextProvider`) tightly coupled to the server's Postgres/tenant layer, so importing it into a standalone package would drag in the whole server. I instead **mirrored** its exact jose pattern (`createRemoteJWKSet` cached per URL + `jwtVerify` with issuer/audience). Flagging in case the team would rather extract a shared `@accounter/auth` package — that'd be a larger, separate refactor.
- **Scopes** are parsed from both `scope` (space-delimited) and `permissions` (array) to cover either Auth0 configuration; fine-grained authorization consuming them arrives in Prompt 11.
- The principal is stored per-request now (unused downstream yet) so Prompt 09 can map identity → business memberships without another handler change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_