### PR TITLE
Test: Mock BusinessesProvider and AdminContextProvider in email ingestion tests

### DIFF
--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Injector } from 'graphql-modules';
 import { DocumentType } from '../../../shared/enums.js';
 import { AnthropicProvider } from '../../app-providers/anthropic.js';
+import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { BusinessesProvider } from '../../financial-entities/providers/businesses.provider.js';
 import { EmailIngestionIngestProvider } from '../providers/email-ingestion-ingest.provider.js';
 import { EmailIngestionControlProvider } from '../providers/email-ingestion-control.provider.js';
 import { IngestOutcome, IngestReasonCode } from '../contracts.js';
@@ -66,8 +68,23 @@ const BASE_INPUT = {
 // A mock operation injector returns a stub Anthropic provider that yields an INVOICE,
 // so figureOutSides attributes the recognized business as the document creditor.
 const extractInvoiceDetails = vi.fn().mockResolvedValue({ type: DocumentType.Invoice });
+// getDocumentFromUrlsAndOcrData falls back to VAT-0 for foreign counterparties when the
+// OCR result carries no VAT — it looks up the counterparty business and the admin's own
+// context to compare locality. Neither is under test here, so both loaders resolve to
+// undefined, which short-circuits that fallback and leaves ocrData.vat untouched.
+const businessesProvider = {
+  getBusinessByIdLoader: { load: vi.fn().mockResolvedValue(undefined) },
+};
+const adminContextProvider = {
+  adminContextByOwnerIdLoader: { load: vi.fn().mockResolvedValue(undefined) },
+};
 const ocrInjector = {
-  get: (token: unknown) => (token === AnthropicProvider ? { extractInvoiceDetails } : undefined),
+  get: (token: unknown) => {
+    if (token === AnthropicProvider) return { extractInvoiceDetails };
+    if (token === BusinessesProvider) return businessesProvider;
+    if (token === AdminContextProvider) return adminContextProvider;
+    return undefined;
+  },
 } as unknown as Injector;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Updated the email ingestion ingest provider test to mock additional dependencies (`BusinessesProvider` and `AdminContextProvider`) that are now required by the `EmailIngestionIngestProvider`.

## Changes
- Added imports for `AdminContextProvider` and `BusinessesProvider`
- Created mock implementations for both providers with their respective loaders (`adminContextByOwnerIdLoader` and `getBusinessByIdLoader`) that resolve to `undefined`
- Updated the `ocrInjector` mock to return these providers when requested, allowing the provider under test to access them without errors
- Added explanatory comments documenting why these mocks resolve to `undefined` and how that affects the VAT fallback logic being tested

## Implementation Details
The mocks are intentionally configured to return `undefined` for loader results, which short-circuits the VAT-0 fallback logic for foreign counterparties. This allows the test to focus on the core OCR data handling without requiring full business and admin context setup.

https://claude.ai/code/session_011szvYSFuDNonQmomvJSeQb