### PR TITLE
chore: deprecate scraper-local-app in favor of scraper-app

### DIFF
--- a/.changeset/deprecate-scraper-local-app.md
+++ b/.changeset/deprecate-scraper-local-app.md
@@ -1,0 +1,16 @@
+---
+---
+
+Deprecate the legacy `@accounter-helper/scraper-local-app` CLI scrape runner now that
+`@accounter/scraper-app` (a local Fastify server + React UI web app) covers the same scraping
+workflow.
+
+- `@accounter-helper/scraper-local-app` is marked deprecated (README banner + package description)
+  and superseded by `@accounter/scraper-app`. It is kept only for rollback until `scraper-app` is
+  fully in production use, and receives no new features.
+- Docs updated to reflect the migration (root `README.md`, root `CLAUDE.md`,
+  `docs/claude-code-setup/spec.md`).
+
+No published-package version bumps: `scraper-local-app` is private and ignored by changesets, and the
+change is documentation-only. Hard removal of `scraper-local-app` from the monorepo is a follow-up
+once the `scraper-app` cutover is complete (see `docs/architecture/scraper-app-refactor/plan.md`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,11 @@ Yarn Berry (v4) monorepo with 18 packages under `packages/`:
   pipeline), `gmail-listener` (legacy single-tenant listener)
 - **Generators**: `pcn874-generator`, `opcn1214-generator`, `shaam6111-generator`,
   `shaam-uniform-format-generator`
-- **Tools**: `scraper-local-app`
-- **Deprecated**: `old-accounter` (excluded from workspaces)
+- **Tools**: `scraper-app` (local scrape web app — Fastify server + React UI; replaces
+  `scraper-local-app`)
+- **Deprecated**: `scraper-local-app` (legacy CLI scrape runner; superseded by `scraper-app` — kept
+  only for rollback until `scraper-app` is fully in production use), `old-accounter` (excluded from
+  workspaces)
 
 Package-specific conventions live in `packages/<name>/CLAUDE.md` (loaded on demand when you work in
 that package).

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ different terminals.
 yarn scrape
 ```
 
+> **Note:** `yarn scrape` runs the deprecated `scraper-local-app` CLI, kept only for rollback. Prefer
+> the [`@accounter/scraper-app`](packages/scraper-app/README.md) web app going forward:
+>
+> ```sh
+> yarn workspace @accounter/scraper-app dev:server
+> ```
+
 9. Generate businesses by visiting http://localhost:4000/graphql
 
 Set your headers at the bottom:

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ different terminals.
 yarn scrape
 ```
 
-> **Note:** `yarn scrape` runs the deprecated `scraper-local-app` CLI, kept only for rollback. Prefer
-> the [`@accounter/scraper-app`](packages/scraper-app/README.md) web app going forward:
+> **Note:** `yarn scrape` runs the deprecated `scraper-local-app` CLI, kept only for rollback.
+> Prefer the [`@accounter/scraper-app`](packages/scraper-app/README.md) web app going forward:
 >
 > ```sh
 > yarn workspace @accounter/scraper-app dev:server

--- a/docs/claude-code-setup/spec.md
+++ b/docs/claude-code-setup/spec.md
@@ -129,8 +129,9 @@ Brief (not file-by-file) overview of the 18 packages grouped by role:
   app-providers)
 - **Generators**: `pcn874-generator`, `opcn1214-generator`, `shaam6111-generator`,
   `shaam-uniform-format-generator`
-- **Tools**: `gmail-listener`, `scraper-local-app`
-- **Deprecated**: `old-accounter` (excluded from workspaces)
+- **Tools**: `gmail-listener`, `scraper-app` (replaces the deprecated `scraper-local-app`)
+- **Deprecated**: `scraper-local-app` (superseded by `scraper-app`), `old-accounter` (excluded from
+  workspaces)
 
 #### 3.4 Build & Test Commands
 

--- a/docs/claude-code-setup/spec.md
+++ b/docs/claude-code-setup/spec.md
@@ -127,9 +127,11 @@ Brief (not file-by-file) overview of the 18 packages grouped by role:
   `israeli-vat-scraper`
 - **Integrations**: `green-invoice-graphql`, `hashavshevet-mesh`, `payper-mesh`, `deel` (via server
   app-providers)
+- **Email ingestion**: `email-ingestion-gateway` (v2 multi-tenant Cloudflare→gateway→server email
+  pipeline), `gmail-listener` (legacy single-tenant listener)
 - **Generators**: `pcn874-generator`, `opcn1214-generator`, `shaam6111-generator`,
   `shaam-uniform-format-generator`
-- **Tools**: `gmail-listener`, `scraper-app` (replaces the deprecated `scraper-local-app`)
+- **Tools**: `scraper-app` (replaces the deprecated `scraper-local-app`)
 - **Deprecated**: `scraper-local-app` (superseded by `scraper-app`), `old-accounter` (excluded from
   workspaces)
 

--- a/packages/scraper-local-app/README.md
+++ b/packages/scraper-local-app/README.md
@@ -1,5 +1,11 @@
 # Scraper Local App
 
+> ⚠️ **Deprecated.** This CLI scrape runner is superseded by
+> [`@accounter/scraper-app`](../scraper-app) — a local web app (Fastify server + React UI) that
+> scrapes Israeli bank accounts and uploads transactions to your Accounter server. It is kept only
+> for rollback until `scraper-app` is fully in production use, and receives no new features. New work
+> should target `scraper-app` — see its [README](../scraper-app/README.md).
+
 The **Scraper Local App** is a sub-package of the **Accounter Fullstack** mono-repo. It is designed
 to handle data scraping tasks locally, enabling users to extract and process personal
 accounting-related data efficiently in a self-contained environment.

--- a/packages/scraper-local-app/README.md
+++ b/packages/scraper-local-app/README.md
@@ -3,8 +3,8 @@
 > ⚠️ **Deprecated.** This CLI scrape runner is superseded by
 > [`@accounter/scraper-app`](../scraper-app) — a local web app (Fastify server + React UI) that
 > scrapes Israeli bank accounts and uploads transactions to your Accounter server. It is kept only
-> for rollback until `scraper-app` is fully in production use, and receives no new features. New work
-> should target `scraper-app` — see its [README](../scraper-app/README.md).
+> for rollback until `scraper-app` is fully in production use, and receives no new features. New
+> work should target `scraper-app` — see its [README](../scraper-app/README.md).
 
 The **Scraper Local App** is a sub-package of the **Accounter Fullstack** mono-repo. It is designed
 to handle data scraping tasks locally, enabling users to extract and process personal

--- a/packages/scraper-local-app/package.json
+++ b/packages/scraper-local-app/package.json
@@ -2,7 +2,7 @@
   "name": "@accounter-helper/scraper-local-app",
   "version": "0.0.0",
   "type": "module",
-  "description": "App for local scrape execution",
+  "description": "[DEPRECATED — superseded by @accounter/scraper-app] App for local scrape execution",
   "license": "MIT",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Follow-up to the scraper-app refactor (`docs/architecture/scraper-app-refactor/`). The new `@accounter/scraper-app` package (Fastify server + React UI) covers the same local scraping workflow, so this **marks the legacy `@accounter-helper/scraper-local-app` CLI runner deprecated**. It does **not** remove anything — the package and the `yarn scrape` script keep working, so rollback stays available until `scraper-app` is fully in production use.

Modeled on the gmail-listener deprecation (#3761).

### 1. Deprecate the `@accounter-helper/scraper-local-app` package
- Prominent **deprecation banner** in its `README.md` and a `[DEPRECATED — superseded by @accounter/scraper-app]` prefix on the package `description`, both pointing to `scraper-app`.

### 2. Acknowledge the migration in docs
- Root `README.md`: added a note to the `yarn scrape` step flagging it as the deprecated path and pointing to `yarn workspace @accounter/scraper-app dev:server`.
- Root `CLAUDE.md`: moved `scraper-local-app` into **Deprecated** and surfaced `scraper-app` as the active tool.
- `docs/claude-code-setup/spec.md`: same Tools/Deprecated update for consistency.

### 3. Changeset
- Added a docs-only changeset. `scraper-local-app` is `private` and matched by the changeset config's `ignore: ["@accounter-helper/*"]`, so there is no publishable version bump — the changeset uses empty frontmatter and just records the intent.

### Scope notes (intentional)
- **Not removed / kept for rollback:** the package code, the root `scrape` script, and its `build:main` / `build:tools` entries in root `package.json` all still work. The scraper-app refactor plan keeps the legacy path live until `scraper-app` is confirmed in production use.
- **Hard removal** of `scraper-local-app` from the monorepo is a **follow-up after cutover completes** (see `docs/architecture/scraper-app-refactor/plan.md`).

### Verification
Documentation-only change. Prose wrapping matches the surrounding files; the repo's prettier prose-wrap is `preserve` (committed docs already exceed 100 cols), so no reflow was introduced. `yarn`/CI was not runnable in this environment (`node_modules` not installed), but no source or config that affects the build was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwQaJu66CrBngC58hn69Dw)_