### PR TITLE
fix(charge-matching): address PR review comments + add changeset

### DIFF
--- a/.changeset/charge-matching-review-screen.md
+++ b/.changeset/charge-matching-review-screen.md
@@ -1,0 +1,15 @@
+---
+"@accounter/server": minor
+"@accounter/client": minor
+---
+
+Add the Charge Matching Review Screen: a guided side-by-side UI for pairing document-based and
+transaction-based charges and merging them one by one.
+
+- Server: new `chargesAwaitingMatchQueue` GraphQL query that returns a paginated queue of unmatched
+  base charges with on-the-fly match suggestions, filterable by business, date range and mode
+  (`DOC_BASE`/`TRANSACTION_BASE`) and sortable `BY_DATE` or `BY_SCORE` (score evaluation capped at
+  the 100 most recent unmatched charges).
+- Client: new `/charges/matching` screen with a filter/sort header, collapsible queue sidebar with
+  per-item pending/matched/skipped status, side-by-side base-vs-suggestion comparison cards,
+  alternative-suggestion switching, and accept (merge) / skip actions.

--- a/packages/client/src/components/charge-matching/charge-detail-card.tsx
+++ b/packages/client/src/components/charge-matching/charge-detail-card.tsx
@@ -25,11 +25,16 @@ function Field({ label, value }: { label: string; value?: string | null }): Reac
 }
 
 export const ChargeDetailCard = ({ charge, confidenceScore, title }: Props): ReactElement => {
-  const documentWithImage = charge.additionalDocuments.find(doc => doc.image);
+  // Defensive fallbacks: keep the card robust even if a relation resolves empty/absent
+  const additionalDocuments = charge.additionalDocuments ?? [];
+  const transactions = charge.transactions ?? [];
+  const miscExpenses = charge.miscExpenses ?? [];
+
+  const documentWithImage = additionalDocuments.find(doc => doc.image);
   const documentTypes = [
-    ...new Set(charge.additionalDocuments.map(doc => doc.documentType).filter(Boolean)),
+    ...new Set(additionalDocuments.map(doc => doc.documentType).filter(Boolean)),
   ].join(', ');
-  const hasExtensions = charge.transactions.length > 0 || charge.miscExpenses.length > 0;
+  const hasExtensions = transactions.length > 0 || miscExpenses.length > 0;
 
   return (
     <Card data-testid="charge-detail-card">
@@ -75,11 +80,11 @@ export const ChargeDetailCard = ({ charge, confidenceScore, title }: Props): Rea
             <AccordionItem value="more-details">
               <AccordionTrigger className="text-sm">More Details</AccordionTrigger>
               <AccordionContent className="flex flex-col gap-3">
-                {charge.transactions.length > 0 && (
+                {transactions.length > 0 && (
                   <div className="flex flex-col gap-1">
                     <span className="text-xs font-semibold text-gray-500">Transactions</span>
                     <ul className="flex flex-col gap-1">
-                      {charge.transactions.map(transaction => (
+                      {transactions.map(transaction => (
                         <li key={transaction.id} className="flex justify-between gap-2 text-sm">
                           <span className="truncate">
                             {transaction.eventDate} · {transaction.sourceDescription}
@@ -92,11 +97,11 @@ export const ChargeDetailCard = ({ charge, confidenceScore, title }: Props): Rea
                     </ul>
                   </div>
                 )}
-                {charge.miscExpenses.length > 0 && (
+                {miscExpenses.length > 0 && (
                   <div className="flex flex-col gap-1">
                     <span className="text-xs font-semibold text-gray-500">Misc Expenses</span>
                     <ul className="flex flex-col gap-1">
-                      {charge.miscExpenses.map(expense => (
+                      {miscExpenses.map(expense => (
                         <li key={expense.id} className="flex justify-between gap-2 text-sm">
                           <span className="truncate">{expense.description ?? 'Misc expense'}</span>
                           <span className="shrink-0 font-medium">{expense.amount.formatted}</span>

--- a/packages/client/src/components/charge-matching/utils.ts
+++ b/packages/client/src/components/charge-matching/utils.ts
@@ -1,10 +1,11 @@
+import { format } from 'date-fns';
 import type { ChargeMatchCardFieldsFragment } from '../../gql/graphql.js';
 
 export function chargeDate(charge: ChargeMatchCardFieldsFragment): string | undefined {
   const raw = charge.minDocumentsDate ?? charge.minEventDate ?? charge.minDebitDate;
-  // Date-only strings parse as UTC midnight; format in UTC so users in
-  // negative offsets don't see the previous day
-  return raw ? new Date(raw).toLocaleDateString(undefined, { timeZone: 'UTC' }) : undefined;
+  // Fixed format via date-fns (matching the app's date cells) — locale-independent,
+  // so presentation is consistent across browsers
+  return raw ? format(new Date(raw), 'dd/MM/yy') : undefined;
 }
 
 export function chargeTitle(charge: ChargeMatchCardFieldsFragment): string {

--- a/packages/server/src/modules/charges-matcher/providers/queue-match-evaluator.provider.ts
+++ b/packages/server/src/modules/charges-matcher/providers/queue-match-evaluator.provider.ts
@@ -74,8 +74,8 @@ export class QueueMatchEvaluatorProvider {
   private async evaluateSingleCharge(chargeId: string): Promise<ChargeMatchProto[]> {
     try {
       const { matches } = await this.chargesMatcherProvider.findMatchesForCharge(chargeId);
-      // findMatchesForCharge returns a fresh array, so sorting in place is safe
-      return matches.sort((a, b) => b.confidenceScore - a.confidenceScore);
+      // Copy before sorting so we never mutate an array owned by another provider
+      return [...matches].sort((a, b) => b.confidenceScore - a.confidenceScore);
     } catch (error) {
       // Evaluation is best-effort: a charge that can't be scored (already
       // matched, missing data, etc.) still shows up in the queue, just with


### PR DESCRIPTION
- queue-match-evaluator: copy the matches array before sorting so a provider-owned array is never mutated in place
- charge-detail-card: defensively fall back to empty arrays for the additionalDocuments/transactions/miscExpenses relations
- utils: format charge dates with date-fns 'dd/MM/yy' (matching the app's date cells) for locale-independent, consistent presentation
- add a changeset for the Charge Matching Review Screen feature


Claude-Session: https://claude.ai/code/session_01JBQoeDJraws6oq8cyxPri3