### PR TITLE
feat(client): persist charge-matching filters in URL query params

### DIFF
--- a/.changeset/charge-matching-filters-url-params.md
+++ b/.changeset/charge-matching-filters-url-params.md
@@ -1,0 +1,8 @@
+---
+"@accounter/client": patch
+---
+
+Persist the Charge Matching screen filters (mode, from/to dates, business and sort-by) in the URL
+query string, so the current selection survives a page refresh and can be shared via link. Filter
+updates are merged into the existing query params, preserving any unrelated params already in the
+URL.

--- a/packages/client/src/components/charge-matching/charge-matching-header.tsx
+++ b/packages/client/src/components/charge-matching/charge-matching-header.tsx
@@ -26,6 +26,59 @@ export const DEFAULT_CHARGE_MATCHING_FILTERS: ChargeMatchingFilters = {
   sortBy: ChargeMatchQueueSortBy.ByDate,
 };
 
+const MODE_VALUES = Object.values(ChargeMatchQueueMode);
+const SORT_BY_VALUES = Object.values(ChargeMatchQueueSortBy);
+
+/**
+ * Read the charge-matching filters from URL query params so the selection
+ * survives a page refresh. Unknown or missing values fall back to the defaults.
+ */
+export function parseChargeMatchingFilters(params: URLSearchParams): ChargeMatchingFilters {
+  const modeParam = params.get('mode');
+  const mode = MODE_VALUES.includes(modeParam as ChargeMatchQueueMode)
+    ? (modeParam as ChargeMatchQueueMode)
+    : DEFAULT_CHARGE_MATCHING_FILTERS.mode;
+
+  const sortByParam = params.get('sortBy');
+  const sortBy = SORT_BY_VALUES.includes(sortByParam as ChargeMatchQueueSortBy)
+    ? (sortByParam as ChargeMatchQueueSortBy)
+    : DEFAULT_CHARGE_MATCHING_FILTERS.sortBy;
+
+  return {
+    businessId: params.get('businessId') || null,
+    fromDate: (params.get('fromDate') as TimelessDateString) || null,
+    toDate: (params.get('toDate') as TimelessDateString) || null,
+    mode,
+    sortBy,
+  };
+}
+
+/**
+ * Serialize the filters into a flat query-param map, omitting empty values and
+ * defaults so the URL stays clean when nothing meaningful is selected.
+ */
+export function chargeMatchingFiltersToSearchParams(
+  filters: ChargeMatchingFilters,
+): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (filters.mode) {
+    params.mode = filters.mode;
+  }
+  if (filters.fromDate) {
+    params.fromDate = filters.fromDate;
+  }
+  if (filters.toDate) {
+    params.toDate = filters.toDate;
+  }
+  if (filters.businessId) {
+    params.businessId = filters.businessId;
+  }
+  if (filters.sortBy !== DEFAULT_CHARGE_MATCHING_FILTERS.sortBy) {
+    params.sortBy = filters.sortBy;
+  }
+  return params;
+}
+
 const MODE_ALL = 'ALL';
 
 type Props = {

--- a/packages/client/src/components/charge-matching/charge-matching-header.tsx
+++ b/packages/client/src/components/charge-matching/charge-matching-header.tsx
@@ -26,6 +26,15 @@ export const DEFAULT_CHARGE_MATCHING_FILTERS: ChargeMatchingFilters = {
   sortBy: ChargeMatchQueueSortBy.ByDate,
 };
 
+/** URL query-param keys owned by the charge-matching filters. */
+export const CHARGE_MATCHING_FILTER_KEYS = [
+  'mode',
+  'fromDate',
+  'toDate',
+  'businessId',
+  'sortBy',
+] as const;
+
 const MODE_VALUES = Object.values(ChargeMatchQueueMode);
 const SORT_BY_VALUES = Object.values(ChargeMatchQueueSortBy);
 

--- a/packages/client/src/components/charge-matching/index.tsx
+++ b/packages/client/src/components/charge-matching/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState, type ReactElement } from 'react';
 import { Check, SkipForward } from 'lucide-react';
+import { useSearchParams } from 'react-router-dom';
 import { useQuery } from 'urql';
 import {
   ChargeMatchCardFieldsFragmentDoc,
@@ -20,8 +21,9 @@ import {
 } from './alternative-suggestions-footer.js';
 import { ChargeDetailCard } from './charge-detail-card.js';
 import {
+  chargeMatchingFiltersToSearchParams,
   ChargeMatchingHeader,
-  DEFAULT_CHARGE_MATCHING_FILTERS,
+  parseChargeMatchingFilters,
   type ChargeMatchingFilters,
 } from './charge-matching-header.js';
 import {
@@ -42,7 +44,20 @@ export type ChargeMatchQueueItem = {
 };
 
 export const ChargeMatchingReviewScreen = (): ReactElement => {
-  const [filters, setFilters] = useState<ChargeMatchingFilters>(DEFAULT_CHARGE_MATCHING_FILTERS);
+  // Filters live in the URL query string so the current selection survives a
+  // page refresh and can be shared via link
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = useMemo<ChargeMatchingFilters>(
+    () => parseChargeMatchingFilters(searchParams),
+    [searchParams],
+  );
+  const setFilters = useCallback(
+    (next: ChargeMatchingFilters): void => {
+      // replace: refining filters shouldn't stack history entries per keystroke
+      setSearchParams(chargeMatchingFiltersToSearchParams(next), { replace: true });
+    },
+    [setSearchParams],
+  );
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   // Changing any filter updates the variables, which triggers a refetch

--- a/packages/client/src/components/charge-matching/index.tsx
+++ b/packages/client/src/components/charge-matching/index.tsx
@@ -21,6 +21,7 @@ import {
 } from './alternative-suggestions-footer.js';
 import { ChargeDetailCard } from './charge-detail-card.js';
 import {
+  CHARGE_MATCHING_FILTER_KEYS,
   chargeMatchingFiltersToSearchParams,
   ChargeMatchingHeader,
   parseChargeMatchingFilters,
@@ -53,8 +54,25 @@ export const ChargeMatchingReviewScreen = (): ReactElement => {
   );
   const setFilters = useCallback(
     (next: ChargeMatchingFilters): void => {
-      // replace: refining filters shouldn't stack history entries per keystroke
-      setSearchParams(chargeMatchingFiltersToSearchParams(next), { replace: true });
+      setSearchParams(
+        prev => {
+          // Merge into the existing params so unrelated query params are
+          // preserved; only our managed keys are set or cleared
+          const merged = new URLSearchParams(prev);
+          const nextParams = chargeMatchingFiltersToSearchParams(next);
+          for (const key of CHARGE_MATCHING_FILTER_KEYS) {
+            const value = nextParams[key];
+            if (value == null) {
+              merged.delete(key);
+            } else {
+              merged.set(key, value);
+            }
+          }
+          return merged;
+        },
+        // replace: refining filters shouldn't stack history entries per keystroke
+        { replace: true },
+      );
     },
     [setSearchParams],
   );


### PR DESCRIPTION
## Summary

Keeps the **Charge Matching** screen filters in the URL query string so the current selection survives a page refresh and can be shared via link.

Persisted filters:
- **Mode** (`mode`) — Doc Base / Transaction Base
- **From / To dates** (`fromDate`, `toDate`)
- **Business** (`businessId`)
- **Sort by** (`sortBy`) — Date / Match Score

## Changes

- `charge-matching-header.tsx`: add `parseChargeMatchingFilters` and `chargeMatchingFiltersToSearchParams` helpers. Parsing validates enum values and falls back to defaults for unknown/missing params; serialization omits empty and default values to keep the URL clean.
- `index.tsx`: drive the filters off `useSearchParams` instead of local component state, making the URL the single source of truth. Filter updates use `replace: true` so refining a filter doesn't stack a history entry per keystroke.

This follows the existing `useSearchParams` pattern already used in `components/business/index.tsx`.

## Testing

Full `yarn install` / `yarn lint` could not be run in this environment — a transitive dependency source (`cdn.sheetjs.com`) is blocked by the sandbox egress policy, unrelated to this change. The change is small, type-safe, and mirrors an existing pattern in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1qavpHnfw9dreVLe3TP3o

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1qavpHnfw9dreVLe3TP3o)_