### PR TITLE
feat(charge-matching): allow selecting a base charge from the queue list

### DIFF
--- a/.changeset/charge-matching-base-selection.md
+++ b/.changeset/charge-matching-base-selection.md
@@ -1,0 +1,8 @@
+---
+"@accounter/client": patch
+---
+
+Charge Matching screen: allow selecting a base charge from the queue sidebar. Clicking an entry pins
+that charge as the active item under review, so you can jump ahead to an upcoming base charge or
+revisit one you skipped instead of only ever seeing the first pending charge. Already-matched entries
+are disabled since they are merged on the backend.

--- a/packages/client/src/components/charge-matching/charge-matching-sidebar.tsx
+++ b/packages/client/src/components/charge-matching/charge-matching-sidebar.tsx
@@ -68,12 +68,15 @@ export const ChargeMatchingSidebar = ({
                 <li key={item.id}>
                   <button
                     type="button"
+                    disabled={status === 'matched'}
                     onClick={() => onSelectItem(item.id)}
                     aria-current={item.id === activeId ? 'true' : undefined}
                     className={cn(
-                      'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/60',
+                      'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
+                      status !== 'matched' && 'hover:bg-accent/60',
                       item.id === activeId && 'bg-accent',
                       status === 'skipped' && 'opacity-50',
+                      status === 'matched' && 'cursor-not-allowed opacity-60',
                     )}
                   >
                     <StatusIcon status={status} />

--- a/packages/client/src/components/charge-matching/charge-matching-sidebar.tsx
+++ b/packages/client/src/components/charge-matching/charge-matching-sidebar.tsx
@@ -18,6 +18,8 @@ type Props = {
   activeId: string | null;
   collapsed: boolean;
   onToggleCollapsed: () => void;
+  /** Pin a base charge as the active item under review */
+  onSelectItem: (id: string) => void;
 };
 
 function StatusIcon({ status }: { status: ChargeMatchItemStatus }): ReactElement {
@@ -37,6 +39,7 @@ export const ChargeMatchingSidebar = ({
   activeId,
   collapsed,
   onToggleCollapsed,
+  onSelectItem,
 }: Props): ReactElement => {
   return (
     <div
@@ -62,21 +65,25 @@ export const ChargeMatchingSidebar = ({
             {items.map(item => {
               const status = statusById[item.id] ?? 'pending';
               return (
-                <li
-                  key={item.id}
-                  className={cn(
-                    'flex items-center gap-2 rounded-md px-2 py-1.5 text-sm',
-                    item.id === activeId && 'bg-accent',
-                    status === 'skipped' && 'opacity-50',
-                  )}
-                >
-                  <StatusIcon status={status} />
-                  <div className="flex min-w-0 flex-col">
-                    <span className="truncate font-medium">{item.title}</span>
-                    <span className="truncate text-xs text-gray-500">
-                      {[item.subtitle, item.amount].filter(Boolean).join(' · ')}
-                    </span>
-                  </div>
+                <li key={item.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelectItem(item.id)}
+                    aria-current={item.id === activeId ? 'true' : undefined}
+                    className={cn(
+                      'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent/60',
+                      item.id === activeId && 'bg-accent',
+                      status === 'skipped' && 'opacity-50',
+                    )}
+                  >
+                    <StatusIcon status={status} />
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate font-medium">{item.title}</span>
+                      <span className="truncate text-xs text-gray-500">
+                        {[item.subtitle, item.amount].filter(Boolean).join(' · ')}
+                      </span>
+                    </div>
+                  </button>
                 </li>
               );
             })}

--- a/packages/client/src/components/charge-matching/index.tsx
+++ b/packages/client/src/components/charge-matching/index.tsx
@@ -82,7 +82,7 @@ export const ChargeMatchingReviewScreen = (): ReactElement => {
   );
 
   const totalCount = data?.chargesAwaitingMatchQueue.totalCount ?? 0;
-  const { activeItem, skipItem, acceptItemStatus } = queue;
+  const { activeItem, selectItem, skipItem, acceptItemStatus } = queue;
 
   // Which suggestion is shown in the comparison view. Null means rank 1; the
   // override is keyed by item id, so advancing the queue naturally falls back
@@ -159,6 +159,7 @@ export const ChargeMatchingReviewScreen = (): ReactElement => {
             activeId={activeItem?.id ?? null}
             collapsed={sidebarCollapsed}
             onToggleCollapsed={() => setSidebarCollapsed(collapsed => !collapsed)}
+            onSelectItem={selectItem}
           />
 
           <div className="flex min-w-0 flex-1 flex-col gap-4">

--- a/packages/client/src/hooks/__tests__/use-charge-match-queue.test.ts
+++ b/packages/client/src/hooks/__tests__/use-charge-match-queue.test.ts
@@ -137,6 +137,74 @@ describe('useChargeMatchQueue', () => {
     await cleanup();
   });
 
+  it('selectItem pins an upcoming base charge as the active item', async () => {
+    const { current, cleanup } = await renderQueueHarness(ITEMS);
+
+    await act(async () => {
+      current().selectItem('c');
+    });
+
+    expect(current().activeIndex).toBe(2);
+    expect(current().activeItem).toEqual({ id: 'c' });
+    // No item has been resolved, so the queue is not done
+    expect(current().isDone).toBe(false);
+
+    await cleanup();
+  });
+
+  it('selectItem can revisit a skipped base charge', async () => {
+    const { current, cleanup } = await renderQueueHarness(ITEMS);
+
+    await act(async () => {
+      current().skipItem('a');
+    });
+    expect(current().activeItem).toEqual({ id: 'b' });
+
+    await act(async () => {
+      current().selectItem('a');
+    });
+    expect(current().activeIndex).toBe(0);
+    expect(current().activeItem).toEqual({ id: 'a' });
+    expect(current().statusById.a).toBe('skipped');
+
+    await cleanup();
+  });
+
+  it('resolving a manually selected charge clears the pin and advances to the next pending', async () => {
+    const { current, cleanup } = await renderQueueHarness(ITEMS);
+
+    await act(async () => {
+      current().selectItem('c');
+    });
+    expect(current().activeItem).toEqual({ id: 'c' });
+
+    await act(async () => {
+      current().acceptItemStatus('c', true);
+    });
+
+    // Pin cleared: falls back to the first still-pending charge
+    expect(current().statusById.c).toBe('matched');
+    expect(current().activeItem).toEqual({ id: 'a' });
+
+    await cleanup();
+  });
+
+  it('selecting a charge that leaves the queue on refetch falls back to first-pending', async () => {
+    const { current, rerender, cleanup } = await renderQueueHarness(ITEMS);
+
+    await act(async () => {
+      current().selectItem('c');
+    });
+    expect(current().activeItem).toEqual({ id: 'c' });
+
+    const refetchedItems: Item[] = [{ id: 'a' }, { id: 'b' }];
+    await rerender(refetchedItems);
+
+    expect(current().activeItem).toEqual({ id: 'a' });
+
+    await cleanup();
+  });
+
   it('resets index and statuses when a new items array arrives (e.g. filters changed)', async () => {
     const { current, rerender, cleanup } = await renderQueueHarness(ITEMS);
 

--- a/packages/client/src/hooks/__tests__/use-charge-match-queue.test.ts
+++ b/packages/client/src/hooks/__tests__/use-charge-match-queue.test.ts
@@ -170,6 +170,30 @@ describe('useChargeMatchQueue', () => {
     await cleanup();
   });
 
+  it('selectItem is a no-op for a matched charge or an id not in the queue', async () => {
+    const { current, cleanup } = await renderQueueHarness(ITEMS);
+
+    await act(async () => {
+      current().acceptItemStatus('a', true);
+    });
+    // Active is now the first pending charge 'b'
+    expect(current().activeItem).toEqual({ id: 'b' });
+
+    // Selecting the matched charge is ignored
+    await act(async () => {
+      current().selectItem('a');
+    });
+    expect(current().activeItem).toEqual({ id: 'b' });
+
+    // Selecting an unknown id is ignored
+    await act(async () => {
+      current().selectItem('zzz');
+    });
+    expect(current().activeItem).toEqual({ id: 'b' });
+
+    await cleanup();
+  });
+
   it('resolving a manually selected charge clears the pin and advances to the next pending', async () => {
     const { current, cleanup } = await renderQueueHarness(ITEMS);
 

--- a/packages/client/src/hooks/use-charge-match-queue.ts
+++ b/packages/client/src/hooks/use-charge-match-queue.ts
@@ -60,13 +60,20 @@ export function useChargeMatchQueue<TItem extends { id: string }>(
 
   // Honor a manual selection while it still points at an item in the queue;
   // otherwise fall back to the first-pending item
-  const selectedIndex =
-    selectedId === null ? -1 : items.findIndex(item => item.id === selectedId);
+  const selectedIndex = selectedId === null ? -1 : items.findIndex(item => item.id === selectedId);
   const activeIndex = selectedIndex === -1 ? derivedIndex : selectedIndex;
 
-  const selectItem = useCallback((id: string) => {
-    setSelectedId(id);
-  }, []);
+  const selectItem = useCallback(
+    (id: string) => {
+      // Ignore ids not in the queue, and matched charges (already merged on the
+      // backend, so there is nothing left to review)
+      if (!items.some(item => item.id === id) || (overrides[id] ?? 'pending') === 'matched') {
+        return;
+      }
+      setSelectedId(id);
+    },
+    [items, overrides],
+  );
 
   const skipItem = useCallback((id: string) => {
     setOverrides(prev => ({ ...prev, [id]: 'skipped' }));

--- a/packages/client/src/hooks/use-charge-match-queue.ts
+++ b/packages/client/src/hooks/use-charge-match-queue.ts
@@ -13,6 +13,11 @@ export type UseChargeMatchQueue<TItem extends { id: string }> = {
   isDone: boolean;
   /** Session-only status per item id (no backend persistence) */
   statusById: Record<string, ChargeMatchItemStatus>;
+  /**
+   * Manually pin a base charge as the active item — used to jump to an upcoming
+   * charge or revisit a skipped one. Passing an id not in the queue is a no-op.
+   */
+  selectItem: (id: string) => void;
   /** Flag an item as skipped and advance to the next one */
   skipItem: (id: string) => void;
   /**
@@ -35,6 +40,9 @@ export function useChargeMatchQueue<TItem extends { id: string }>(
   items: TItem[],
 ): UseChargeMatchQueue<TItem> {
   const [overrides, setOverrides] = useState<Record<string, ChargeMatchItemStatus>>({});
+  // A manually pinned base charge takes precedence over the derived first-pending
+  // item, letting the user jump to an upcoming charge or revisit a skipped one.
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const statusById = useMemo(() => {
     const statuses: Record<string, ChargeMatchItemStatus> = {};
@@ -48,10 +56,22 @@ export function useChargeMatchQueue<TItem extends { id: string }>(
     () => items.findIndex(item => (overrides[item.id] ?? 'pending') === 'pending'),
     [items, overrides],
   );
-  const activeIndex = firstPendingIndex === -1 ? items.length : firstPendingIndex;
+  const derivedIndex = firstPendingIndex === -1 ? items.length : firstPendingIndex;
+
+  // Honor a manual selection while it still points at an item in the queue;
+  // otherwise fall back to the first-pending item
+  const selectedIndex =
+    selectedId === null ? -1 : items.findIndex(item => item.id === selectedId);
+  const activeIndex = selectedIndex === -1 ? derivedIndex : selectedIndex;
+
+  const selectItem = useCallback((id: string) => {
+    setSelectedId(id);
+  }, []);
 
   const skipItem = useCallback((id: string) => {
     setOverrides(prev => ({ ...prev, [id]: 'skipped' }));
+    // Drop any manual pin so the queue advances to the next pending charge
+    setSelectedId(null);
   }, []);
 
   const acceptItemStatus = useCallback((id: string, success: boolean) => {
@@ -60,14 +80,17 @@ export function useChargeMatchQueue<TItem extends { id: string }>(
       return;
     }
     setOverrides(prev => ({ ...prev, [id]: 'matched' }));
+    // Drop any manual pin so the queue advances to the next pending charge
+    setSelectedId(null);
   }, []);
 
   return {
     items,
     activeIndex,
     activeItem: items[activeIndex] ?? null,
-    isDone: activeIndex >= items.length,
+    isDone: derivedIndex >= items.length,
     statusById,
+    selectItem,
     skipItem,
     acceptItemStatus,
   };


### PR DESCRIPTION
## Summary

On the Charge Matching review screen, the base charge under review was always the first still-pending item in the queue — there was no way to jump ahead to an upcoming base charge or go back to one you had skipped. This PR makes the sidebar queue entries clickable so the reviewer can pin any base charge as the active item.

## Changes

- **`use-charge-match-queue.ts`**: add `selectItem(id)`. A manually pinned charge takes precedence over the derived first-pending item, but only while it still points at an item in the queue — otherwise it falls back to first-pending (e.g. the pinned charge dropped out on a refetch). Accepting or skipping clears the pin so the queue resumes its natural advance.
- **`charge-matching-sidebar.tsx`**: render each queue entry as a `<button>` wired to a new `onSelectItem` prop, with `aria-current` on the active row and a hover affordance.
- **`index.tsx`**: pass `selectItem` through to the sidebar.
- **Tests**: cover pinning an upcoming charge, revisiting a skipped charge, clearing the pin on accept, and falling back when the pinned charge leaves the queue.

## Notes

Selection is session-only (consistent with the existing skipped/matched status tracking) — no backend changes.

I was unable to run `yarn install`/lint/tests locally because a transitive dependency (`xlsx` served from `cdn.sheetjs.com`) is blocked by this environment's egress policy; CI will exercise the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Df2oYjmPsXXy6tMpdEg2rq)_