### PR TITLE
feat(charges-matcher): skip charge types that don't require document matching

### DIFF
--- a/.changeset/charge-matching-doc-requirements.md
+++ b/.changeset/charge-matching-doc-requirements.md
@@ -1,0 +1,9 @@
+---
+"@accounter/server": patch
+---
+
+Exclude charge types that never require document matching from the
+awaiting-match queue. Only COMMON, BUSINESS_TRIP and untyped charges (which
+resolve to one of those) are expected to hold both documents and transactions;
+BANK_DEPOSIT, CREDITCARD_BANK, DIVIDEND, FOREIGN_SECURITIES, INTERNAL, VAT,
+PAYROLL, CONVERSION and FINANCIAL charges are now skipped.

--- a/packages/server/src/modules/charges-matcher/__tests__/charges-awaiting-match-queue.test.ts
+++ b/packages/server/src/modules/charges-matcher/__tests__/charges-awaiting-match-queue.test.ts
@@ -19,11 +19,18 @@ function makeCharge(
     transactions = 0,
     invoices = 0,
     receipts = 0,
-  }: { transactions?: number; invoices?: number; receipts?: number } = {},
+    type = null,
+  }: {
+    transactions?: number;
+    invoices?: number;
+    receipts?: number;
+    type?: string | null;
+  } = {},
 ) {
   return {
     id,
     owner_id: OWNER_ID,
+    type,
     transactions_count: transactions ? String(transactions) : null,
     invoices_count: invoices ? String(invoices) : null,
     receipts_count: receipts ? String(receipts) : null,
@@ -132,6 +139,51 @@ describe('chargesAwaitingMatchQueue resolver', () => {
 
       expect(result.baseCharges.map(c => c.baseCharge.id)).toEqual(['tx-1', 'doc-1']);
       expect(result.totalCount).toBe(2);
+    });
+
+    it('should exclude base-charges of types that never require a document match', async () => {
+      const nonMatchableTypes = [
+        'BANK_DEPOSIT',
+        'CREDITCARD_BANK',
+        'DIVIDEND',
+        'FOREIGN_SECURITIES',
+        'INTERNAL',
+        'VAT',
+        'PAYROLL',
+        'CONVERSION',
+        'FINANCIAL',
+      ];
+      const { injector } = createTestContext({
+        charges: [
+          ...nonMatchableTypes.map((type, i) => makeCharge(`skip-${i}`, { transactions: 1, type })),
+          txCharge('tx-1'),
+          docCharge('doc-1'),
+        ],
+      });
+
+      const result = await resolve(null, baseArgs, { injector }, null);
+
+      expect(result.baseCharges.map(c => c.baseCharge.id)).toEqual(['tx-1', 'doc-1']);
+      expect(result.totalCount).toBe(2);
+    });
+
+    it('should include COMMON, BUSINESS_TRIP and untyped base-charges', async () => {
+      const { injector } = createTestContext({
+        charges: [
+          makeCharge('common-1', { transactions: 1, type: 'COMMON' }),
+          makeCharge('trip-1', { invoices: 1, type: 'BUSINESS_TRIP' }),
+          txCharge('untyped-1'),
+        ],
+      });
+
+      const result = await resolve(null, baseArgs, { injector }, null);
+
+      expect(result.baseCharges.map(c => c.baseCharge.id)).toEqual([
+        'common-1',
+        'trip-1',
+        'untyped-1',
+      ]);
+      expect(result.totalCount).toBe(3);
     });
 
     it('should treat a transaction charge with invoice-only documents as unmatched', async () => {

--- a/packages/server/src/modules/charges-matcher/helpers/awaiting-match-queue.helper.ts
+++ b/packages/server/src/modules/charges-matcher/helpers/awaiting-match-queue.helper.ts
@@ -1,6 +1,34 @@
+import type { charge_type } from '../../charges/types.js';
 import type { ChargesMatcherModule } from '../types.js';
 
 type ChargeMatchQueueMode = ChargesMatcherModule.ChargeMatchQueueMode;
+
+/**
+ * DB charge types that never require a document ↔ transaction match, since no
+ * accounting documents are expected for them. Charges of these types are
+ * excluded from the awaiting-match queue.
+ */
+const NON_MATCHABLE_CHARGE_TYPES = new Set<charge_type>([
+  'BANK_DEPOSIT',
+  'CREDITCARD_BANK',
+  'DIVIDEND',
+  'FOREIGN_SECURITIES',
+  'INTERNAL',
+  'VAT',
+  'PAYROLL',
+  'CONVERSION',
+  'FINANCIAL',
+]);
+
+/**
+ * Only COMMON and BUSINESS_TRIP charges (or charges with a not-yet-resolved
+ * `null` type, which resolve to either COMMON or BUSINESS_TRIP) are expected to
+ * hold both documents and transactions, so only they belong in the
+ * awaiting-match queue.
+ */
+export function chargeRequiresMatch(charge: { type?: charge_type | null }): boolean {
+  return !charge.type || !NON_MATCHABLE_CHARGE_TYPES.has(charge.type);
+}
 
 /**
  * Max number of charges evaluated when sorting the queue BY_SCORE. Scoring is

--- a/packages/server/src/modules/charges-matcher/helpers/awaiting-match-queue.helper.ts
+++ b/packages/server/src/modules/charges-matcher/helpers/awaiting-match-queue.helper.ts
@@ -4,21 +4,14 @@ import type { ChargesMatcherModule } from '../types.js';
 type ChargeMatchQueueMode = ChargesMatcherModule.ChargeMatchQueueMode;
 
 /**
- * DB charge types that never require a document ↔ transaction match, since no
- * accounting documents are expected for them. Charges of these types are
- * excluded from the awaiting-match queue.
+ * DB charge types that are expected to hold both documents and transactions,
+ * and therefore require a document ↔ transaction match. Every other type (e.g.
+ * BANK_DEPOSIT, CREDITCARD_BANK, DIVIDEND, FOREIGN_SECURITIES, INTERNAL, VAT,
+ * PAYROLL, CONVERSION, FINANCIAL) never needs an accounting document and is
+ * excluded from the awaiting-match queue. A whitelist keeps new,
+ * non-matchable types out of the queue by default.
  */
-const NON_MATCHABLE_CHARGE_TYPES = new Set<charge_type>([
-  'BANK_DEPOSIT',
-  'CREDITCARD_BANK',
-  'DIVIDEND',
-  'FOREIGN_SECURITIES',
-  'INTERNAL',
-  'VAT',
-  'PAYROLL',
-  'CONVERSION',
-  'FINANCIAL',
-]);
+const MATCHABLE_CHARGE_TYPES = new Set<charge_type>(['COMMON', 'BUSINESS_TRIP']);
 
 /**
  * Only COMMON and BUSINESS_TRIP charges (or charges with a not-yet-resolved
@@ -27,7 +20,7 @@ const NON_MATCHABLE_CHARGE_TYPES = new Set<charge_type>([
  * awaiting-match queue.
  */
 export function chargeRequiresMatch(charge: { type?: charge_type | null }): boolean {
-  return !charge.type || !NON_MATCHABLE_CHARGE_TYPES.has(charge.type);
+  return !charge.type || MATCHABLE_CHARGE_TYPES.has(charge.type);
 }
 
 /**

--- a/packages/server/src/modules/charges-matcher/resolvers/charges-awaiting-match-queue.resolver.ts
+++ b/packages/server/src/modules/charges-matcher/resolvers/charges-awaiting-match-queue.resolver.ts
@@ -3,6 +3,7 @@ import { AdminContextProvider } from '../../admin-context/providers/admin-contex
 import { ChargesProvider } from '../../charges/providers/charges.provider.js';
 import {
   BY_SCORE_EVALUATION_CAP,
+  chargeRequiresMatch,
   matchesQueueMode,
 } from '../helpers/awaiting-match-queue.helper.js';
 import { QueueMatchEvaluatorProvider } from '../providers/queue-match-evaluator.provider.js';
@@ -28,7 +29,9 @@ export const chargesAwaitingMatchQueueResolver: ChargesMatcherModule.Resolvers =
           toDate,
         });
 
-        const queue = charges.filter(charge => matchesQueueMode(charge, mode));
+        const queue = charges.filter(
+          charge => chargeRequiresMatch(charge) && matchesQueueMode(charge, mode),
+        );
 
         const safeLimit = Math.max(0, limit ?? 20);
         const safeOffset = Math.max(0, offset ?? 0);


### PR DESCRIPTION
## What

The awaiting-match queue (`chargesAwaitingMatchQueue`) now ignores base-charges whose type never requires a document ↔ transaction match.

## Why

The matching queue only makes sense for charges expected to hold **both** documents and transactions. The following charge types never need an accounting document, so surfacing them in the queue is noise:

`BANK_DEPOSIT`, `CREDITCARD_BANK`, `DIVIDEND`, `FOREIGN_SECURITIES`, `INTERNAL`, `VAT`, `PAYROLL`, `CONVERSION`, `FINANCIAL`

Only `COMMON` and `BUSINESS_TRIP` charges — or charges with a not-yet-resolved `null` type, which resolve to one of those — are kept.

## Changes

- `helpers/awaiting-match-queue.helper.ts`: added `chargeRequiresMatch()` and the `NON_MATCHABLE_CHARGE_TYPES` set.
- `resolvers/charges-awaiting-match-queue.resolver.ts`: applied `chargeRequiresMatch` alongside the existing `matchesQueueMode` filter.
- Added unit tests covering exclusion of non-matchable types and inclusion of `COMMON` / `BUSINESS_TRIP` / untyped charges.
- Added a changeset.

## Notes

`yarn install` could not complete in this environment because the `xlsx` dependency is fetched from `cdn.sheetjs.com`, which the sandbox egress policy blocks (403), so the test suite was not run here. The added tests follow the existing suite's patterns; the DB result already exposes `type` via `SELECT c.*` in `getChargesByFilters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwwFfcu4qVPGPjnS8RQBko)_