### PR TITLE
perf(charges-matcher): score match candidates in parallel (2/3)

### DIFF
--- a/.changeset/charge-matching-queue-parallel-scoring.md
+++ b/.changeset/charge-matching-queue-parallel-scoring.md
@@ -1,0 +1,8 @@
+---
+"@accounter/server": patch
+---
+
+Score charge-match candidates in parallel. `findMatches` previously scored candidates in a
+sequential `await` loop, which serialized the per-candidate client and issued-document-status
+DataLoader lookups inside `scoreMatch` into an N+1. Scoring now runs with `Promise.all` so those
+loads batch. Ordering is unaffected (results are sorted afterwards), so match output is unchanged.

--- a/packages/server/src/modules/charges-matcher/providers/single-match.provider.ts
+++ b/packages/server/src/modules/charges-matcher/providers/single-match.provider.ts
@@ -7,7 +7,7 @@
 
 import type { Injector } from 'graphql-modules';
 import { isWithinDateWindow } from '../helpers/candidate-filter.helper.js';
-import type { DocumentCharge, MatchScore, TransactionCharge } from '../types.js';
+import type { DocumentCharge, TransactionCharge } from '../types.js';
 import { aggregateDocuments } from './document-aggregator.js';
 import { scoreMatch } from './match-scorer.provider.js';
 import { aggregateTransactions } from './transaction-aggregator.js';
@@ -211,19 +211,13 @@ export async function findMatches(
   const scoredResults = await Promise.all(
     windowFilteredCandidates.map(async (candidate): Promise<ScoredCandidate | null> => {
       try {
-        let matchScore: MatchScore;
-        let txCharge: TransactionCharge;
-        let docCharge: DocumentCharge;
-
-        if (isSourceTransaction) {
-          txCharge = sourceCharge;
-          docCharge = candidate as DocumentCharge;
-          matchScore = await scoreMatch(txCharge, docCharge, userId, injector);
-        } else {
-          txCharge = candidate as TransactionCharge;
-          docCharge = sourceCharge;
-          matchScore = await scoreMatch(txCharge, docCharge, userId, injector);
-        }
+        const txCharge = isSourceTransaction
+          ? (sourceCharge as TransactionCharge)
+          : (candidate as TransactionCharge);
+        const docCharge = isSourceTransaction
+          ? (candidate as DocumentCharge)
+          : (sourceCharge as DocumentCharge);
+        const matchScore = await scoreMatch(txCharge, docCharge, userId, injector);
 
         // Calculate date proximity for tie-breaking
         const dateProximity = calculateDateProximity(txCharge, docCharge);
@@ -237,9 +231,12 @@ export async function findMatches(
           _txCharge: txCharge,
           _docCharge: docCharge,
         };
-      } catch {
-        // Skip candidates that fail scoring (e.g., mixed currencies, invalid data)
-        // This is expected behavior - not all candidates will be scoreable
+      } catch (error) {
+        // Scoring is best-effort: a candidate that can't be scored (mixed
+        // currencies, unaggregatable data, a failed lookup, etc.) is skipped
+        // rather than failing the batch. Log it so genuine system errors (DB /
+        // network) surface instead of silently producing an empty match list.
+        console.error(`Failed to score candidate ${candidate.chargeId}:`, error);
         return null;
       }
     }),

--- a/packages/server/src/modules/charges-matcher/providers/single-match.provider.ts
+++ b/packages/server/src/modules/charges-matcher/providers/single-match.provider.ts
@@ -198,45 +198,56 @@ export async function findMatches(
     );
   }
 
-  // Step 8: Score all remaining candidates
-  const scoredCandidates: Array<
-    MatchResult & { _txCharge?: TransactionCharge; _docCharge?: DocumentCharge }
-  > = [];
+  // Step 8: Score all remaining candidates.
+  // Scoring is done in parallel: each `scoreMatch` awaits DataLoader lookups
+  // (client + issued-documents status), so a sequential loop would serialize
+  // those into an N+1. Running them together lets the loaders batch. Ordering
+  // is irrelevant here — results are sorted in Step 9.
+  type ScoredCandidate = MatchResult & {
+    _txCharge?: TransactionCharge;
+    _docCharge?: DocumentCharge;
+  };
 
-  for (const candidate of windowFilteredCandidates) {
-    try {
-      let matchScore: MatchScore;
-      let txCharge: TransactionCharge;
-      let docCharge: DocumentCharge;
+  const scoredResults = await Promise.all(
+    windowFilteredCandidates.map(async (candidate): Promise<ScoredCandidate | null> => {
+      try {
+        let matchScore: MatchScore;
+        let txCharge: TransactionCharge;
+        let docCharge: DocumentCharge;
 
-      if (isSourceTransaction) {
-        txCharge = sourceCharge;
-        docCharge = candidate as DocumentCharge;
-        matchScore = await scoreMatch(txCharge, docCharge, userId, injector);
-      } else {
-        txCharge = candidate as TransactionCharge;
-        docCharge = sourceCharge;
-        matchScore = await scoreMatch(txCharge, docCharge, userId, injector);
+        if (isSourceTransaction) {
+          txCharge = sourceCharge;
+          docCharge = candidate as DocumentCharge;
+          matchScore = await scoreMatch(txCharge, docCharge, userId, injector);
+        } else {
+          txCharge = candidate as TransactionCharge;
+          docCharge = sourceCharge;
+          matchScore = await scoreMatch(txCharge, docCharge, userId, injector);
+        }
+
+        // Calculate date proximity for tie-breaking
+        const dateProximity = calculateDateProximity(txCharge, docCharge);
+
+        return {
+          chargeId: candidate.chargeId,
+          confidenceScore: matchScore.confidenceScore,
+          components: matchScore.components,
+          dateProximity,
+          gentleMode: matchScore.gentleMode === true,
+          _txCharge: txCharge,
+          _docCharge: docCharge,
+        };
+      } catch {
+        // Skip candidates that fail scoring (e.g., mixed currencies, invalid data)
+        // This is expected behavior - not all candidates will be scoreable
+        return null;
       }
+    }),
+  );
 
-      // Calculate date proximity for tie-breaking
-      const dateProximity = calculateDateProximity(txCharge, docCharge);
-
-      scoredCandidates.push({
-        chargeId: candidate.chargeId,
-        confidenceScore: matchScore.confidenceScore,
-        components: matchScore.components,
-        dateProximity,
-        gentleMode: matchScore.gentleMode === true,
-        _txCharge: txCharge,
-        _docCharge: docCharge,
-      });
-    } catch {
-      // Skip candidates that fail scoring (e.g., mixed currencies, invalid data)
-      // This is expected behavior - not all candidates will be scoreable
-      continue;
-    }
-  }
+  const scoredCandidates = scoredResults.filter(
+    (candidate): candidate is ScoredCandidate => candidate !== null,
+  );
 
   // Step 9: Sort by confidence descending, then by date proximity tie-breaker
   scoredCandidates.sort((a, b) => {


### PR DESCRIPTION
## Context

**PR 2 of 3** in the `chargesAwaitingMatchQueue` performance series. Stacked on top of #3982 (base is that PR's branch, not `main`; retarget to `main` once #3982 merges).

1. #3982 — shared candidate pool
2. **This PR — parallelize the per-candidate scoring loop**
3. `@defer` the match suggestions so base charges paint immediately

## Problem

`findMatches` scored candidates in a sequential `for … await scoreMatch` loop. Each `scoreMatch` awaits DataLoader lookups (`ClientsProvider` registered-client check and `IssuedDocumentsProvider` status). Awaiting one candidate before starting the next serialized those loads into a classic N+1 — one client query and one issued-docs query per candidate, back to back.

## Change

Score candidates with `Promise.all` instead of the sequential loop. Because the loads now happen within the same tick, the DataLoaders batch them into a couple of queries instead of hundreds.

Ordering is unaffected: candidates are still sorted by confidence (with the existing date-proximity tie-breaker) in the next step, and `Array.map` preserves input order so the stable-sort behavior is identical. Unscoreable candidates are still dropped (they now return `null` and are filtered out).

## Files

- `providers/single-match.provider.ts` — Step 8 scoring loop → `Promise.all` + filter.

## Testing

⚠️ Same environment limitation as #3982: `yarn install` fails on the policy-blocked `cdn.sheetjs.com` (`xlsx`) fetch, so I could not run the suite locally. **CI should run** the `charges-matcher` unit + integration tests. This change is purely a sequential→parallel refactor of existing logic; `single-match` and `match-scorer` tests cover the scoring behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVAbrnSqJcoqq8BRyDStKY)_