### PR TITLE
Migrate VAT report wrapper tables to NewChargesTable

### DIFF
--- a/packages/client/src/components/reports/vat-monthly-report/business-trips-table.tsx
+++ b/packages/client/src/components/reports/vat-monthly-report/business-trips-table.tsx
@@ -1,9 +1,10 @@
 import { useState, type ReactElement } from 'react';
 import { PanelTopClose, PanelTopOpen } from 'lucide-react';
+import type { OnChangeFn, RowSelectionState } from '@tanstack/react-table';
 import { Card } from '@/components/ui/card.js';
 import { VatReportBusinessTripsFieldsFragmentDoc } from '../../../gql/graphql.js';
 import { getFragmentData, type FragmentType } from '../../../gql/index.js';
-import { ChargesTable } from '../../charges/charges-table.js';
+import { NewChargesTable } from '../../charges/new-charges-table.js';
 import { Button } from '../../ui/button.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
@@ -11,21 +12,21 @@ import { Button } from '../../ui/button.js';
   fragment VatReportBusinessTripsFields on VatReportResult {
     businessTrips {
       id
-      ...ChargesTableFields
+      ...ChargeForChargesTableFields
     }
   }
 `;
 
 interface Props {
   data?: FragmentType<typeof VatReportBusinessTripsFieldsFragmentDoc>;
-  toggleMergeCharge: (chargeId: string) => void;
-  mergeSelectedCharges: Set<string>;
+  rowSelection: RowSelectionState;
+  onRowSelectionChange: OnChangeFn<RowSelectionState>;
 }
 
 export const BusinessTripsTable = ({
   data,
-  toggleMergeCharge,
-  mergeSelectedCharges,
+  rowSelection,
+  onRowSelectionChange,
 }: Props): ReactElement => {
   const chargesData = getFragmentData(VatReportBusinessTripsFieldsFragmentDoc, data);
   const [isOpened, setIsOpened] = useState(true);
@@ -47,11 +48,10 @@ export const BusinessTripsTable = ({
         </h2>
       </div>
       {isOpened && chargesData && (
-        <ChargesTable
+        <NewChargesTable
           data={chargesData.businessTrips}
-          isAllOpened={false}
-          toggleMergeCharge={toggleMergeCharge}
-          mergeSelectedCharges={mergeSelectedCharges}
+          rowSelection={rowSelection}
+          onRowSelectionChange={onRowSelectionChange}
         />
       )}
     </Card>

--- a/packages/client/src/components/reports/vat-monthly-report/index.tsx
+++ b/packages/client/src/components/reports/vat-monthly-report/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { format } from 'date-fns';
 import { Loader2 } from 'lucide-react';
+import type { RowSelectionState } from '@tanstack/react-table';
 import { useQuery } from 'urql';
 import {
   ChargeFilterType,
@@ -50,7 +51,10 @@ export const VatMonthlyReport = (): ReactElement => {
           monthDate: format(new Date(), 'yyyy-MM-15') as TimelessDateString,
         },
   );
-  const [mergeSelectedCharges, setMergeSelectedCharges] = useState<Array<string>>([]);
+  // Single selection source of truth, shared by every sub-table so charges picked in one table
+  // participate in cross-table actions (merge, and future ledger/tag actions). Keyed by charge id
+  // to match `NewChargesTable`'s `getRowId`.
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   // auto default admin business if not set
   useEffect(() => {
@@ -74,20 +78,30 @@ export const VatMonthlyReport = (): ReactElement => {
     pause: filter.financialEntityId === '',
   });
 
-  const toggleMergeCharge = useCallback(
-    (chargeId: string) => {
-      if (mergeSelectedCharges.includes(chargeId)) {
-        setMergeSelectedCharges(mergeSelectedCharges.filter(id => id !== chargeId));
-      } else {
-        setMergeSelectedCharges([...mergeSelectedCharges, chargeId]);
-      }
-    },
-    [mergeSelectedCharges],
+  const selectedChargeIds = useMemo(
+    () => Object.entries(rowSelection).flatMap(([id, selected]) => (selected ? [id] : [])),
+    [rowSelection],
   );
 
-  function onResetMerge(): void {
-    setMergeSelectedCharges([]);
-  }
+  // Legacy `Set`-based selection API still consumed by the income/expenses tables, derived from the
+  // shared `rowSelection` so all sub-tables stay in sync until those tables are migrated too.
+  const mergeSelectedChargesSet = useMemo(() => new Set(selectedChargeIds), [selectedChargeIds]);
+
+  const toggleMergeCharge = useCallback((chargeId: string) => {
+    setRowSelection(old => {
+      const next = { ...old };
+      if (next[chargeId]) {
+        delete next[chargeId];
+      } else {
+        next[chargeId] = true;
+      }
+      return next;
+    });
+  }, []);
+
+  const onResetMerge = useCallback((): void => {
+    setRowSelection({});
+  }, []);
 
   useEffect(() => {
     setFiltersContext(
@@ -95,7 +109,7 @@ export const VatMonthlyReport = (): ReactElement => {
         <PCNGenerator filter={filter} isLoading={fetching} />
         <VatMonthlyReportFilter filter={{ ...filter }} setFilter={setFilter} />
         <MergeChargesButton
-          selected={mergeSelectedCharges.map(id => ({
+          selected={selectedChargeIds.map(id => ({
             id,
             onChange: (): void => {
               return;
@@ -105,12 +119,7 @@ export const VatMonthlyReport = (): ReactElement => {
         />
       </div>,
     );
-  }, [data, filter, fetching, setFiltersContext, mergeSelectedCharges]);
-
-  const mergeSelectedChargesSet = useMemo(
-    () => new Set(mergeSelectedCharges),
-    [mergeSelectedCharges],
-  );
+  }, [data, filter, fetching, setFiltersContext, selectedChargeIds, onResetMerge]);
 
   return (
     <PageLayout
@@ -143,20 +152,20 @@ export const VatMonthlyReport = (): ReactElement => {
 
             <MissingInfoTable
               data={data?.vatReport}
-              toggleMergeCharge={toggleMergeCharge}
-              mergeSelectedCharges={mergeSelectedChargesSet}
+              rowSelection={rowSelection}
+              onRowSelectionChange={setRowSelection}
             />
 
             <BusinessTripsTable
               data={data?.vatReport}
-              toggleMergeCharge={toggleMergeCharge}
-              mergeSelectedCharges={mergeSelectedChargesSet}
+              rowSelection={rowSelection}
+              onRowSelectionChange={setRowSelection}
             />
 
             <MiscTable
               data={data?.vatReport}
-              toggleMergeCharge={toggleMergeCharge}
-              mergeSelectedCharges={mergeSelectedChargesSet}
+              rowSelection={rowSelection}
+              onRowSelectionChange={setRowSelection}
             />
           </div>
         </div>

--- a/packages/client/src/components/reports/vat-monthly-report/index.tsx
+++ b/packages/client/src/components/reports/vat-monthly-report/index.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { format } from 'date-fns';
 import { Loader2 } from 'lucide-react';
-import type { RowSelectionState } from '@tanstack/react-table';
 import { useQuery } from 'urql';
+import type { RowSelectionState } from '@tanstack/react-table';
 import {
   ChargeFilterType,
   VatMonthlyReportDocument,
@@ -119,7 +119,7 @@ export const VatMonthlyReport = (): ReactElement => {
         />
       </div>,
     );
-  }, [data, filter, fetching, setFiltersContext, selectedChargeIds, onResetMerge]);
+  }, [filter, fetching, setFiltersContext, setFilter, selectedChargeIds, onResetMerge]);
 
   return (
     <PageLayout

--- a/packages/client/src/components/reports/vat-monthly-report/misc-table.tsx
+++ b/packages/client/src/components/reports/vat-monthly-report/misc-table.tsx
@@ -1,9 +1,10 @@
 import { useState, type ReactElement } from 'react';
 import { PanelTopClose, PanelTopOpen } from 'lucide-react';
+import type { OnChangeFn, RowSelectionState } from '@tanstack/react-table';
 import { Card } from '@/components/ui/card.js';
 import { VatReportMiscTableFieldsFragmentDoc } from '../../../gql/graphql.js';
 import { getFragmentData, type FragmentType } from '../../../gql/index.js';
-import { ChargesTable } from '../../charges/charges-table.js';
+import { NewChargesTable } from '../../charges/new-charges-table.js';
 import { Button } from '../../ui/button.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
@@ -11,22 +12,18 @@ import { Button } from '../../ui/button.js';
   fragment VatReportMiscTableFields on VatReportResult {
     differentMonthDoc {
       id
-      ...ChargesTableFields
+      ...ChargeForChargesTableFields
     }
   }
 `;
 
 type Props = {
   data?: FragmentType<typeof VatReportMiscTableFieldsFragmentDoc>;
-  toggleMergeCharge: (chargeId: string) => void;
-  mergeSelectedCharges: Set<string>;
+  rowSelection: RowSelectionState;
+  onRowSelectionChange: OnChangeFn<RowSelectionState>;
 };
 
-export const MiscTable = ({
-  data,
-  toggleMergeCharge,
-  mergeSelectedCharges,
-}: Props): ReactElement => {
+export const MiscTable = ({ data, rowSelection, onRowSelectionChange }: Props): ReactElement => {
   const chargesData = getFragmentData(VatReportMiscTableFieldsFragmentDoc, data);
   const [isOpened, setIsOpened] = useState(true);
 
@@ -47,11 +44,10 @@ export const MiscTable = ({
         </h2>
       </div>
       {isOpened && chargesData && (
-        <ChargesTable
+        <NewChargesTable
           data={chargesData.differentMonthDoc}
-          isAllOpened={false}
-          toggleMergeCharge={toggleMergeCharge}
-          mergeSelectedCharges={mergeSelectedCharges}
+          rowSelection={rowSelection}
+          onRowSelectionChange={onRowSelectionChange}
         />
       )}
     </Card>

--- a/packages/client/src/components/reports/vat-monthly-report/missing-info-table.tsx
+++ b/packages/client/src/components/reports/vat-monthly-report/missing-info-table.tsx
@@ -1,9 +1,10 @@
 import { useState, type ReactElement } from 'react';
 import { PanelTopClose, PanelTopOpen } from 'lucide-react';
+import type { OnChangeFn, RowSelectionState } from '@tanstack/react-table';
 import { Card } from '@/components/ui/card.js';
 import { VatReportMissingInfoFieldsFragmentDoc } from '../../../gql/graphql.js';
 import { getFragmentData, type FragmentType } from '../../../gql/index.js';
-import { ChargesTable } from '../../charges/charges-table.js';
+import { NewChargesTable } from '../../charges/new-charges-table.js';
 import { Button } from '../../ui/button.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
@@ -11,21 +12,21 @@ import { Button } from '../../ui/button.js';
   fragment VatReportMissingInfoFields on VatReportResult {
     missingInfo {
       id
-      ...ChargesTableFields
+      ...ChargeForChargesTableFields
     }
   }
 `;
 
 interface Props {
   data?: FragmentType<typeof VatReportMissingInfoFieldsFragmentDoc>;
-  toggleMergeCharge: (chargeId: string) => void;
-  mergeSelectedCharges: Set<string>;
+  rowSelection: RowSelectionState;
+  onRowSelectionChange: OnChangeFn<RowSelectionState>;
 }
 
 export const MissingInfoTable = ({
   data,
-  toggleMergeCharge,
-  mergeSelectedCharges,
+  rowSelection,
+  onRowSelectionChange,
 }: Props): ReactElement => {
   const chargesData = getFragmentData(VatReportMissingInfoFieldsFragmentDoc, data);
   const [isOpened, setIsOpened] = useState(true);
@@ -47,11 +48,10 @@ export const MissingInfoTable = ({
         </h2>
       </div>
       {isOpened && chargesData && (
-        <ChargesTable
+        <NewChargesTable
           data={chargesData.missingInfo}
-          isAllOpened={false}
-          toggleMergeCharge={toggleMergeCharge}
-          mergeSelectedCharges={mergeSelectedCharges}
+          rowSelection={rowSelection}
+          onRowSelectionChange={onRowSelectionChange}
         />
       )}
     </Card>


### PR DESCRIPTION
## What

Migrates the VAT monthly report's charge sub-tables onto the new `NewChargesTable`, using the externally-controlled `rowSelection` API added in #3986 so selection is shared across every sub-table (enabling cross-table actions — merge today, ledger regeneration / tag updates later).

### Migrated to `NewChargesTable`
These already wrapped the legacy `ChargesTable` over `Charge` data, so the swap was just the fragment + table component:
- `missing-info-table.tsx`
- `business-trips-table.tsx`
- `misc-table.tsx`

Each now spreads `...ChargeForChargesTableFields` (was `...ChargesTableFields`) and renders `NewChargesTable` with controlled `rowSelection` / `onRowSelectionChange`.

### Parent report (`index.tsx`)
- Holds a single `RowSelectionState` (keyed by charge id, matching `NewChargesTable`'s `getRowId`) as the one selection source of truth.
- Passes it directly to the three migrated tables.
- Derives the legacy `Set` + `toggleMergeCharge` API from the same state for the income/expenses tables, so all sub-tables stay in sync.
- `MergeChargesButton` and reset now read/clear the shared state.

## Not migrated (needs your call) — income & expenses tables

`income-section/income-table.tsx` and `expenses-section/expenses-table.tsx` are **left on their existing bespoke tables** and only re-wired to the shared selection state. They can't be migrated by "just updating the fragment + component":

- They render over `VatReportRecord`, **not** `Charge`. Each record only carries `chargeId` — not the `...ChargeForChargesTableFields` charge fragment — and a single charge can map to multiple records, so `NewChargesTable` can't be fed from this data without a schema/data-model change.
- They show VAT-report-specific columns that have no equivalent in `NewChargesTable`: record type, business + VAT number, invoice image/serial/allocation number, invoice & transaction dates, foreign/local amounts, the VAT breakdowns (local VAT, VAT after deduction, actual/rounded VAT), **cumulative amount / cumulative VAT** running totals, and tax-reduced amount.
- They have a detailed ⇄ summarized view toggle (`SectionSummary`) that `NewChargesTable` doesn't provide.

Migrating them would drop the core VAT figures, so I've flagged it here rather than doing a lossy migration. Options for a follow-up: extend `NewChargesTable` with configurable extra columns + a data adapter, or keep these as dedicated VAT tables. Let me know which direction you'd prefer.

## Notes
- Minor visual change: the three migrated tables now use `NewChargesTable`'s bordered/fit-width layout instead of the Mantine full-width table.
- `yarn generate` / `lint` / `build` could **not** be run in this environment — `yarn install` is blocked by the network policy (the `xlsx` dep of `node-xlsx` is fetched from `cdn.sheetjs.com`, which returns 403). Please run `yarn generate && yarn lint` locally; the fragment rename requires codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzCkrszbFU3gNW4YbJLCCh)_