### PR TITLE
feat(client): sort charges amount column by absolute value

### DIFF
--- a/packages/client/src/components/charges/columns.tsx
+++ b/packages/client/src/components/charges/columns.tsx
@@ -64,6 +64,12 @@ export const columns: ColumnDef<ChargeRow>[] = [
     accessorKey: 'amount.value',
     header: ({ column }) => <DataTableColumnHeader column={column} title="Amount" />,
     cell: ({ row }) => (row.original.amount ? <Amount {...row.original.amount} /> : null),
+    // Sort by absolute amount so charges are ordered by magnitude regardless of income/expense sign.
+    sortingFn: (rowA, rowB) => {
+      const a = Math.abs(rowA.original.amount?.value ?? 0);
+      const b = Math.abs(rowB.original.amount?.value ?? 0);
+      return a - b;
+    },
   },
   {
     accessorKey: 'vat.value',


### PR DESCRIPTION
## What

Extends the sort behavior of the **Amount** column in the new charges table (`packages/client/src/components/charges/columns.tsx`) to sort by **absolute (ABS) amount**.

## Why

Previously the Amount column sorted by the signed value, mixing income (positive) and expense (negative) charges by sign. Sorting by absolute value orders charges by magnitude regardless of income/expense direction, which is more useful when scanning for the largest transactions.

## How

Added a custom `sortingFn` to the amount column def that compares `Math.abs(value)` of each row:

```ts
sortingFn: (rowA, rowB) => {
  const a = Math.abs(rowA.original.amount?.value ?? 0);
  const b = Math.abs(rowB.original.amount?.value ?? 0);
  return a - b;
},
```

Asc/Desc from the existing column header dropdown now sort by magnitude.

## Notes

`yarn lint` / typecheck could not be run in this environment — a fresh `yarn install` fails because the `xlsx` dependency host `cdn.sheetjs.com` is blocked by the egress policy. The change itself is a small, type-safe addition (`sortingFn` receives `Row<ChargeRow>`; `amount?.value ?? 0` is a `number`, matching the required numeric comparator return).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFbQBepd85RbH2Bobvt4AD

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFbQBepd85RbH2Bobvt4AD)_