### PR TITLE
fix(client): wire charges merge button to new table selection

### DIFF
--- a/packages/client/src/components/screens/charges/all-charges.tsx
+++ b/packages/client/src/components/screens/charges/all-charges.tsx
@@ -2,6 +2,7 @@ import { useCallback, useContext, useEffect, useMemo, useState, type ReactElemen
 import { Loader2, PanelTopClose, PanelTopOpen } from 'lucide-react';
 import { useQuery } from 'urql';
 import { LoadingOverlay } from '@mantine/core';
+import type { RowSelectionState } from '@tanstack/react-table';
 import { NewChargesTable } from '@/components/charges/new-charges-table.js';
 import { AllChargesDocument, type ChargeFilter } from '../../../gql/graphql.js';
 import { useStableValue } from '../../../hooks/use-stable-value.js';
@@ -31,9 +32,7 @@ import { Button } from '../../ui/button.js';
 export const AllCharges = (): ReactElement => {
   const { setFiltersContext } = useContext(FiltersContext);
   const [isAllOpened, setIsAllOpened] = useState<boolean>(false);
-  const [mergeSelectedCharges, setMergeSelectedCharges] = useState<
-    Array<{ id: string; onChange: () => void }>
-  >([]);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const { get } = useUrlQuery();
   const [activePage, setActivePage] = useState(get('page') ? Number(get('page')) : 0);
   const uriFilters = get('chargesFilters');
@@ -74,8 +73,23 @@ export const AllCharges = (): ReactElement => {
   const chargeNodes = useStableValue(data?.allCharges?.nodes);
 
   const resetMergeList = useCallback((): void => {
-    setMergeSelectedCharges([]);
+    setRowSelection({});
   }, []);
+
+  // Derive the merge button's input from the row-selection map. Each selected charge gets an
+  // `onChange` that refetches the list, so the table refreshes once a merge completes.
+  const mergeSelectedCharges = useMemo(
+    () =>
+      Object.entries(rowSelection)
+        .filter(([, isSelected]) => isSelected)
+        .map(([id]) => ({
+          id,
+          onChange: (): void => {
+            fetchCharges({ requestPolicy: 'network-only' });
+          },
+        })),
+    [rowSelection, fetchCharges],
+  );
 
   // Only the page count is consumed from the query result here. Depend on it
   // directly (instead of the whole `data`/`fetching`) so the filters bar isn't
@@ -133,7 +147,11 @@ export const AllCharges = (): ReactElement => {
         // (the stale rows stay visible underneath instead of blinking away).
         <div className="relative">
           <LoadingOverlay visible={fetching} overlayBlur={1} />
-          <NewChargesTable data={chargeNodes} />
+          <NewChargesTable
+            data={chargeNodes}
+            rowSelection={rowSelection}
+            onRowSelectionChange={setRowSelection}
+          />
         </div>
       ) : (
         <span>Please apply filters</span>


### PR DESCRIPTION
## Problem

After migrating the All Charges screen to the **New Charges Table**, the **Merge** button (`packages/client/src/components/screens/charges/all-charges.tsx:110`) stopped working — it stayed disabled even when two or more charges were selected.

## Root cause

`NewChargesTable` manages row selection internally through TanStack Table's `rowSelection` state (there's a select-checkbox column wired to `row.toggleSelected`). However, `AllCharges` kept a *separate* `mergeSelectedCharges` state that was never populated — nothing connected the table's selection back up to the parent. As a result, `MergeChargesButton` always received an empty `selected` array, so `distinctIDs.size > 1` was never true and the button remained disabled.

(The old `ChargesTable` used a `toggleMergeCharge` callback prop to push selections up to the parent; the new table replaced that with TanStack's controlled-selection API, but the parent screen was never updated to consume it.)

## Fix

`NewChargesTable` already supports controlled selection via its `rowSelection` / `onRowSelectionChange` props — this change just connects them:

- Lift the row-selection map (`RowSelectionState`, keyed by charge id) into `AllCharges` and pass it to `NewChargesTable` as controlled selection.
- Derive `mergeSelectedCharges` from that map, so the merge button sees the live selection.
- `resetMergeList` now clears the selection map (used by the merge dialog's cancel/reset/complete flows).
- Each selected charge's `onChange` refetches the charges list, so the table refreshes once a merge completes.

## Testing

I was unable to run `yarn lint` / `yarn build` in this environment: `yarn install` fails because a dependency is fetched from `cdn.sheetjs.com`, which the sandbox's egress policy blocks (HTTP 403). The change is type-safe by construction — `RowSelectionState` is `Record<string, boolean>`, and a `useState` setter is the canonical value for TanStack's `onRowSelectionChange`. Please run the local build/lint as part of review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01THrYmD7HkHudxqZ5DwXPkd)_