### PR TITLE
fix(client): address review feedback on new charge cells

### DIFF
--- a/packages/client/src/components/charges/new-cells/counterparty.tsx
+++ b/packages/client/src/components/charges/new-cells/counterparty.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { Indicator } from '@mantine/core';
 import { ROUTES } from '@/router/routes.js';
 import type { ChargeType } from '../../../helpers/index.js';
+import { shouldHaveCounterparty } from '../utils.js';
 
 export type CounterpartyProps = {
   counterparty:
@@ -20,23 +21,7 @@ export const Counterparty = ({
   type,
   isMissing,
 }: CounterpartyProps): ReactElement => {
-  const shouldHaveCounterparty = useMemo((): boolean => {
-    switch (type) {
-      case 'BusinessTripCharge':
-      case 'DividendCharge':
-      case 'ConversionCharge':
-      case 'SalaryCharge':
-      case 'InternalTransferCharge':
-        return false;
-      default:
-        return true;
-    }
-  }, [type]);
-
-  const isError = useMemo(
-    () => shouldHaveCounterparty && isMissing,
-    [shouldHaveCounterparty, isMissing],
-  );
+  const isError = useMemo(() => shouldHaveCounterparty(type) && isMissing, [type, isMissing]);
   const { name, id } = counterparty ?? { name: 'Missing', id: undefined };
 
   return (

--- a/packages/client/src/components/charges/new-cells/counterparty.tsx
+++ b/packages/client/src/components/charges/new-cells/counterparty.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactElement } from 'react';
+import { type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import { Indicator } from '@mantine/core';
 import { ROUTES } from '@/router/routes.js';
@@ -21,7 +21,7 @@ export const Counterparty = ({
   type,
   isMissing,
 }: CounterpartyProps): ReactElement => {
-  const isError = useMemo(() => shouldHaveCounterparty(type) && isMissing, [type, isMissing]);
+  const isError = shouldHaveCounterparty(type) && !!isMissing;
   const { name, id } = counterparty ?? { name: 'Missing', id: undefined };
 
   return (

--- a/packages/client/src/components/charges/new-cells/tags.tsx
+++ b/packages/client/src/components/charges/new-cells/tags.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ReactElement } from 'react';
+import { useCallback, useState, type ReactElement } from 'react';
 import { Group, Indicator, Text } from '@mantine/core';
 import { useUpdateCharge } from '../../../hooks/use-update-charge.js';
 import { ConfirmMiniButton, ListCapsule, SimilarChargesByIdModal } from '../../common/index.js';
@@ -19,23 +19,12 @@ export const Tags = ({
   onChange,
 }: TagsProps): ReactElement => {
   const { updateCharge, fetching } = useUpdateCharge();
-  const [tags, setTags] = useState<typeof originalTags>(originalTags);
 
   const [similarChargesOpen, setSimilarChargesOpen] = useState(false);
 
   const hasAlternative = isMissing && !!suggestedTags?.length;
 
-  useEffect(() => {
-    if (originalTags?.length && !tags.length) {
-      setTags(originalTags);
-    }
-  }, [originalTags, tags.length]);
-
-  useEffect(() => {
-    if (tags.length === 0 && hasAlternative) {
-      setTags(suggestedTags ?? []);
-    }
-  }, [tags.length, suggestedTags, hasAlternative]);
+  const tags = originalTags?.length ? originalTags : hasAlternative ? suggestedTags : [];
 
   const updateTag = useCallback(
     async (tags?: Array<{ id: string }>) => {

--- a/packages/client/src/components/charges/new-cells/vat.tsx
+++ b/packages/client/src/components/charges/new-cells/vat.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactElement } from 'react';
+import { type ReactElement } from 'react';
 import { Indicator } from '@mantine/core';
 import { Currency } from '../../../gql/graphql.js';
 import { formatAmountWithCurrency } from '../../../helpers/index.js';
@@ -11,15 +11,9 @@ export type VatProps = {
 };
 
 export const Vat = ({ value, currency, amountValue, missingInfo }: VatProps): ReactElement => {
-  const isLocalCurrencyButNoVat = useMemo(
-    () => value == null && currency === Currency.Ils,
-    [value, currency],
-  );
-  const vatIsNegativeToAmount = useMemo(
-    () =>
-      ((value ?? 0) > 0 && (amountValue ?? 0) < 0) || ((value ?? 0) < 0 && (amountValue ?? 0) > 0),
-    [value, amountValue],
-  );
+  const isLocalCurrencyButNoVat = value == null && currency === Currency.Ils;
+  const vatIsNegativeToAmount =
+    ((value ?? 0) > 0 && (amountValue ?? 0) < 0) || ((value ?? 0) < 0 && (amountValue ?? 0) > 0);
   const isError = isLocalCurrencyButNoVat || vatIsNegativeToAmount;
 
   return (

--- a/packages/client/src/components/charges/new-cells/vat.tsx
+++ b/packages/client/src/components/charges/new-cells/vat.tsx
@@ -12,7 +12,7 @@ export type VatProps = {
 
 export const Vat = ({ value, currency, amountValue, missingInfo }: VatProps): ReactElement => {
   const isLocalCurrencyButNoVat = useMemo(
-    () => !value && currency === Currency.Ils,
+    () => value == null && currency === Currency.Ils,
     [value, currency],
   );
   const vatIsNegativeToAmount = useMemo(


### PR DESCRIPTION
## What

Addresses the code-review feedback left on [#3988](https://github.com/Urigo/accounter-fullstack/pull/3988). The comments there actually target files introduced by the base refactor branch (`claude/refactor-branch-latest-main-qjagny`), so the fixes are applied on top of that branch here.

## Changes

**`new-cells/tags.tsx`** — Derive `tags` during render instead of syncing `originalTags`/`suggestedTags` into local `useState` via `useEffect`. The previous `!tags.length` guard meant any updated/refetched tags were ignored once the list was non-empty. Since the component never mutates the list locally, the state and both effects are removed.

**`new-cells/vat.tsx`** — Use a nullish check (`value == null`) instead of a falsy check (`!value`) in `isLocalCurrencyButNoVat`. A VAT value of `0` (zero-rated / exempt, a valid and common case in Israel) was being flagged as an error.

**`new-cells/counterparty.tsx`** — Import and reuse the shared `shouldHaveCounterparty` utility from `../utils.js` instead of duplicating the charge-type switch locally.

## Notes

`yarn lint` / prettier could not be run — a fresh `yarn install` fails in this environment because the `xlsx` dependency host `cdn.sheetjs.com` is blocked by the egress policy. Changes were formatted manually to match the surrounding style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FD42vXMXrMorW8LsJ29esJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FD42vXMXrMorW8LsJ29esJ)_