### PR TITLE
feat(client): add optional CSV export to New Charges Table

### DIFF
--- a/packages/client/src/components/charges/__tests__/download-charges-csv.test.ts
+++ b/packages/client/src/components/charges/__tests__/download-charges-csv.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import type { ChargeForCsvExportFieldsFragment } from '../../../gql/graphql.js';
+import { convertChargesToCsv, escapeCsvField } from '../charges-csv.js';
+
+describe('escapeCsvField', () => {
+  it('leaves plain values untouched', () => {
+    expect(escapeCsvField('hello')).toBe('hello');
+    expect(escapeCsvField('')).toBe('');
+  });
+
+  it('quotes and escapes values containing commas, quotes, or newlines', () => {
+    expect(escapeCsvField('a,b')).toBe('"a,b"');
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+    expect(escapeCsvField('line1\nline2')).toBe('"line1\nline2"');
+  });
+});
+
+// Minimal charge fixture. `getFragmentData` is an identity function at runtime, so plain nested
+// objects for transactions/documents are read correctly by the flattening helpers.
+function makeCharge(
+  overrides: Partial<ChargeForCsvExportFieldsFragment> = {},
+): ChargeForCsvExportFieldsFragment {
+  return {
+    __typename: 'CommonCharge',
+    id: 'charge-1',
+    minEventDate: '2024-01-15',
+    minDebitDate: '2024-01-20',
+    minDocumentsDate: '2024-01-10',
+    totalAmount: { raw: 1234.5, currency: 'ILS' },
+    vat: { raw: 200 },
+    counterparty: { id: 'cp-1', name: 'Acme Ltd' },
+    userDescription: 'office supplies',
+    tags: [{ id: 't1', name: 'office' }],
+    taxCategory: { id: 'tc1', name: 'Expenses' },
+    accountantApproval: 'PENDING',
+    validationData: { isValid: false, missingInfo: ['DOCUMENTS', 'VAT'] },
+    missingInfoSuggestions: { description: 'suggested', tags: [] },
+    metadata: {
+      transactionsCount: 1,
+      documentsCount: 0,
+      invoicesCount: 0,
+      receiptsCount: 0,
+      ledgerCount: 2,
+      miscExpensesCount: 0,
+      openDocuments: false,
+      invalidLedger: 'VALID',
+    },
+    ledger: { balance: { isBalanced: true }, validate: { isValid: true, errors: [] } },
+    transactions: [
+      {
+        id: 'tx-1',
+        eventDate: '2024-01-15',
+        amount: { raw: -1234.5, formatted: '-1,234.50 ₪' },
+        account: { id: 'acc-1', name: 'Bank Hapoalim', type: 'BANK_ACCOUNT' },
+        sourceDescription: 'card, purchase',
+        referenceKey: 'REF1',
+        counterparty: { id: 'cp-1', name: 'Acme Ltd' },
+      },
+    ],
+    additionalDocuments: [],
+    ...overrides,
+  } as unknown as ChargeForCsvExportFieldsFragment;
+}
+
+describe('convertChargesToCsv', () => {
+  it('emits a header row with the expected validation columns', () => {
+    const csv = convertChargesToCsv([makeCharge()]);
+    const [header] = csv.split('\r\n');
+    for (const col of [
+      'Charge ID',
+      'Is Valid',
+      'Missing Documents',
+      'Missing VAT',
+      'Ledger Status',
+      'Transactions Detail',
+      'Documents Detail',
+    ]) {
+      expect(header).toContain(col);
+    }
+  });
+
+  it('maps validation data to per-type boolean columns', () => {
+    const csv = convertChargesToCsv([makeCharge()]);
+    const header = csv.split('\r\n')[0].split(',');
+    const row = csv.split('\r\n')[1];
+    // Naive split is unsafe for quoted cells, so assert via a parsed record instead.
+    const record = parseCsvRow(row);
+    const get = (key: string): string => record[header.indexOf(key)];
+
+    expect(get('Is Valid')).toBe('No');
+    expect(get('Missing Documents')).toBe('Yes');
+    expect(get('Missing VAT')).toBe('Yes');
+    expect(get('Missing Tags')).toBe('No');
+    expect(get('Amount')).toBe('1234.50');
+    expect(get('Currency')).toBe('ILS');
+  });
+
+  it('flattens transactions into a single quoted cell', () => {
+    const csv = convertChargesToCsv([makeCharge()]);
+    // The transaction sourceDescription contains a comma, so the detail cell must be quoted.
+    expect(csv).toContain('"2024-01-15 | -1,234.50 ₪ | Bank Hapoalim | card, purchase | REF1 | Acme Ltd"');
+  });
+
+  it('produces one data row per charge', () => {
+    const csv = convertChargesToCsv([makeCharge({ id: 'a' }), makeCharge({ id: 'b' })]);
+    // header + 2 data rows (no cell contains a bare newline that starts a new record here besides
+    // quoted multiline cells, which parseCsvRow-awareness is not needed for this count check).
+    const records = splitCsvRecords(csv);
+    expect(records).toHaveLength(3);
+  });
+});
+
+// --- tiny RFC-4180-aware helpers for assertions (test-only) ---
+
+function splitCsvRecords(csv: string): string[] {
+  const records: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < csv.length; i++) {
+    const char = csv[i];
+    if (char === '"') {
+      inQuotes = !inQuotes;
+      current += char;
+    } else if (!inQuotes && char === '\r' && csv[i + 1] === '\n') {
+      records.push(current);
+      current = '';
+      i++;
+    } else {
+      current += char;
+    }
+  }
+  if (current !== '') {
+    records.push(current);
+  }
+  return records;
+}
+
+function parseCsvRow(row: string): string[] {
+  const fields: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < row.length; i++) {
+    const char = row[i];
+    if (char === '"') {
+      if (inQuotes && row[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (!inQuotes && char === ',') {
+      fields.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  fields.push(current);
+  return fields;
+}

--- a/packages/client/src/components/charges/charges-csv.ts
+++ b/packages/client/src/components/charges/charges-csv.ts
@@ -26,7 +26,7 @@ const columns: ColumnDef[] = [
   { key: 'Documents Date', valueFn: charge => formatDate(charge.minDocumentsDate) },
   { key: 'Counterparty', valueFn: charge => charge.counterparty?.name ?? '' },
   { key: 'Description', valueFn: charge => charge.userDescription?.trim() ?? '' },
-  { key: 'Tags', valueFn: charge => charge.tags.map(tag => tag.name).join('; ') },
+  { key: 'Tags', valueFn: charge => (charge.tags ?? []).map(tag => tag.name).join('; ') },
   { key: 'Tax Category', valueFn: charge => charge.taxCategory?.name ?? '' },
   {
     key: 'Business Trip',
@@ -88,7 +88,7 @@ function missingInfoColumns(): ColumnDef[] {
 }
 
 function transactionsDetail(charge: ChargeForCsvExportFieldsFragment): string {
-  return charge.transactions
+  return (charge.transactions ?? [])
     .map(rawTransaction => {
       const transaction: TransactionForTransactionsTableFieldsFragment = getFragmentData(
         TransactionForTransactionsTableFieldsFragmentDoc,
@@ -107,7 +107,7 @@ function transactionsDetail(charge: ChargeForCsvExportFieldsFragment): string {
 }
 
 function documentsDetail(charge: ChargeForCsvExportFieldsFragment): string {
-  return charge.additionalDocuments
+  return (charge.additionalDocuments ?? [])
     .map(rawDocument => {
       const document: TableDocumentsRowFieldsFragment = getFragmentData(
         TableDocumentsRowFieldsFragmentDoc,

--- a/packages/client/src/components/charges/charges-csv.ts
+++ b/packages/client/src/components/charges/charges-csv.ts
@@ -1,0 +1,165 @@
+import { format } from 'date-fns';
+import {
+  MissingChargeInfo,
+  TableDocumentsRowFieldsFragmentDoc,
+  TransactionForTransactionsTableFieldsFragmentDoc,
+  type ChargeForCsvExportFieldsFragment,
+  type TableDocumentsRowFieldsFragment,
+  type TransactionForTransactionsTableFieldsFragment,
+} from '../../gql/graphql.js';
+import { getFragmentData } from '../../gql/index.js';
+
+// Pure CSV-building logic for the charges export, kept free of React/urql/barrel imports so it can
+// be unit-tested in isolation (the component barrel drags heavy deps like pdfjs into the test env).
+
+type ColumnDef = { key: string; valueFn: (charge: ChargeForCsvExportFieldsFragment) => string };
+
+const columns: ColumnDef[] = [
+  { key: 'Charge ID', valueFn: charge => charge.id },
+  { key: 'Type', valueFn: charge => charge.__typename ?? '' },
+  {
+    key: 'Date',
+    valueFn: charge =>
+      formatDate(charge.minDebitDate ?? charge.minEventDate ?? charge.minDocumentsDate),
+  },
+  { key: 'Event Date', valueFn: charge => formatDate(charge.minEventDate) },
+  { key: 'Documents Date', valueFn: charge => formatDate(charge.minDocumentsDate) },
+  { key: 'Counterparty', valueFn: charge => charge.counterparty?.name ?? '' },
+  { key: 'Description', valueFn: charge => charge.userDescription?.trim() ?? '' },
+  { key: 'Tags', valueFn: charge => charge.tags.map(tag => tag.name).join('; ') },
+  { key: 'Tax Category', valueFn: charge => charge.taxCategory?.name ?? '' },
+  {
+    key: 'Business Trip',
+    valueFn: charge =>
+      'businessTrip' in charge && charge.businessTrip ? charge.businessTrip.name : '',
+  },
+  { key: 'Accountant Approval', valueFn: charge => charge.accountantApproval ?? '' },
+  { key: 'Amount', valueFn: charge => formatNumber(charge.totalAmount?.raw) },
+  { key: 'Currency', valueFn: charge => charge.totalAmount?.currency ?? '' },
+  { key: 'VAT', valueFn: charge => formatNumber(charge.vat?.raw) },
+  { key: 'Is Valid', valueFn: charge => formatBoolean(charge.validationData?.isValid) },
+  ...missingInfoColumns(),
+  {
+    key: 'Valid Credit Card Amount',
+    valueFn: charge =>
+      'validCreditCardAmount' in charge ? formatBoolean(charge.validCreditCardAmount) : '',
+  },
+  { key: 'Ledger Status', valueFn: charge => charge.metadata?.invalidLedger ?? '' },
+  { key: 'Ledger Balanced', valueFn: charge => formatBoolean(charge.ledger?.balance?.isBalanced) },
+  { key: 'Ledger Errors', valueFn: charge => (charge.ledger?.validate?.errors ?? []).join('; ') },
+  { key: 'Transactions Count', valueFn: charge => formatCount(charge.metadata?.transactionsCount) },
+  { key: 'Documents Count', valueFn: charge => formatCount(charge.metadata?.documentsCount) },
+  { key: 'Invoices Count', valueFn: charge => formatCount(charge.metadata?.invoicesCount) },
+  { key: 'Receipts Count', valueFn: charge => formatCount(charge.metadata?.receiptsCount) },
+  { key: 'Ledger Count', valueFn: charge => formatCount(charge.metadata?.ledgerCount) },
+  {
+    key: 'Misc Expenses Count',
+    valueFn: charge => formatCount(charge.metadata?.miscExpensesCount),
+  },
+  { key: 'Has Open Documents', valueFn: charge => formatBoolean(charge.metadata?.openDocuments) },
+  {
+    key: 'Suggested Description',
+    valueFn: charge => charge.missingInfoSuggestions?.description?.trim() ?? '',
+  },
+  {
+    key: 'Suggested Tags',
+    valueFn: charge => (charge.missingInfoSuggestions?.tags ?? []).map(tag => tag.name).join('; '),
+  },
+  { key: 'Transactions Detail', valueFn: charge => transactionsDetail(charge) },
+  { key: 'Documents Detail', valueFn: charge => documentsDetail(charge) },
+];
+
+// One boolean column per missing-info type so a reviewer can filter/scan each dimension.
+function missingInfoColumns(): ColumnDef[] {
+  const entries: Array<[string, MissingChargeInfo]> = [
+    ['Missing Counterparty', MissingChargeInfo.Counterparty],
+    ['Missing Description', MissingChargeInfo.Description],
+    ['Missing Documents', MissingChargeInfo.Documents],
+    ['Missing Tags', MissingChargeInfo.Tags],
+    ['Missing Transactions', MissingChargeInfo.Transactions],
+    ['Missing VAT', MissingChargeInfo.Vat],
+    ['Missing Tax Category', MissingChargeInfo.TaxCategory],
+  ];
+  return entries.map(([key, info]) => ({
+    key,
+    valueFn: charge =>
+      charge.validationData ? formatBoolean(charge.validationData.missingInfo.includes(info)) : '',
+  }));
+}
+
+function transactionsDetail(charge: ChargeForCsvExportFieldsFragment): string {
+  return charge.transactions
+    .map(rawTransaction => {
+      const transaction: TransactionForTransactionsTableFieldsFragment = getFragmentData(
+        TransactionForTransactionsTableFieldsFragmentDoc,
+        rawTransaction,
+      );
+      return [
+        formatDate(transaction.eventDate),
+        transaction.amount.formatted ?? formatNumber(transaction.amount.raw),
+        transaction.account?.name ?? '',
+        transaction.sourceDescription ?? '',
+        transaction.referenceKey ?? '',
+        transaction.counterparty?.name ?? '',
+      ].join(' | ');
+    })
+    .join('\n');
+}
+
+function documentsDetail(charge: ChargeForCsvExportFieldsFragment): string {
+  return charge.additionalDocuments
+    .map(rawDocument => {
+      const document: TableDocumentsRowFieldsFragment = getFragmentData(
+        TableDocumentsRowFieldsFragmentDoc,
+        rawDocument,
+      );
+      const isFinancial = 'amount' in document;
+      return [
+        document.documentType ?? '',
+        isFinancial ? formatDate(document.date) : '',
+        isFinancial
+          ? `${document.amount?.formatted ?? formatNumber(document.amount?.raw)} ${document.amount?.currency ?? ''}`.trim()
+          : '',
+        isFinancial ? (document.vat?.formatted ?? formatNumber(document.vat?.raw)) : '',
+        isFinancial ? (document.serialNumber ?? '') : '',
+        isFinancial ? `${document.creditor?.name ?? ''} → ${document.debtor?.name ?? ''}` : '',
+      ].join(' | ');
+    })
+    .join('\n');
+}
+
+export function convertChargesToCsv(charges: ChargeForCsvExportFieldsFragment[]): string {
+  const header = columns.map(column => escapeCsvField(column.key)).join(',');
+  const rows = charges.map(charge =>
+    columns.map(column => escapeCsvField(column.valueFn(charge))).join(','),
+  );
+  return [header, ...rows].join('\r\n');
+}
+
+export function escapeCsvField(value: string): string {
+  if (value === '') {
+    return '';
+  }
+  // RFC-4180 quoting: wrap in quotes and double any internal quotes when the field carries a
+  // comma, quote, or newline (the flattened transactions/documents cells are multiline).
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function formatDate(date?: string | Date | null): string {
+  return date ? format(new Date(date), 'yyyy-MM-dd') : '';
+}
+
+function formatNumber(value?: number | null): string {
+  return value == null ? '' : value.toFixed(2);
+}
+
+function formatCount(value?: number | null): string {
+  return value == null ? '' : String(value);
+}
+
+function formatBoolean(value?: boolean | null): string {
+  return value == null ? '' : value ? 'Yes' : 'No';
+}

--- a/packages/client/src/components/charges/download-charges-csv.tsx
+++ b/packages/client/src/components/charges/download-charges-csv.tsx
@@ -1,0 +1,125 @@
+import { useCallback, type ReactElement } from 'react';
+import { format } from 'date-fns';
+import { useClient } from 'urql';
+import {
+  ChargesForCsvExportDocument,
+  type ChargeForCsvExportFieldsFragment,
+} from '../../gql/graphql.js';
+import { DownloadCSVButton } from '../common/index.js';
+import { convertChargesToCsv } from './charges-csv.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  fragment ChargeForCsvExportFields on Charge {
+    id
+    __typename
+    minEventDate
+    minDebitDate
+    minDocumentsDate
+    totalAmount {
+      raw
+      currency
+    }
+    vat {
+      raw
+    }
+    counterparty {
+      id
+      name
+    }
+    userDescription
+    tags {
+      id
+      name
+    }
+    taxCategory {
+      id
+      name
+    }
+    accountantApproval
+    validationData {
+      isValid
+      missingInfo
+    }
+    missingInfoSuggestions {
+      description
+      tags {
+        id
+        name
+      }
+    }
+    metadata {
+      transactionsCount
+      documentsCount
+      invoicesCount
+      receiptsCount
+      ledgerCount
+      miscExpensesCount
+      openDocuments
+      invalidLedger
+    }
+    ledger {
+      balance {
+        isBalanced
+      }
+      validate {
+        isValid
+        errors
+      }
+    }
+    transactions {
+      id
+      ...TransactionForTransactionsTableFields
+    }
+    additionalDocuments {
+      id
+      ...TableDocumentsRowFields
+    }
+    ... on BusinessTripCharge {
+      businessTrip {
+        id
+        name
+      }
+    }
+    ... on CreditcardBankCharge {
+      validCreditCardAmount
+    }
+  }
+`;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  query ChargesForCsvExport($chargeIDs: [UUID!]!) {
+    chargesByIDs(chargeIDs: $chargeIDs) {
+      id
+      ...ChargeForCsvExportFields
+    }
+  }
+`;
+
+interface Props {
+  /** Charge ids to export. Typically the table's selected rows, or all rows when none selected. */
+  chargeIds: string[];
+  /** Optional business name, mixed into the generated file name. */
+  businessName?: string;
+}
+
+export const DownloadChargesCsv = ({ chargeIds, businessName }: Props): ReactElement => {
+  const client = useClient();
+
+  const createFileVariables = useCallback(async () => {
+    const fileName = `${businessName ? `business_${businessName}_` : ''}charges_${format(new Date(), 'yyyy-MM-dd')}`;
+    if (chargeIds.length === 0) {
+      return { fileContent: '', fileName };
+    }
+    const { data } = await client
+      .query(ChargesForCsvExportDocument, { chargeIDs: chargeIds })
+      .toPromise();
+    const charges = (data?.chargesByIDs ?? []) as ChargeForCsvExportFieldsFragment[];
+    return { fileContent: convertChargesToCsv(charges), fileName };
+  }, [client, chargeIds, businessName]);
+
+  return (
+    <DownloadCSVButton createFileVariables={createFileVariables} label="Download charges CSV" />
+  );
+};

--- a/packages/client/src/components/charges/new-charges-table.tsx
+++ b/packages/client/src/components/charges/new-charges-table.tsx
@@ -33,6 +33,7 @@ import type { TaxCategoryProps } from './cells/tax-category.js';
 import type { VatProps } from './cells/vat.js';
 import { BatchChargesExtendedInfoProvider } from './charges-extended-info-loader.js';
 import { columns } from './columns.js';
+import { DownloadChargesCsv } from './download-charges-csv.js';
 import { ChargeRow } from './new-charges-row.js';
 import { shouldHaveCounterparty, shouldHaveTaxCategory, shouldHaveVat } from './utils.js';
 
@@ -250,6 +251,12 @@ interface Props {
    * query instead of one `FetchCharge` query per row.
    */
   isAllOpened?: boolean;
+  /**
+   * When true, render a CSV export button above the table. The parent decides whether to expose it
+   * (e.g. the All Charges screen, mainly for reviewing charges with validation/missing-info issues).
+   * Defaults to hidden. Exports the selected rows when a selection is active, otherwise all rows.
+   */
+  showExport?: boolean;
 }
 
 export const NewChargesTable = ({
@@ -257,6 +264,7 @@ export const NewChargesTable = ({
   rowSelection: controlledRowSelection,
   onRowSelectionChange,
   isAllOpened = false,
+  showExport = false,
 }: Props): ReactElement => {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -338,44 +346,55 @@ export const NewChargesTable = ({
   // single query.
   const chargeIds = useMemo(() => charges.map(charge => charge.id), [charges]);
 
+  // Export the active selection when one exists, otherwise every charge currently in the table.
+  const selectedIds = Object.keys(rowSelection).filter(id => rowSelection[id]);
+  const exportIds = selectedIds.length > 0 ? selectedIds : chargeIds;
+
   return (
     <BatchChargesExtendedInfoProvider chargeIds={chargeIds} active={isAllOpened}>
-      <div className="overflow-hidden rounded-md border w-auto max-w-fit [&>div]:w-auto [&>div]:max-w-fit">
-        <Table className="w-auto max-w-fit">
-          <TableHeader>
-            {table.getHeaderGroups().map(headerGroup => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map(header => (
-                  <TableHead key={header.id} colSpan={header.colSpan}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(header.column.columnDef.header, header.getContext())}
-                  </TableHead>
-                ))}
-                <TableHead />
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody className="w-auto max-w-fit">
-            {table.getRowModel().rows?.length ? (
-              table
-                .getRowModel()
-                .rows.map(row => (
-                  <ChargeRow
-                    key={row.id}
-                    row={row}
-                    updateCharge={(newCharge: ChargeRow) => updateCharge(row.index, newCharge)}
-                  />
-                ))
-            ) : (
-              <TableRow>
-                <TableCell colSpan={columns.length} className="h-24 text-center">
-                  No results.
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
+      <div className="flex flex-col gap-2 w-auto max-w-fit">
+        {showExport && (
+          <div className="flex justify-end">
+            <DownloadChargesCsv chargeIds={exportIds} />
+          </div>
+        )}
+        <div className="overflow-hidden rounded-md border w-auto max-w-fit [&>div]:w-auto [&>div]:max-w-fit">
+          <Table className="w-auto max-w-fit">
+            <TableHeader>
+              {table.getHeaderGroups().map(headerGroup => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map(header => (
+                    <TableHead key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableHead>
+                  ))}
+                  <TableHead />
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody className="w-auto max-w-fit">
+              {table.getRowModel().rows?.length ? (
+                table
+                  .getRowModel()
+                  .rows.map(row => (
+                    <ChargeRow
+                      key={row.id}
+                      row={row}
+                      updateCharge={(newCharge: ChargeRow) => updateCharge(row.index, newCharge)}
+                    />
+                  ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-24 text-center">
+                    No results.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
       </div>
     </BatchChargesExtendedInfoProvider>
   );

--- a/packages/client/src/components/common/buttons/download-csv-button.tsx
+++ b/packages/client/src/components/common/buttons/download-csv-button.tsx
@@ -1,5 +1,6 @@
-import { useCallback, type ReactElement } from 'react';
-import { FileDown } from 'lucide-react';
+import { useCallback, useState, type ReactElement } from 'react';
+import { FileDown, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils.js';
 import { Button } from '../../ui/button.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../ui/tooltip.js';
 
@@ -28,21 +29,51 @@ export const DownloadCSVButton = ({
   buttonContent,
   label,
 }: Props): ReactElement => {
-  const onClick = useCallback(() => {
-    createFileVariables().then(({ fileContent, fileName }) => {
+  const [loading, setLoading] = useState(false);
+
+  // Preparing the file (e.g. fetching export data) can take a moment. Track a loading state so we
+  // can surface progress and guard against re-clicks while a download is being prepared.
+  const onClick = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { fileContent, fileName } = await createFileVariables();
       csvDownload(fileContent, fileName);
-    });
+    } finally {
+      setLoading(false);
+    }
   }, [createFileVariables]);
+
+  const {
+    className: buttonClassName,
+    disabled: buttonDisabled,
+    ...restButtonProps
+  } = buttonProps ?? {};
 
   return (
     <Tooltip>
       <TooltipTrigger>
-        <Button variant="outline" className="p-2" {...buttonProps} onClick={onClick}>
-          {buttonContent || <FileDown size={20} />}
+        <Button
+          variant="outline"
+          className={cn('relative p-2', buttonClassName)}
+          disabled={loading || buttonDisabled}
+          aria-busy={loading}
+          {...restButtonProps}
+          onClick={onClick}
+        >
+          {/* Keep the original content in place (just hidden) so the button size stays stable, and
+              overlay a centered spinner while preparing the file. */}
+          <span className={loading ? 'invisible' : 'contents'}>
+            {buttonContent || <FileDown size={20} />}
+          </span>
+          {loading && (
+            <span className="absolute inset-0 flex items-center justify-center">
+              <Loader2 className="h-5 w-5 animate-spin" />
+            </span>
+          )}
         </Button>
       </TooltipTrigger>
       <TooltipContent>
-        <p>{label || 'Download CSV'}</p>
+        <p>{loading ? 'Preparing download…' : label || 'Download CSV'}</p>
       </TooltipContent>
     </Tooltip>
   );

--- a/packages/client/src/components/screens/charges/all-charges.tsx
+++ b/packages/client/src/components/screens/charges/all-charges.tsx
@@ -151,6 +151,7 @@ export const AllCharges = (): ReactElement => {
             rowSelection={rowSelection}
             onRowSelectionChange={setRowSelection}
             isAllOpened={isAllOpened}
+            showExport
           />
         </div>
       ) : (


### PR DESCRIPTION
## What & why

After the migration to `NewChargesTable`, this adds an **opt-in CSV export** button, aimed at reviewing charges where validation fails or info is missing. Reviewers can dump the current table (or a selection) and audit validation/missing-info, ledger status, and the underlying transactions/documents in one file.

## How it works

- **Opt-in via prop** — `NewChargesTable` gains a `showExport?: boolean` (default hidden) so each of the four parent screens decides whether to expose the button. Enabled here only on the **All Charges** screen.
- **Selection-aware scope** — exports the active row selection when one exists (the table already supports controlled `rowSelection`), otherwise every charge currently in the table.
- **On-click fetch** — `DownloadChargesCsv` fetches export detail only when clicked, via the existing `chargesByIDs` query, so the parent table queries stay light. Reuses the shared `DownloadCSVButton`.
- **Pure builder** — CSV generation lives in `charges-csv.ts` (no React/urql imports) with RFC-4180 quoting, covered by unit tests.

## Columns

- **Identity/classification:** charge id, type, dates, counterparty, description, tags, tax category, business trip, accountant approval
- **Money:** amount, currency, VAT
- **Charge validation:** `Is Valid` + one boolean column per missing-info type (Counterparty / Description / Documents / Tags / Transactions / VAT / Tax Category), plus valid-credit-card-amount
- **Ledger validation:** status (`invalidLedger`), balanced, errors
- **Counts:** transactions / documents / invoices / receipts / ledger / misc-expenses / has-open-documents
- **Suggestions:** suggested description & tags
- **Extended detail:** `Transactions Detail` and `Documents Detail` — one flattened, newline-separated cell each, reusing the existing `TransactionForTransactionsTableFields` and `TableDocumentsRowFields` fragments

## Notes

- No server changes — reuses the existing `chargesByIDs` query.
- Charge-level `validationData.balance` is intentionally not used (the resolver never populates it); balance/ledger signals come from `ledger.balance` and `metadata.invalidLedger` instead.
- `yarn install` in this environment is currently blocked by a pre-existing transitive dependency (`node-xlsx` → `xlsx` from `cdn.sheetjs.com`, denied by egress policy), unrelated to this change. Verification (codegen, `tsc`, `eslint`, unit tests) was run after temporarily remapping only that blocked tarball to the npm-published `xlsx`; that remap was reverted and is **not** part of this PR.

## Verification

- `yarn generate` — new query/fragment codegen succeeds
- Client `tsc --noEmit` — clean
- `eslint` on changed files — clean
- Unit tests for the CSV builder (headers, per-type missing-info booleans, quoting of multiline detail cells, one row per charge) — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHejJGiFfWdpRR5WdXVVqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHejJGiFfWdpRR5WdXVVqY)_