### PR TITLE
fix(client): wire up expand-all in new charges table + batch loader

### DIFF
--- a/.changeset/new-charges-table-expand-all-batch-loader.md
+++ b/.changeset/new-charges-table-expand-all-batch-loader.md
@@ -1,0 +1,18 @@
+---
+"@accounter/client": patch
+---
+
+Fix whole-table "expand all" in the new charges table and load the expanded rows efficiently.
+
+- `new-charges-table.tsx`: the table now accepts an `isAllOpened` prop and drives tanstack-table's
+  `expanded` state from it (`true` expands every row, `{}` collapses them). Previously the toolbar's
+  expand-all button toggled local `isAllOpened` state that was never passed to the table, so nothing
+  happened; per-charge expansion via the row button was unaffected.
+- New `charges-extended-info-loader.tsx`: a `BatchChargesExtendedInfoProvider` that, while expand-all
+  is active, hydrates every expanded row's extended info with a single `chargesByIDs` query instead
+  of one `FetchCharge` query per row (which was 100 queries for a full 100-row page). Its selection
+  set mirrors `FetchCharge`, including the same deferred fragments, so a batched charge is
+  interchangeable with a single-charge result.
+- `charge-extended-info.tsx`: consumes the batch loader when it's active (pausing its own per-charge
+  query and delegating refetch-on-change to the batch); otherwise behaves exactly as before.
+- Wired `isAllOpened` through the all-charges, missing-info-charges and single-charge screens.

--- a/packages/client/src/components/charges/charge-extended-info.tsx
+++ b/packages/client/src/components/charges/charge-extended-info.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Image } from 'lucide-react';
 import { useQuery } from 'urql';
 import { Box, Collapse, Loader } from '@mantine/core';
@@ -31,6 +31,7 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '..
 import { Button } from '../ui/button.js';
 import { ChargeErrors } from './charge-errors.js';
 import { ChargeTransactionsTable } from './charge-transactions-table.js';
+import { BatchChargesExtendedInfoContext } from './charges-extended-info-loader.js';
 import { ChargeBankDeposit } from './extended-info/bank-deposit.js';
 import { ChargeMatches } from './extended-info/charge-matches.js';
 import { ConversionInfo } from './extended-info/conversion-info.js';
@@ -129,24 +130,38 @@ export function ChargeExtendedInfo({
   const [chargeId, setChargeId] = useState<string>(chargeID);
   const [opened, setOpened] = useState(false);
   const [chargeState, setChargeState] = useState<FetchChargeQuery['charge'] | undefined>(undefined);
-  const [{ data, fetching }, refetchExtensionInfo] = useQuery({
+
+  // When the table is in batch-open mode, a single `chargesByIDs` query (the batch loader) hydrates
+  // every expanded row. Consume that shared result instead of firing this component's own
+  // `FetchCharge` query — which is paused while the loader is active.
+  const batch = useContext(BatchChargesExtendedInfoContext);
+  const [{ data, fetching: singleFetching }, refetchExtensionInfo] = useQuery({
     query: FetchChargeDocument,
     variables: {
       chargeId,
     },
+    pause: batch.active,
   });
+
+  const incomingCharge = batch.active ? batch.getCharge(chargeID) : data?.charge;
+  const fetching = batch.active ? batch.fetching : singleFetching;
 
   // Keep a deeply-equal-stable reference so descendants only re-render when the
   // charge actually changed (urql yields a fresh object on every refetch).
   const charge = useStableValue(chargeState);
 
   const onExtendedChange = useCallback(() => {
-    refetchExtensionInfo({ requestPolicy: 'network-only' });
+    if (batch.active) {
+      // A batched charge was mutated: refetch the whole batch so every row stays consistent.
+      batch.refetch();
+    } else {
+      refetchExtensionInfo({ requestPolicy: 'network-only' });
+    }
     onChange();
-  }, [refetchExtensionInfo, onChange]);
+  }, [batch, refetchExtensionInfo, onChange]);
 
   useEffect(() => {
-    const incoming = data?.charge;
+    const incoming = incomingCharge;
     if (!incoming) {
       return;
     }
@@ -173,13 +188,14 @@ export function ChargeExtendedInfo({
       }
       return merged as FetchChargeQuery['charge'];
     });
-  }, [data]);
+  }, [incomingCharge]);
 
   useEffect(() => {
-    if (parentFetching) {
+    // The batch loader owns refetching while it's active; only nudge the single-charge query here.
+    if (parentFetching && !batch.active) {
       refetchExtensionInfo();
     }
-  }, [parentFetching, refetchExtensionInfo]);
+  }, [parentFetching, refetchExtensionInfo, batch.active]);
 
   // Switching to a different charge: sync the query variable and clear the
   // previous charge so the loader shows (instead of leaking stale details

--- a/packages/client/src/components/charges/charge-extended-info.tsx
+++ b/packages/client/src/components/charges/charge-extended-info.tsx
@@ -3,6 +3,7 @@ import { Image } from 'lucide-react';
 import { useQuery } from 'urql';
 import { Box, Collapse, Loader } from '@mantine/core';
 import {
+  ChargeExpansionFieldsFragmentDoc,
   ChargeLedgerRecordsTableFieldsFragmentDoc,
   ChargesTableErrorsFieldsFragmentDoc,
   ChargeTableTransactionsFieldsFragmentDoc,
@@ -14,7 +15,7 @@ import {
   TableDocumentsFieldsFragmentDoc,
   TableMiscExpensesFieldsFragmentDoc,
   TableSalariesFieldsFragmentDoc,
-  type FetchChargeQuery,
+  type ChargeExpansionFieldsFragment,
 } from '../../gql/graphql.js';
 import { getFragmentData, isFragmentReady, type FragmentType } from '../../gql/index.js';
 import { useStableValue } from '../../hooks/use-stable-value.js';
@@ -44,38 +45,46 @@ import { SalariesTable } from './extended-info/salaries-info.js';
 /* GraphQL */ `
   query FetchCharge($chargeId: UUID!) {
     charge(chargeId: $chargeId) {
-      __typename
       id
-      metadata {
-        transactionsCount
-        documentsCount
-        receiptsCount
-        invoicesCount
-        ledgerCount
-        miscExpensesCount
-        isLedgerLocked
-        openDocuments
-      }
-      totalAmount {
-        raw
-      }
-      ...DocumentsGalleryFields @defer
-      ...TableDocumentsFields @defer
-      ...ChargeLedgerRecordsTableFields @defer
-      ...ChargeTableTransactionsFields @defer
-      ...ConversionChargeInfo @defer
-      ...CreditcardBankChargeInfo @defer
-      ...TableSalariesFields @defer
-      ... on BusinessTripCharge {
-        businessTrip {
-          id
-          ...BusinessTripReportFields
-        }
-      }
-      ...ChargesTableErrorsFields @defer
-      ...TableMiscExpensesFields @defer
-      ...ExchangeRatesInfo @defer
+      ...ChargeExpansionFields
     }
+  }
+`;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  fragment ChargeExpansionFields on Charge {
+    id
+    __typename
+    metadata {
+      transactionsCount
+      documentsCount
+      receiptsCount
+      invoicesCount
+      ledgerCount
+      miscExpensesCount
+      isLedgerLocked
+      openDocuments
+    }
+    totalAmount {
+      raw
+    }
+    ...DocumentsGalleryFields @defer
+    ...TableDocumentsFields @defer
+    ...ChargeLedgerRecordsTableFields @defer
+    ...ChargeTableTransactionsFields @defer
+    ...ConversionChargeInfo @defer
+    ...CreditcardBankChargeInfo @defer
+    ...TableSalariesFields @defer
+    ... on BusinessTripCharge {
+      businessTrip {
+        id
+        ...BusinessTripReportFields
+      }
+    }
+    ...ChargesTableErrorsFields @defer
+    ...TableMiscExpensesFields @defer
+    ...ExchangeRatesInfo @defer
   }
 `;
 
@@ -129,7 +138,9 @@ export function ChargeExtendedInfo({
   const [accordionItems, setAccordionItems] = useState<string[]>([]);
   const [chargeId, setChargeId] = useState<string>(chargeID);
   const [opened, setOpened] = useState(false);
-  const [chargeState, setChargeState] = useState<FetchChargeQuery['charge'] | undefined>(undefined);
+  const [chargeState, setChargeState] = useState<ChargeExpansionFieldsFragment | undefined>(
+    undefined,
+  );
 
   // When the table is in batch-open mode, a single `chargesByIDs` query (the batch loader) hydrates
   // every expanded row. Consume that shared result instead of firing this component's own
@@ -143,7 +154,10 @@ export function ChargeExtendedInfo({
     pause: batch.active,
   });
 
-  const incomingCharge = batch.active ? batch.getCharge(chargeID) : data?.charge;
+  const incomingCharge = getFragmentData(
+    ChargeExpansionFieldsFragmentDoc,
+    batch.active ? batch.getCharge(chargeID) : data?.charge,
+  );
   const fetching = batch.active ? batch.fetching : singleFetching;
 
   // Keep a deeply-equal-stable reference so descendants only re-render when the
@@ -186,7 +200,7 @@ export function ChargeExtendedInfo({
           merged[key] = value;
         }
       }
-      return merged as FetchChargeQuery['charge'];
+      return merged as ChargeExpansionFieldsFragment;
     });
   }, [incomingCharge]);
 

--- a/packages/client/src/components/charges/charges-extended-info-loader.tsx
+++ b/packages/client/src/components/charges/charges-extended-info-loader.tsx
@@ -1,0 +1,122 @@
+import { createContext, useCallback, useMemo, type ReactElement, type ReactNode } from 'react';
+import { useQuery } from 'urql';
+import { ChargesExtendedInfoBatchDocument, type FetchChargeQuery } from '../../gql/graphql.js';
+
+// A single query that fetches the extended info for many charges at once. It mirrors the
+// selection set of `FetchCharge` (see `charge-extended-info.tsx`) — including the same deferred
+// fragments — so the per-charge `ChargeExtendedInfo` component can consume a batched charge
+// interchangeably with the result of its own single-charge query.
+//
+// This is the "loader" behind the table's batch-open (expand-all) action: instead of every
+// expanded row firing its own `FetchCharge` query (100 queries for a full page), one
+// `chargesByIDs` query hydrates them all.
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  query ChargesExtendedInfoBatch($chargeIDs: [UUID!]!) {
+    chargesByIDs(chargeIDs: $chargeIDs) {
+      __typename
+      id
+      metadata {
+        transactionsCount
+        documentsCount
+        receiptsCount
+        invoicesCount
+        ledgerCount
+        miscExpensesCount
+        isLedgerLocked
+        openDocuments
+      }
+      totalAmount {
+        raw
+      }
+      ...DocumentsGalleryFields @defer
+      ...TableDocumentsFields @defer
+      ...ChargeLedgerRecordsTableFields @defer
+      ...ChargeTableTransactionsFields @defer
+      ...ConversionChargeInfo @defer
+      ...CreditcardBankChargeInfo @defer
+      ...TableSalariesFields @defer
+      ... on BusinessTripCharge {
+        businessTrip {
+          id
+          ...BusinessTripReportFields
+        }
+      }
+      ...ChargesTableErrorsFields @defer
+      ...TableMiscExpensesFields @defer
+      ...ExchangeRatesInfo @defer
+    }
+  }
+`;
+
+type ExtendedCharge = FetchChargeQuery['charge'];
+
+interface BatchChargesExtendedInfoContextValue {
+  /** Whether the batch loader is active (batch-open / expand-all is on). */
+  active: boolean;
+  /** Whether the batched query is currently in flight. */
+  fetching: boolean;
+  /** Returns the batched extended info for a charge, or undefined if not (yet) loaded. */
+  getCharge: (chargeId: string) => ExtendedCharge | undefined;
+  /** Refetch the whole batch (network-only). Used when a batched charge is mutated. */
+  refetch: () => void;
+}
+
+const noop = (): void => void 0;
+
+export const BatchChargesExtendedInfoContext = createContext<BatchChargesExtendedInfoContextValue>({
+  active: false,
+  fetching: false,
+  getCharge: () => undefined,
+  refetch: noop,
+});
+
+interface Props {
+  /** Ids of all charges the loader should hydrate when active (typically every row on the page). */
+  chargeIds: string[];
+  /** When true, run the single batched query; when false, the loader stays paused (per-row mode). */
+  active: boolean;
+  children: ReactNode;
+}
+
+export function BatchChargesExtendedInfoProvider({
+  chargeIds,
+  active,
+  children,
+}: Props): ReactElement {
+  const [{ data, fetching }, refetchQuery] = useQuery({
+    query: ChargesExtendedInfoBatchDocument,
+    variables: { chargeIDs: chargeIds },
+    pause: !active || chargeIds.length === 0,
+  });
+
+  const chargesById = useMemo(() => {
+    const map = new Map<string, ExtendedCharge>();
+    for (const charge of data?.chargesByIDs ?? []) {
+      // The batched charge is structurally identical to a `FetchCharge` charge (same selection
+      // set); cast so consumers can treat both sources uniformly.
+      map.set(charge.id, charge as unknown as ExtendedCharge);
+    }
+    return map;
+  }, [data]);
+
+  const refetch = useCallback(() => {
+    refetchQuery({ requestPolicy: 'network-only' });
+  }, [refetchQuery]);
+
+  const value = useMemo<BatchChargesExtendedInfoContextValue>(
+    () => ({
+      active,
+      fetching: active ? fetching : false,
+      getCharge: (chargeId: string) => chargesById.get(chargeId),
+      refetch,
+    }),
+    [active, fetching, chargesById, refetch],
+  );
+
+  return (
+    <BatchChargesExtendedInfoContext.Provider value={value}>
+      {children}
+    </BatchChargesExtendedInfoContext.Provider>
+  );
+}

--- a/packages/client/src/components/charges/charges-extended-info-loader.tsx
+++ b/packages/client/src/components/charges/charges-extended-info-loader.tsx
@@ -14,37 +14,8 @@ import { ChargesExtendedInfoBatchDocument, type FetchChargeQuery } from '../../g
 /* GraphQL */ `
   query ChargesExtendedInfoBatch($chargeIDs: [UUID!]!) {
     chargesByIDs(chargeIDs: $chargeIDs) {
-      __typename
       id
-      metadata {
-        transactionsCount
-        documentsCount
-        receiptsCount
-        invoicesCount
-        ledgerCount
-        miscExpensesCount
-        isLedgerLocked
-        openDocuments
-      }
-      totalAmount {
-        raw
-      }
-      ...DocumentsGalleryFields @defer
-      ...TableDocumentsFields @defer
-      ...ChargeLedgerRecordsTableFields @defer
-      ...ChargeTableTransactionsFields @defer
-      ...ConversionChargeInfo @defer
-      ...CreditcardBankChargeInfo @defer
-      ...TableSalariesFields @defer
-      ... on BusinessTripCharge {
-        businessTrip {
-          id
-          ...BusinessTripReportFields
-        }
-      }
-      ...ChargesTableErrorsFields @defer
-      ...TableMiscExpensesFields @defer
-      ...ExchangeRatesInfo @defer
+      ...ChargeExpansionFields
     }
   }
 `;

--- a/packages/client/src/components/charges/new-charges-table.tsx
+++ b/packages/client/src/components/charges/new-charges-table.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useState, type ReactElement } from 'react';
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
 import {
   flexRender,
   getCoreRowModel,
+  getExpandedRowModel,
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
   type ColumnFiltersState,
+  type ExpandedState,
   type OnChangeFn,
   type RowSelectionState,
   type SortingState,
@@ -29,6 +31,7 @@ import type { MoreInfoProps } from './cells/more-info.js';
 import type { TagsProps } from './cells/tags.js';
 import type { TaxCategoryProps } from './cells/tax-category.js';
 import type { VatProps } from './cells/vat.js';
+import { BatchChargesExtendedInfoProvider } from './charges-extended-info-loader.js';
 import { columns } from './columns.js';
 import { ChargeRow } from './new-charges-row.js';
 import { shouldHaveCounterparty, shouldHaveTaxCategory, shouldHaveVat } from './utils.js';
@@ -241,16 +244,31 @@ interface Props {
   rowSelection?: RowSelectionState;
   /** Selection change handler for controlled selection. Receives a charge-id keyed map. */
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
+  /**
+   * When true, every charge in the table is expanded (batch-open / expand-all). Toggling it also
+   * activates a single batched loader so the expanded rows are hydrated by one `chargesByIDs`
+   * query instead of one `FetchCharge` query per row.
+   */
+  isAllOpened?: boolean;
 }
 
 export const NewChargesTable = ({
   data,
   rowSelection: controlledRowSelection,
   onRowSelectionChange,
+  isAllOpened = false,
 }: Props): ReactElement => {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [internalRowSelection, setInternalRowSelection] = useState<RowSelectionState>({});
+  const [expanded, setExpanded] = useState<ExpandedState>({});
+
+  // Drive the whole-table expansion from the `isAllOpened` flag. `expanded === true` is
+  // tanstack-table's "all rows expanded" sentinel; `{}` collapses everything. Setting it here
+  // (rather than only in `initialState`) keeps toggling the button responsive after mount.
+  useEffect(() => {
+    setExpanded(isAllOpened ? true : {});
+  }, [isAllOpened]);
 
   // Controlled whenever a parent supplies the state; otherwise self-managed. When controlled
   // without a change handler (e.g. a read-only selection), fall back to a no-op setter so the
@@ -298,12 +316,15 @@ export const NewChargesTable = ({
     onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    onExpandedChange: setExpanded,
+    getExpandedRowModel: getExpandedRowModel(),
     enableRowSelection: true,
     onRowSelectionChange: setRowSelection,
     state: {
       sorting,
       columnFilters,
       rowSelection,
+      expanded,
     },
     initialState: {
       pagination: {
@@ -313,43 +334,49 @@ export const NewChargesTable = ({
     },
   });
 
+  // Ids of every charge in the table, fed to the batch loader so expand-all hydrates them all in a
+  // single query.
+  const chargeIds = useMemo(() => charges.map(charge => charge.id), [charges]);
+
   return (
-    <div className="overflow-hidden rounded-md border w-auto max-w-fit [&>div]:w-auto [&>div]:max-w-fit">
-      <Table className="w-auto max-w-fit">
-        <TableHeader>
-          {table.getHeaderGroups().map(headerGroup => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map(header => (
-                <TableHead key={header.id} colSpan={header.colSpan}>
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(header.column.columnDef.header, header.getContext())}
-                </TableHead>
-              ))}
-              <TableHead />
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody className="w-auto max-w-fit">
-          {table.getRowModel().rows?.length ? (
-            table
-              .getRowModel()
-              .rows.map(row => (
-                <ChargeRow
-                  key={row.id}
-                  row={row}
-                  updateCharge={(newCharge: ChargeRow) => updateCharge(row.index, newCharge)}
-                />
-              ))
-          ) : (
-            <TableRow>
-              <TableCell colSpan={columns.length} className="h-24 text-center">
-                No results.
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
-    </div>
+    <BatchChargesExtendedInfoProvider chargeIds={chargeIds} active={isAllOpened}>
+      <div className="overflow-hidden rounded-md border w-auto max-w-fit [&>div]:w-auto [&>div]:max-w-fit">
+        <Table className="w-auto max-w-fit">
+          <TableHeader>
+            {table.getHeaderGroups().map(headerGroup => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map(header => (
+                  <TableHead key={header.id} colSpan={header.colSpan}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+                <TableHead />
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody className="w-auto max-w-fit">
+            {table.getRowModel().rows?.length ? (
+              table
+                .getRowModel()
+                .rows.map(row => (
+                  <ChargeRow
+                    key={row.id}
+                    row={row}
+                    updateCharge={(newCharge: ChargeRow) => updateCharge(row.index, newCharge)}
+                  />
+                ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </BatchChargesExtendedInfoProvider>
   );
 };

--- a/packages/client/src/components/screens/charges/all-charges.tsx
+++ b/packages/client/src/components/screens/charges/all-charges.tsx
@@ -150,6 +150,7 @@ export const AllCharges = (): ReactElement => {
             data={chargeNodes}
             rowSelection={rowSelection}
             onRowSelectionChange={setRowSelection}
+            isAllOpened={isAllOpened}
           />
         </div>
       ) : (

--- a/packages/client/src/components/screens/charges/charge.tsx
+++ b/packages/client/src/components/screens/charges/charge.tsx
@@ -58,9 +58,6 @@ export const Charge = ({ chargeId }: Props): ReactElement => {
   return isLoading ? (
     <AccounterLoader />
   ) : (
-    <NewChargesTable
-      data={chargeData?.charge ? [chargeData.charge] : []}
-      isAllOpened
-    />
+    <NewChargesTable data={chargeData?.charge ? [chargeData.charge] : []} isAllOpened />
   );
 };

--- a/packages/client/src/components/screens/charges/charge.tsx
+++ b/packages/client/src/components/screens/charges/charge.tsx
@@ -60,7 +60,7 @@ export const Charge = ({ chargeId }: Props): ReactElement => {
   ) : (
     <NewChargesTable
       data={chargeData?.charge ? [chargeData.charge] : []}
-      // isAllOpened
+      isAllOpened
     />
   );
 };

--- a/packages/client/src/components/screens/charges/missing-info-charges.tsx
+++ b/packages/client/src/components/screens/charges/missing-info-charges.tsx
@@ -102,7 +102,7 @@ export const MissingInfoCharges = (): ReactElement => {
           rowSelection={rowSelection}
           onRowSelectionChange={setRowSelection}
           data={data?.chargesWithMissingRequiredInfo?.nodes}
-          // isAllOpened={isAllOpened}
+          isAllOpened={isAllOpened}
         />
       )}
     </PageLayout>


### PR DESCRIPTION
## What & why

The refactored charges table (`new-charges-table.tsx`) kept the per-charge expansion (`columns.tsx` expand button) but the **whole-table "expand all"** that the legacy table exposed via `isAllOpened` was lost: the toolbar button in the all-charges / missing-info screens toggled local `isAllOpened` state that was **never passed to the table**, so clicking it did nothing.

This PR restores full-table expansion and — as requested — makes batch-open efficient: expanding a full page now issues **one** query instead of one per row.

## Changes

- **`new-charges-table.tsx`** — new `isAllOpened` prop drives tanstack-table's `expanded` state (`true` = all rows expanded, `{}` = collapsed). Wired `onExpandedChange` / `getExpandedRowModel` so per-row toggling still works.
- **`charges-extended-info-loader.tsx`** (new) — `BatchChargesExtendedInfoProvider`, a client-side loader. While expand-all is active it hydrates every expanded row's extended info with a single `chargesByIDs` query instead of 100 `FetchCharge` queries for a 100-row page. Its selection set mirrors `FetchCharge` (same deferred fragments), so a batched charge is interchangeable with a single-charge result.
- **`charge-extended-info.tsx`** — consumes the batch loader when active (pausing its own per-charge query and delegating refetch-on-change to the batch); otherwise unchanged behaviour.
- **Screens** — `all-charges.tsx`, `missing-info-charges.tsx` (was commented out) and the single-charge `charge.tsx` now pass `isAllOpened` through.
- Added a changeset.

## How it works

`isAllOpened` does double duty: it sets the table's expanded state **and** activates the batch loader via context. When off, each row falls back to its own `FetchCharge` query exactly as before — no behaviour change for individual expansion.

## Notes

`yarn generate` / `yarn lint` / `yarn build` could not be run in this environment: `yarn install` is blocked by an egress policy denial (403) for `cdn.sheetjs.com`, a transitive dependency source. The new GraphQL operation only references the existing `chargesByIDs` server field and fragments that already exist in the client, so codegen should validate cleanly in a normal environment/CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016oU9hdxCDzhkyGPbE8bRi3)_