### PR TITLE
fix(client): update charges by stable id instead of row index

### DIFF
--- a/packages/client/src/components/charges/new-charges-table.tsx
+++ b/packages/client/src/components/charges/new-charges-table.tsx
@@ -289,16 +289,10 @@ export const NewChargesTable = ({
 
   const [charges, setCharges] = useState<ChargeRow[]>([]);
 
-  // Function to update a specific cell value
-  const updateCharge = (chargeIndex: number, updatedCharge: ChargeRow) => {
-    setCharges(old =>
-      old.map((row, index) => {
-        if (index === chargeIndex) {
-          return updatedCharge;
-        }
-        return row;
-      }),
-    );
+  // Update a specific charge by its stable id. Matching on id (rather than row index) keeps the
+  // update correct when the table is sorted, filtered, or paginated.
+  const updateCharge = (chargeId: string, updatedCharge: ChargeRow) => {
+    setCharges(old => old.map(row => (row.id === chargeId ? updatedCharge : row)));
   };
 
   // Update charges when data changes
@@ -382,7 +376,7 @@ export const NewChargesTable = ({
                     <ChargeRow
                       key={row.id}
                       row={row}
-                      updateCharge={(newCharge: ChargeRow) => updateCharge(row.index, newCharge)}
+                      updateCharge={(newCharge: ChargeRow) => updateCharge(row.id, newCharge)}
                     />
                   ))
               ) : (

--- a/packages/client/src/components/charges/new-charges-table.tsx
+++ b/packages/client/src/components/charges/new-charges-table.tsx
@@ -373,13 +373,7 @@ export const NewChargesTable = ({
               {table.getRowModel().rows?.length ? (
                 table
                   .getRowModel()
-                  .rows.map(row => (
-                    <ChargeRow
-                      key={row.id}
-                      row={row}
-                      updateCharge={updateCharge}
-                    />
-                  ))
+                  .rows.map(row => <ChargeRow key={row.id} row={row} updateCharge={updateCharge} />)
               ) : (
                 <TableRow>
                   <TableCell colSpan={columns.length} className="h-24 text-center">

--- a/packages/client/src/components/charges/new-charges-table.tsx
+++ b/packages/client/src/components/charges/new-charges-table.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
 import {
   flexRender,
   getCoreRowModel,
@@ -289,11 +289,12 @@ export const NewChargesTable = ({
 
   const [charges, setCharges] = useState<ChargeRow[]>([]);
 
-  // Update a specific charge by its stable id. Matching on id (rather than row index) keeps the
-  // update correct when the table is sorted, filtered, or paginated.
-  const updateCharge = (chargeId: string, updatedCharge: ChargeRow) => {
-    setCharges(old => old.map(row => (row.id === chargeId ? updatedCharge : row)));
-  };
+  // Update a charge by its stable id (carried on the updated row). Matching on id (rather than row
+  // index) keeps the update correct when the table is sorted, filtered, or paginated. Memoized so
+  // the reference stays stable — `ChargeRow` lists it in a `useEffect` dependency array.
+  const updateCharge = useCallback((updatedCharge: ChargeRow) => {
+    setCharges(old => old.map(row => (row.id === updatedCharge.id ? updatedCharge : row)));
+  }, []);
 
   // Update charges when data changes
   useEffect(() => {
@@ -376,7 +377,7 @@ export const NewChargesTable = ({
                     <ChargeRow
                       key={row.id}
                       row={row}
-                      updateCharge={(newCharge: ChargeRow) => updateCharge(row.id, newCharge)}
+                      updateCharge={updateCharge}
                     />
                   ))
               ) : (


### PR DESCRIPTION
## What & why

In `NewChargesTable`, `updateCharge` matched rows by their **position** in the `charges` array (`row.index`). Because the table sorts, filters, and paginates, the rendered `row.index` no longer lines up with the underlying array position — so an inline cell edit could write the update onto the **wrong** charge.

This switches the update to match on the stable charge **id**:

```ts
const updateCharge = (chargeId: string, updatedCharge: ChargeRow) => {
  setCharges(old => old.map(row => (row.id === chargeId ? updatedCharge : row)));
};
```

and passes `row.id` (not `row.index`) from the row renderer.

## Context

This addresses a robustness nit raised by the review bot on #3992. It's pre-existing base-branch behavior (not part of the CSV export feature), so it's split out here against `claude/refactor-branch-latest-main-qjagny`.

## Verification

- Client `tsc --noEmit` — clean
- `eslint` on the changed file — clean (only the pre-existing `useReactTable` compiler warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHejJGiFfWdpRR5WdXVVqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHejJGiFfWdpRR5WdXVVqY)_