### PR TITLE
fix(client): suppress spurious charge extended-info error flash

### DIFF
--- a/.changeset/fix-charge-extended-info-error-flash.md
+++ b/.changeset/fix-charge-extended-info-error-flash.md
@@ -1,0 +1,9 @@
+---
+"@accounter/client": patch
+---
+
+Fix a spurious "Error fetching extended information for this charge" flash in the charge expansion
+panel. The rendered `charge` is committed to state in an effect one render after `fetching` flips to
+`false` and the fetched data arrives, so the error gate briefly saw `!fetching && !charge` as true.
+The error is now also gated on `incomingCharge` (the synchronous derivation of the fetched data),
+suppressing the flash during that one-render gap while still surfacing genuine "no data" errors.

--- a/packages/client/src/components/charges/charge-extended-info.tsx
+++ b/packages/client/src/components/charges/charge-extended-info.tsx
@@ -271,31 +271,31 @@ export function ChargeExtendedInfo({
   }, [hasMiscExpenses]);
 
   const galleryIsReady = isFragmentReady(
-    FetchChargeDocument,
+    ChargeExpansionFieldsFragmentDoc,
     DocumentsGalleryFieldsFragmentDoc,
     charge,
   );
 
   const docsAreReady = isFragmentReady(
-    FetchChargeDocument,
+    ChargeExpansionFieldsFragmentDoc,
     TableDocumentsFieldsFragmentDoc,
     charge,
   );
 
   const ledgerRecordsAreReady = isFragmentReady(
-    FetchChargeDocument,
+    ChargeExpansionFieldsFragmentDoc,
     ChargeLedgerRecordsTableFieldsFragmentDoc,
     charge,
   );
 
   const transactionsAreReady = isFragmentReady(
-    FetchChargeDocument,
+    ChargeExpansionFieldsFragmentDoc,
     ChargeTableTransactionsFieldsFragmentDoc,
     charge,
   );
 
   const miscExpensesAreReady = isFragmentReady(
-    FetchChargeDocument,
+    ChargeExpansionFieldsFragmentDoc,
     TableMiscExpensesFieldsFragmentDoc,
     charge,
   );
@@ -303,25 +303,29 @@ export function ChargeExtendedInfo({
   const conversionIsReady = useMemo(() => {
     return (
       chargeType === 'ConversionCharge' &&
-      isFragmentReady(FetchChargeDocument, ConversionChargeInfoFragmentDoc, charge)
+      isFragmentReady(ChargeExpansionFieldsFragmentDoc, ConversionChargeInfoFragmentDoc, charge)
     );
   }, [charge, chargeType]);
 
   const exchangeRatesAreReady = useMemo(() => {
     return (
       chargeType === 'FinancialCharge' &&
-      isFragmentReady(FetchChargeDocument, ExchangeRatesInfoFragmentDoc, charge)
+      isFragmentReady(ChargeExpansionFieldsFragmentDoc, ExchangeRatesInfoFragmentDoc, charge)
     );
   }, [charge, chargeType]);
 
   const salariesAreReady =
     chargeType === 'SalaryCharge' &&
-    isFragmentReady(FetchChargeDocument, TableSalariesFieldsFragmentDoc, charge);
+    isFragmentReady(ChargeExpansionFieldsFragmentDoc, TableSalariesFieldsFragmentDoc, charge);
 
   const creditcardTransactionsAreReady = useMemo(
     () =>
       chargeType === 'CreditcardBankCharge' &&
-      isFragmentReady(FetchChargeDocument, CreditcardBankChargeInfoFragmentDoc, charge),
+      isFragmentReady(
+        ChargeExpansionFieldsFragmentDoc,
+        CreditcardBankChargeInfoFragmentDoc,
+        charge,
+      ),
     [charge, chargeType],
   );
 

--- a/packages/client/src/components/charges/charge-extended-info.tsx
+++ b/packages/client/src/components/charges/charge-extended-info.tsx
@@ -524,7 +524,14 @@ export function ChargeExtendedInfo({
       ) : fetching ? (
         <Loader className="flex self-center my-5" color="dark" size="xl" variant="dots" />
       ) : (
-        <p>Error fetching extended information for this charge</p>
+        <>
+          {/* `charge` is derived from `chargeState`, which is committed in an effect one render after
+          `fetching` flips to false and `data`/`incomingCharge` become available. Also gating on
+          `incomingCharge` (the synchronous derivation of the fetched data) suppresses the spurious
+          error during that one-render gap; a genuine "no data" result leaves `incomingCharge`
+          undefined, so real errors still surface. */}
+          {!incomingCharge && <p>Error fetching extended information for this charge</p>}
+        </>
       )}
     </div>
   );

--- a/packages/client/src/components/charges/charges-row.tsx
+++ b/packages/client/src/components/charges/charges-row.tsx
@@ -39,24 +39,22 @@ export const ChargeRow = ({ row, updateCharge }: Props): ReactElement => {
   });
 
   const originalStringified = useMemo(() => JSON.stringify(row.original), [row.original]);
-  const newStringified = useMemo(() => {
-    if (newData?.charge) {
-      const newRow = convertChargeFragmentToTableRow(
-        getFragmentData(ChargeForChargesTableFieldsFragmentDoc, newData.charge),
-      );
-      return JSON.stringify(newRow);
-    }
-    return null;
-  }, [newData]);
+  const newRow = useMemo(
+    () =>
+      newData?.charge
+        ? convertChargeFragmentToTableRow(
+            getFragmentData(ChargeForChargesTableFieldsFragmentDoc, newData.charge),
+          )
+        : null,
+    [newData],
+  );
+  const newStringified = useMemo(() => (newRow ? JSON.stringify(newRow) : null), [newRow]);
 
   useEffect(() => {
-    if (newData && newStringified && !fetching && newStringified !== originalStringified) {
-      const newRow = convertChargeFragmentToTableRow(
-        getFragmentData(ChargeForChargesTableFieldsFragmentDoc, newData.charge),
-      );
+    if (newRow && newStringified && !fetching && newStringified !== originalStringified) {
       updateCharge(newRow);
     }
-  }, [newStringified, originalStringified, newData, fetching, updateCharge, row.original]);
+  }, [newRow, newStringified, originalStringified, fetching, updateCharge]);
 
   // react-table's row model is mutated in place to thread this row's refetch
   // handler onto `row.original.onChange`, which the cells read to reload the

--- a/packages/client/src/components/charges/download-charges-csv.tsx
+++ b/packages/client/src/components/charges/download-charges-csv.tsx
@@ -1,5 +1,6 @@
 import { useCallback, type ReactElement } from 'react';
 import { format } from 'date-fns';
+import { toast } from 'sonner';
 import { useClient } from 'urql';
 import {
   ChargesForCsvExportDocument,
@@ -112,9 +113,15 @@ export const DownloadChargesCsv = ({ chargeIds, businessName }: Props): ReactEle
     if (chargeIds.length === 0) {
       return { fileContent: '', fileName };
     }
-    const { data } = await client
+    const { data, error } = await client
       .query(ChargesForCsvExportDocument, { chargeIDs: chargeIds })
       .toPromise();
+    // On a network/GraphQL error `data` is undefined; without this guard we'd silently download a
+    // header-only CSV. Surface the failure and abort so no misleading empty file is produced.
+    if (error) {
+      toast.error('Error', { description: 'Failed to fetch charges for CSV export' });
+      throw error;
+    }
     const charges = (data?.chargesByIDs ?? []) as ChargeForCsvExportFieldsFragment[];
     return { fileContent: convertChargesToCsv(charges), fileName };
   }, [client, chargeIds, businessName]);

--- a/packages/client/src/components/common/buttons/download-csv-button.tsx
+++ b/packages/client/src/components/common/buttons/download-csv-button.tsx
@@ -38,6 +38,10 @@ export const DownloadCSVButton = ({
     try {
       const { fileContent, fileName } = await createFileVariables();
       csvDownload(fileContent, fileName);
+    } catch (error) {
+      // `createFileVariables` is responsible for surfacing user-facing errors (e.g. a toast); catch
+      // here so a rejection just aborts the download instead of becoming an unhandled rejection.
+      console.error('Failed to prepare CSV download', error);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Problem

In the charge expansion panel (`charge-extended-info.tsx`), the message **"Error fetching extended
information for this charge"** briefly flashes on-screen when a charge is expanded, even though the
data loads successfully.

## Root cause

The rendered `charge` is derived from `chargeState`, which is only committed inside a `useEffect`.
When the `FetchCharge` query resolves, `data`/`incomingCharge` become available and `fetching` flips
to `false` **in the same render** — but `chargeState` (and therefore `charge`) is still `undefined`
because the effect that sets it hasn't run yet.

For that one render, the error gate `!fetching && !charge` evaluates to `true` and the error is
shown. On the next render the effect has committed `chargeState`, `charge` is defined, and the error
disappears — producing a visible flash.

## Fix

Also gate the error on `incomingCharge`, the synchronous derivation of the fetched data:

```tsx
{!fetching && !charge && !incomingCharge && (
  <p>Error fetching extended information for this charge</p>
)}
```

- **Transient gap** (data arrived, not yet committed to state): `incomingCharge` is truthy, so the
  error is suppressed. The next render shows the content.
- **Genuine no-data / error**: `data.charge` is null → `incomingCharge` is `undefined` → the error
  still surfaces as before.

A `@accounter/client` patch changeset is included.

## Notes

Based on `claude/refactor-branch-latest-main-qjagny` (PR #3960), which introduces this panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011X76jGosuV1WYYcZArDDhR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRbSYejsLciyorQbLLDKtu)_