### PR TITLE
feat(mcp-server): identity mapping to business scope (MCP Prompt 09)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -15,9 +15,20 @@ Early scaffolding. This package is being built incrementally following the promp
 implementation blueprint. It currently contains the package skeleton, strict environment
 configuration, a minimal HTTP server with a `/health` endpoint and graceful shutdown, an MCP
 transport route (`POST /mcp`) that speaks JSON-RPC 2.0 and lists an internal smoke tool, per-request
-structured logging with request/correlation ids, the OAuth protected-resource metadata endpoint, and
-Auth0 bearer-token verification on the MCP endpoint. Fine-grained authorization and production tools
-are not implemented yet.
+structured logging with request/correlation ids, the OAuth protected-resource metadata endpoint,
+Auth0 bearer-token verification, and identity mapping from a verified token to an internal user +
+business-membership context. Fine-grained authorization and production tools are not implemented
+yet.
+
+## Identity & tenant scope
+
+A verified token is mapped to an `McpAuthContext` — `userId`, `roles` (token scopes), business
+`memberships`, and a `defaultReadScope` (every business the user belongs to). Memberships are read
+from the token's `memberships` custom claim by default (the source is pluggable so a later step can
+resolve them from the GraphQL upstream instead). Requested scope narrowing is validated against the
+user's memberships: any business id outside them is rejected rather than silently dropped. These
+shapes and rules mirror the server package's tenant-isolation model
+(`packages/server/src/shared/helpers/auth-scope.ts`).
 
 ## OAuth discovery
 

--- a/packages/mcp-server/src/auth/__tests__/identity.test.ts
+++ b/packages/mcp-server/src/auth/__tests__/identity.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import type { AuthPrincipal } from '../token.js';
+import {
+  buildAuthContext,
+  dedupeMemberships,
+  IdentityMappingError,
+  membershipsFromClaims,
+  narrowReadScope,
+  readScopeFromMemberships,
+  resolveAuthContext,
+  resolveRequestedReadScope,
+} from '../identity.js';
+
+function principal(overrides: Partial<AuthPrincipal> = {}): AuthPrincipal {
+  return {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: ['read:charges'],
+    email: 'a@b.com',
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+    ...overrides,
+  };
+}
+
+const M = (businessId: string, roleId = 'accountant') => ({ businessId, roleId });
+
+describe('readScopeFromMemberships', () => {
+  it('is every business, de-duplicated and order-preserving', () => {
+    expect(readScopeFromMemberships([M('b1'), M('b2'), M('b1')])).toEqual({
+      businessIds: ['b1', 'b2'],
+    });
+  });
+});
+
+describe('narrowReadScope', () => {
+  const memberships = [M('b1'), M('b2'), M('b3')];
+
+  it('returns the requested subset (de-duplicated, order preserved)', () => {
+    expect(narrowReadScope(memberships, ['b2', 'b1', 'b2'])).toEqual({ businessIds: ['b2', 'b1'] });
+  });
+
+  it('returns null when any requested id is outside memberships', () => {
+    expect(narrowReadScope(memberships, ['b2', 'bX'])).toBeNull();
+  });
+});
+
+describe('dedupeMemberships', () => {
+  it('keeps the first occurrence per business id', () => {
+    expect(dedupeMemberships([M('b1', 'r1'), M('b1', 'r2'), M('b2', 'r3')])).toEqual([
+      M('b1', 'r1'),
+      M('b2', 'r3'),
+    ]);
+  });
+});
+
+describe('buildAuthContext', () => {
+  it('maps a user with multiple businesses to context + default scope', () => {
+    const ctx = buildAuthContext(principal(), [M('b1'), M('b2')]);
+    expect(ctx.userId).toBe('user-1');
+    expect(ctx.auth0UserId).toBe('user-1');
+    expect(ctx.email).toBe('a@b.com');
+    expect(ctx.roles).toEqual(['read:charges']);
+    expect(ctx.memberships).toEqual([M('b1'), M('b2')]);
+    expect(ctx.defaultReadScope).toEqual({ businessIds: ['b1', 'b2'] });
+  });
+
+  it('accepts a valid user with no memberships (empty scope)', () => {
+    const ctx = buildAuthContext(principal(), []);
+    expect(ctx.memberships).toEqual([]);
+    expect(ctx.defaultReadScope).toEqual({ businessIds: [] });
+  });
+
+  it('throws IdentityMappingError when the subject is missing', () => {
+    expect(() => buildAuthContext(principal({ subject: '' }), [M('b1')])).toThrow(
+      IdentityMappingError,
+    );
+  });
+});
+
+describe('resolveRequestedReadScope', () => {
+  const ctx = buildAuthContext(principal(), [M('b1'), M('b2'), M('b3')]);
+
+  it('defaults to all memberships when nothing is requested', () => {
+    expect(resolveRequestedReadScope(ctx)).toEqual({ businessIds: ['b1', 'b2', 'b3'] });
+    expect(resolveRequestedReadScope(ctx, [])).toEqual({ businessIds: ['b1', 'b2', 'b3'] });
+  });
+
+  it('narrows to a requested subset', () => {
+    expect(resolveRequestedReadScope(ctx, ['b3', 'b1'])).toEqual({ businessIds: ['b3', 'b1'] });
+  });
+
+  it('returns null for a requested id outside the memberships', () => {
+    expect(resolveRequestedReadScope(ctx, ['b1', 'bX'])).toBeNull();
+  });
+});
+
+describe('membershipsFromClaims', () => {
+  it('parses camelCase and snake_case entries and de-duplicates', () => {
+    const p = principal({
+      claims: {
+        sub: 'user-1',
+        memberships: [
+          { businessId: 'b1', roleId: 'admin' },
+          { business_id: 'b2', role_id: 'accountant' },
+          { businessId: 'b1', roleId: 'ignored-duplicate' },
+        ],
+      },
+    });
+    expect(membershipsFromClaims(p)).toEqual([M('b1', 'admin'), M('b2', 'accountant')]);
+  });
+
+  it('ignores malformed entries and a non-array claim', () => {
+    expect(membershipsFromClaims(principal({ claims: { sub: 'u', memberships: 'nope' } }))).toEqual(
+      [],
+    );
+    expect(
+      membershipsFromClaims(
+        principal({ claims: { sub: 'u', memberships: [null, {}, { roleId: 'x' }, 42] } }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('resolveAuthContext', () => {
+  it('reads memberships from the token claim by default', async () => {
+    const p = principal({
+      claims: { sub: 'user-1', memberships: [{ businessId: 'b1', roleId: 'admin' }] },
+    });
+    const ctx = await resolveAuthContext(p);
+    expect(ctx.memberships).toEqual([M('b1', 'admin')]);
+    expect(ctx.defaultReadScope).toEqual({ businessIds: ['b1'] });
+  });
+
+  it('supports an injected async membership source (multi-business)', async () => {
+    const ctx = await resolveAuthContext(principal(), async () => [M('b1'), M('b2')]);
+    expect(ctx.defaultReadScope).toEqual({ businessIds: ['b1', 'b2'] });
+    // and narrowing works against the resolved memberships
+    expect(resolveRequestedReadScope(ctx, ['b2'])).toEqual({ businessIds: ['b2'] });
+  });
+});

--- a/packages/mcp-server/src/auth/__tests__/identity.test.ts
+++ b/packages/mcp-server/src/auth/__tests__/identity.test.ts
@@ -117,9 +117,27 @@ describe('membershipsFromClaims', () => {
     );
     expect(
       membershipsFromClaims(
-        principal({ claims: { sub: 'u', memberships: [null, {}, { roleId: 'x' }, 42] } }),
+        principal({
+          claims: { sub: 'u', memberships: [null, {}, { roleId: 'x' }, 42, ['b1', 'r1']] },
+        }),
       ),
     ).toEqual([]);
+  });
+
+  it('coerces a numeric roleId but never stringifies object/array roles', () => {
+    expect(
+      membershipsFromClaims(
+        principal({
+          claims: {
+            sub: 'u',
+            memberships: [
+              { businessId: 'b1', roleId: 7 },
+              { businessId: 'b2', roleId: { nested: true } },
+            ],
+          },
+        }),
+      ),
+    ).toEqual([M('b1', '7'), M('b2', '')]);
   });
 });
 

--- a/packages/mcp-server/src/auth/__tests__/identity.test.ts
+++ b/packages/mcp-server/src/auth/__tests__/identity.test.ts
@@ -124,7 +124,10 @@ describe('membershipsFromClaims', () => {
     ).toEqual([]);
   });
 
-  it('coerces a numeric roleId but never stringifies object/array roles', () => {
+  it('coerces a numeric roleId but rejects entries with object/array roles', () => {
+    // A present-but-non-primitive role marks a malformed entry: it is dropped
+    // entirely rather than coerced to '', so its businessId cannot slip into the
+    // derived read scope. A missing role is still allowed (empty role).
     expect(
       membershipsFromClaims(
         principal({
@@ -133,11 +136,13 @@ describe('membershipsFromClaims', () => {
             memberships: [
               { businessId: 'b1', roleId: 7 },
               { businessId: 'b2', roleId: { nested: true } },
+              { businessId: 'b3', roleId: ['array-role'] },
+              { businessId: 'b4' },
             ],
           },
         }),
       ),
-    ).toEqual([M('b1', '7'), M('b2', '')]);
+    ).toEqual([M('b1', '7'), M('b4', '')]);
   });
 });
 

--- a/packages/mcp-server/src/auth/identity.ts
+++ b/packages/mcp-server/src/auth/identity.ts
@@ -115,7 +115,8 @@ export type MembershipSource = (
 ) => readonly BusinessMembership[] | Promise<readonly BusinessMembership[]>;
 
 function coerceMembership(entry: unknown): BusinessMembership | null {
-  if (!entry || typeof entry !== 'object') {
+  // Arrays are objects too; exclude them and any non-object claim entries.
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
     return null;
   }
   const record = entry as Record<string, unknown>;
@@ -123,8 +124,15 @@ function coerceMembership(entry: unknown): BusinessMembership | null {
   if (typeof businessId !== 'string' || businessId.length === 0) {
     return null;
   }
-  const roleId = record.roleId ?? record.role_id ?? '';
-  return { businessId, roleId: typeof roleId === 'string' ? roleId : String(roleId) };
+  // Only accept a string or number role; never stringify arbitrary objects.
+  const rawRoleId = record.roleId ?? record.role_id;
+  const roleId =
+    typeof rawRoleId === 'string'
+      ? rawRoleId
+      : typeof rawRoleId === 'number'
+        ? String(rawRoleId)
+        : '';
+  return { businessId, roleId };
 }
 
 /** De-duplicate memberships by business id (first occurrence wins). */

--- a/packages/mcp-server/src/auth/identity.ts
+++ b/packages/mcp-server/src/auth/identity.ts
@@ -1,0 +1,208 @@
+import type { IncomingMessage } from 'node:http';
+import type { AuthPrincipal } from './token.js';
+
+/**
+ * Identity mapping: verified token → internal user + business membership context.
+ *
+ * The membership / read-scope shapes and rules mirror the server package
+ * (`packages/server/src/shared/types/auth.ts` and `shared/helpers/auth-scope.ts`)
+ * so the connector enforces the same tenant-isolation model. They are mirrored
+ * rather than imported to keep this package standalone; a shared `@accounter/auth`
+ * package would let both consume one source of truth.
+ *
+ * Phase 1 is read-only: no write-target resolution is performed here.
+ */
+
+/** A single business the user belongs to, with the role they hold in it. */
+export interface BusinessMembership {
+  businessId: string;
+  roleId: string;
+}
+
+/** The set of businesses a request is authorized to read from. */
+export interface AuthorizedReadScope {
+  businessIds: string[];
+}
+
+/** Internal auth context derived from a verified access token. */
+export interface McpAuthContext {
+  /** Stable user id (token `sub`). */
+  userId: string;
+  /** Auth0 user id (same as `sub` for Auth0-issued tokens). */
+  auth0UserId: string;
+  email: string | null;
+  /** Granted roles/scopes from the token. */
+  roles: readonly string[];
+  /** All businesses the user belongs to. */
+  memberships: readonly BusinessMembership[];
+  /** Default read scope = every business the user belongs to. */
+  defaultReadScope: AuthorizedReadScope;
+  /** The verified principal this context was built from. */
+  principal: AuthPrincipal;
+}
+
+/** Raised when a verified token cannot be mapped to a valid user. */
+export class IdentityMappingError extends Error {
+  public readonly code = 'identity_unresolved';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'IdentityMappingError';
+  }
+}
+
+/**
+ * Default read scope = every business the user belongs to, de-duplicated and
+ * order-preserving. Mirrors the server's `readScopeFromMemberships`.
+ */
+export function readScopeFromMemberships(
+  memberships: readonly BusinessMembership[],
+): AuthorizedReadScope {
+  return { businessIds: [...new Set(memberships.map(m => m.businessId))] };
+}
+
+/**
+ * Narrow a user's memberships to a requested set of business ids. Returns the
+ * requested ids (de-duplicated, request order preserved) as the read scope, or
+ * `null` if ANY requested id is outside the user's memberships — callers must
+ * reject rather than silently dropping unknown ids. Mirrors the server's
+ * `narrowReadScope`.
+ */
+export function narrowReadScope(
+  memberships: readonly BusinessMembership[],
+  requestedBusinessIds: readonly string[],
+): AuthorizedReadScope | null {
+  const allowed = new Set(memberships.map(m => m.businessId));
+  const seen = new Set<string>();
+  const businessIds: string[] = [];
+  for (const businessId of requestedBusinessIds) {
+    if (!allowed.has(businessId)) {
+      return null;
+    }
+    if (!seen.has(businessId)) {
+      seen.add(businessId);
+      businessIds.push(businessId);
+    }
+  }
+  return { businessIds };
+}
+
+/**
+ * Resolve the effective read scope for a request: no requested ids ⇒ the
+ * default (all memberships); otherwise the requested subset, or `null` when any
+ * requested id falls outside the user's memberships.
+ */
+export function resolveRequestedReadScope(
+  context: McpAuthContext,
+  requestedBusinessIds?: readonly string[],
+): AuthorizedReadScope | null {
+  if (!requestedBusinessIds || requestedBusinessIds.length === 0) {
+    return context.defaultReadScope;
+  }
+  return narrowReadScope(context.memberships, requestedBusinessIds);
+}
+
+/**
+ * Custom claim carrying the user's business memberships. Auth0 must be
+ * configured to emit it (via a login/enrichment action). Entries accept either
+ * camelCase or snake_case keys.
+ */
+export const MEMBERSHIPS_CLAIM = 'memberships';
+
+/** A function that resolves a principal's memberships (claims, upstream, …). */
+export type MembershipSource = (
+  principal: AuthPrincipal,
+) => readonly BusinessMembership[] | Promise<readonly BusinessMembership[]>;
+
+function coerceMembership(entry: unknown): BusinessMembership | null {
+  if (!entry || typeof entry !== 'object') {
+    return null;
+  }
+  const record = entry as Record<string, unknown>;
+  const businessId = record.businessId ?? record.business_id;
+  if (typeof businessId !== 'string' || businessId.length === 0) {
+    return null;
+  }
+  const roleId = record.roleId ?? record.role_id ?? '';
+  return { businessId, roleId: typeof roleId === 'string' ? roleId : String(roleId) };
+}
+
+/** De-duplicate memberships by business id (first occurrence wins). */
+export function dedupeMemberships(
+  memberships: readonly BusinessMembership[],
+): BusinessMembership[] {
+  const seen = new Set<string>();
+  const result: BusinessMembership[] = [];
+  for (const membership of memberships) {
+    if (!seen.has(membership.businessId)) {
+      seen.add(membership.businessId);
+      result.push(membership);
+    }
+  }
+  return result;
+}
+
+/** Default membership source: read the `memberships` custom claim off the token. */
+export const membershipsFromClaims: MembershipSource = principal => {
+  const raw = principal.claims[MEMBERSHIPS_CLAIM];
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const memberships: BusinessMembership[] = [];
+  for (const entry of raw) {
+    const membership = coerceMembership(entry);
+    if (membership) {
+      memberships.push(membership);
+    }
+  }
+  return dedupeMemberships(memberships);
+};
+
+/**
+ * Assemble an {@link McpAuthContext} from a verified principal and its resolved
+ * memberships. Throws {@link IdentityMappingError} when the principal has no
+ * subject (cannot identify a user). An empty membership set is a valid user
+ * with no business access — authorization (later step) decides what that user
+ * may do.
+ */
+export function buildAuthContext(
+  principal: AuthPrincipal,
+  memberships: readonly BusinessMembership[],
+): McpAuthContext {
+  if (!principal.subject) {
+    throw new IdentityMappingError('verified token has no subject claim');
+  }
+  const deduped = dedupeMemberships(memberships);
+  return {
+    userId: principal.subject,
+    auth0UserId: principal.subject,
+    email: principal.email,
+    roles: principal.scopes,
+    memberships: deduped,
+    defaultReadScope: readScopeFromMemberships(deduped),
+    principal,
+  };
+}
+
+/**
+ * Resolve the full auth context for a verified principal using the given
+ * membership source (defaults to reading the token's `memberships` claim).
+ */
+export async function resolveAuthContext(
+  principal: AuthPrincipal,
+  source: MembershipSource = membershipsFromClaims,
+): Promise<McpAuthContext> {
+  const memberships = await source(principal);
+  return buildAuthContext(principal, memberships);
+}
+
+// Associate a resolved auth context with its request for downstream steps.
+const contextByRequest = new WeakMap<IncomingMessage, McpAuthContext>();
+
+export function setAuthContext(req: IncomingMessage, context: McpAuthContext): void {
+  contextByRequest.set(req, context);
+}
+
+export function getAuthContext(req: IncomingMessage): McpAuthContext | undefined {
+  return contextByRequest.get(req);
+}

--- a/packages/mcp-server/src/auth/identity.ts
+++ b/packages/mcp-server/src/auth/identity.ts
@@ -124,14 +124,21 @@ function coerceMembership(entry: unknown): BusinessMembership | null {
   if (typeof businessId !== 'string' || businessId.length === 0) {
     return null;
   }
-  // Only accept a string or number role; never stringify arbitrary objects.
+  // The role may be absent (treated as an empty role). But a *present* role of a
+  // non-primitive type (object/array/boolean) marks a malformed entry: reject it
+  // outright rather than coercing to '' and letting a bad claim still contribute
+  // its businessId to the derived read scope.
   const rawRoleId = record.roleId ?? record.role_id;
-  const roleId =
-    typeof rawRoleId === 'string'
-      ? rawRoleId
-      : typeof rawRoleId === 'number'
-        ? String(rawRoleId)
-        : '';
+  let roleId: string;
+  if (rawRoleId === undefined || rawRoleId === null) {
+    roleId = '';
+  } else if (typeof rawRoleId === 'string') {
+    roleId = rawRoleId;
+  } else if (typeof rawRoleId === 'number') {
+    roleId = String(rawRoleId);
+  } else {
+    return null;
+  }
   return { businessId, roleId };
 }
 

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -191,6 +191,27 @@ describe('mcpHttpHandler', () => {
     resetEnvCache();
   });
 
+  it('challenges with 401 + error="invalid_token" when identity mapping fails', async () => {
+    vi.stubEnv('MCP_PUBLIC_BASE_URL', 'https://mcp.example.com');
+    vi.stubEnv('AUTH0_ISSUER_URL', 'https://tenant.auth0.com/');
+    vi.stubEnv('AUTH0_AUDIENCE', 'aud');
+    vi.stubEnv('GRAPHQL_UPSTREAM_URL', 'http://localhost:4000/graphql');
+    const { resetEnvCache } = await import('../../config/env.js');
+    resetEnvCache();
+    // A verified token with no subject cannot be mapped to a user, so
+    // resolveAuthContext throws IdentityMappingError — a 401, not a 5xx.
+    mockVerify.mockResolvedValue({ ...PRINCIPAL, subject: '', claims: {} });
+
+    const res = mockRes();
+    await mcpHttpHandler(mockReq(rpc('tools/list')), res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+    const wwwAuth = res.setHeader.mock.calls.find(([name]) => name === 'WWW-Authenticate');
+    expect(wwwAuth?.[1]).toContain('error="invalid_token"');
+    vi.unstubAllEnvs();
+    resetEnvCache();
+  });
+
   it('propagates infrastructure errors instead of returning a misleading 401', async () => {
     // An error without a token-validation code (e.g. a JWKS outage) must bubble
     // up so the request becomes a 5xx, not a 401.

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { resolveAuthContext, setAuthContext } from '../auth/identity.js';
 import {
   extractBearerToken,
   setAuthPrincipal,
@@ -168,6 +169,10 @@ async function authenticate(
   try {
     const principal = await verifyAccessToken(token);
     setAuthPrincipal(req, principal);
+    // Map the verified identity to internal user + business membership context.
+    // An empty membership set is a valid user with no access; per-tool policy
+    // (a later step) decides what that permits.
+    setAuthContext(req, await resolveAuthContext(principal));
     return principal;
   } catch (error) {
     // Only an invalid token is a 401; infrastructure failures (e.g. a JWKS

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { resolveAuthContext, setAuthContext } from '../auth/identity.js';
+import { IdentityMappingError, resolveAuthContext, setAuthContext } from '../auth/identity.js';
 import {
   extractBearerToken,
   setAuthPrincipal,
@@ -175,10 +175,11 @@ async function authenticate(
     setAuthContext(req, await resolveAuthContext(principal));
     return principal;
   } catch (error) {
-    // Only an invalid token is a 401; infrastructure failures (e.g. a JWKS
-    // outage) propagate so the request surfaces as a 5xx rather than a
-    // misleading auth error.
-    if (!(error instanceof TokenVerificationError)) {
+    // An invalid token, or a verified token that cannot be mapped to a usable
+    // identity (e.g. a missing subject claim), is a 401. Infrastructure failures
+    // (e.g. a JWKS outage) propagate so the request surfaces as a 5xx rather than
+    // a misleading auth error.
+    if (!(error instanceof TokenVerificationError) && !(error instanceof IdentityMappingError)) {
       throw error;
     }
     // Log the reason only — never the token.


### PR DESCRIPTION
## Summary

Implements **Prompt 09 – Identity mapping to business scope** (see
[`docs/mcp/spec.md`](../blob/main/docs/mcp/spec.md) §7). Maps a verified token
to an internal user + business-membership context, mirroring the server's
tenant-isolation model.

> **Stacked PR:** targets `claude/mcp-prompt-08-token-verify` (Prompt 08, #3973).
> Review/merge Prompts 05→08 first; this diff shows only the Prompt 09 changes.

## Changes

- **`src/auth/identity.ts`**
  - `McpAuthContext` — `userId`, `auth0UserId`, `email`, `roles` (token scopes), `memberships`, `defaultReadScope`, and the source `principal`.
  - Scope helpers mirroring `packages/server/.../auth-scope.ts`: `readScopeFromMemberships` (default = all memberships), `narrowReadScope` (subset-only; returns `null` if any requested id is outside memberships), and `resolveRequestedReadScope` (no request ⇒ default; otherwise the narrowed subset or `null`).
  - `MembershipSource` — pluggable; default `membershipsFromClaims` reads the token's `memberships` custom claim (camelCase or snake_case entries, de-duplicated). A later step can swap in a GraphQL-backed source.
  - `IdentityMappingError` — the clear failure mode when a verified token has no subject. An empty membership set is a **valid** user with no access (authorization decides what that permits).
  - Per-request context store (`setAuthContext`/`getAuthContext`).
- **`src/mcp/handler.ts`** — after token verification, resolve and store the auth context on the request.
- **Tests** — multi-business mapping, default/narrowed/out-of-scope behavior, claim parsing (valid/malformed/non-array), an injected async source, and the missing-subject failure. 112 tests total.
- **`README.md`** — Identity & tenant scope section.

## Validation

- `yarn workspace @accounter/mcp-server test` → 112 passed
- `yarn workspace @accounter/mcp-server lint` / `typecheck` / `build` → pass

## Notes / open decisions

- **Reuse vs. mirror (same call as Prompt 08).** The server's membership/scope types and helpers are pure, but live inside `@accounter/server`, which is a graphql-modules/Postgres app rather than a library. I mirrored the shapes and rules (`BusinessMembership`, `AuthorizedReadScope`, `narrowReadScope` semantics) here and flagged extracting a shared `@accounter/auth` package as a follow-up.
- **Where memberships come from.** The GraphQL upstream client is Prompt 12, so Prompt 09 defaults to reading a `memberships` **token claim** (Auth0 configured to emit it) and keeps the source pluggable. This keeps the step self-contained and lets Prompt 11/12 wire a DB/GraphQL-backed resolver without another refactor.
- **Non-blocking wiring.** The context is resolved and stored but not yet enforced — the smoke path is unchanged. Enforcement (deny with `AUTHORIZATION_ERROR`) is Prompt 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_