### PR TITLE
feat(mcp-server): hardened upstream GraphQL client (MCP Prompt 12)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -16,9 +16,20 @@ implementation blueprint. It currently contains the package skeleton, strict env
 configuration, a minimal HTTP server with a `/health` endpoint and graceful shutdown, an MCP
 transport route (`POST /mcp`) that speaks JSON-RPC 2.0 and lists an internal smoke tool, per-request
 structured logging with request/correlation ids, the OAuth protected-resource metadata endpoint,
-Auth0 bearer-token verification, and identity mapping from a verified token to an internal user +
-business-membership context. Fine-grained authorization and production tools are not implemented
-yet.
+Auth0 bearer-token verification, identity mapping from a verified token to an internal user +
+business-membership context, a curated tool registry with strict input validation, a per-tool
+authorization policy evaluator, and a hardened upstream GraphQL client. Production tools that use
+these building blocks are not implemented yet.
+
+## Upstream GraphQL client
+
+Tool handlers talk to the Accounter GraphQL server through a single hardened client
+(`src/upstream/graphql-client.ts`): a strict per-request **timeout** with cancellation, **bounded
+retries** for idempotent read failures only (network errors, timeouts, and 5xx — never 4xx
+auth/validation errors or GraphQL-level errors), **header propagation** of the correlation id and
+the caller's `Authorization` bearer token, and **sanitized** upstream errors (no stack traces or
+internal details). Phase 1 is read-only: mutations/subscriptions are refused, and there is **no**
+generic "execute anything" surface — tools use typed read-only wrappers via `createReadOperation`.
 
 ## Identity & tenant scope
 

--- a/packages/mcp-server/src/upstream/__tests__/graphql-client.test.ts
+++ b/packages/mcp-server/src/upstream/__tests__/graphql-client.test.ts
@@ -65,6 +65,17 @@ describe('UpstreamGraphQLClient.query — read-only guard', () => {
       client(fetchImpl as unknown as typeof fetch).query({ query: 'subscription S { x }' }, ctx),
     ).rejects.toBeInstanceOf(UpstreamError);
   });
+
+  it('refuses a mutation smuggled after a leading query (multi-operation)', async () => {
+    const fetchImpl = vi.fn();
+    await expect(
+      client(fetchImpl as unknown as typeof fetch).query(
+        { query: 'query Q { x } mutation M { deleteCharge }', operationName: 'M' },
+        ctx,
+      ),
+    ).rejects.toBeInstanceOf(UpstreamError);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });
 
 describe('UpstreamGraphQLClient.query — timeout & retries', () => {
@@ -133,6 +144,31 @@ describe('UpstreamGraphQLClient.query — GraphQL errors', () => {
     await expect(
       client(fetchImpl as unknown as typeof fetch).query({ query: 'query { x }' }, ctx),
     ).rejects.toMatchObject({ message: 'Upstream returned no data' });
+  });
+
+  it('sanitizes a non-JSON response instead of leaking the parse error', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => {
+            throw new SyntaxError('Unexpected token < in JSON');
+          },
+        }) as unknown as Response,
+    );
+    await expect(
+      client(fetchImpl as unknown as typeof fetch).query({ query: 'query { x }' }, ctx),
+    ).rejects.toMatchObject({ code: 'UPSTREAM_ERROR', message: 'Upstream returned a non-JSON response' });
+  });
+
+  it('tolerates null entries in the errors array', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ errors: [null, { message: 'Access denied' }] }),
+    );
+    await expect(
+      client(fetchImpl as unknown as typeof fetch).query({ query: 'query { x }' }, ctx),
+    ).rejects.toMatchObject({ code: 'UPSTREAM_ERROR', retryable: false });
   });
 });
 

--- a/packages/mcp-server/src/upstream/__tests__/graphql-client.test.ts
+++ b/packages/mcp-server/src/upstream/__tests__/graphql-client.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createReadOperation,
+  UpstreamError,
+  UpstreamGraphQLClient,
+} from '../graphql-client.js';
+
+const ENDPOINT = 'http://localhost:4000/graphql';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function client(fetchImpl: typeof fetch, maxRetries = 2) {
+  return new UpstreamGraphQLClient({ endpoint: ENDPOINT, timeoutMs: 1000, maxRetries, fetchImpl });
+}
+
+const ctx = { correlationId: 'corr-1', authorization: 'Bearer tok' };
+
+describe('UpstreamGraphQLClient.query — success & headers', () => {
+  it('returns data and propagates correlation id + Authorization', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ data: { charges: [{ id: '1' }] } }));
+    const result = await client(fetchImpl as unknown as typeof fetch).query<{
+      charges: Array<{ id: string }>;
+    }>({ query: 'query Q { charges { id } }' }, ctx);
+
+    expect(result).toEqual({ charges: [{ id: '1' }] });
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe(ENDPOINT);
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers['X-Correlation-Id']).toBe('corr-1');
+    expect(headers.Authorization).toBe('Bearer tok');
+  });
+
+  it('omits Authorization when the context has no token', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ data: { ok: true } }));
+    await client(fetchImpl as unknown as typeof fetch).query(
+      { query: 'query { ok }' },
+      { correlationId: 'c' },
+    );
+    const headers = (fetchImpl.mock.calls[0][1] as RequestInit).headers as Record<string, string>;
+    expect('Authorization' in headers).toBe(false);
+  });
+});
+
+describe('UpstreamGraphQLClient.query — read-only guard', () => {
+  it('refuses mutations without calling fetch', async () => {
+    const fetchImpl = vi.fn();
+    await expect(
+      client(fetchImpl as unknown as typeof fetch).query(
+        { query: '  mutation M { deleteCharge }' },
+        ctx,
+      ),
+    ).rejects.toMatchObject({ code: 'UPSTREAM_ERROR', retryable: false });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('refuses subscriptions', async () => {
+    const fetchImpl = vi.fn();
+    await expect(
+      client(fetchImpl as unknown as typeof fetch).query({ query: 'subscription S { x }' }, ctx),
+    ).rejects.toBeInstanceOf(UpstreamError);
+  });
+});
+
+describe('UpstreamGraphQLClient.query — timeout & retries', () => {
+  it('maps an aborted request to a retryable TIMEOUT_ERROR', async () => {
+    const abortErr = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    const fetchImpl = vi.fn(async () => {
+      throw abortErr;
+    });
+    await expect(
+      client(fetchImpl as unknown as typeof fetch, 0).query({ query: 'query { x }' }, ctx),
+    ).rejects.toMatchObject({ code: 'TIMEOUT_ERROR', retryable: true });
+  });
+
+  it('retries a 503 up to maxRetries then succeeds', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}, 503))
+      .mockResolvedValueOnce(jsonResponse({}, 503))
+      .mockResolvedValueOnce(jsonResponse({ data: { ok: 1 } }));
+    const result = await client(fetchImpl as unknown as typeof fetch, 2).query(
+      { query: 'query { ok }' },
+      ctx,
+    );
+    expect(result).toEqual({ ok: 1 });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry a 400 (validation/client error)', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}, 400));
+    await expect(
+      client(fetchImpl as unknown as typeof fetch).query({ query: 'query { x }' }, ctx),
+    ).rejects.toMatchObject({ code: 'UPSTREAM_ERROR', retryable: false });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a 401 (auth error)', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}, 401));
+    await expect(
+      client(fetchImpl as unknown as typeof fetch).query({ query: 'query { x }' }, ctx),
+    ).rejects.toMatchObject({ retryable: false });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after exhausting retries on persistent 5xx', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}, 500));
+    await expect(
+      client(fetchImpl as unknown as typeof fetch, 2).query({ query: 'query { x }' }, ctx),
+    ).rejects.toBeInstanceOf(UpstreamError);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('UpstreamGraphQLClient.query — GraphQL errors', () => {
+  it('sanitizes GraphQL errors and does not retry them', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ errors: [{ message: 'Charge not found' }, { message: 'Access denied' }] }),
+    );
+    await expect(
+      client(fetchImpl as unknown as typeof fetch).query({ query: 'query { x }' }, ctx),
+    ).rejects.toMatchObject({ code: 'UPSTREAM_ERROR', retryable: false });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when the response has no data', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}));
+    await expect(
+      client(fetchImpl as unknown as typeof fetch).query({ query: 'query { x }' }, ctx),
+    ).rejects.toMatchObject({ message: 'Upstream returned no data' });
+  });
+});
+
+describe('createReadOperation', () => {
+  it('runs a typed read operation and maps the data', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ data: { tags: [{ name: 'food' }] } }));
+    const listTags = createReadOperation<
+      { tags: Array<{ name: string }> },
+      Record<string, never>,
+      string[]
+    >('query Tags { tags { name } }', data => data.tags.map(t => t.name));
+
+    const names = await listTags(client(fetchImpl as unknown as typeof fetch), {}, ctx);
+    expect(names).toEqual(['food']);
+  });
+});

--- a/packages/mcp-server/src/upstream/__tests__/graphql-client.test.ts
+++ b/packages/mcp-server/src/upstream/__tests__/graphql-client.test.ts
@@ -89,6 +89,23 @@ describe('UpstreamGraphQLClient.query — timeout & retries', () => {
     ).rejects.toMatchObject({ code: 'TIMEOUT_ERROR', retryable: true });
   });
 
+  it('maps an abort while reading the body to a retryable TIMEOUT_ERROR', async () => {
+    const abortErr = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    const fetchImpl = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => {
+            throw abortErr;
+          },
+        }) as unknown as Response,
+    );
+    await expect(
+      client(fetchImpl as unknown as typeof fetch, 0).query({ query: 'query { x }' }, ctx),
+    ).rejects.toMatchObject({ code: 'TIMEOUT_ERROR', retryable: true });
+  });
+
   it('retries a 503 up to maxRetries then succeeds', async () => {
     const fetchImpl = vi
       .fn()
@@ -169,6 +186,23 @@ describe('UpstreamGraphQLClient.query — GraphQL errors', () => {
     await expect(
       client(fetchImpl as unknown as typeof fetch).query({ query: 'query { x }' }, ctx),
     ).rejects.toMatchObject({ code: 'UPSTREAM_ERROR', retryable: false });
+  });
+
+  it('normalizes whitespace and caps long GraphQL error messages', async () => {
+    const noisy = `Internal error:\n  ${'x'.repeat(500)}\n\tinternal stack line`;
+    const fetchImpl = vi.fn(async () => jsonResponse({ errors: [{ message: noisy }] }));
+    let caught: unknown;
+    try {
+      await client(fetchImpl as unknown as typeof fetch).query({ query: 'query { x }' }, ctx);
+    } catch (error) {
+      caught = error;
+    }
+    const message = (caught as Error).message;
+    expect(message).not.toMatch(/[\n\t]/);
+    // Single message is capped at 200 chars, so the trailing "stack line" is dropped.
+    expect(message.length).toBeLessThanOrEqual(200);
+    expect(message.startsWith('Internal error: xxxx')).toBe(true);
+    expect(message).not.toContain('internal stack line');
   });
 });
 

--- a/packages/mcp-server/src/upstream/default-client.ts
+++ b/packages/mcp-server/src/upstream/default-client.ts
@@ -1,0 +1,21 @@
+import { env } from '../config/env.js';
+import { UpstreamGraphQLClient } from './graphql-client.js';
+
+let cached: UpstreamGraphQLClient | undefined;
+
+/**
+ * The process-wide upstream GraphQL client, configured from the environment
+ * (endpoint + timeout budget). Lazily created and memoized.
+ */
+export function getUpstreamClient(): UpstreamGraphQLClient {
+  cached ??= new UpstreamGraphQLClient({
+    endpoint: env.upstream.graphqlUrl,
+    timeoutMs: env.upstream.timeoutMs,
+  });
+  return cached;
+}
+
+/** Test-only: reset the memoized client. */
+export function resetUpstreamClient(): void {
+  cached = undefined;
+}

--- a/packages/mcp-server/src/upstream/graphql-client.ts
+++ b/packages/mcp-server/src/upstream/graphql-client.ts
@@ -1,0 +1,193 @@
+/**
+ * Shared upstream GraphQL client used by tool handlers.
+ *
+ * Design constraints (spec §5.3, §8.3, §10):
+ * - Phase 1 is read-only: mutations/subscriptions are refused.
+ * - No generic "execute anything" is exposed to tools — tools call typed
+ *   read-only operation wrappers built on `createReadOperation`, never this
+ *   engine directly.
+ * - A strict timeout budget with cancellation; bounded retries for idempotent
+ *   read failures only (never on auth/validation errors).
+ * - The correlation id and the caller's Authorization header are propagated
+ *   upstream; the raw token is never logged or persisted.
+ * - Upstream errors are sanitized (no stack traces / internal SQL details).
+ */
+
+export type UpstreamErrorCode = 'UPSTREAM_ERROR' | 'TIMEOUT_ERROR';
+
+/** Sanitized upstream failure. Carries no stack traces or internal details. */
+export class UpstreamError extends Error {
+  constructor(
+    public readonly code: UpstreamErrorCode,
+    message: string,
+    public readonly retryable: boolean,
+  ) {
+    super(message);
+    this.name = 'UpstreamError';
+  }
+}
+
+export interface GraphQLRequest<TVariables = Record<string, unknown>> {
+  query: string;
+  variables?: TVariables;
+  operationName?: string;
+}
+
+/** Per-call context propagated to the upstream server. */
+export interface UpstreamRequestContext {
+  correlationId: string;
+  /**
+   * Authorization header value (`Bearer <token>`) forwarded from the
+   * authenticated request. Never logged. Omitted ⇒ no header sent.
+   */
+  authorization?: string;
+}
+
+export interface UpstreamClientConfig {
+  endpoint: string;
+  timeoutMs: number;
+  /** Max retry attempts for idempotent read failures (default 2). */
+  maxRetries?: number;
+  /** Injectable fetch (defaults to global fetch) for testing. */
+  fetchImpl?: typeof fetch;
+}
+
+interface GraphQLResponseBody<TData> {
+  data?: TData;
+  errors?: Array<{ message?: unknown }>;
+}
+
+// Leading whitespace + line comments, then the operation keyword.
+const NON_READ_OPERATION_RE = /^(?:\s|#[^\n]*\n?)*(mutation|subscription)\b/i;
+
+function assertReadOnly(query: string): void {
+  if (NON_READ_OPERATION_RE.test(query)) {
+    throw new UpstreamError('UPSTREAM_ERROR', 'Only read-only operations are permitted', false);
+  }
+}
+
+/** Collapse GraphQL error messages into a single business-safe string. */
+function sanitizeGraphQLErrors(errors: Array<{ message?: unknown }>): string {
+  const messages = errors
+    .map(error => (typeof error.message === 'string' ? error.message : ''))
+    .map(message => message.trim())
+    .filter(Boolean)
+    .slice(0, 3);
+  return messages.length > 0 ? messages.join('; ') : 'Upstream GraphQL error';
+}
+
+export class UpstreamGraphQLClient {
+  private readonly endpoint: string;
+  private readonly timeoutMs: number;
+  private readonly maxRetries: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(config: UpstreamClientConfig) {
+    this.endpoint = config.endpoint;
+    this.timeoutMs = config.timeoutMs;
+    this.maxRetries = config.maxRetries ?? 2;
+    this.fetchImpl = config.fetchImpl ?? globalThis.fetch;
+  }
+
+  /**
+   * Execute a read-only GraphQL operation with timeout, bounded retries, header
+   * propagation, and error sanitization. Internal engine — tools use typed
+   * wrappers ({@link createReadOperation}), not this method directly.
+   */
+  async query<TData>(request: GraphQLRequest, context: UpstreamRequestContext): Promise<TData> {
+    assertReadOnly(request.query);
+
+    let attempt = 0;
+    // Total tries = 1 + maxRetries; only retryable failures loop.
+    for (;;) {
+      try {
+        return await this.executeOnce<TData>(request, context);
+      } catch (error) {
+        const isRetryable = error instanceof UpstreamError && error.retryable;
+        if (!isRetryable || attempt >= this.maxRetries) {
+          throw error;
+        }
+        attempt += 1;
+      }
+    }
+  }
+
+  private async executeOnce<TData>(
+    request: GraphQLRequest,
+    context: UpstreamRequestContext,
+  ): Promise<TData> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'X-Correlation-Id': context.correlationId,
+    };
+    // Forward the caller's bearer token so upstream applies the same identity.
+    if (context.authorization) {
+      headers.Authorization = context.authorization;
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(this.endpoint, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          query: request.query,
+          variables: request.variables ?? {},
+          ...(request.operationName ? { operationName: request.operationName } : {}),
+        }),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new UpstreamError('TIMEOUT_ERROR', 'Upstream request timed out', true);
+      }
+      // Network/connection error — a read may be safely retried.
+      throw new UpstreamError('UPSTREAM_ERROR', 'Upstream request failed', true);
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      // 5xx is transient (retryable); 4xx (auth/validation) is not.
+      const retryable = response.status >= 500;
+      throw new UpstreamError(
+        'UPSTREAM_ERROR',
+        `Upstream responded with status ${response.status}`,
+        retryable,
+      );
+    }
+
+    const body = (await response.json()) as GraphQLResponseBody<TData>;
+    if (body.errors && body.errors.length > 0) {
+      // GraphQL-level errors are not retried (not transient).
+      throw new UpstreamError('UPSTREAM_ERROR', sanitizeGraphQLErrors(body.errors), false);
+    }
+    if (body.data === undefined) {
+      throw new UpstreamError('UPSTREAM_ERROR', 'Upstream returned no data', false);
+    }
+    return body.data;
+  }
+}
+
+/**
+ * Build a typed, read-only operation wrapper. This is the ONLY surface tool
+ * handlers use to talk to the upstream — there is no generic execute exposed to
+ * tools. `map` shapes the raw GraphQL data into the tool's return type.
+ */
+export function createReadOperation<TData, TVariables extends Record<string, unknown>, TResult>(
+  query: string,
+  map: (data: TData) => TResult,
+): (
+  client: UpstreamGraphQLClient,
+  variables: TVariables,
+  context: UpstreamRequestContext,
+) => Promise<TResult> {
+  return async (client, variables, context) => {
+    const data = await client.query<TData>({ query, variables }, context);
+    return map(data);
+  };
+}

--- a/packages/mcp-server/src/upstream/graphql-client.ts
+++ b/packages/mcp-server/src/upstream/graphql-client.ts
@@ -57,8 +57,11 @@ interface GraphQLResponseBody<TData> {
   errors?: Array<{ message?: unknown }>;
 }
 
-// Leading whitespace + line comments, then the operation keyword.
-const NON_READ_OPERATION_RE = /^(?:\s|#[^\n]*\n?)*(mutation|subscription)\b/i;
+// Reject a `mutation`/`subscription` keyword anywhere in the document, not just
+// at the start — a multi-operation document could otherwise smuggle a mutation
+// past a leading `query` and select it via `operationName`. Our own wrappers only
+// send read queries, so over-rejecting here is a safe default.
+const NON_READ_OPERATION_RE = /\b(mutation|subscription)\b/i;
 
 function assertReadOnly(query: string): void {
   if (NON_READ_OPERATION_RE.test(query)) {
@@ -69,7 +72,9 @@ function assertReadOnly(query: string): void {
 /** Collapse GraphQL error messages into a single business-safe string. */
 function sanitizeGraphQLErrors(errors: Array<{ message?: unknown }>): string {
   const messages = errors
-    .map(error => (typeof error.message === 'string' ? error.message : ''))
+    .map(error =>
+      error && typeof error === 'object' && typeof error.message === 'string' ? error.message : '',
+    )
     .map(message => message.trim())
     .filter(Boolean)
     .slice(0, 3);
@@ -161,8 +166,21 @@ export class UpstreamGraphQLClient {
       );
     }
 
-    const body = (await response.json()) as GraphQLResponseBody<TData>;
-    if (body.errors && body.errors.length > 0) {
+    let body: GraphQLResponseBody<TData>;
+    try {
+      body = (await response.json()) as GraphQLResponseBody<TData>;
+    } catch {
+      // Non-JSON body (e.g. an HTML error page) — sanitize rather than leak.
+      throw new UpstreamError('UPSTREAM_ERROR', 'Upstream returned a non-JSON response', false);
+    }
+    if (!body || typeof body !== 'object') {
+      throw new UpstreamError(
+        'UPSTREAM_ERROR',
+        'Upstream returned an invalid response body',
+        false,
+      );
+    }
+    if (Array.isArray(body.errors) && body.errors.length > 0) {
       // GraphQL-level errors are not retried (not transient).
       throw new UpstreamError('UPSTREAM_ERROR', sanitizeGraphQLErrors(body.errors), false);
     }

--- a/packages/mcp-server/src/upstream/graphql-client.ts
+++ b/packages/mcp-server/src/upstream/graphql-client.ts
@@ -15,7 +15,12 @@
 
 export type UpstreamErrorCode = 'UPSTREAM_ERROR' | 'TIMEOUT_ERROR';
 
-/** Sanitized upstream failure. Carries no stack traces or internal details. */
+/**
+ * Sanitized upstream failure. Its `message` is business-safe: it never carries
+ * upstream stack traces, SQL, or other internal upstream details. (Like any JS
+ * Error it still has a local `.stack` for this call site — that's ours, not the
+ * upstream's internals.)
+ */
 export class UpstreamError extends Error {
   constructor(
     public readonly code: UpstreamErrorCode,
@@ -69,16 +74,27 @@ function assertReadOnly(query: string): void {
   }
 }
 
+/** Max characters kept per individual upstream error message. */
+const MAX_ERROR_MESSAGE_LENGTH = 200;
+/** Max characters for the combined sanitized error string. */
+const MAX_SANITIZED_ERROR_LENGTH = 500;
+
 /** Collapse GraphQL error messages into a single business-safe string. */
 function sanitizeGraphQLErrors(errors: Array<{ message?: unknown }>): string {
   const messages = errors
     .map(error =>
       error && typeof error === 'object' && typeof error.message === 'string' ? error.message : '',
     )
-    .map(message => message.trim())
+    // Normalize whitespace (collapse newlines/tabs/runs of spaces) and cap each
+    // message so a verbose upstream error can neither bloat logs nor smuggle
+    // multi-line internal detail into the business-safe summary.
+    .map(message => message.replace(/\s+/g, ' ').trim().slice(0, MAX_ERROR_MESSAGE_LENGTH))
     .filter(Boolean)
     .slice(0, 3);
-  return messages.length > 0 ? messages.join('; ') : 'Upstream GraphQL error';
+  if (messages.length === 0) {
+    return 'Upstream GraphQL error';
+  }
+  return messages.join('; ').slice(0, MAX_SANITIZED_ERROR_LENGTH);
 }
 
 export class UpstreamGraphQLClient {
@@ -134,60 +150,70 @@ export class UpstreamGraphQLClient {
       headers.Authorization = context.authorization;
     }
 
-    let response: Response;
+    // The timeout budget spans the entire exchange — obtaining the response AND
+    // consuming its body — so an upstream that sends headers then stalls the body
+    // is still aborted. The timer is cleared only once everything is done.
     try {
-      response = await this.fetchImpl(this.endpoint, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({
-          query: request.query,
-          variables: request.variables ?? {},
-          ...(request.operationName ? { operationName: request.operationName } : {}),
-        }),
-        signal: controller.signal,
-      });
-    } catch (error) {
-      if (error instanceof Error && error.name === 'AbortError') {
-        throw new UpstreamError('TIMEOUT_ERROR', 'Upstream request timed out', true);
+      let response: Response;
+      try {
+        response = await this.fetchImpl(this.endpoint, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            query: request.query,
+            variables: request.variables ?? {},
+            ...(request.operationName ? { operationName: request.operationName } : {}),
+          }),
+          signal: controller.signal,
+        });
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+          throw new UpstreamError('TIMEOUT_ERROR', 'Upstream request timed out', true);
+        }
+        // Network/connection error — a read may be safely retried.
+        throw new UpstreamError('UPSTREAM_ERROR', 'Upstream request failed', true);
       }
-      // Network/connection error — a read may be safely retried.
-      throw new UpstreamError('UPSTREAM_ERROR', 'Upstream request failed', true);
+
+      if (!response.ok) {
+        // 5xx is transient (retryable); 4xx (auth/validation) is not.
+        const retryable = response.status >= 500;
+        throw new UpstreamError(
+          'UPSTREAM_ERROR',
+          `Upstream responded with status ${response.status}`,
+          retryable,
+        );
+      }
+
+      let body: GraphQLResponseBody<TData>;
+      try {
+        body = (await response.json()) as GraphQLResponseBody<TData>;
+      } catch (error) {
+        // An abort raised while streaming the body is a timeout, not a malformed
+        // body — classify it as a retryable TIMEOUT_ERROR.
+        if (error instanceof Error && error.name === 'AbortError') {
+          throw new UpstreamError('TIMEOUT_ERROR', 'Upstream request timed out', true);
+        }
+        // Non-JSON body (e.g. an HTML error page) — sanitize rather than leak.
+        throw new UpstreamError('UPSTREAM_ERROR', 'Upstream returned a non-JSON response', false);
+      }
+      if (!body || typeof body !== 'object') {
+        throw new UpstreamError(
+          'UPSTREAM_ERROR',
+          'Upstream returned an invalid response body',
+          false,
+        );
+      }
+      if (Array.isArray(body.errors) && body.errors.length > 0) {
+        // GraphQL-level errors are not retried (not transient).
+        throw new UpstreamError('UPSTREAM_ERROR', sanitizeGraphQLErrors(body.errors), false);
+      }
+      if (body.data === undefined) {
+        throw new UpstreamError('UPSTREAM_ERROR', 'Upstream returned no data', false);
+      }
+      return body.data;
     } finally {
       clearTimeout(timer);
     }
-
-    if (!response.ok) {
-      // 5xx is transient (retryable); 4xx (auth/validation) is not.
-      const retryable = response.status >= 500;
-      throw new UpstreamError(
-        'UPSTREAM_ERROR',
-        `Upstream responded with status ${response.status}`,
-        retryable,
-      );
-    }
-
-    let body: GraphQLResponseBody<TData>;
-    try {
-      body = (await response.json()) as GraphQLResponseBody<TData>;
-    } catch {
-      // Non-JSON body (e.g. an HTML error page) — sanitize rather than leak.
-      throw new UpstreamError('UPSTREAM_ERROR', 'Upstream returned a non-JSON response', false);
-    }
-    if (!body || typeof body !== 'object') {
-      throw new UpstreamError(
-        'UPSTREAM_ERROR',
-        'Upstream returned an invalid response body',
-        false,
-      );
-    }
-    if (Array.isArray(body.errors) && body.errors.length > 0) {
-      // GraphQL-level errors are not retried (not transient).
-      throw new UpstreamError('UPSTREAM_ERROR', sanitizeGraphQLErrors(body.errors), false);
-    }
-    if (body.data === undefined) {
-      throw new UpstreamError('UPSTREAM_ERROR', 'Upstream returned no data', false);
-    }
-    return body.data;
   }
 }
 


### PR DESCRIPTION
## Summary

Implements **Prompt 12 – GraphQL upstream client with timeout/retry guardrails**
(see [`docs/mcp/spec.md`](../blob/main/docs/mcp/spec.md) §5.3, §10.3, §10.4). Adds
the single shared client that tool handlers use to reach the Accounter GraphQL
server.

> **Stacked PR:** targets `claude/mcp-prompt-11-policy-evaluator` (Prompt 11, #4012).
> Review/merge Prompts 05→11 first; this diff shows only the Prompt 12 changes.

## Changes

- **`src/upstream/graphql-client.ts`** — `UpstreamGraphQLClient`:
  - **Timeout + cancellation** via `AbortController` (a per-call budget); an aborted request maps to a retryable `TIMEOUT_ERROR`.
  - **Bounded retries for idempotent reads only** — network errors, timeouts, and 5xx are retried up to `maxRetries` (default 2); 4xx (auth/validation) and GraphQL-level errors are **never** retried.
  - **Header propagation** — `X-Correlation-Id` and the caller's `Authorization` bearer token are forwarded; the raw token is never logged.
  - **Sanitized errors** — `UpstreamError` (`UPSTREAM_ERROR` / `TIMEOUT_ERROR`, `retryable` flag) with business-safe messages only (GraphQL error messages collapsed, capped; no stack traces / SQL).
  - **Read-only guard** — mutations/subscriptions are refused (phase-1 non-goal). `createReadOperation` is the only surface tools use — there is **no** generic execute-anything API.
- **`src/upstream/default-client.ts`** — env-backed, memoized client factory (endpoint + timeout from config).
- **Tests** — success + header propagation (correlation id & Authorization, omitted when absent), read-only guard, timeout mapping, retry eligibility (503 retried then success, 400/401 not retried, exhaustion on persistent 5xx), GraphQL-error sanitization, and a `createReadOperation` round-trip. 140 tests total.

## Validation

- `yarn workspace @accounter/mcp-server test` → 140 passed
- `yarn workspace @accounter/mcp-server lint` / `typecheck` / `build` → pass

## Notes / open decisions

- **`Authorization` forwarding.** The prompt asks to forward the caller's bearer token upstream. The client accepts it via `UpstreamRequestContext.authorization`; **populating** it from the authenticated request (the token captured at verification time) is wired when the first real tool executes (Prompt 13). Forwarding the user's own token means upstream re-applies the exact same identity/tenant checks — defense in depth over the connector's own policy evaluator.
- **Retry backoff.** Retries are immediate (no delay) to stay within the tight tool-latency budget; if we want jittered backoff, that's a small follow-up. Retries are capped and only for idempotent reads, so this is safe.
- **`fetch`-based** (Node global) with an injectable `fetchImpl` for hermetic tests — no `graphql-request` dependency, keeping full control over timeout/retry/headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_