### PR TITLE
feat(mcp-server): charges search tool + registry wiring (MCP Prompt 13)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -18,8 +18,21 @@ transport route (`POST /mcp`) that speaks JSON-RPC 2.0 and lists an internal smo
 structured logging with request/correlation ids, the OAuth protected-resource metadata endpoint,
 Auth0 bearer-token verification, identity mapping from a verified token to an internal user +
 business-membership context, a curated tool registry with strict input validation, a per-tool
-authorization policy evaluator, and a hardened upstream GraphQL client. Production tools that use
-these building blocks are not implemented yet.
+authorization policy evaluator, and a hardened upstream GraphQL client. The first production tool
+(read-only charges search) is wired into `tools/list` / `tools/call` and enforces input validation,
+authorization policy, and business-scope narrowing before execution.
+
+## Tools
+
+`tools/call` for a registered tool runs input validation → authorization policy → handler, and maps
+failures to a tool result with `isError` and a `{ code, message, correlationId, retryable? }`
+payload (spec §10.2): `VALIDATION_ERROR`, `AUTHORIZATION_ERROR`, `UPSTREAM_ERROR`, `TIMEOUT_ERROR`,
+`INTERNAL_ERROR`.
+
+- **`accounter_search_charges`** — read-only charges search/browse within the caller's authorized
+  businesses. Optional `businessIds` (subset of memberships), `fromDate`/`toDate` (bounded to 366
+  days), `tags`, `freeText`, and `flow` (`ALL`/`INCOME`/`EXPENSE`), with bounded pagination
+  (`pageSize` ≤ 50). Returns normalized charges plus pagination metadata.
 
 ## Upstream GraphQL client
 

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -1,9 +1,10 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildAuthContext } from '../../auth/identity.js';
 import { TokenVerificationError } from '../../auth/token.js';
 import { verifyAccessToken } from '../../auth/verifier.js';
-import { handleMcpBody, MCP_PROTOCOL_VERSION, mcpHttpHandler } from '../handler.js';
+import { dispatchMcpRequest, handleMcpBody, MCP_PROTOCOL_VERSION, mcpHttpHandler } from '../handler.js';
 import type { JsonRpcErrorResponse, JsonRpcSuccess } from '../jsonrpc.js';
 import { JsonRpcErrorCode } from '../jsonrpc.js';
 import { SMOKE_TOOL_NAME } from '../tools.js';
@@ -238,6 +239,39 @@ describe('mcpHttpHandler', () => {
       'jwks endpoint unreachable',
     );
     expect(res.writeHead).not.toHaveBeenCalledWith(401, expect.anything());
+  });
+});
+
+describe('dispatchMcpRequest — registry integration', () => {
+  const auth = buildAuthContext(
+    {
+      subject: 'user-1',
+      issuer: 'https://tenant.auth0.com/',
+      audience: 'aud',
+      scopes: [],
+      email: null,
+      expiresAt: undefined,
+      claims: { sub: 'user-1' },
+    },
+    [],
+  );
+
+  it('lists the smoke tool alongside the registered production tools', async () => {
+    const response = (await dispatchMcpRequest(
+      { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      { auth, correlationId: 'c' },
+    )) as JsonRpcSuccess;
+    const names = (response.result as { tools: Array<{ name: string }> }).tools.map(t => t.name);
+    expect(names).toContain(SMOKE_TOOL_NAME);
+    expect(names).toContain('accounter_search_charges');
+  });
+
+  it('returns InvalidParams for an unknown tool name', async () => {
+    const response = (await dispatchMcpRequest(
+      { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'nope' } },
+      { auth, correlationId: 'c' },
+    )) as JsonRpcErrorResponse;
+    expect(response.error.code).toBe(JsonRpcErrorCode.InvalidParams);
   });
 });
 

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -1,5 +1,11 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { IdentityMappingError, resolveAuthContext, setAuthContext } from '../auth/identity.js';
+import {
+  getAuthContext,
+  IdentityMappingError,
+  resolveAuthContext,
+  setAuthContext,
+  type McpAuthContext,
+} from '../auth/identity.js';
 import {
   extractBearerToken,
   setAuthPrincipal,
@@ -12,6 +18,8 @@ import { generateId, getRequestContext } from '../context.js';
 import { createRequestLogger, log } from '../logger.js';
 import { sendUnauthorized } from '../oauth/challenge.js';
 import { protectedResourceMetadataUrl } from '../oauth/metadata.js';
+import { executeRegisteredTool } from '../tools/execute.js';
+import { toolRegistry } from '../tools/registry-instance.js';
 import { getUpstreamClient } from '../upstream/default-client.js';
 import { createUpstreamMembershipSource } from '../upstream/memberships.js';
 import { getServiceVersion, SERVICE_NAME } from '../version.js';
@@ -100,30 +108,104 @@ export function handleRpcRequest(request: JsonRpcRequest): JsonRpcResponse | nul
   }
 }
 
-/**
- * Process a raw (already string-decoded) request body into a JSON-RPC response.
- * Returns `null` for notifications. Never throws for malformed input — it maps
- * to the appropriate JSON-RPC error instead.
- */
-export function handleMcpBody(raw: string): JsonRpcResponse | null {
+/** Parse a raw body into a JSON-RPC request or a terminal error response. */
+function parseMcpBody(raw: string): { request: JsonRpcRequest } | { response: JsonRpcResponse } {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch {
-    return failure(null, JsonRpcErrorCode.ParseError, 'Parse error: body is not valid JSON');
+    return {
+      response: failure(null, JsonRpcErrorCode.ParseError, 'Parse error: body is not valid JSON'),
+    };
   }
 
   // JSON-RPC batching is not supported by MCP 2025-06-18.
   if (Array.isArray(parsed)) {
-    return failure(null, JsonRpcErrorCode.InvalidRequest, 'Batch requests are not supported');
+    return {
+      response: failure(null, JsonRpcErrorCode.InvalidRequest, 'Batch requests are not supported'),
+    };
   }
 
   const request = asJsonRpcRequest(parsed);
   if (!request) {
-    return failure(null, JsonRpcErrorCode.InvalidRequest, 'Invalid JSON-RPC 2.0 request');
+    return {
+      response: failure(null, JsonRpcErrorCode.InvalidRequest, 'Invalid JSON-RPC 2.0 request'),
+    };
+  }
+  return { request };
+}
+
+/**
+ * Process a raw (already string-decoded) request body into a JSON-RPC response.
+ * Returns `null` for notifications. Never throws for malformed input — it maps
+ * to the appropriate JSON-RPC error instead. Synchronous path: does not execute
+ * registry tools (see {@link dispatchMcpBody}).
+ */
+export function handleMcpBody(raw: string): JsonRpcResponse | null {
+  const parsed = parseMcpBody(raw);
+  return 'response' in parsed ? parsed.response : handleRpcRequest(parsed.request);
+}
+
+/** Per-request context for the authenticated tool-dispatch path. */
+export interface McpDispatchContext {
+  auth: McpAuthContext;
+  correlationId: string;
+  /** Caller's Authorization header value, forwarded upstream (never logged). */
+  authorization?: string;
+}
+
+/**
+ * Async dispatch used by the HTTP handler. Handles `tools/list` (curated
+ * registry + the smoke tool) and `tools/call` for registered tools (validation
+ * → policy → execution), delegating everything else to {@link handleRpcRequest}.
+ */
+export async function dispatchMcpRequest(
+  request: JsonRpcRequest,
+  context: McpDispatchContext,
+): Promise<JsonRpcResponse | null> {
+  if (isNotification(request)) {
+    return null;
+  }
+  const id = request.id ?? null;
+
+  if (request.method === 'tools/list') {
+    return success(id, { tools: [...listedTools, ...toolRegistry.describe()] });
+  }
+
+  if (request.method === 'tools/call') {
+    const params = (request.params ?? {}) as { name?: unknown; arguments?: unknown };
+    const name = typeof params.name === 'string' ? params.name : '';
+    if (name === SMOKE_TOOL_NAME) {
+      return success(id, runSmokeTool(params.arguments));
+    }
+    const tool = toolRegistry.get(name);
+    if (!tool) {
+      return failure(id, JsonRpcErrorCode.InvalidParams, `Unknown tool: ${name}`);
+    }
+    const result = await executeRegisteredTool({
+      tool,
+      rawArgs: params.arguments,
+      auth: context.auth,
+      correlationId: context.correlationId,
+      authorization: context.authorization,
+      client: getUpstreamClient(),
+    });
+    return success(id, result);
   }
 
   return handleRpcRequest(request);
+}
+
+/** Parse + async-dispatch a raw body. Returns `null` for notifications. */
+export async function dispatchMcpBody(
+  raw: string,
+  context: McpDispatchContext,
+): Promise<JsonRpcResponse | null> {
+  const parsed = parseMcpBody(raw);
+  if ('response' in parsed) {
+    return parsed.response;
+  }
+  return dispatchMcpRequest(parsed.request, context);
 }
 
 function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
@@ -247,7 +329,20 @@ export async function mcpHttpHandler(req: IncomingMessage, res: ServerResponse):
     return;
   }
 
-  const response = handleMcpBody(raw);
+  const auth = getAuthContext(req);
+  if (!auth) {
+    // Should be set by authenticate(); treat an unexpected miss as internal.
+    log('error', 'authenticated request is missing its auth context');
+    sendJson(res, 500, failure(null, JsonRpcErrorCode.InternalError, 'Internal server error'));
+    return;
+  }
+
+  const response = await dispatchMcpBody(raw, {
+    auth,
+    correlationId: getRequestContext(req)?.correlationId ?? '',
+    authorization:
+      typeof req.headers.authorization === 'string' ? req.headers.authorization : undefined,
+  });
 
   if (response === null) {
     // Notification: acknowledge without a JSON-RPC response body.

--- a/packages/mcp-server/src/tools/__tests__/charges.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/charges.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { searchChargesTool } from '../charges.js';
+import { executeRegisteredTool } from '../execute.js';
+
+function authContext(businessIds: string[]): McpAuthContext {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: [],
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+  return buildAuthContext(
+    principal,
+    businessIds.map(businessId => ({ businessId, roleId: 'accountant' })),
+  );
+}
+
+function clientReturning(data: unknown, capture?: (body: unknown) => void) {
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    capture?.(JSON.parse(init.body as string));
+    return { ok: true, status: 200, json: async () => ({ data }) } as unknown as Response;
+  });
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+function run(client: UpstreamGraphQLClient, auth: McpAuthContext, rawArgs: unknown) {
+  return executeRegisteredTool({
+    tool: searchChargesTool,
+    rawArgs,
+    auth,
+    correlationId: 'corr-1',
+    client,
+    authorization: 'Bearer tok',
+  });
+}
+
+const oneCharge = {
+  allCharges: {
+    nodes: [
+      {
+        id: 'c1',
+        userDescription: 'Coffee',
+        totalAmount: { raw: 12.5, formatted: '₪12.50', currency: 'ILS' },
+        minEventDate: '2026-01-05',
+      },
+    ],
+    pageInfo: { totalPages: 1, totalRecords: 1, currentPage: 1, pageSize: 25 },
+  },
+};
+
+describe('searchChargesTool — successful read', () => {
+  it('normalizes charges and pagination', async () => {
+    const client = clientReturning(oneCharge);
+    const result = await run(client, authContext(['b1']), { fromDate: '2026-01-01' });
+
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as {
+      charges: Array<{ id: string; amount: { value: number } | null }>;
+      pagination: { totalRecords: number; hasNextPage: boolean };
+    };
+    expect(structured.charges).toEqual([
+      {
+        id: 'c1',
+        description: 'Coffee',
+        amount: { value: 12.5, formatted: '₪12.50', currency: 'ILS' },
+        date: '2026-01-05',
+      },
+    ]);
+    expect(structured.pagination.totalRecords).toBe(1);
+    expect(structured.pagination.hasNextPage).toBe(false);
+  });
+
+  it('scopes the query to the authorized businesses (byBusinesses)', async () => {
+    let sentBody: unknown;
+    const client = clientReturning(oneCharge, body => (sentBody = body));
+    await run(client, authContext(['b1', 'b2']), {});
+    const variables = (sentBody as { variables: { filters: { byBusinesses: string[] } } }).variables;
+    expect(variables.filters.byBusinesses).toEqual(['b1', 'b2']);
+  });
+
+  it('narrows the scope to a requested subset', async () => {
+    let sentBody: unknown;
+    const client = clientReturning(oneCharge, body => (sentBody = body));
+    await run(client, authContext(['b1', 'b2', 'b3']), { businessIds: ['b2'] });
+    const variables = (sentBody as { variables: { filters: { byBusinesses: string[] } } }).variables;
+    expect(variables.filters.byBusinesses).toEqual(['b2']);
+  });
+});
+
+describe('searchChargesTool — empty results', () => {
+  it('reports no matches', async () => {
+    const client = clientReturning({
+      allCharges: {
+        nodes: [],
+        pageInfo: { totalPages: 0, totalRecords: 0, currentPage: 1, pageSize: 25 },
+      },
+    });
+    const result = await run(client, authContext(['b1']), {});
+    expect(result.isError).toBeUndefined();
+    expect((result.structuredContent as { charges: unknown[] }).charges).toEqual([]);
+    expect(result.content[0].text).toMatch(/No charges/);
+  });
+});
+
+describe('searchChargesTool — invalid filters', () => {
+  it('rejects an unknown field (VALIDATION_ERROR)', async () => {
+    const client = clientReturning(oneCharge);
+    const result = await run(client, authContext(['b1']), { bogus: true });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects a bad date format', async () => {
+    const client = clientReturning(oneCharge);
+    const result = await run(client, authContext(['b1']), { fromDate: '01/01/2026' });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects an inverted date range', async () => {
+    const client = clientReturning(oneCharge);
+    const result = await run(client, authContext(['b1']), {
+      fromDate: '2026-02-01',
+      toDate: '2026-01-01',
+    });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { message: string }).message).toMatch(/on or before/);
+  });
+
+  it('rejects a page size above the cap', async () => {
+    const client = clientReturning(oneCharge);
+    const result = await run(client, authContext(['b1']), { pageSize: 500 });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('searchChargesTool — scope enforcement', () => {
+  it('denies a requested business outside the memberships (AUTHORIZATION_ERROR)', async () => {
+    const client = clientReturning(oneCharge);
+    const result = await run(client, authContext(['b1']), { businessIds: ['bX'] });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('AUTHORIZATION_ERROR');
+  });
+
+  it('denies a caller with no business memberships', async () => {
+    const client = clientReturning(oneCharge);
+    const result = await run(client, authContext([]), {});
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('AUTHORIZATION_ERROR');
+  });
+});
+
+describe('searchChargesTool — upstream failure', () => {
+  it('maps an upstream error to a retryable UPSTREAM/TIMEOUT result', async () => {
+    const fetchImpl = vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) }) as unknown as Response);
+    const client = new UpstreamGraphQLClient({
+      endpoint: 'http://localhost:4000/graphql',
+      timeoutMs: 1000,
+      maxRetries: 0,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const result = await run(client, authContext(['b1']), {});
+    expect(result.isError).toBe(true);
+    const structured = result.structuredContent as { code: string; retryable: boolean };
+    expect(structured.code).toBe('UPSTREAM_ERROR');
+    expect(structured.retryable).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/charges.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/charges.test.ts
@@ -127,6 +127,14 @@ describe('searchChargesTool — invalid filters', () => {
     expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
   });
 
+  it('rejects a single impossible date that still matches the format', async () => {
+    const client = clientReturning(oneCharge);
+    // Passes the regex but is an impossible calendar date; only fromDate given.
+    const result = await run(client, authContext(['b1']), { fromDate: '2026-13-01' });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { message: string }).message).toBe('Invalid fromDate');
+  });
+
   it('rejects an inverted date range', async () => {
     const client = clientReturning(oneCharge);
     const result = await run(client, authContext(['b1']), {

--- a/packages/mcp-server/src/tools/__tests__/charges.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/charges.test.ts
@@ -95,6 +95,22 @@ describe('searchChargesTool — successful read', () => {
     const variables = (sentBody as { variables: { filters: { byBusinesses: string[] } } }).variables;
     expect(variables.filters.byBusinesses).toEqual(['b2']);
   });
+
+  it('requests the first upstream page (0-based) for the default page', async () => {
+    let sentBody: unknown;
+    const client = clientReturning(oneCharge, body => (sentBody = body));
+    await run(client, authContext(['b1']), {});
+    const variables = (sentBody as { variables: { page: number } }).variables;
+    expect(variables.page).toBe(0);
+  });
+
+  it('translates the 1-based page to the upstream 0-based page index', async () => {
+    let sentBody: unknown;
+    const client = clientReturning(oneCharge, body => (sentBody = body));
+    await run(client, authContext(['b1']), { page: 2 });
+    const variables = (sentBody as { variables: { page: number } }).variables;
+    expect(variables.page).toBe(1);
+  });
 });
 
 describe('searchChargesTool — empty results', () => {
@@ -133,6 +149,16 @@ describe('searchChargesTool — invalid filters', () => {
     const result = await run(client, authContext(['b1']), { fromDate: '2026-13-01' });
     expect(result.isError).toBe(true);
     expect((result.structuredContent as { message: string }).message).toBe('Invalid fromDate');
+  });
+
+  it('rejects a day-overflow date that Date.parse would silently roll over', async () => {
+    const client = clientReturning(oneCharge);
+    // 2026-02-31 is not a real date; Date.parse rolls it to March, so it must be
+    // caught by explicit calendar validation, not just a NaN check.
+    const result = await run(client, authContext(['b1']), { toDate: '2026-02-31' });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+    expect((result.structuredContent as { message: string }).message).toBe('Invalid toDate');
   });
 
   it('rejects an inverted date range', async () => {

--- a/packages/mcp-server/src/tools/charges.ts
+++ b/packages/mcp-server/src/tools/charges.ts
@@ -1,0 +1,186 @@
+import { z } from 'zod';
+import { ToolInputError } from './execute.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+
+/**
+ * Tool 1: read-only charges search/browse (spec §8.2).
+ *
+ * Results are always scoped to the caller's authorized businesses (the resolved
+ * read scope), with bounded pagination and a bounded date range.
+ */
+
+export const SEARCH_CHARGES_TOOL_NAME = 'accounter_search_charges';
+
+/** Hard caps to keep responses bounded (spec §9.1, §9.3). */
+export const MAX_PAGE_SIZE = 50;
+export const DEFAULT_PAGE_SIZE = 25;
+export const MAX_DATE_RANGE_DAYS = 366;
+
+const TIMELESS_DATE = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format');
+
+const searchChargesInput = z.object({
+  businessIds: z
+    .array(z.string().min(1))
+    .max(50)
+    .optional()
+    .describe('Narrow results to these business ids (must be a subset of your memberships).'),
+  fromDate: TIMELESS_DATE.optional().describe('Only charges on/after this date (YYYY-MM-DD).'),
+  toDate: TIMELESS_DATE.optional().describe('Only charges on/before this date (YYYY-MM-DD).'),
+  tags: z.array(z.string().min(1)).max(20).optional().describe('Only charges carrying these tags.'),
+  freeText: z.string().min(1).max(200).optional().describe('Free-text search across the charge.'),
+  flow: z
+    .enum(['ALL', 'INCOME', 'EXPENSE'])
+    .optional()
+    .default('ALL')
+    .describe('Restrict to income or expense charges.'),
+  page: z.number().int().positive().optional().default(1),
+  pageSize: z.number().int().positive().max(MAX_PAGE_SIZE).optional().default(DEFAULT_PAGE_SIZE),
+});
+
+type SearchChargesInput = z.infer<typeof searchChargesInput>;
+
+const SEARCH_CHARGES_QUERY = /* GraphQL */ `
+  query McpSearchCharges($filters: ChargeFilter, $page: Int!, $limit: Int!) {
+    allCharges(filters: $filters, page: $page, limit: $limit) {
+      nodes {
+        id
+        userDescription
+        totalAmount {
+          raw
+          formatted
+          currency
+        }
+        minEventDate
+      }
+      pageInfo {
+        totalPages
+        totalRecords
+        currentPage
+        pageSize
+      }
+    }
+  }
+`;
+
+interface RawCharge {
+  id: string;
+  userDescription: string | null;
+  totalAmount: { raw: number; formatted: string; currency: string } | null;
+  minEventDate: string | null;
+}
+
+interface SearchChargesData {
+  allCharges: {
+    nodes: RawCharge[];
+    pageInfo: {
+      totalPages: number;
+      totalRecords: number;
+      currentPage: number | null;
+      pageSize: number | null;
+    };
+  };
+}
+
+/** Normalized charge shape returned to the caller. */
+export interface NormalizedCharge {
+  id: string;
+  description: string | null;
+  amount: { value: number; formatted: string; currency: string } | null;
+  date: string | null;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Reject an inverted or too-wide date range before hitting the upstream. */
+function assertDateRange(input: SearchChargesInput): void {
+  if (!input.fromDate || !input.toDate) {
+    return;
+  }
+  const from = Date.parse(input.fromDate);
+  const to = Date.parse(input.toDate);
+  if (Number.isNaN(from) || Number.isNaN(to)) {
+    throw new ToolInputError('Invalid fromDate/toDate');
+  }
+  if (from > to) {
+    throw new ToolInputError('fromDate must be on or before toDate');
+  }
+  if ((to - from) / DAY_MS > MAX_DATE_RANGE_DAYS) {
+    throw new ToolInputError(`Date range must not exceed ${MAX_DATE_RANGE_DAYS} days`);
+  }
+}
+
+function buildFilters(input: SearchChargesInput, businessIds: readonly string[]) {
+  const filters: Record<string, unknown> = { chargesType: input.flow };
+  // Always scope to the authorized businesses.
+  if (businessIds.length > 0) {
+    filters.byBusinesses = [...businessIds];
+  }
+  if (input.fromDate) filters.fromDate = input.fromDate;
+  if (input.toDate) filters.toDate = input.toDate;
+  if (input.tags && input.tags.length > 0) filters.byTags = input.tags;
+  if (input.freeText) filters.freeText = input.freeText;
+  return filters;
+}
+
+function normalizeCharge(charge: RawCharge): NormalizedCharge {
+  return {
+    id: charge.id,
+    description: charge.userDescription,
+    amount: charge.totalAmount
+      ? {
+          value: charge.totalAmount.raw,
+          formatted: charge.totalAmount.formatted,
+          currency: charge.totalAmount.currency,
+        }
+      : null,
+    date: charge.minEventDate,
+  };
+}
+
+async function handler(
+  input: SearchChargesInput,
+  context: ToolExecutionContext,
+): Promise<ToolResult> {
+  assertDateRange(input);
+
+  const data = await context.client.query<SearchChargesData>(
+    {
+      query: SEARCH_CHARGES_QUERY,
+      variables: {
+        filters: buildFilters(input, context.readScope.businessIds),
+        page: input.page,
+        limit: input.pageSize,
+      },
+    },
+    { correlationId: context.correlationId, authorization: context.authorization },
+  );
+
+  const charges = data.allCharges.nodes.map(normalizeCharge);
+  const { pageInfo } = data.allCharges;
+  const pagination = {
+    page: pageInfo.currentPage ?? input.page,
+    pageSize: pageInfo.pageSize ?? input.pageSize,
+    totalPages: pageInfo.totalPages,
+    totalRecords: pageInfo.totalRecords,
+    hasNextPage: (pageInfo.currentPage ?? input.page) < pageInfo.totalPages,
+  };
+
+  const summary =
+    charges.length === 0
+      ? 'No charges matched the given filters.'
+      : `Found ${pagination.totalRecords} charge(s); showing page ${pagination.page} of ${pagination.totalPages} (${charges.length} on this page).`;
+
+  return {
+    content: [{ type: 'text', text: summary }],
+    structuredContent: { charges, pagination },
+  };
+}
+
+export const searchChargesTool: ToolDefinition<typeof searchChargesInput> = {
+  name: SEARCH_CHARGES_TOOL_NAME,
+  description:
+    'Search and browse accounting charges within your authorized businesses. Supports date range, tag, free-text, and income/expense filters with bounded pagination. Read-only.',
+  inputSchema: searchChargesInput,
+  policy: { requiresBusinessScope: true, dataClassification: 'business' },
+  handler,
+};

--- a/packages/mcp-server/src/tools/charges.ts
+++ b/packages/mcp-server/src/tools/charges.ts
@@ -91,21 +91,25 @@ export interface NormalizedCharge {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-/** Reject an inverted or too-wide date range before hitting the upstream. */
+/** Reject an invalid, inverted, or too-wide date range before hitting upstream. */
 function assertDateRange(input: SearchChargesInput): void {
-  if (!input.fromDate || !input.toDate) {
-    return;
+  // Validate each supplied date even when only one is present — a value can
+  // match the format regex yet be an impossible calendar date (e.g. 2026-02-31).
+  const from = input.fromDate ? Date.parse(input.fromDate) : undefined;
+  const to = input.toDate ? Date.parse(input.toDate) : undefined;
+  if (from !== undefined && Number.isNaN(from)) {
+    throw new ToolInputError('Invalid fromDate');
   }
-  const from = Date.parse(input.fromDate);
-  const to = Date.parse(input.toDate);
-  if (Number.isNaN(from) || Number.isNaN(to)) {
-    throw new ToolInputError('Invalid fromDate/toDate');
+  if (to !== undefined && Number.isNaN(to)) {
+    throw new ToolInputError('Invalid toDate');
   }
-  if (from > to) {
-    throw new ToolInputError('fromDate must be on or before toDate');
-  }
-  if ((to - from) / DAY_MS > MAX_DATE_RANGE_DAYS) {
-    throw new ToolInputError(`Date range must not exceed ${MAX_DATE_RANGE_DAYS} days`);
+  if (from !== undefined && to !== undefined) {
+    if (from > to) {
+      throw new ToolInputError('fromDate must be on or before toDate');
+    }
+    if (Math.round((to - from) / DAY_MS) > MAX_DATE_RANGE_DAYS) {
+      throw new ToolInputError(`Date range must not exceed ${MAX_DATE_RANGE_DAYS} days`);
+    }
   }
 }
 

--- a/packages/mcp-server/src/tools/charges.ts
+++ b/packages/mcp-server/src/tools/charges.ts
@@ -91,17 +91,45 @@ export interface NormalizedCharge {
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Parse a strict `YYYY-MM-DD` string to a UTC timestamp, or `null` if it is not a
+ * real calendar date. `Date.parse` alone is unsafe here: it silently rolls
+ * impossible dates over (e.g. `2026-02-31` → `2026-03-03`) instead of failing, so
+ * we verify the parsed components round-trip back to the input.
+ */
+function parseCalendarDate(value: string): number | null {
+  const [year, month, day] = value.split('-').map(Number);
+  const timestamp = Date.UTC(year, month - 1, day);
+  const date = new Date(timestamp);
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return timestamp;
+}
+
 /** Reject an invalid, inverted, or too-wide date range before hitting upstream. */
 function assertDateRange(input: SearchChargesInput): void {
   // Validate each supplied date even when only one is present — a value can
   // match the format regex yet be an impossible calendar date (e.g. 2026-02-31).
-  const from = input.fromDate ? Date.parse(input.fromDate) : undefined;
-  const to = input.toDate ? Date.parse(input.toDate) : undefined;
-  if (from !== undefined && Number.isNaN(from)) {
-    throw new ToolInputError('Invalid fromDate');
+  let from: number | undefined;
+  let to: number | undefined;
+  if (input.fromDate !== undefined) {
+    const parsed = parseCalendarDate(input.fromDate);
+    if (parsed === null) {
+      throw new ToolInputError('Invalid fromDate');
+    }
+    from = parsed;
   }
-  if (to !== undefined && Number.isNaN(to)) {
-    throw new ToolInputError('Invalid toDate');
+  if (input.toDate !== undefined) {
+    const parsed = parseCalendarDate(input.toDate);
+    if (parsed === null) {
+      throw new ToolInputError('Invalid toDate');
+    }
+    to = parsed;
   }
   if (from !== undefined && to !== undefined) {
     if (from > to) {
@@ -152,7 +180,10 @@ async function handler(
       query: SEARCH_CHARGES_QUERY,
       variables: {
         filters: buildFilters(input, context.readScope.businessIds),
-        page: input.page,
+        // The tool exposes a 1-based `page`, but upstream `allCharges` is 0-based
+        // (it slices `[page * limit, (page + 1) * limit]`), so translate here —
+        // otherwise page 1 would skip the first page of results.
+        page: input.page - 1,
         limit: input.pageSize,
       },
     },

--- a/packages/mcp-server/src/tools/execute.ts
+++ b/packages/mcp-server/src/tools/execute.ts
@@ -1,4 +1,5 @@
 import type { McpAuthContext } from '../auth/identity.js';
+import { log } from '../logger.js';
 import { UpstreamError } from '../upstream/graphql-client.js';
 import type { UpstreamGraphQLClient } from '../upstream/graphql-client.js';
 import { evaluateToolPolicy } from './policy.js';
@@ -147,6 +148,15 @@ export async function executeRegisteredTool(params: ExecuteToolParams): Promise<
         retryable: error.retryable,
       });
     }
+    // Unexpected failure — log it (with the tool + correlation id) so the
+    // observability gap doesn't hide production bugs; the caller only sees a
+    // generic message.
+    log('error', 'unexpected error during tool execution', {
+      tool: tool.name,
+      correlationId,
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
     return toolErrorResult({
       code: 'INTERNAL_ERROR',
       message: 'Tool execution failed',

--- a/packages/mcp-server/src/tools/execute.ts
+++ b/packages/mcp-server/src/tools/execute.ts
@@ -1,0 +1,156 @@
+import type { McpAuthContext } from '../auth/identity.js';
+import { UpstreamError } from '../upstream/graphql-client.js';
+import type { UpstreamGraphQLClient } from '../upstream/graphql-client.js';
+import { evaluateToolPolicy } from './policy.js';
+import {
+  validateToolInput,
+  type ToolDefinition,
+  type ToolExecutionContext,
+  type ToolResult,
+  type ToolValidationIssue,
+} from './registry.js';
+
+/**
+ * Curated tool execution: input validation → authorization policy → handler,
+ * with deterministic error mapping to the spec's error taxonomy (§10.2).
+ *
+ * Tool-execution failures are returned as an MCP tool result with `isError`
+ * and a structured `{ code, message, correlationId, retryable? }` payload (the
+ * unified error mapper in a later step formalizes this shape) rather than as
+ * protocol-level JSON-RPC errors, so the model can read them.
+ */
+
+/** Machine error codes surfaced to tool callers (spec §10.2). */
+export type ToolErrorCode =
+  | 'VALIDATION_ERROR'
+  | 'AUTHORIZATION_ERROR'
+  | 'UPSTREAM_ERROR'
+  | 'TIMEOUT_ERROR'
+  | 'INTERNAL_ERROR';
+
+/**
+ * A domain-validation failure a handler can throw (e.g. cross-field bounds not
+ * expressible in the input schema). Mapped to a VALIDATION_ERROR result.
+ */
+export class ToolInputError extends Error {
+  public readonly code = 'VALIDATION_ERROR';
+
+  constructor(
+    message: string,
+    public readonly issues?: ToolValidationIssue[],
+  ) {
+    super(message);
+    this.name = 'ToolInputError';
+  }
+}
+
+interface ToolErrorDetails {
+  code: ToolErrorCode;
+  message: string;
+  correlationId: string;
+  retryable?: boolean;
+  issues?: ToolValidationIssue[];
+}
+
+/** Build an MCP tool-result error carrying the taxonomy fields. */
+export function toolErrorResult(details: ToolErrorDetails): ToolResult {
+  return {
+    content: [{ type: 'text', text: `${details.code}: ${details.message}` }],
+    isError: true,
+    structuredContent: {
+      code: details.code,
+      message: details.message,
+      correlationId: details.correlationId,
+      ...(details.retryable !== undefined && { retryable: details.retryable }),
+      ...(details.issues && details.issues.length > 0 && { issues: details.issues }),
+    },
+  };
+}
+
+/** Optional per-tool convention: an input field carrying scope narrowing. */
+function requestedBusinessIds(input: unknown): string[] | undefined {
+  if (input && typeof input === 'object') {
+    const value = (input as { businessIds?: unknown }).businessIds;
+    if (Array.isArray(value) && value.every(id => typeof id === 'string')) {
+      return value as string[];
+    }
+  }
+  return undefined;
+}
+
+export interface ExecuteToolParams {
+  tool: ToolDefinition;
+  rawArgs: unknown;
+  auth: McpAuthContext;
+  correlationId: string;
+  client: UpstreamGraphQLClient;
+  authorization?: string;
+}
+
+/**
+ * Validate, authorize, and execute a registered tool. Always resolves to a
+ * {@link ToolResult} — success or a taxonomy-tagged error result.
+ */
+export async function executeRegisteredTool(params: ExecuteToolParams): Promise<ToolResult> {
+  const { tool, rawArgs, auth, correlationId, client, authorization } = params;
+
+  // 1. Strict input validation (unknown fields rejected).
+  const validation = validateToolInput(tool, rawArgs);
+  if (!validation.ok) {
+    return toolErrorResult({
+      code: 'VALIDATION_ERROR',
+      message: validation.error.message,
+      correlationId,
+      issues: validation.error.issues,
+    });
+  }
+  const input = validation.data;
+
+  // 2. Authorization policy (roles + business scope narrowing).
+  const decision = evaluateToolPolicy({
+    policy: tool.policy,
+    auth,
+    requestedBusinessIds: requestedBusinessIds(input),
+  });
+  if (!decision.allowed) {
+    return toolErrorResult({
+      code: 'AUTHORIZATION_ERROR',
+      message: decision.error.message,
+      correlationId,
+    });
+  }
+
+  // 3. Execute the handler.
+  const context: ToolExecutionContext = {
+    auth,
+    readScope: decision.readScope,
+    correlationId,
+    client,
+    authorization,
+  };
+  try {
+    return await tool.handler(input, context);
+  } catch (error) {
+    if (error instanceof ToolInputError) {
+      return toolErrorResult({
+        code: 'VALIDATION_ERROR',
+        message: error.message,
+        correlationId,
+        issues: error.issues,
+      });
+    }
+    if (error instanceof UpstreamError) {
+      return toolErrorResult({
+        code: error.code,
+        message: error.message,
+        correlationId,
+        retryable: error.retryable,
+      });
+    }
+    return toolErrorResult({
+      code: 'INTERNAL_ERROR',
+      message: 'Tool execution failed',
+      correlationId,
+    });
+  }
+}

--- a/packages/mcp-server/src/tools/registry-instance.ts
+++ b/packages/mcp-server/src/tools/registry-instance.ts
@@ -1,0 +1,10 @@
+import { searchChargesTool } from './charges.js';
+import { ToolRegistry } from './registry.js';
+
+/**
+ * The process-wide registry of curated production tools. Tools register here as
+ * they are added; the MCP transport lists and dispatches from this instance.
+ */
+export const toolRegistry = new ToolRegistry();
+
+toolRegistry.register(searchChargesTool);

--- a/packages/mcp-server/src/tools/registry.ts
+++ b/packages/mcp-server/src/tools/registry.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { AuthorizedReadScope, McpAuthContext } from '../auth/identity.js';
+import type { UpstreamGraphQLClient } from '../upstream/graphql-client.js';
 
 /**
  * Curated tool registry abstraction.
@@ -34,6 +35,10 @@ export interface ToolExecutionContext {
   readScope: AuthorizedReadScope;
   /** Correlation id for tracing/log/upstream propagation. */
   correlationId: string;
+  /** Shared upstream GraphQL client for read-only operations. */
+  client: UpstreamGraphQLClient;
+  /** Caller's Authorization header, forwarded upstream (never logged). */
+  authorization?: string;
 }
 
 export interface ToolTextContent {


### PR DESCRIPTION
## Summary

Implements **Prompt 13 – Tool 1: charges search/browse (read-only)** (see
[`docs/mcp/spec.md`](../blob/main/docs/mcp/spec.md) §8). Adds the first
production tool and wires the curated registry into the live `POST /mcp` path.

> **Stacked PR:** targets `claude/mcp-prompt-12-graphql-client` (Prompt 12, #4013).
> Review/merge Prompts 09→12 first; this diff shows only the Prompt 13 changes.

## Changes

- **`src/tools/charges.ts`** — `accounter_search_charges`: read-only `allCharges` query, always scoped to the caller's authorized businesses (`byBusinesses` = resolved read scope). Strict input: optional `businessIds` (scope narrowing), `fromDate`/`toDate` (bounded to **366 days**, format-checked), `tags`, `freeText`, `flow` (`ALL`/`INCOME`/`EXPENSE`), and bounded pagination (`pageSize` ≤ **50**). Returns normalized charges + pagination metadata.
- **`src/tools/execute.ts`** — `executeRegisteredTool`: validation → policy → handler, mapping failures to MCP tool results with `isError` and `{ code, message, correlationId, retryable? }` (`VALIDATION_ERROR`, `AUTHORIZATION_ERROR`, `UPSTREAM_ERROR`, `TIMEOUT_ERROR`, `INTERNAL_ERROR`). `ToolInputError` lets handlers raise domain validation (e.g. date bounds).
- **`src/tools/registry-instance.ts`** — process-wide registry with the charges tool registered.
- **`src/mcp/handler.ts`** — async dispatch (`dispatchMcpBody`/`dispatchMcpRequest`): `tools/list` now returns the smoke tool **plus** the registry's tools, and `tools/call` executes registered tools. `ToolExecutionContext` carries the upstream client + `authorization`; the client is built lazily so unauthenticated/basic paths never touch upstream config.
- **Tests** — charges: successful read (normalized), empty results, invalid filters (unknown field, bad date, inverted range, oversized page), scope narrowing + enforcement, and upstream-failure mapping; dispatch lists the tool and rejects unknown names. 153 tests total.

## Validation

- `yarn workspace @accounter/mcp-server test` → 153 passed
- `yarn workspace @accounter/mcp-server lint` / `typecheck` / `build` → pass

## Notes / open decisions

- **GraphQL query accuracy.** The query targets the real server schema (`allCharges(filters: ChargeFilter, page, limit): PaginatedCharges`, `PageInfo`, `FinancialAmount`) verified from `packages/server`. Tests mock the upstream, so field selections aren't live-validated — worth a smoke check against a running server before release.
- **Tool-error convention.** Execution failures are returned as `tools/call` **results** with `isError: true` (per MCP), not JSON-RPC protocol errors; only unknown-tool / malformed params stay protocol-level (`InvalidParams`). The unified error mapper (Prompt 17) will formalize this shape.
- **Scope narrowing input.** By convention a tool's optional `businessIds` field drives policy scope narrowing; the resolved scope is what the handler queries with. Happy to move this to an MCP-level param instead if preferred.
- The smoke tool remains listed alongside the production tool; it's removed at final wiring (Prompt 24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_