### PR TITLE
feat(mcp-server): balance report tool (MCP Prompt 15)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -37,6 +37,9 @@ payload (spec §10.2): `VALIDATION_ERROR`, `AUTHORIZATION_ERROR`, `UPSTREAM_ERRO
   Deterministically sorted (name, then id) and size-capped (≤ 500).
 - **`accounter_list_tax_categories`** — list tax categories (id, name, IRS code, bookkeeping sort
   code, active flag), optionally filtered by name or active status. Same deterministic sort + cap.
+- **`accounter_balance_report`** — read-only balance report (transactions) for one of your
+  businesses over a bounded date range (≤ 366 days). Requires `business_owner`/`accountant` role;
+  rows are capped at 500 with a `truncated` flag.
 
 ## Upstream GraphQL client
 

--- a/packages/mcp-server/src/tools/__tests__/reports.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/reports.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { executeRegisteredTool } from '../execute.js';
+import { balanceReportTool, MAX_REPORT_ROWS } from '../reports.js';
+
+function authContext(businessIds: string[], roles: string[] = ['accountant']): McpAuthContext {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: roles,
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+  return buildAuthContext(
+    principal,
+    businessIds.map(businessId => ({ businessId, roleId: 'accountant' })),
+  );
+}
+
+function clientReturning(rows: unknown[], capture?: (body: unknown) => void) {
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    capture?.(JSON.parse(init.body as string));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { transactionsForBalanceReport: rows } }),
+    } as unknown as Response;
+  });
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+function row(id: string) {
+  return {
+    id,
+    chargeId: `charge-${id}`,
+    date: '2026-01-05',
+    isFee: false,
+    description: 'x',
+    amount: { raw: 10, formatted: '₪10', currency: 'ILS' },
+  };
+}
+
+const run = (client: UpstreamGraphQLClient, auth: McpAuthContext, rawArgs: unknown) =>
+  executeRegisteredTool({
+    tool: balanceReportTool,
+    rawArgs,
+    auth,
+    correlationId: 'c',
+    client,
+    authorization: 'Bearer t',
+  });
+
+const validArgs = { businessId: 'b1', fromDate: '2026-01-01', toDate: '2026-03-01' };
+
+describe('balanceReportTool — valid report', () => {
+  it('returns normalized rows scoped to the requested business (ownerId)', async () => {
+    let sent: unknown;
+    const client = clientReturning([row('t1')], body => (sent = body));
+    const result = await run(client, authContext(['b1', 'b2']), validArgs);
+
+    expect(result.isError).toBeUndefined();
+    expect((sent as { variables: { ownerId: string } }).variables.ownerId).toBe('b1');
+    const structured = result.structuredContent as { rows: unknown[]; rowCount: number; businessId: string };
+    expect(structured.businessId).toBe('b1');
+    expect(structured.rowCount).toBe(1);
+    expect(structured.rows).toEqual([
+      {
+        id: 't1',
+        chargeId: 'charge-t1',
+        date: '2026-01-05',
+        isFee: false,
+        description: 'x',
+        amount: { value: 10, formatted: '₪10', currency: 'ILS' },
+      },
+    ]);
+  });
+});
+
+describe('balanceReportTool — invalid range', () => {
+  it('rejects an inverted date range', async () => {
+    const client = clientReturning([]);
+    const result = await run(client, authContext(['b1']), {
+      businessId: 'b1',
+      fromDate: '2026-03-01',
+      toDate: '2026-01-01',
+    });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects a range wider than the cap', async () => {
+    const client = clientReturning([]);
+    const result = await run(client, authContext(['b1']), {
+      businessId: 'b1',
+      fromDate: '2024-01-01',
+      toDate: '2026-01-01',
+    });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { message: string }).message).toMatch(/must not exceed/);
+  });
+
+  it('rejects a bad date format', async () => {
+    const client = clientReturning([]);
+    const result = await run(client, authContext(['b1']), {
+      businessId: 'b1',
+      fromDate: '2026/01/01',
+      toDate: '2026-02-01',
+    });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('balanceReportTool — oversized results', () => {
+  it('caps rows at MAX_REPORT_ROWS and flags truncation', async () => {
+    const many = Array.from({ length: MAX_REPORT_ROWS + 5 }, (_, i) => row(`t${i}`));
+    const client = clientReturning(many);
+    const result = await run(client, authContext(['b1']), validArgs);
+    const structured = result.structuredContent as { rows: unknown[]; rowCount: number; truncated: boolean };
+    expect(structured.rows).toHaveLength(MAX_REPORT_ROWS);
+    expect(structured.rowCount).toBe(MAX_REPORT_ROWS + 5);
+    expect(structured.truncated).toBe(true);
+  });
+});
+
+describe('balanceReportTool — authorization', () => {
+  it('denies a caller without the required role', async () => {
+    const client = clientReturning([]);
+    const result = await run(client, authContext(['b1'], ['read:charges']), validArgs);
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('AUTHORIZATION_ERROR');
+  });
+
+  it('denies a business outside the caller memberships', async () => {
+    const client = clientReturning([]);
+    const result = await run(client, authContext(['b2']), validArgs);
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('AUTHORIZATION_ERROR');
+  });
+});

--- a/packages/mcp-server/src/tools/execute.ts
+++ b/packages/mcp-server/src/tools/execute.ts
@@ -68,13 +68,20 @@ export function toolErrorResult(details: ToolErrorDetails): ToolResult {
   };
 }
 
-/** Optional per-tool convention: an input field carrying scope narrowing. */
+/**
+ * Optional per-tool convention: input fields carrying scope narrowing. Either a
+ * `businessIds` array or a singular `businessId` string is honored.
+ */
 function requestedBusinessIds(input: unknown): string[] | undefined {
-  if (input && typeof input === 'object') {
-    const value = (input as { businessIds?: unknown }).businessIds;
-    if (Array.isArray(value) && value.every(id => typeof id === 'string')) {
-      return value as string[];
-    }
+  if (!input || typeof input !== 'object') {
+    return undefined;
+  }
+  const record = input as { businessIds?: unknown; businessId?: unknown };
+  if (Array.isArray(record.businessIds) && record.businessIds.every(id => typeof id === 'string')) {
+    return record.businessIds as string[];
+  }
+  if (typeof record.businessId === 'string') {
+    return [record.businessId];
   }
   return undefined;
 }

--- a/packages/mcp-server/src/tools/registry-instance.ts
+++ b/packages/mcp-server/src/tools/registry-instance.ts
@@ -1,6 +1,7 @@
 import { searchChargesTool } from './charges.js';
 import { listTagsTool, listTaxCategoriesTool } from './lookups.js';
 import { ToolRegistry } from './registry.js';
+import { balanceReportTool } from './reports.js';
 
 /**
  * The process-wide registry of curated production tools. Tools register here as
@@ -11,3 +12,4 @@ export const toolRegistry = new ToolRegistry();
 toolRegistry.register(searchChargesTool);
 toolRegistry.register(listTagsTool);
 toolRegistry.register(listTaxCategoriesTool);
+toolRegistry.register(balanceReportTool);

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -1,0 +1,143 @@
+import { z } from 'zod';
+import { ToolInputError } from './execute.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+
+/**
+ * Tool 3: a selected read-only report (spec §8.2).
+ *
+ * Phase 1 exposes one report — the balance report — for a single authorized
+ * business over a bounded date range. Output rows are capped to avoid large
+ * unbounded payloads. Role-gated to business owners / accountants.
+ */
+
+export const BALANCE_REPORT_TOOL_NAME = 'accounter_balance_report';
+
+/** Bounds keeping the payload deterministic and small (spec §9.1, §9.3). */
+export const MAX_REPORT_DATE_RANGE_DAYS = 366;
+export const MAX_REPORT_ROWS = 500;
+
+const TIMELESS_DATE = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format');
+
+const balanceReportInput = z.object({
+  businessId: z
+    .string()
+    .min(1)
+    .describe('The business to report on (must be one of your memberships).'),
+  fromDate: TIMELESS_DATE.describe('Start of the reporting period (YYYY-MM-DD).'),
+  toDate: TIMELESS_DATE.describe('End of the reporting period (YYYY-MM-DD).'),
+  reportType: z
+    .enum(['BALANCE'])
+    .optional()
+    .default('BALANCE')
+    .describe('Report type. Only BALANCE is supported in phase 1.'),
+});
+
+type BalanceReportInput = z.infer<typeof balanceReportInput>;
+
+const BALANCE_REPORT_QUERY = /* GraphQL */ `
+  query McpBalanceReport($fromDate: TimelessDate!, $toDate: TimelessDate!, $ownerId: UUID) {
+    transactionsForBalanceReport(fromDate: $fromDate, toDate: $toDate, ownerId: $ownerId) {
+      id
+      chargeId
+      date
+      isFee
+      description
+      amount {
+        raw
+        formatted
+        currency
+      }
+    }
+  }
+`;
+
+interface RawBalanceRow {
+  id: string;
+  chargeId: string;
+  date: string;
+  isFee: boolean;
+  description: string | null;
+  amount: { raw: number; formatted: string; currency: string };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function assertDateRange(input: BalanceReportInput): void {
+  const from = Date.parse(input.fromDate);
+  const to = Date.parse(input.toDate);
+  if (Number.isNaN(from) || Number.isNaN(to)) {
+    throw new ToolInputError('Invalid fromDate/toDate');
+  }
+  if (from > to) {
+    throw new ToolInputError('fromDate must be on or before toDate');
+  }
+  if ((to - from) / DAY_MS > MAX_REPORT_DATE_RANGE_DAYS) {
+    throw new ToolInputError(`Date range must not exceed ${MAX_REPORT_DATE_RANGE_DAYS} days`);
+  }
+}
+
+async function handler(
+  input: BalanceReportInput,
+  context: ToolExecutionContext,
+): Promise<ToolResult> {
+  assertDateRange(input);
+
+  // Policy has already confirmed the requested business is within scope; use the
+  // narrowed scope as the single owner.
+  const ownerId = context.readScope.businessIds[0];
+
+  const data = await context.client.query<{ transactionsForBalanceReport: RawBalanceRow[] }>(
+    {
+      query: BALANCE_REPORT_QUERY,
+      variables: { fromDate: input.fromDate, toDate: input.toDate, ownerId },
+    },
+    { correlationId: context.correlationId, authorization: context.authorization },
+  );
+
+  const all = data.transactionsForBalanceReport;
+  const truncated = all.length > MAX_REPORT_ROWS;
+  const rows = all.slice(0, MAX_REPORT_ROWS).map(row => ({
+    id: row.id,
+    chargeId: row.chargeId,
+    date: row.date,
+    isFee: row.isFee,
+    description: row.description,
+    amount: {
+      value: row.amount.raw,
+      formatted: row.amount.formatted,
+      currency: row.amount.currency,
+    },
+  }));
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Balance report for ${input.fromDate}–${input.toDate}: ${all.length} transaction(s)${
+          truncated ? ` (showing first ${MAX_REPORT_ROWS})` : ''
+        }.`,
+      },
+    ],
+    structuredContent: {
+      reportType: input.reportType,
+      businessId: ownerId,
+      period: { fromDate: input.fromDate, toDate: input.toDate },
+      rows,
+      rowCount: all.length,
+      truncated,
+    },
+  };
+}
+
+export const balanceReportTool: ToolDefinition<typeof balanceReportInput> = {
+  name: BALANCE_REPORT_TOOL_NAME,
+  description:
+    'Generate a read-only balance report (transactions) for one of your businesses over a bounded date range. Requires business owner or accountant role.',
+  inputSchema: balanceReportInput,
+  policy: {
+    requiredRoles: ['business_owner', 'accountant'],
+    requiresBusinessScope: true,
+    dataClassification: 'business',
+  },
+  handler,
+};

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -83,8 +83,12 @@ async function handler(
   assertDateRange(input);
 
   // Policy has already confirmed the requested business is within scope; use the
-  // narrowed scope as the single owner.
+  // narrowed scope as the single owner. Assert defensively — a business-scoped
+  // tool must never reach upstream without a concrete owner.
   const ownerId = context.readScope.businessIds[0];
+  if (!ownerId) {
+    throw new ToolInputError('No authorized business in scope for this report');
+  }
 
   const data = await context.client.query<{ transactionsForBalanceReport: RawBalanceRow[] }>(
     {
@@ -94,7 +98,8 @@ async function handler(
     { correlationId: context.correlationId, authorization: context.authorization },
   );
 
-  const all = data.transactionsForBalanceReport;
+  // Defend against a null/absent list from a nullable upstream field.
+  const all = data.transactionsForBalanceReport ?? [];
   const truncated = all.length > MAX_REPORT_ROWS;
   const rows = all.slice(0, MAX_REPORT_ROWS).map(row => ({
     id: row.id,


### PR DESCRIPTION
## Summary

Implements **Prompt 15 – Tool 3: selected report read operation** (see
[`docs/mcp/spec.md`](../blob/main/docs/mcp/spec.md) §8.2). Adds one high-value
read-only report.

> **Stacked PR:** targets `claude/mcp-prompt-14-lookup-tools` (Prompt 14, #4015).
> Review/merge Prompts 09→14 first; this diff shows only the Prompt 15 changes.

## Changes

- **`src/tools/reports.ts`** — `accounter_balance_report` (`transactionsForBalanceReport`):
  - Strict input with tight limits: a single `businessId`, `fromDate`/`toDate` (bounded to **366 days**, format-checked), and a `reportType` enum (`BALANCE`, the only phase-1 value).
  - **Role-gated** (`business_owner` / `accountant`, matching the server's `@requiresAnyRole`).
  - Output rows **capped at 500** with a `truncated` flag to avoid large payloads; normalized rows + period + count.
- **`src/tools/execute.ts`** — the scope-narrowing convention now also accepts a **singular** `businessId` (not just `businessIds[]`), so the report's business is validated as a subset of the caller's memberships (`AUTHORIZATION_ERROR` when out of scope) and passed as the report's `ownerId`.
- **`src/tools/registry-instance.ts`** — the report tool registered.
- **Tests** — valid report (owner scoping + normalization), invalid range (inverted, too-wide, bad format), oversized-result truncation, and role/scope denial. 167 tests total.

## Validation

- `yarn workspace @accounter/mcp-server test` → 167 passed
- `yarn workspace @accounter/mcp-server lint` / `typecheck` / `build` → pass

## Notes / open decisions

- **Report choice.** I picked the **balance report** because it has a clean bounded date-range + single-owner shape and is role-gated — good coverage of the policy machinery. The `reportType` enum has one value now so adding more reports later is non-breaking.
- **Row cap.** Capped at 500 rows in-tool with a `truncated` flag; the shared truncation framework (Prompt 16) will generalize this and add continuation hints.
- Query fields verified against `packages/server` (`transactionsForBalanceReport`, `BalanceTransactions`, `FinancialAmount`); upstream is mocked in tests, so worth a live smoke check before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_