### PR TITLE
feat(mcp-server): per-user/business/tool rate limiting (MCP Prompt 18)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -37,6 +37,11 @@ the serialized payload (dropping whole trailing items — never invalid JSON), r
 / `totalCount` / `truncated`, and attaches a `continuation` hint whenever not all results were
 returned (an upstream cap or the payload-size guard).
 
+Each `tools/call` is rate-limited (`src/rate-limit/`) with an in-memory fixed-window counter keyed
+by **user + business scope + tool**, enforced before any upstream call. Exceeding the limit returns
+a `RATE_LIMIT_ERROR` with `retryAfterMs`. Limits are configured via `MCP_RATE_LIMIT_CONFIG`
+(`{"windowMs":60000,"max":60}` by default).
+
 - **`accounter_search_charges`** — read-only charges search/browse within the caller's authorized
   businesses. Optional `businessIds` (subset of memberships), `fromDate`/`toDate` (bounded to 366
   days), `tags`, `freeText`, and `flow` (`ALL`/`INCOME`/`EXPENSE`), with bounded pagination

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -18,6 +18,7 @@ import { generateId, getRequestContext } from '../context.js';
 import { createRequestLogger, log } from '../logger.js';
 import { sendUnauthorized } from '../oauth/challenge.js';
 import { protectedResourceMetadataUrl } from '../oauth/metadata.js';
+import { getRateLimiter } from '../rate-limit/default-limiter.js';
 import { executeRegisteredTool } from '../tools/execute.js';
 import { toolRegistry } from '../tools/registry-instance.js';
 import { getUpstreamClient } from '../upstream/default-client.js';
@@ -189,6 +190,7 @@ export async function dispatchMcpRequest(
       correlationId: context.correlationId,
       authorization: context.authorization,
       client: getUpstreamClient(),
+      limiter: getRateLimiter(),
     });
     return success(id, result);
   }

--- a/packages/mcp-server/src/rate-limit/__tests__/limiter.test.ts
+++ b/packages/mcp-server/src/rate-limit/__tests__/limiter.test.ts
@@ -79,4 +79,11 @@ describe('parseRateLimitConfig', () => {
     expect(parseRateLimitConfig('not json')).toEqual(DEFAULT_RATE_LIMIT);
     expect(parseRateLimitConfig('{"windowMs":-5,"max":0}')).toEqual(DEFAULT_RATE_LIMIT);
   });
+
+  it('does not let a fractional max collapse to 0 (which would block everything)', () => {
+    // Math.floor(0.5) === 0; must fall back to the default rather than max: 0.
+    expect(parseRateLimitConfig('{"max":0.5}').max).toBe(DEFAULT_RATE_LIMIT.max);
+    // A value >= 1 is floored normally.
+    expect(parseRateLimitConfig('{"max":5.9}').max).toBe(5);
+  });
 });

--- a/packages/mcp-server/src/rate-limit/__tests__/limiter.test.ts
+++ b/packages/mcp-server/src/rate-limit/__tests__/limiter.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_RATE_LIMIT,
+  parseRateLimitConfig,
+  RateLimiter,
+  rateLimitKey,
+} from '../limiter.js';
+
+describe('rateLimitKey', () => {
+  it('scopes the key to identity + sorted business scope + tool', () => {
+    expect(rateLimitKey({ userId: 'u1', toolName: 't', businessIds: ['b2', 'b1'] })).toBe(
+      'u1|b1,b2|t',
+    );
+  });
+
+  it('uses "none" when there is no business scope', () => {
+    expect(rateLimitKey({ userId: 'u1', toolName: 't', businessIds: [] })).toBe('u1|none|t');
+  });
+});
+
+describe('RateLimiter', () => {
+  it('allows a burst up to the max then denies', () => {
+    const limiter = new RateLimiter({ windowMs: 1000, max: 3 }, () => 0);
+    expect(limiter.check('k').allowed).toBe(true);
+    expect(limiter.check('k').allowed).toBe(true);
+    const third = limiter.check('k');
+    expect(third.allowed).toBe(true);
+    expect(third.remaining).toBe(0);
+
+    const denied = limiter.check('k');
+    expect(denied.allowed).toBe(false);
+    expect(denied.remaining).toBe(0);
+    expect(denied.retryAfterMs).toBe(1000);
+  });
+
+  it('keeps separate buckets per key', () => {
+    const limiter = new RateLimiter({ windowMs: 1000, max: 1 }, () => 0);
+    expect(limiter.check('a').allowed).toBe(true);
+    expect(limiter.check('a').allowed).toBe(false);
+    expect(limiter.check('b').allowed).toBe(true);
+  });
+
+  it('resets when the window elapses', () => {
+    let now = 0;
+    const limiter = new RateLimiter({ windowMs: 1000, max: 1 }, () => now);
+    expect(limiter.check('k').allowed).toBe(true);
+    expect(limiter.check('k').allowed).toBe(false);
+    now = 1000; // window boundary
+    expect(limiter.check('k').allowed).toBe(true);
+  });
+
+  it('a denied request does not consume additional budget', () => {
+    let now = 0;
+    const limiter = new RateLimiter({ windowMs: 1000, max: 1 }, () => now);
+    limiter.check('k'); // allowed
+    limiter.check('k'); // denied
+    limiter.check('k'); // denied
+    now = 1000;
+    // Only one allowed in the next window (bucket count reset to 0, not carried).
+    expect(limiter.check('k').allowed).toBe(true);
+    expect(limiter.check('k').allowed).toBe(false);
+  });
+});
+
+describe('parseRateLimitConfig', () => {
+  it('returns defaults for empty/absent input', () => {
+    expect(parseRateLimitConfig(undefined)).toEqual(DEFAULT_RATE_LIMIT);
+    expect(parseRateLimitConfig('')).toEqual(DEFAULT_RATE_LIMIT);
+  });
+
+  it('parses a valid JSON config', () => {
+    expect(parseRateLimitConfig('{"windowMs":30000,"max":10}')).toEqual({
+      windowMs: 30_000,
+      max: 10,
+    });
+  });
+
+  it('falls back to defaults on invalid JSON or values', () => {
+    expect(parseRateLimitConfig('not json')).toEqual(DEFAULT_RATE_LIMIT);
+    expect(parseRateLimitConfig('{"windowMs":-5,"max":0}')).toEqual(DEFAULT_RATE_LIMIT);
+  });
+});

--- a/packages/mcp-server/src/rate-limit/default-limiter.ts
+++ b/packages/mcp-server/src/rate-limit/default-limiter.ts
@@ -1,0 +1,18 @@
+import { env } from '../config/env.js';
+import { parseRateLimitConfig, RateLimiter } from './limiter.js';
+
+let cached: RateLimiter | undefined;
+
+/**
+ * The process-wide rate limiter, configured from `MCP_RATE_LIMIT_CONFIG`.
+ * Lazily created and memoized.
+ */
+export function getRateLimiter(): RateLimiter {
+  cached ??= new RateLimiter(parseRateLimitConfig(env.rateLimit.raw));
+  return cached;
+}
+
+/** Test-only: reset the memoized limiter. */
+export function resetRateLimiter(): void {
+  cached = undefined;
+}

--- a/packages/mcp-server/src/rate-limit/limiter.ts
+++ b/packages/mcp-server/src/rate-limit/limiter.ts
@@ -1,0 +1,111 @@
+/**
+ * In-memory rate limiter (spec §11.4).
+ *
+ * A fixed-window counter keyed by authenticated identity + business scope +
+ * tool. Enforced before expensive upstream calls. Phase 1 uses an in-process
+ * store; a shared store can replace it later without changing callers.
+ */
+
+export interface RateLimitConfig {
+  /** Window length in milliseconds. */
+  windowMs: number;
+  /** Max requests allowed per key per window. */
+  max: number;
+}
+
+export const DEFAULT_RATE_LIMIT: RateLimitConfig = { windowMs: 60_000, max: 60 };
+
+export interface RateLimitResult {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  /** Milliseconds until the current window resets. */
+  retryAfterMs: number;
+}
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+/** Build a limiter key scoped to identity + business scope + tool. */
+export function rateLimitKey(params: {
+  userId: string;
+  toolName: string;
+  businessIds: readonly string[];
+}): string {
+  const scope = params.businessIds.length > 0 ? [...params.businessIds].sort().join(',') : 'none';
+  return `${params.userId}|${scope}|${params.toolName}`;
+}
+
+export class RateLimiter {
+  private readonly buckets = new Map<string, Bucket>();
+  private readonly windowMs: number;
+  private readonly max: number;
+  private readonly now: () => number;
+
+  constructor(config: RateLimitConfig = DEFAULT_RATE_LIMIT, now: () => number = Date.now) {
+    this.windowMs = config.windowMs;
+    this.max = config.max;
+    this.now = now;
+  }
+
+  /**
+   * Record a request against `key` and report whether it is allowed. A denied
+   * request does not consume additional budget.
+   */
+  check(key: string): RateLimitResult {
+    const now = this.now();
+    let bucket = this.buckets.get(key);
+    if (!bucket || now >= bucket.resetAt) {
+      bucket = { count: 0, resetAt: now + this.windowMs };
+      this.buckets.set(key, bucket);
+    }
+
+    if (bucket.count >= this.max) {
+      return {
+        allowed: false,
+        limit: this.max,
+        remaining: 0,
+        retryAfterMs: Math.max(0, bucket.resetAt - now),
+      };
+    }
+
+    bucket.count += 1;
+    return {
+      allowed: true,
+      limit: this.max,
+      remaining: this.max - bucket.count,
+      retryAfterMs: Math.max(0, bucket.resetAt - now),
+    };
+  }
+
+  /** Test/ops helper: drop all counters. */
+  reset(): void {
+    this.buckets.clear();
+  }
+}
+
+/**
+ * Parse the `MCP_RATE_LIMIT_CONFIG` value (JSON `{ "windowMs": …, "max": … }`).
+ * Falls back to {@link DEFAULT_RATE_LIMIT} on empty/invalid input.
+ */
+export function parseRateLimitConfig(raw: string | undefined): RateLimitConfig {
+  if (!raw || raw.trim() === '') {
+    return DEFAULT_RATE_LIMIT;
+  }
+  try {
+    const parsed = JSON.parse(raw) as { windowMs?: unknown; max?: unknown };
+    const windowMs =
+      typeof parsed.windowMs === 'number' && Number.isFinite(parsed.windowMs) && parsed.windowMs > 0
+        ? parsed.windowMs
+        : DEFAULT_RATE_LIMIT.windowMs;
+    const max =
+      typeof parsed.max === 'number' && Number.isFinite(parsed.max) && parsed.max > 0
+        ? Math.floor(parsed.max)
+        : DEFAULT_RATE_LIMIT.max;
+    return { windowMs, max };
+  } catch {
+    return DEFAULT_RATE_LIMIT;
+  }
+}

--- a/packages/mcp-server/src/rate-limit/limiter.ts
+++ b/packages/mcp-server/src/rate-limit/limiter.ts
@@ -23,10 +23,22 @@ export interface RateLimitResult {
   retryAfterMs: number;
 }
 
+/**
+ * Minimal structural limiter contract. Callers depend on this rather than the
+ * concrete {@link RateLimiter} class so an alternative implementation (e.g. a
+ * shared/Redis-backed limiter) can be swapped in without signature changes.
+ */
+export interface RateLimiterLike {
+  check(key: string): RateLimitResult;
+}
+
 interface Bucket {
   count: number;
   resetAt: number;
 }
+
+/** How many `check` calls between opportunistic sweeps of expired buckets. */
+const SWEEP_EVERY = 1000;
 
 /** Build a limiter key scoped to identity + business scope + tool. */
 export function rateLimitKey(params: {
@@ -38,11 +50,12 @@ export function rateLimitKey(params: {
   return `${params.userId}|${scope}|${params.toolName}`;
 }
 
-export class RateLimiter {
+export class RateLimiter implements RateLimiterLike {
   private readonly buckets = new Map<string, Bucket>();
   private readonly windowMs: number;
   private readonly max: number;
   private readonly now: () => number;
+  private checksSinceSweep = 0;
 
   constructor(config: RateLimitConfig = DEFAULT_RATE_LIMIT, now: () => number = Date.now) {
     this.windowMs = config.windowMs;
@@ -56,6 +69,7 @@ export class RateLimiter {
    */
   check(key: string): RateLimitResult {
     const now = this.now();
+    this.maybeSweep(now);
     let bucket = this.buckets.get(key);
     if (!bucket || now >= bucket.resetAt) {
       bucket = { count: 0, resetAt: now + this.windowMs };
@@ -80,9 +94,29 @@ export class RateLimiter {
     };
   }
 
+  /**
+   * Periodically drop buckets whose window has already elapsed so the map does
+   * not grow without bound in a long-lived process with many distinct keys.
+   * Runs at most once per {@link SWEEP_EVERY} checks to keep `check` O(1)
+   * amortized.
+   */
+  private maybeSweep(now: number): void {
+    this.checksSinceSweep += 1;
+    if (this.checksSinceSweep < SWEEP_EVERY) {
+      return;
+    }
+    this.checksSinceSweep = 0;
+    for (const [key, bucket] of this.buckets) {
+      if (now >= bucket.resetAt) {
+        this.buckets.delete(key);
+      }
+    }
+  }
+
   /** Test/ops helper: drop all counters. */
   reset(): void {
     this.buckets.clear();
+    this.checksSinceSweep = 0;
   }
 }
 
@@ -100,10 +134,14 @@ export function parseRateLimitConfig(raw: string | undefined): RateLimitConfig {
       typeof parsed.windowMs === 'number' && Number.isFinite(parsed.windowMs) && parsed.windowMs > 0
         ? parsed.windowMs
         : DEFAULT_RATE_LIMIT.windowMs;
-    const max =
-      typeof parsed.max === 'number' && Number.isFinite(parsed.max) && parsed.max > 0
+    // Floor before the positivity check so a fractional value in (0, 1) — e.g.
+    // `{ "max": 0.5 }` — falls back to the default instead of becoming `max: 0`,
+    // which would rate-limit every request.
+    const flooredMax =
+      typeof parsed.max === 'number' && Number.isFinite(parsed.max)
         ? Math.floor(parsed.max)
-        : DEFAULT_RATE_LIMIT.max;
+        : Number.NaN;
+    const max = flooredMax >= 1 ? flooredMax : DEFAULT_RATE_LIMIT.max;
     return { windowMs, max };
   } catch {
     return DEFAULT_RATE_LIMIT;

--- a/packages/mcp-server/src/tools/__tests__/rate-limit.execute.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/rate-limit.execute.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { RateLimiter } from '../../rate-limit/limiter.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { searchChargesTool } from '../charges.js';
+import { executeRegisteredTool } from '../execute.js';
+
+function authContext(businessIds: string[]): McpAuthContext {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: [],
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+  return buildAuthContext(
+    principal,
+    businessIds.map(businessId => ({ businessId, roleId: 'accountant' })),
+  );
+}
+
+function client() {
+  const fetchImpl = vi.fn(
+    async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: { allCharges: { nodes: [], pageInfo: { totalPages: 0, totalRecords: 0, currentPage: 1, pageSize: 25 } } },
+        }),
+      }) as unknown as Response,
+  );
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+function run(limiter: RateLimiter, auth: McpAuthContext) {
+  return executeRegisteredTool({
+    tool: searchChargesTool,
+    rawArgs: {},
+    auth,
+    correlationId: 'corr-1',
+    client: client(),
+    authorization: 'Bearer tok',
+    limiter,
+  });
+}
+
+describe('executeRegisteredTool — rate limiting', () => {
+  it('allows within the limit, then returns RATE_LIMIT_ERROR', async () => {
+    const limiter = new RateLimiter({ windowMs: 1000, max: 2 }, () => 0);
+    const auth = authContext(['b1']);
+
+    expect((await run(limiter, auth)).isError).toBeUndefined();
+    expect((await run(limiter, auth)).isError).toBeUndefined();
+
+    const limited = await run(limiter, auth);
+    expect(limited.isError).toBe(true);
+    const structured = limited.structuredContent as { code: string; retryable: boolean; retryAfterMs: number };
+    expect(structured.code).toBe('RATE_LIMIT_ERROR');
+    expect(structured.retryable).toBe(true);
+    expect(structured.retryAfterMs).toBe(1000);
+  });
+
+  it('keys the limit by tool + business scope (different scope is independent)', async () => {
+    const limiter = new RateLimiter({ windowMs: 1000, max: 1 }, () => 0);
+    expect((await run(limiter, authContext(['b1']))).isError).toBeUndefined();
+    // Same user + tool but a different business scope → separate bucket.
+    expect((await run(limiter, authContext(['b2']))).isError).toBeUndefined();
+    // Repeat of the first scope is now limited.
+    expect((await run(limiter, authContext(['b1']))).isError).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/tools/execute.ts
+++ b/packages/mcp-server/src/tools/execute.ts
@@ -6,7 +6,7 @@ import {
   toToolErrorResult,
 } from '../errors/taxonomy.js';
 import { log } from '../logger.js';
-import { rateLimitKey, type RateLimiter } from '../rate-limit/limiter.js';
+import { rateLimitKey, type RateLimiterLike } from '../rate-limit/limiter.js';
 import type { UpstreamGraphQLClient } from '../upstream/graphql-client.js';
 import { evaluateToolPolicy } from './policy.js';
 import {
@@ -55,7 +55,7 @@ export interface ExecuteToolParams {
   client: UpstreamGraphQLClient;
   authorization?: string;
   /** Optional rate limiter; when provided, enforced before the handler runs. */
-  limiter?: RateLimiter;
+  limiter?: RateLimiterLike;
 }
 
 /**

--- a/packages/mcp-server/src/tools/execute.ts
+++ b/packages/mcp-server/src/tools/execute.ts
@@ -6,6 +6,7 @@ import {
   toToolErrorResult,
 } from '../errors/taxonomy.js';
 import { log } from '../logger.js';
+import { rateLimitKey, type RateLimiter } from '../rate-limit/limiter.js';
 import type { UpstreamGraphQLClient } from '../upstream/graphql-client.js';
 import { evaluateToolPolicy } from './policy.js';
 import {
@@ -53,6 +54,8 @@ export interface ExecuteToolParams {
   correlationId: string;
   client: UpstreamGraphQLClient;
   authorization?: string;
+  /** Optional rate limiter; when provided, enforced before the handler runs. */
+  limiter?: RateLimiter;
 }
 
 /**
@@ -60,7 +63,7 @@ export interface ExecuteToolParams {
  * {@link ToolResult} — success or a taxonomy-tagged error result.
  */
 export async function executeRegisteredTool(params: ExecuteToolParams): Promise<ToolResult> {
-  const { tool, rawArgs, auth, correlationId, client, authorization } = params;
+  const { tool, rawArgs, auth, correlationId, client, authorization, limiter } = params;
 
   // 1. Strict input validation (unknown fields rejected).
   const validation = validateToolInput(tool, rawArgs);
@@ -85,7 +88,30 @@ export async function executeRegisteredTool(params: ExecuteToolParams): Promise<
     );
   }
 
-  // 3. Execute the handler.
+  // 3. Rate limit (before any expensive upstream call), keyed by
+  // identity + business scope + tool.
+  if (limiter) {
+    const outcome = limiter.check(
+      rateLimitKey({
+        userId: auth.userId,
+        toolName: tool.name,
+        businessIds: decision.readScope.businessIds,
+      }),
+    );
+    if (!outcome.allowed) {
+      const retryAfterSeconds = Math.ceil(outcome.retryAfterMs / 1000);
+      return toToolErrorResult(
+        errorPayload(
+          'RATE_LIMIT_ERROR',
+          `Rate limit exceeded. Retry in ${retryAfterSeconds}s.`,
+          correlationId,
+          { retryAfterMs: outcome.retryAfterMs },
+        ),
+      );
+    }
+  }
+
+  // 4. Execute the handler.
   const context: ToolExecutionContext = {
     auth,
     readScope: decision.readScope,


### PR DESCRIPTION
## Summary

Implements **Prompt 18 – Rate limiting middleware** (see
[`docs/mcp/spec.md`](../blob/main/docs/mcp/spec.md) §11.4). Adds an in-memory
limiter enforced before any upstream call.

> **Stacked PR:** targets `claude/mcp-prompt-17-error-taxonomy` (Prompt 17, #4021).
> Review/merge Prompts 09→17 first; this diff shows only the Prompt 18 changes.

## Changes

- **`src/rate-limit/limiter.ts`** — `RateLimiter`, a fixed-window counter with an **injectable clock** (deterministic tests). `rateLimitKey` scopes buckets to **`userId` + sorted business scope + tool** (spec §11.4). `parseRateLimitConfig` reads `MCP_RATE_LIMIT_CONFIG` (JSON) with safe defaults (`{ windowMs: 60000, max: 60 }`).
- **`src/rate-limit/default-limiter.ts`** — lazily-memoized, env-backed process limiter.
- **`src/tools/execute.ts`** — an optional `limiter` is enforced **after** authorization and **before** the handler (so it's ahead of the upstream call). Over-limit returns a `RATE_LIMIT_ERROR` via the unified taxonomy with `retryAfterMs`.
- **`src/mcp/handler.ts`** — the dispatch path passes the process limiter (built lazily, only when a real tool runs).
- **Tests** — burst-then-deny, per-key isolation, window reset, denied-doesn't-consume, config parsing, and end-to-end limiting through `executeRegisteredTool` (incl. business-scope keying). 202 tests total.

## Validation

- `yarn workspace @accounter/mcp-server test` → 202 passed
- `yarn workspace @accounter/mcp-server lint` / `typecheck` / `build` → pass

## Notes / open decisions

- **In-memory, per-process** (spec allows this for phase 1). For a multi-instance deployment this should move to a shared store (Redis); the `RateLimiter` interface is small enough to swap.
- **`limiter` is optional** on `executeRegisteredTool` so the existing tool unit tests run without touching env; the live dispatch path always supplies it.
- **Fixed-window** (not token-bucket) for simplicity and determinism; conservative default (60/min per user·scope·tool) to be tuned after observing production traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_