### PR TITLE
feat(mcp-server): metrics and tracing telemetry (prompt 19)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -110,7 +110,8 @@ process (labels never carry PII — only tool names, outcome classes, and error 
 - **`requestsTotal`** — request counter keyed by `"<tool>|<outcome>"`, where outcome is `success` or
   one of the taxonomy-derived error classes (`validation_error`, `authentication_error`,
   `authorization_error`, `rate_limited`, `upstream_error`, `timeout_error`, `internal_error`).
-- **`latencyMs`** — a cumulative latency histogram (buckets in ms plus `+Inf`, with `count`/`sum`).
+- **`latencyMs`** — a latency histogram with per-bucket (non-cumulative) counts in ms plus an
+  `+Inf` overflow bucket, alongside running `count`/`sum` totals.
 - **`authFailuresTotal`** — auth failure counter keyed by reason (`missing_token`, `invalid_token`).
 - **`upstreamErrorsTotal`** — upstream failure counter keyed by category.
 - **`rateLimitedTotal`** — total rate-limited requests.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -20,7 +20,9 @@ Auth0 bearer-token verification, identity mapping from a verified token to an in
 business-membership context, a curated tool registry with strict input validation, a per-tool
 authorization policy evaluator, and a hardened upstream GraphQL client. The first production tool
 (read-only charges search) is wired into `tools/list` / `tools/call` and enforces input validation,
-authorization policy, and business-scope narrowing before execution.
+authorization policy, and business-scope narrowing before execution. Operational telemetry
+(request/outcome counters, a latency histogram, auth-failure counters, and tracing spans) is
+recorded per process and exposed at `GET /metrics`.
 
 ## Tools
 
@@ -95,9 +97,37 @@ signals that tokens are accepted only via the `Authorization` header, never quer
 
 Every request is assigned a `requestId` and a `correlationId` (the latter inherited from an inbound
 `X-Correlation-Id` header when present, otherwise generated). The correlation id is echoed back on
-the response. Structured JSON logs are emitted at request start and completion, carrying
-`requestId`, `correlationId`, `method`, `route`, and — on completion — `status` and `latencyMs`.
-Secrets and authorization headers are never logged.
+the response and propagated upstream via the `X-Correlation-Id` header on every GraphQL call.
+Structured JSON logs are emitted at request start and completion, carrying `requestId`,
+`correlationId`, `method`, `route`, and — on completion — `status` and `latencyMs`. Secrets and
+authorization headers are never logged.
+
+### Metrics
+
+An in-memory metrics registry (`src/observability/metrics.ts`) records operational telemetry per
+process (labels never carry PII — only tool names, outcome classes, and error categories):
+
+- **`requestsTotal`** — request counter keyed by `"<tool>|<outcome>"`, where outcome is `success` or
+  one of the taxonomy-derived error classes (`validation_error`, `authentication_error`,
+  `authorization_error`, `rate_limited`, `upstream_error`, `timeout_error`, `internal_error`).
+- **`latencyMs`** — a cumulative latency histogram (buckets in ms plus `+Inf`, with `count`/`sum`).
+- **`authFailuresTotal`** — auth failure counter keyed by reason (`missing_token`, `invalid_token`).
+- **`upstreamErrorsTotal`** — upstream failure counter keyed by category.
+- **`rateLimitedTotal`** — total rate-limited requests.
+
+A snapshot is exposed at `GET /metrics`:
+
+```bash
+curl http://localhost:3100/metrics
+```
+
+### Tracing spans
+
+Lightweight tracing spans (`src/observability/tracing.ts`) wrap the key units of work — token
+verification (`auth:verify`), tool execution (`tool:<name>`), and each upstream GraphQL call
+(`upstream:graphql`) — emitting structured `span start`/`span end` debug logs carrying the
+correlation id and span duration. The implementation is deliberately dependency-free so it can be
+swapped for OpenTelemetry later without touching call sites.
 
 ## Running locally
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -110,8 +110,8 @@ process (labels never carry PII — only tool names, outcome classes, and error 
 - **`requestsTotal`** — request counter keyed by `"<tool>|<outcome>"`, where outcome is `success` or
   one of the taxonomy-derived error classes (`validation_error`, `authentication_error`,
   `authorization_error`, `rate_limited`, `upstream_error`, `timeout_error`, `internal_error`).
-- **`latencyMs`** — a latency histogram with per-bucket (non-cumulative) counts in ms plus an
-  `+Inf` overflow bucket, alongside running `count`/`sum` totals.
+- **`latencyMs`** — a latency histogram with per-bucket (non-cumulative) counts in ms plus an `+Inf`
+  overflow bucket, alongside running `count`/`sum` totals.
 - **`authFailuresTotal`** — auth failure counter keyed by reason (`missing_token`, `invalid_token`).
 - **`upstreamErrorsTotal`** — upstream failure counter keyed by category.
 - **`rateLimitedTotal`** — total rate-limited requests.

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -18,6 +18,8 @@ import { generateId, getRequestContext } from '../context.js';
 import { createRequestLogger, log } from '../logger.js';
 import { sendUnauthorized } from '../oauth/challenge.js';
 import { protectedResourceMetadataUrl } from '../oauth/metadata.js';
+import { getMetrics } from '../observability/metrics.js';
+import { withSpan } from '../observability/tracing.js';
 import { getRateLimiter } from '../rate-limit/default-limiter.js';
 import { executeRegisteredTool } from '../tools/execute.js';
 import { toolRegistry } from '../tools/registry-instance.js';
@@ -191,6 +193,7 @@ export async function dispatchMcpRequest(
       authorization: context.authorization,
       client: getUpstreamClient(),
       limiter: getRateLimiter(),
+      metrics: getMetrics(),
     });
     return success(id, result);
   }
@@ -254,8 +257,10 @@ async function authenticate(
   req: IncomingMessage,
   res: ServerResponse,
 ): Promise<AuthPrincipal | null> {
+  const correlationId = getRequestContext(req)?.correlationId ?? '';
   const token = extractBearerToken(req);
   if (!token) {
+    getMetrics().recordAuthFailure('missing_token');
     sendUnauthorized(res, {
       resourceMetadataUrl: protectedResourceMetadataUrl(env.server.publicBaseUrl),
     });
@@ -263,7 +268,7 @@ async function authenticate(
   }
 
   try {
-    const principal = await verifyAccessToken(token);
+    const principal = await withSpan('auth:verify', correlationId, () => verifyAccessToken(token));
     setAuthPrincipal(req, principal);
     // Map the verified identity to internal user + business membership context.
     // Memberships are resolved from the Accounter server (not token claims) by
@@ -285,6 +290,7 @@ async function authenticate(
     if (!(error instanceof TokenVerificationError) && !(error instanceof IdentityMappingError)) {
       throw error;
     }
+    getMetrics().recordAuthFailure('invalid_token');
     // Log the reason only — never the token.
     const context = getRequestContext(req);
     if (context) {

--- a/packages/mcp-server/src/observability/__tests__/metrics.test.ts
+++ b/packages/mcp-server/src/observability/__tests__/metrics.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import type { McpErrorCode } from '../../errors/taxonomy.js';
+import {
+  getMetrics,
+  LATENCY_BUCKETS_MS,
+  Metrics,
+  outcomeForCode,
+  resetMetrics,
+  type RequestOutcome,
+} from '../metrics.js';
+
+describe('outcomeForCode', () => {
+  const cases: Array<[McpErrorCode, RequestOutcome]> = [
+    ['VALIDATION_ERROR', 'validation_error'],
+    ['AUTHENTICATION_ERROR', 'authentication_error'],
+    ['AUTHORIZATION_ERROR', 'authorization_error'],
+    ['RATE_LIMIT_ERROR', 'rate_limited'],
+    ['UPSTREAM_ERROR', 'upstream_error'],
+    ['TIMEOUT_ERROR', 'timeout_error'],
+    ['INTERNAL_ERROR', 'internal_error'],
+  ];
+
+  it.each(cases)('maps %s to %s', (code, outcome) => {
+    expect(outcomeForCode(code)).toBe(outcome);
+  });
+});
+
+describe('Metrics', () => {
+  it('counts requests keyed by tool + outcome', () => {
+    const metrics = new Metrics();
+    metrics.recordRequest('search_charges', 'success', 12);
+    metrics.recordRequest('search_charges', 'success', 20);
+    metrics.recordRequest('search_charges', 'validation_error', 3);
+
+    const snapshot = metrics.snapshot();
+    expect(snapshot.requestsTotal).toEqual({
+      'search_charges|success': 2,
+      'search_charges|validation_error': 1,
+    });
+  });
+
+  it('accumulates latency count and sum', () => {
+    const metrics = new Metrics();
+    metrics.observeLatency(10);
+    metrics.observeLatency(30);
+
+    const { latencyMs } = metrics.snapshot();
+    expect(latencyMs.count).toBe(2);
+    expect(latencyMs.sum).toBe(40);
+  });
+
+  it('places latencies into the correct histogram buckets', () => {
+    const metrics = new Metrics();
+    metrics.observeLatency(3); // <= 5
+    metrics.observeLatency(5); // <= 5 (boundary is inclusive)
+    metrics.observeLatency(7); // <= 10
+    metrics.observeLatency(9999); // +Inf
+
+    const { buckets } = metrics.snapshot().latencyMs;
+    expect(buckets['5']).toBe(2);
+    expect(buckets['10']).toBe(1);
+    expect(buckets['+Inf']).toBe(1);
+  });
+
+  it('exposes a bucket label for every configured bound plus +Inf', () => {
+    const metrics = new Metrics();
+    const { buckets } = metrics.snapshot().latencyMs;
+    for (const bound of LATENCY_BUCKETS_MS) {
+      expect(buckets).toHaveProperty(String(bound));
+    }
+    expect(buckets).toHaveProperty('+Inf');
+  });
+
+  it('counts auth failures, upstream errors, and rate limits', () => {
+    const metrics = new Metrics();
+    metrics.recordAuthFailure('missing_token');
+    metrics.recordAuthFailure('invalid_token');
+    metrics.recordAuthFailure('invalid_token');
+    metrics.recordUpstreamError('upstream_error');
+    metrics.recordRateLimited();
+    metrics.recordRateLimited();
+
+    const snapshot = metrics.snapshot();
+    expect(snapshot.authFailuresTotal).toEqual({ missing_token: 1, invalid_token: 2 });
+    expect(snapshot.upstreamErrorsTotal).toEqual({ upstream_error: 1 });
+    expect(snapshot.rateLimitedTotal).toBe(2);
+  });
+
+  it('reset() clears all counters and the histogram', () => {
+    const metrics = new Metrics();
+    metrics.recordRequest('t', 'success', 10);
+    metrics.recordAuthFailure('missing_token');
+    metrics.recordUpstreamError('upstream_error');
+    metrics.recordRateLimited();
+
+    metrics.reset();
+
+    const snapshot = metrics.snapshot();
+    expect(snapshot.requestsTotal).toEqual({});
+    expect(snapshot.authFailuresTotal).toEqual({});
+    expect(snapshot.upstreamErrorsTotal).toEqual({});
+    expect(snapshot.rateLimitedTotal).toBe(0);
+    expect(snapshot.latencyMs.count).toBe(0);
+    expect(snapshot.latencyMs.sum).toBe(0);
+    expect(snapshot.latencyMs.buckets['+Inf']).toBe(0);
+  });
+});
+
+describe('getMetrics / resetMetrics', () => {
+  it('returns a memoized process-wide singleton', () => {
+    expect(getMetrics()).toBe(getMetrics());
+  });
+
+  it('resetMetrics clears the singleton without replacing it', () => {
+    const before = getMetrics();
+    before.recordRateLimited();
+    resetMetrics();
+    expect(getMetrics()).toBe(before);
+    expect(getMetrics().snapshot().rateLimitedTotal).toBe(0);
+  });
+});

--- a/packages/mcp-server/src/observability/__tests__/tracing.test.ts
+++ b/packages/mcp-server/src/observability/__tests__/tracing.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as logger from '../../logger.js';
+import { withSpan } from '../tracing.js';
+
+function spyLog() {
+  return vi.spyOn(logger, 'log').mockImplementation(() => {});
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('withSpan', () => {
+  it('returns the wrapped function result', async () => {
+    spyLog();
+    await expect(withSpan('work', 'corr-1', async () => 42)).resolves.toBe(42);
+  });
+
+  it('emits a start and a successful end span carrying the correlation id', async () => {
+    const log = spyLog();
+    await withSpan('tool:search', 'corr-1', async () => 'ok');
+
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenNthCalledWith(1, 'debug', 'span start', {
+      span: 'tool:search',
+      correlationId: 'corr-1',
+    });
+    const [, , endFields] = log.mock.calls[1];
+    expect(endFields).toMatchObject({ span: 'tool:search', correlationId: 'corr-1', ok: true });
+    expect(typeof (endFields as { durationMs: number }).durationMs).toBe('number');
+  });
+
+  it('logs a failed end span and re-throws the error', async () => {
+    const log = spyLog();
+    const boom = new TypeError('nope');
+
+    await expect(
+      withSpan('auth:verify', 'corr-2', async () => {
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+
+    const [, , endFields] = log.mock.calls[1];
+    expect(endFields).toMatchObject({
+      span: 'auth:verify',
+      correlationId: 'corr-2',
+      ok: false,
+      error: 'TypeError',
+    });
+  });
+});

--- a/packages/mcp-server/src/observability/metrics.ts
+++ b/packages/mcp-server/src/observability/metrics.ts
@@ -43,7 +43,11 @@ export function outcomeForCode(code: McpErrorCode): RequestOutcome {
 export const LATENCY_BUCKETS_MS = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000] as const;
 
 interface Histogram {
-  /** Cumulative counts per bucket, plus a final +Inf bucket. */
+  /**
+   * Per-bucket counts (non-cumulative): each entry counts observations that
+   * fell into that single bucket, plus a final `+Inf` overflow bucket. The
+   * running total is tracked separately in `count`.
+   */
   buckets: number[];
   count: number;
   sum: number;

--- a/packages/mcp-server/src/observability/metrics.ts
+++ b/packages/mcp-server/src/observability/metrics.ts
@@ -1,0 +1,151 @@
+import type { McpErrorCode } from '../errors/taxonomy.js';
+
+/**
+ * In-memory operational metrics (spec §11.2).
+ *
+ * Counters and a latency histogram, aggregated per process. `snapshot()`
+ * renders a plain object for a `/metrics` endpoint or tests. Labels never carry
+ * PII — only tool names, outcome classes, and error categories.
+ */
+
+/** Outcome class recorded per tool request. */
+export type RequestOutcome =
+  | 'success'
+  | 'validation_error'
+  | 'authentication_error'
+  | 'authorization_error'
+  | 'rate_limited'
+  | 'upstream_error'
+  | 'timeout_error'
+  | 'internal_error';
+
+/** Map an error taxonomy code to its request-outcome label. */
+export function outcomeForCode(code: McpErrorCode): RequestOutcome {
+  switch (code) {
+    case 'VALIDATION_ERROR':
+      return 'validation_error';
+    case 'AUTHENTICATION_ERROR':
+      return 'authentication_error';
+    case 'AUTHORIZATION_ERROR':
+      return 'authorization_error';
+    case 'RATE_LIMIT_ERROR':
+      return 'rate_limited';
+    case 'UPSTREAM_ERROR':
+      return 'upstream_error';
+    case 'TIMEOUT_ERROR':
+      return 'timeout_error';
+    case 'INTERNAL_ERROR':
+      return 'internal_error';
+  }
+}
+
+/** Upper bounds (ms) for the latency histogram buckets. */
+export const LATENCY_BUCKETS_MS = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000] as const;
+
+interface Histogram {
+  /** Cumulative counts per bucket, plus a final +Inf bucket. */
+  buckets: number[];
+  count: number;
+  sum: number;
+}
+
+export interface MetricsSnapshot {
+  /** `mcp_requests_total` keyed by `"<tool>|<outcome>"`. */
+  requestsTotal: Record<string, number>;
+  /** `auth_failures_total` keyed by reason. */
+  authFailuresTotal: Record<string, number>;
+  /** `upstream_graphql_errors_total` keyed by category. */
+  upstreamErrorsTotal: Record<string, number>;
+  /** `rate_limited_total`. */
+  rateLimitedTotal: number;
+  /** `mcp_request_latency_ms` histogram. */
+  latencyMs: { count: number; sum: number; buckets: Record<string, number> };
+}
+
+function inc(map: Map<string, number>, key: string): void {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+export class Metrics {
+  private readonly requests = new Map<string, number>();
+  private readonly authFailures = new Map<string, number>();
+  private readonly upstreamErrors = new Map<string, number>();
+  private rateLimited = 0;
+  private readonly latency: Histogram = {
+    buckets: new Array(LATENCY_BUCKETS_MS.length + 1).fill(0),
+    count: 0,
+    sum: 0,
+  };
+
+  /** Record a finished tool request with its outcome and latency. */
+  recordRequest(tool: string, outcome: RequestOutcome, latencyMs: number): void {
+    inc(this.requests, `${tool}|${outcome}`);
+    this.observeLatency(latencyMs);
+  }
+
+  observeLatency(ms: number): void {
+    this.latency.count += 1;
+    this.latency.sum += ms;
+    let placed = false;
+    for (let i = 0; i < LATENCY_BUCKETS_MS.length; i += 1) {
+      if (ms <= LATENCY_BUCKETS_MS[i]) {
+        this.latency.buckets[i] += 1;
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      this.latency.buckets[LATENCY_BUCKETS_MS.length] += 1; // +Inf
+    }
+  }
+
+  recordAuthFailure(reason: string): void {
+    inc(this.authFailures, reason);
+  }
+
+  recordUpstreamError(category: string): void {
+    inc(this.upstreamErrors, category);
+  }
+
+  recordRateLimited(): void {
+    this.rateLimited += 1;
+  }
+
+  snapshot(): MetricsSnapshot {
+    const bucketLabels: Record<string, number> = {};
+    for (const [i, bound] of LATENCY_BUCKETS_MS.entries()) {
+      bucketLabels[String(bound)] = this.latency.buckets[i];
+    }
+    bucketLabels['+Inf'] = this.latency.buckets[LATENCY_BUCKETS_MS.length];
+    return {
+      requestsTotal: Object.fromEntries(this.requests),
+      authFailuresTotal: Object.fromEntries(this.authFailures),
+      upstreamErrorsTotal: Object.fromEntries(this.upstreamErrors),
+      rateLimitedTotal: this.rateLimited,
+      latencyMs: { count: this.latency.count, sum: this.latency.sum, buckets: bucketLabels },
+    };
+  }
+
+  reset(): void {
+    this.requests.clear();
+    this.authFailures.clear();
+    this.upstreamErrors.clear();
+    this.rateLimited = 0;
+    this.latency.buckets.fill(0);
+    this.latency.count = 0;
+    this.latency.sum = 0;
+  }
+}
+
+let processMetrics: Metrics | undefined;
+
+/** The process-wide metrics registry (no env dependency). */
+export function getMetrics(): Metrics {
+  processMetrics ??= new Metrics();
+  return processMetrics;
+}
+
+/** Test-only: reset the process metrics registry. */
+export function resetMetrics(): void {
+  getMetrics().reset();
+}

--- a/packages/mcp-server/src/observability/tracing.ts
+++ b/packages/mcp-server/src/observability/tracing.ts
@@ -1,0 +1,37 @@
+import { log } from '../logger.js';
+
+/**
+ * Minimal tracing spans (spec §11.3).
+ *
+ * Wraps a unit of work (auth validation, an upstream call, tool execution) and
+ * emits structured start/end debug logs carrying the correlation id and the
+ * span duration. Deliberately lightweight — no external tracer dependency — so
+ * it can be swapped for OpenTelemetry later without touching call sites.
+ */
+export async function withSpan<T>(
+  name: string,
+  correlationId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const start = performance.now();
+  log('debug', 'span start', { span: name, correlationId });
+  try {
+    const result = await fn();
+    log('debug', 'span end', {
+      span: name,
+      correlationId,
+      durationMs: Math.round(performance.now() - start),
+      ok: true,
+    });
+    return result;
+  } catch (error) {
+    log('debug', 'span end', {
+      span: name,
+      correlationId,
+      durationMs: Math.round(performance.now() - start),
+      ok: false,
+      error: error instanceof Error ? error.name : 'unknown',
+    });
+    throw error;
+  }
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -7,6 +7,7 @@ import {
   buildProtectedResourceMetadata,
   PROTECTED_RESOURCE_METADATA_PATH,
 } from './oauth/metadata.js';
+import { getMetrics } from './observability/metrics.js';
 import { getServiceVersion, SERVICE_NAME } from './version.js';
 
 /**
@@ -45,6 +46,10 @@ export const routes: Record<string, Record<string, RouteHandler>> = {
         uptimeSeconds: Math.round(process.uptime()),
       };
       sendJson(res, 200, body);
+    },
+    // Operational metrics snapshot (counters + latency histogram).
+    '/metrics': (_req, res) => {
+      sendJson(res, 200, getMetrics().snapshot());
     },
     // OAuth 2.0 Protected Resource Metadata (RFC 9728) — lets Claude clients
     // discover the Auth0 authorization server for this resource.

--- a/packages/mcp-server/src/tools/__tests__/metrics.execute.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/metrics.execute.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { Metrics } from '../../observability/metrics.js';
+import { RateLimiter } from '../../rate-limit/limiter.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { SEARCH_CHARGES_TOOL_NAME, searchChargesTool } from '../charges.js';
+import { executeRegisteredTool } from '../execute.js';
+
+function authContext(businessIds: string[] = ['b1']): McpAuthContext {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: [],
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+  return buildAuthContext(
+    principal,
+    businessIds.map(businessId => ({ businessId, roleId: 'accountant' })),
+  );
+}
+
+function client() {
+  const fetchImpl = vi.fn(
+    async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: {
+            allCharges: {
+              nodes: [],
+              pageInfo: { totalPages: 0, totalRecords: 0, currentPage: 1, pageSize: 25 },
+            },
+          },
+        }),
+      }) as unknown as Response,
+  );
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+describe('executeRegisteredTool — metrics', () => {
+  it('records a success outcome and one latency observation', async () => {
+    const metrics = new Metrics();
+    const result = await executeRegisteredTool({
+      tool: searchChargesTool,
+      rawArgs: {},
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: client(),
+      metrics,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const snapshot = metrics.snapshot();
+    expect(snapshot.requestsTotal[`${SEARCH_CHARGES_TOOL_NAME}|success`]).toBe(1);
+    expect(snapshot.latencyMs.count).toBe(1);
+  });
+
+  it('records a validation_error outcome for bad input', async () => {
+    const metrics = new Metrics();
+    const result = await executeRegisteredTool({
+      tool: searchChargesTool,
+      rawArgs: { unknownField: true },
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: client(),
+      metrics,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(metrics.snapshot().requestsTotal[`${SEARCH_CHARGES_TOOL_NAME}|validation_error`]).toBe(1);
+  });
+
+  it('records a rate_limited outcome and bumps the rate-limited counter', async () => {
+    const metrics = new Metrics();
+    const limiter = new RateLimiter({ windowMs: 1000, max: 0 }, () => 0);
+    const result = await executeRegisteredTool({
+      tool: searchChargesTool,
+      rawArgs: {},
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: client(),
+      limiter,
+      metrics,
+    });
+
+    expect(result.isError).toBe(true);
+    const snapshot = metrics.snapshot();
+    expect(snapshot.requestsTotal[`${SEARCH_CHARGES_TOOL_NAME}|rate_limited`]).toBe(1);
+    expect(snapshot.rateLimitedTotal).toBe(1);
+  });
+
+  it('is a no-op when no metrics registry is provided', async () => {
+    const result = await executeRegisteredTool({
+      tool: searchChargesTool,
+      rawArgs: {},
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: client(),
+    });
+    expect(result.isError).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/src/tools/execute.ts
+++ b/packages/mcp-server/src/tools/execute.ts
@@ -4,8 +4,11 @@ import {
   isInternalError,
   toErrorPayload,
   toToolErrorResult,
+  type McpErrorCode,
 } from '../errors/taxonomy.js';
 import { log } from '../logger.js';
+import { outcomeForCode, type Metrics, type RequestOutcome } from '../observability/metrics.js';
+import { withSpan } from '../observability/tracing.js';
 import { rateLimitKey, type RateLimiterLike } from '../rate-limit/limiter.js';
 import type { UpstreamGraphQLClient } from '../upstream/graphql-client.js';
 import { evaluateToolPolicy } from './policy.js';
@@ -56,13 +59,59 @@ export interface ExecuteToolParams {
   authorization?: string;
   /** Optional rate limiter; when provided, enforced before the handler runs. */
   limiter?: RateLimiterLike;
+  /** Optional metrics registry; when provided, records outcome + latency. */
+  metrics?: Metrics;
+}
+
+/** The error taxonomy codes that map to a known request outcome. */
+const KNOWN_ERROR_CODES = new Set<string>([
+  'VALIDATION_ERROR',
+  'AUTHENTICATION_ERROR',
+  'AUTHORIZATION_ERROR',
+  'UPSTREAM_ERROR',
+  'TIMEOUT_ERROR',
+  'RATE_LIMIT_ERROR',
+  'INTERNAL_ERROR',
+]);
+
+/** Derive the metrics outcome label from a finished tool result. */
+function outcomeOf(result: ToolResult): RequestOutcome {
+  if (!result.isError) {
+    return 'success';
+  }
+  const code = (result.structuredContent as { code?: string } | undefined)?.code;
+  // Guard against a handler returning `isError` with a non-taxonomy code: fall
+  // back to `internal_error` rather than recording a `<tool>|undefined` key.
+  return code && KNOWN_ERROR_CODES.has(code)
+    ? outcomeForCode(code as McpErrorCode)
+    : 'internal_error';
 }
 
 /**
  * Validate, authorize, and execute a registered tool. Always resolves to a
- * {@link ToolResult} — success or a taxonomy-tagged error result.
+ * {@link ToolResult} — success or a taxonomy-tagged error result. Records
+ * request outcome, latency, and error-category metrics when a registry is
+ * provided.
  */
 export async function executeRegisteredTool(params: ExecuteToolParams): Promise<ToolResult> {
+  const { metrics } = params;
+  const start = performance.now();
+  const result = await runTool(params);
+
+  if (metrics) {
+    const outcome = outcomeOf(result);
+    metrics.recordRequest(params.tool.name, outcome, Math.round(performance.now() - start));
+    if (outcome === 'rate_limited') {
+      metrics.recordRateLimited();
+    } else if (outcome === 'upstream_error' || outcome === 'timeout_error') {
+      metrics.recordUpstreamError(outcome);
+    }
+  }
+
+  return result;
+}
+
+async function runTool(params: ExecuteToolParams): Promise<ToolResult> {
   const { tool, rawArgs, auth, correlationId, client, authorization, limiter } = params;
 
   // 1. Strict input validation (unknown fields rejected).
@@ -120,7 +169,10 @@ export async function executeRegisteredTool(params: ExecuteToolParams): Promise<
     authorization,
   };
   try {
-    return await tool.handler(input, context);
+    // Span covers the handler + its upstream calls for tracing.
+    return await withSpan(`tool:${tool.name}`, correlationId, async () =>
+      tool.handler(input, context),
+    );
   } catch (error) {
     // Log unexpected (unmapped) failures so bugs aren't hidden; the caller only
     // ever sees the generic, sanitized INTERNAL_ERROR message.

--- a/packages/mcp-server/src/upstream/graphql-client.ts
+++ b/packages/mcp-server/src/upstream/graphql-client.ts
@@ -13,6 +13,8 @@
  * - Upstream errors are sanitized (no stack traces / internal SQL details).
  */
 
+import { withSpan } from '../observability/tracing.js';
+
 export type UpstreamErrorCode = 'UPSTREAM_ERROR' | 'TIMEOUT_ERROR';
 
 /**
@@ -118,19 +120,23 @@ export class UpstreamGraphQLClient {
   async query<TData>(request: GraphQLRequest, context: UpstreamRequestContext): Promise<TData> {
     assertReadOnly(request.query);
 
-    let attempt = 0;
-    // Total tries = 1 + maxRetries; only retryable failures loop.
-    for (;;) {
-      try {
-        return await this.executeOnce<TData>(request, context);
-      } catch (error) {
-        const isRetryable = error instanceof UpstreamError && error.retryable;
-        if (!isRetryable || attempt >= this.maxRetries) {
-          throw error;
+    // Span covers all retry attempts; the correlation id also propagates to the
+    // upstream server via the X-Correlation-Id header on each attempt.
+    return withSpan('upstream:graphql', context.correlationId, async () => {
+      let attempt = 0;
+      // Total tries = 1 + maxRetries; only retryable failures loop.
+      for (;;) {
+        try {
+          return await this.executeOnce<TData>(request, context);
+        } catch (error) {
+          const isRetryable = error instanceof UpstreamError && error.retryable;
+          if (!isRetryable || attempt >= this.maxRetries) {
+            throw error;
+          }
+          attempt += 1;
         }
-        attempt += 1;
       }
-    }
+    });
   }
 
   private async executeOnce<TData>(


### PR DESCRIPTION
## Summary

Implements **Prompt 19 — Metrics and tracing integration** from
[`docs/mcp/implementation-blueprint.md`](../blob/mcp-setup/docs/mcp/implementation-blueprint.md),
adding the operational telemetry required for production readiness (spec §11.2/§11.3). Stacked on
top of the prompt 18 branch (`claude/mcp-prompt-18-rate-limiting`).

## What's included

**Metrics registry** — `src/observability/metrics.ts`
- `requestsTotal` — request counter keyed by `"<tool>|<outcome>"` (outcome is `success` or a
  taxonomy-derived error class).
- `latencyMs` — cumulative latency histogram (fixed ms buckets + `+Inf`, with `count`/`sum`).
- `authFailuresTotal` — auth-failure counter keyed by reason (`missing_token`, `invalid_token`).
- `upstreamErrorsTotal` — upstream failure counter keyed by category.
- `rateLimitedTotal` — total rate-limited requests.
- `outcomeForCode()` maps every error taxonomy code to its outcome label.
- Process-wide memoized singleton via `getMetrics()`. Labels carry **no PII** — only tool names,
  outcome classes, and error categories.

**Tracing spans** — `src/observability/tracing.ts`
- Dependency-free `withSpan(name, correlationId, fn)` emitting structured `span start`/`span end`
  debug logs with the correlation id and duration.
- Wired around token verification (`auth:verify`), tool execution (`tool:<name>`), and each upstream
  GraphQL call (`upstream:graphql`).

**Wiring**
- The tool executor records outcome + latency (and rate-limited/upstream sub-counters) via an
  optional injected `Metrics`.
- The transport handler records auth-failure counters by reason.
- `GET /metrics` exposes a snapshot.
- Correlation id already propagates upstream via the `X-Correlation-Id` header; the upstream span
  makes each call traceable.

## Testing

- `src/observability/__tests__/metrics.test.ts` — counters, histogram bucketing, snapshot, reset,
  singleton, and full `outcomeForCode` mapping.
- `src/observability/__tests__/tracing.test.ts` — `withSpan` result passthrough, start/end logging,
  and error re-throw with a failed span.
- `src/tools/__tests__/metrics.execute.test.ts` — executor records success / validation_error /
  rate_limited outcomes and is a no-op without a registry.

`yarn workspace @accounter/mcp-server typecheck`, `lint`, and `test` (224 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_