### PR TITLE
test(mcp-server): complete the unit test matrix (prompt 20)

### DIFF
--- a/packages/mcp-server/src/auth/__tests__/token.test.ts
+++ b/packages/mcp-server/src/auth/__tests__/token.test.ts
@@ -3,9 +3,12 @@ import { generateKeyPair, type JWTVerifyGetKey, type KeyObject, SignJWT } from '
 import { beforeAll, describe, expect, it } from 'vitest';
 import {
   extractBearerToken,
+  getAuthPrincipal,
+  setAuthPrincipal,
   toPrincipal,
   TokenVerificationError,
   verifyAccessTokenWithKey,
+  type AuthPrincipal,
 } from '../token.js';
 
 const ISSUER = 'https://tenant.auth0.com/';
@@ -131,5 +134,55 @@ describe('verifyAccessTokenWithKey', () => {
     await expect(
       verifyAccessTokenWithKey(token, getKey, { issuer: ISSUER, audience: AUDIENCE }),
     ).rejects.toBe(infra);
+  });
+
+  it('accepts a valid token verified through a key-resolver function', async () => {
+    const token = await sign({});
+    const getKey: JWTVerifyGetKey = async () => publicKey;
+    const principal = await verifyAccessTokenWithKey(token, getKey, {
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    });
+    expect(principal.subject).toBe('user-1');
+  });
+
+  it('rejects a signature-valid token that is missing the subject claim', async () => {
+    // Signed correctly (so jwtVerify passes) but carries no `sub` — toPrincipal
+    // must reject it, and the error surfaces as a TokenVerificationError.
+    const token = await new SignJWT({ scope: 'read:charges' })
+      .setProtectedHeader({ alg: 'RS256' })
+      .setIssuer(ISSUER)
+      .setAudience(AUDIENCE)
+      .setExpirationTime('2h')
+      .sign(privateKey);
+    await expect(
+      verifyAccessTokenWithKey(token, publicKey, { issuer: ISSUER, audience: AUDIENCE }),
+    ).rejects.toBeInstanceOf(TokenVerificationError);
+  });
+});
+
+describe('setAuthPrincipal / getAuthPrincipal', () => {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: ISSUER,
+    audience: AUDIENCE,
+    scopes: [],
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+
+  it('round-trips a principal stored on a request', () => {
+    const request = req();
+    expect(getAuthPrincipal(request)).toBeUndefined();
+    setAuthPrincipal(request, principal);
+    expect(getAuthPrincipal(request)).toBe(principal);
+  });
+
+  it('keeps principals isolated per request', () => {
+    const a = req();
+    const b = req();
+    setAuthPrincipal(a, principal);
+    expect(getAuthPrincipal(b)).toBeUndefined();
   });
 });

--- a/packages/mcp-server/src/config/__tests__/env.test.ts
+++ b/packages/mcp-server/src/config/__tests__/env.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest';
-import { EnvValidationError, parseEnv } from '../env.js';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EnvValidationError, loadEnv, parseEnv } from '../env.js';
 
 const validEnv: NodeJS.ProcessEnv = {
   MCP_PUBLIC_BASE_URL: 'https://mcp.example.com',
@@ -109,5 +111,44 @@ describe('parseEnv — invalid configuration', () => {
     // whitespace is a non-empty string at the schema level; emptiness is only
     // enforced against the literal empty string.
     expect(() => parseEnv({ ...validEnv, AUTH0_AUDIENCE: '' })).toThrow(EnvValidationError);
+  });
+});
+
+describe('loadEnv — fail-fast startup', () => {
+  // Point dotenv at a nonexistent file so no real .env leaks into the source.
+  const missingEnvFile = resolve(tmpdir(), 'accounter-mcp-nonexistent.env');
+  const originalTestEnvFile = process.env.TEST_ENV_FILE;
+
+  afterEach(() => {
+    if (originalTestEnvFile === undefined) {
+      delete process.env.TEST_ENV_FILE;
+    } else {
+      process.env.TEST_ENV_FILE = originalTestEnvFile;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('reports the invalid variables and exits the process', () => {
+    process.env.TEST_ENV_FILE = missingEnvFile;
+    const exit = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code}`);
+    }) as never);
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => loadEnv({})).toThrow('process.exit:1');
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(String(errorLog.mock.calls[0]?.[0])).toContain('Invalid environment variables');
+  });
+
+  it('returns a validated config for a valid source without exiting', () => {
+    process.env.TEST_ENV_FILE = missingEnvFile;
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called unexpectedly');
+    }) as never);
+
+    const config = loadEnv({ ...validEnv });
+    expect(config.server.port).toBe(3100);
+    expect(config.upstream.graphqlUrl).toBe('http://localhost:4000/graphql');
+    expect(exit).not.toHaveBeenCalled();
   });
 });

--- a/packages/mcp-server/src/tools/__tests__/charges.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/charges.test.ts
@@ -174,6 +174,23 @@ describe('searchChargesTool — invalid filters', () => {
     expect((result.structuredContent as { message: string }).message).toMatch(/on or before/);
   });
 
+  it('rejects a single impossible toDate that still matches the format', async () => {
+    const client = clientReturning(oneCharge);
+    const result = await run(client, authContext(['b1']), { toDate: '2026-13-01' });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { message: string }).message).toBe('Invalid toDate');
+  });
+
+  it('rejects a date range wider than the cap', async () => {
+    const client = clientReturning(oneCharge);
+    const result = await run(client, authContext(['b1']), {
+      fromDate: '2024-01-01',
+      toDate: '2026-01-01',
+    });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { message: string }).message).toMatch(/must not exceed/);
+  });
+
   it('rejects a page size above the cap', async () => {
     const client = clientReturning(oneCharge);
     const result = await run(client, authContext(['b1']), { pageSize: 500 });

--- a/packages/mcp-server/src/tools/__tests__/output.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/output.test.ts
@@ -35,6 +35,26 @@ describe('shapeListResult — within limits', () => {
   });
 });
 
+describe('shapeListResult — default summary', () => {
+  it('reports "No results." when there are no items', () => {
+    const result = shapeListResult({ items: [], itemsKey: 'things' });
+    expect(result.content[0].text).toBe('No results.');
+    const structured = result.structuredContent as { totalCount: number; truncated: boolean };
+    expect(structured.totalCount).toBe(0);
+    expect(structured.truncated).toBe(false);
+  });
+
+  it('reports returned-of-total with a truncated marker', () => {
+    const result = shapeListResult({ items: [{ a: 1 }], itemsKey: 'things', total: 5 });
+    expect(result.content[0].text).toBe('Returning 1 of 5 result(s) (truncated).');
+  });
+
+  it('omits the truncated marker when everything is returned', () => {
+    const result = shapeListResult({ items: [{ a: 1 }, { a: 2 }], itemsKey: 'things' });
+    expect(result.content[0].text).toBe('Returning 2 of 2 result(s).');
+  });
+});
+
 describe('shapeListResult — result cap (total > items)', () => {
   it('marks truncated with a result_cap continuation when more exist upstream', () => {
     const result = shapeListResult({ items: [{ a: 1 }], itemsKey: 'things', total: 10 });

--- a/packages/mcp-server/src/tools/__tests__/reports.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/reports.test.ts
@@ -121,6 +121,21 @@ describe('balanceReportTool — invalid range', () => {
     expect(result.isError).toBe(true);
     expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
   });
+
+  it('rejects an impossible date that still matches the format', async () => {
+    const client = clientReturning([]);
+    // Passes the schema's format regex but is not a real calendar date, so the
+    // handler's own Date.parse guard (not zod) must reject it.
+    const result = await run(client, authContext(['b1']), {
+      businessId: 'b1',
+      fromDate: '2026-13-01',
+      toDate: '2026-03-01',
+    });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { message: string }).message).toBe(
+      'Invalid fromDate/toDate',
+    );
+  });
 });
 
 describe('balanceReportTool — oversized results', () => {


### PR DESCRIPTION
## Summary

Implements **Prompt 20 — Unit test matrix completion** from
[`docs/mcp/implementation-blueprint.md`](../blob/mcp-setup/docs/mcp/implementation-blueprint.md).
Rounds out deterministic, service-free unit coverage across the core modules the blueprint calls
out. Stacked on top of the prompt 19 branch (`claude/mcp-prompt-19-metrics-tracing`).

## What's added

- **Env config validation** — cover `loadEnv`'s fail-fast startup path (invalid environment → printed
  report + `process.exit(1)`, with `process.exit`/`console.error` stubbed) and the valid-source happy
  path. dotenv is pointed at a nonexistent file so no real `.env` leaks in.
- **Token validation edge cases** — verification through a key-resolver function, rejection of a
  signature-valid token that is missing the `sub` claim, and the per-request principal store
  (`setAuthPrincipal`/`getAuthPrincipal` round-trip + isolation between requests).
- **Registry/schema validation** — charges tool now covers a single impossible `toDate` and an
  over-cap date range; the balance report tool covers a regex-passing but impossible date.
- **Output truncation** — default-summary branches (`No results.`, and returned-of-total with and
  without the truncated marker).

The policy evaluator and error mapper (taxonomy) already had thorough dedicated suites; the gaps
addressed here are the ones the coverage report flagged.

## Coverage

Package branch coverage improves from **~83.9% → ~85.9%** (statements ~89.5% → ~90.8%); `token.ts`
reaches full line coverage. All tests are deterministic and call no external services.

`yarn workspace @accounter/mcp-server lint`, `typecheck`, and `test` (236 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_