### PR TITLE
fix(client): defer misc expense transaction query until modal opens

### DIFF
--- a/packages/client/src/components/common/modals/insert-misc-expense-modal.tsx
+++ b/packages/client/src/components/common/modals/insert-misc-expense-modal.tsx
@@ -47,7 +47,7 @@ export const InsertMiscExpenseModal = ({
 
   const [{ data: transactionData, fetching: fetchingTransaction }] = useQuery({
     query: MiscExpenseTransactionFieldsDocument,
-    pause: !transactionId,
+    pause: !dialogOpen || !transactionId,
     variables: {
       transactionId,
     },


### PR DESCRIPTION
## Problem

Every row in the charge-expansion transactions table renders an
`InsertMiscExpenseModal` (via the "Insert Misc Expense" button in
`packages/client/src/components/transactions-table/columns.tsx`). That
modal runs the `MiscExpenseTransactionFields` query
(`transactionsByIDs`) on mount, gated only by
`pause: !transactionId`. Because `transactionId` is always present, the
query fired for **every** transaction row regardless of whether the modal
was ever opened — one network request per row on every table render.

## Fix

Pause the query until the dialog is actually open by including the
`dialogOpen` state in the `pause` condition:

```diff
-    pause: !transactionId,
+    pause: !dialogOpen || !transactionId,
```

Now `MiscExpenseTransactionFields` only runs when the user opens the
Insert Misc Expense modal for a given row. The existing
`fetchingTransaction` gating and `defaultValues` wiring continue to work
unchanged — the data is fetched on open, just as before it was consumed.

## Testing

- No behavioral change to the modal contents; only the timing of the
  query is deferred.
- Dependencies are not installed in the CI sandbox, so `yarn lint` could
  not be run here; the change is a single-line edit that follows the
  existing urql `pause` pattern used elsewhere in the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPVFZUXVrJEw268fQ9c53b

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPVFZUXVrJEw268fQ9c53b)_