### PR TITLE
Optimize VAT report by deferring expensive charge validation

### DIFF
--- a/.changeset/@accounter_server-4043-dependencies.md
+++ b/.changeset/@accounter_server-4043-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@accounter/server": patch
+---
+dependencies updates:
+  - Updated dependency [`@opentelemetry/auto-instrumentations-node@0.79.0` ↗︎](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node/v/0.79.0) (from `0.78.0`, in `dependencies`)
+  - Updated dependency [`auth0@6.1.0` ↗︎](https://www.npmjs.com/package/auth0/v/6.1.0) (from `6.0.0`, in `dependencies`)

--- a/.changeset/vat-monthly-report-perf.md
+++ b/.changeset/vat-monthly-report-perf.md
@@ -1,0 +1,20 @@
+---
+"@accounter/server": patch
+"@accounter/client": patch
+---
+
+Optimize the VAT monthly report and the flows backed by `getVatRecords` (monthly-VAT ledger
+validation, description suggestions, and PCN874 generation):
+
+- `getVatRecords` now accepts an `includeChargeBuckets` option (default `true`). The
+  ledger-generation, monthly-VAT-suggestion and PCN874 callers read only `income`/`expenses`, so they
+  pass `false` to skip the per-charge `validateCharge` + business-trip pass that builds the
+  `missingInfo` / `differentMonthDoc` / `businessTrips` buckets those callers discard.
+- `adjustTaxRecord` passes the enriched charge row (instead of its id) to the transaction/document
+  meta helpers, serving the precomputed aggregates from the fast path instead of firing extra
+  DataLoader batches per record.
+- `validateCharge` is memoized per request (injector-keyed), so the VAT report's bucketing pass and
+  the `Charge.validationData` field resolver share a single validation per charge rather than
+  computing it twice.
+- The VAT report screen dedupes its query document once at module load, keeping a stable query
+  reference across renders.

--- a/packages/client/src/components/reports/vat-monthly-report/index.tsx
+++ b/packages/client/src/components/reports/vat-monthly-report/index.tsx
@@ -37,6 +37,11 @@ import { VatMonthlyReportFilter } from './vat-monthly-report-filters.js';
   }
 `;
 
+// Dedupe the fragments once at module load: the document never depends on render
+// state, so hoisting it keeps a stable query reference across renders (a fresh
+// object each render would re-key the urql operation) without an empty-deps hook.
+const vatMonthlyReportQuery = dedupeFragments(VatMonthlyReportDocument);
+
 export const VatMonthlyReport = (): ReactElement => {
   const { get } = useUrlQuery();
   const { setFiltersContext } = useContext(FiltersContext);
@@ -69,13 +74,9 @@ export const VatMonthlyReport = (): ReactElement => {
     }
   }, [filter, userContext?.context.adminBusinessId]);
 
-  // Deduping the fragments produces a fresh document object; memoize it so the
-  // query identity is stable across renders and urql doesn't re-key the operation.
-  const query = useMemo(() => dedupeFragments(VatMonthlyReportDocument), []);
-
   // fetch data
   const [{ data, fetching }] = useQuery({
-    query,
+    query: vatMonthlyReportQuery,
     variables: {
       filters: filter,
     },

--- a/packages/client/src/components/reports/vat-monthly-report/index.tsx
+++ b/packages/client/src/components/reports/vat-monthly-report/index.tsx
@@ -69,9 +69,13 @@ export const VatMonthlyReport = (): ReactElement => {
     }
   }, [filter, userContext?.context.adminBusinessId]);
 
+  // Deduping the fragments produces a fresh document object; memoize it so the
+  // query identity is stable across renders and urql doesn't re-key the operation.
+  const query = useMemo(() => dedupeFragments(VatMonthlyReportDocument), []);
+
   // fetch data
   const [{ data, fetching }] = useQuery({
-    query: dedupeFragments(VatMonthlyReportDocument),
+    query,
     variables: {
       filters: filter,
     },

--- a/packages/server/src/modules/charges/helpers/validate.helper.ts
+++ b/packages/server/src/modules/charges/helpers/validate.helper.ts
@@ -20,7 +20,39 @@ import {
   isEnrichedFilteredCharge,
 } from './common.helper.js';
 
-export const validateCharge = async (
+/**
+ * Request-scoped memoization of charge validation, keyed by the
+ * operation-scoped injector. `validateCharge` is run once per charge while the
+ * VAT report buckets charges by missing info, then again by the
+ * `Charge.validationData` field resolver for the same charges — cache the
+ * validation promise so the second pass reuses the first result instead of
+ * re-deriving it. Charges are immutable within a single (read) request, so the
+ * two callers always see identical input.
+ */
+const validationCache = new WeakMap<
+  Injector,
+  Map<string, Promise<ResolversTypes['ValidationData']>>
+>();
+
+export const validateCharge = (
+  charge: IGetChargesByIdsResult,
+  injector: Injector,
+): Promise<ResolversTypes['ValidationData']> => {
+  let cache = validationCache.get(injector);
+  if (!cache) {
+    cache = new Map();
+    validationCache.set(injector, cache);
+  }
+  const cached = cache.get(charge.id);
+  if (cached) {
+    return cached;
+  }
+  const result = computeChargeValidation(charge, injector);
+  cache.set(charge.id, result);
+  return result;
+};
+
+const computeChargeValidation = async (
   charge: IGetChargesByIdsResult,
   injector: Injector,
 ): Promise<ResolversTypes['ValidationData']> => {

--- a/packages/server/src/modules/charges/resolvers/charge-suggestions/__tests__/monthly-vat-suggestions.resolver.test.ts
+++ b/packages/server/src/modules/charges/resolvers/charge-suggestions/__tests__/monthly-vat-suggestions.resolver.test.ts
@@ -58,6 +58,7 @@ describe('missingMonthlyVatInfoSuggestions', () => {
         },
       },
       injector,
+      { includeChargeBuckets: false },
     );
     expect(result).toEqual({
       description: 'VAT for 04/2026',

--- a/packages/server/src/modules/charges/resolvers/charge-suggestions/monthly-vat-suggestions.resolver.ts
+++ b/packages/server/src/modules/charges/resolvers/charge-suggestions/monthly-vat-suggestions.resolver.ts
@@ -46,6 +46,7 @@ export const missingMonthlyVatInfoSuggestions: ResolverFn<
         },
       },
       injector,
+      { includeChargeBuckets: false },
     );
 
     const monthlyVatTotalAmount = calculateMonthlyVatTotalAmount(

--- a/packages/server/src/modules/ledger/resolvers/ledger-generation/monthly-vat-ledger-generation.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger-generation/monthly-vat-ledger-generation.resolver.ts
@@ -84,6 +84,7 @@ export const generateLedgerRecordsForMonthlyVat: ResolverFn<
       const { income, expenses } = await getVatRecords(
         { filters: { financialEntityId: charge.owner_id, monthDate } },
         injector,
+        { includeChargeBuckets: false },
       );
 
       return {

--- a/packages/server/src/modules/reports/helpers/pcn.helper.ts
+++ b/packages/server/src/modules/reports/helpers/pcn.helper.ts
@@ -251,6 +251,7 @@ export async function getPcn874String(
   const vatRecords = await getVatRecords(
     { filters: { monthDate, financialEntityId: businessId } },
     injector,
+    { includeChargeBuckets: false },
   );
   const reportMonth = format(new Date(monthDate), 'yyyyMM');
   const reportContent = generatePcnFromVatRecords(

--- a/packages/server/src/modules/reports/helpers/vat-report.helper.ts
+++ b/packages/server/src/modules/reports/helpers/vat-report.helper.ts
@@ -97,8 +97,10 @@ export async function adjustTaxRecord(
         .get(DepreciationProvider)
         .getDepreciationRecordsByChargeIdLoader.load(charge.id)
         .then(records => records.length > 0),
-      getChargeTransactionsMeta(charge.id, injector),
-      getChargeDocumentsMeta(charge.id, injector),
+      // Pass the charge row (not its id) so the enriched fast path serves the
+      // precomputed transaction/document meta instead of firing loader batches.
+      getChargeTransactionsMeta(charge, injector),
+      getChargeDocumentsMeta(charge, injector),
     ]);
 
     const isDecreasedVat = charge.is_property;

--- a/packages/server/src/modules/reports/resolvers/get-vat-records.resolver.ts
+++ b/packages/server/src/modules/reports/resolvers/get-vat-records.resolver.ts
@@ -19,10 +19,23 @@ import {
   type VatReportRecordSources,
 } from '../helpers/vat-report.helper.js';
 
+export type GetVatRecordsOptions = {
+  /**
+   * Whether to compute the `missingInfo` / `differentMonthDoc` / `businessTrips`
+   * charge buckets. Building them runs `validateCharge` plus a business-trip
+   * load for every charge in the month — work that only the VAT report screen
+   * consumes. The ledger-validation, description-suggestion and PCN874 callers
+   * read only `income`/`expenses`, so they pass `false` to skip it entirely.
+   */
+  includeChargeBuckets?: boolean;
+};
+
 export const getVatRecords = async (
   { filters }: Partial<QueryVatReportArgs>,
   injector: Injector,
+  options: GetVatRecordsOptions = {},
 ): Promise<ResolversTypes['VatReportResult']> => {
+  const { includeChargeBuckets = true } = options;
   const {
     authorities: { vatReportExcludedBusinessNames },
   } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
@@ -192,40 +205,43 @@ export const getVatRecords = async (
       ]);
     }
 
-    // validate charges for missing info
-    const validatedCharges = await Promise.all<{
-      charge: IGetChargesByIdsResult;
-      isValid: boolean;
-      businessTripId: string | null;
-    }>(
-      charges.map(async charge => {
-        const [validation, businessTrip] = await Promise.all([
-          validateCharge(charge, injector),
-          injector.get(BusinessTripsProvider).getBusinessTripsByChargeIdLoader.load(charge.id),
-        ]);
-        if (!('isValid' in validation)) {
-          throw new Error('Error validating charge');
-        }
-        return {
-          charge,
-          isValid: validation.isValid,
-          businessTripId: businessTrip?.id ?? null,
-        };
-      }),
-    );
+    // validate charges for missing info (only needed by the VAT report screen —
+    // the income/expenses-only callers skip this expensive per-charge pass)
+    if (includeChargeBuckets) {
+      const validatedCharges = await Promise.all<{
+        charge: IGetChargesByIdsResult;
+        isValid: boolean;
+        businessTripId: string | null;
+      }>(
+        charges.map(async charge => {
+          const [validation, businessTrip] = await Promise.all([
+            validateCharge(charge, injector),
+            injector.get(BusinessTripsProvider).getBusinessTripsByChargeIdLoader.load(charge.id),
+          ]);
+          if (!('isValid' in validation)) {
+            throw new Error('Error validating charge');
+          }
+          return {
+            charge,
+            isValid: validation.isValid,
+            businessTripId: businessTrip?.id ?? null,
+          };
+        }),
+      );
 
-    for (const { charge, isValid, businessTripId } of validatedCharges) {
-      if (businessTripId) {
-        // If valid and has business trip, add to business trips
-        response.businessTrips.push(charge);
-      } else if (isValid) {
-        if (!includedChargeIDs.has(charge.id)) {
-          // If valid but not yet included, add to charges with different month doc
-          response.differentMonthDoc.push(charge);
+      for (const { charge, isValid, businessTripId } of validatedCharges) {
+        if (businessTripId) {
+          // If valid and has business trip, add to business trips
+          response.businessTrips.push(charge);
+        } else if (isValid) {
+          if (!includedChargeIDs.has(charge.id)) {
+            // If valid but not yet included, add to charges with different month doc
+            response.differentMonthDoc.push(charge);
+          }
+        } else {
+          // add to charges with missing info
+          response.missingInfo.push(charge);
         }
-      } else {
-        // add to charges with missing info
-        response.missingInfo.push(charge);
       }
     }
 


### PR DESCRIPTION
## Summary

Refactors the VAT report generation to defer expensive per-charge validation and business-trip lookups only when needed. The VAT report screen requires detailed charge buckets (missing info, different month docs, business trips), but other callers (ledger validation, description suggestions, PCN874 export) only need income/expenses totals and can skip this work entirely.

## Key Changes

- **New `GetVatRecordsOptions` type** with `includeChargeBuckets` flag (defaults to `true` for backward compatibility)
  - When `false`, skips the `validateCharge` + business-trip loader pass that only the VAT report UI consumes
  - Reduces database load for income/expenses-only callers

- **Charge validation caching** in `validate.helper.ts`
  - Wraps `validateCharge` with request-scoped memoization keyed by injector
  - Reuses validation results when the same charge is validated multiple times within a single request
  - Prevents redundant validation when VAT report buckets charges and then the `Charge.validationData` field resolver validates them again

- **Updated callers** to pass `{ includeChargeBuckets: false }`:
  - `missingMonthlyVatInfoSuggestions` (description suggestions)
  - `generateLedgerRecordsForMonthlyVat` (ledger validation)
  - `getPcn874String` (PCN874 export)

- **Client optimization** in `VatMonthlyReport`
  - Memoizes the deduplicated GraphQL document so query identity remains stable across renders
  - Prevents urql from re-keying the operation on every render

- **Micro-optimization** in `adjustTaxRecord`
  - Passes charge row (not just ID) to `getChargeTransactionsMeta` and `getChargeDocumentsMeta`
  - Allows these functions to use precomputed transaction/document metadata from the charge object instead of firing loader batches

## Implementation Details

- The validation cache uses `WeakMap<Injector, Map<chargeId, Promise>>` to ensure cleanup when the injector is garbage collected
- Caching the promise (not the result) ensures concurrent validation calls for the same charge still await a single computation
- All changes are backward compatible; existing callers default to the current behavior

https://claude.ai/code/session_016nLBncBf7VDSXFYTz8wZ3T