### PR TITLE
fix(client): make drawer form inputs (tags, date, currency, selects) usable inside PopUpDrawer

### DIFF
--- a/.changeset/fix-inputs-portaling-in-drawer.md
+++ b/.changeset/fix-inputs-portaling-in-drawer.md
@@ -1,0 +1,21 @@
+---
+"@accounter/client": patch
+---
+
+Fix form inputs being unusable inside `PopUpDrawer` (e.g. the Edit Charge, Edit Transaction and Edit
+Document modals). The drawer's underlying Radix Dialog is always modal and traps focus, so overlays
+portaled to `document.body` could not be focused and clicking them was treated as an "outside"
+interaction that closed the drawer.
+
+Following the same portal-container approach already used by `ComboBox`, these inputs now portal
+their overlays into the drawer's content element when one is present (and keep the default
+`document.body` portaling everywhere else):
+
+- `MultiSelect` — the tags input's options list and search were unclickable and clicking outside the
+  options closed the drawer (fixes #4040); its overflow tooltip now portals into the layer too.
+- `DatePickerInput` — the calendar's day buttons could not be clicked and closed the drawer.
+- Currency inputs (`CurrencyCodeInput` / currency search) — the currency select and search popover.
+- The financial-entity / document-type `Select`s in the Edit Transaction and document field forms.
+
+The shared `Select` and `Tooltip` UI primitives now accept an optional `container` prop to enable
+this.

--- a/packages/client/src/components/common/forms/edit-transaction.tsx
+++ b/packages/client/src/components/common/forms/edit-transaction.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../helpers/index.js';
 import { useGetFinancialEntities } from '../../../hooks/use-get-financial-entities.js';
 import { useUpdateTransaction } from '../../../hooks/use-update-transaction.js';
+import { usePortalContainer } from '../../../providers/portal-container.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../ui/select.js';
 import { Switch } from '../../ui/switch.js';
@@ -45,6 +46,9 @@ type Props = {
 };
 
 export const EditTransaction = ({ transactionID, onDone, onChange }: Props): ReactElement => {
+  // This form renders inside PopUpDrawer, whose focus-trapping dialog blocks interaction with
+  // anything portaled to `document.body`. See `usePortalContainer`.
+  const portalContainer = usePortalContainer();
   const [{ data: transactionData, fetching: fetchingTransaction }] = useQuery({
     query: EditTransactionDocument,
     variables: {
@@ -118,7 +122,10 @@ export const EditTransaction = ({ transactionID, onDone, onChange }: Props): Rea
                             <SelectValue placeholder="Scroll to see all options" />
                           </SelectTrigger>
                         </FormControl>
-                        <SelectContent onClick={event => event.stopPropagation()}>
+                        <SelectContent
+                          onClick={event => event.stopPropagation()}
+                          container={portalContainer}
+                        >
                           {financialEntities.map(({ value, label }) => (
                             <SelectItem key={value} value={value}>
                               {label}

--- a/packages/client/src/components/common/forms/modify-document-fields.tsx
+++ b/packages/client/src/components/common/forms/modify-document-fields.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../../gql/graphql.js';
 import { TIMELESS_DATE_REGEX } from '../../../helpers/consts.js';
 import { useGetFinancialEntities } from '../../../hooks/use-get-financial-entities.js';
+import { usePortalContainer } from '../../../providers/portal-container.js';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { Input } from '../../ui/input.js';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../ui/select.js';
@@ -33,6 +34,9 @@ export const ModifyDocumentFields = ({
 }: ModifyDocumentFieldsProps): ReactElement => {
   const { control, watch, trigger } = formManager;
   const [showExtendedFields, setShowExtendedFields] = useState<boolean>(false);
+  // These fields render inside PopUpDrawer, whose focus-trapping dialog blocks interaction with
+  // anything portaled to `document.body`. See `usePortalContainer`.
+  const portalContainer = usePortalContainer();
 
   const { selectableFinancialEntities: financialEntities, fetching: fetchingFinancialEntities } =
     useGetFinancialEntities();
@@ -74,7 +78,7 @@ export const ModifyDocumentFields = ({
                   <SelectValue placeholder="Select type" />
                 </SelectTrigger>
               </FormControl>
-              <SelectContent onClick={event => event.stopPropagation()}>
+              <SelectContent onClick={event => event.stopPropagation()} container={portalContainer}>
                 {Object.entries(DocumentType).map(([label, value]) => (
                   <SelectItem key={value} value={value}>
                     {label}

--- a/packages/client/src/components/common/inputs/currency-input.tsx
+++ b/packages/client/src/components/common/inputs/currency-input.tsx
@@ -3,6 +3,7 @@ import { Check, ChevronDownIcon } from 'lucide-react';
 import { NumberInput } from '@mantine/core';
 import { Currency } from '../../../gql/graphql.js';
 import { cn } from '../../../lib/utils.js';
+import { usePortalContainer } from '../../../providers/portal-container.js';
 import { Button } from '../../ui/button.js';
 import {
   Command,
@@ -30,6 +31,8 @@ type CurrencyCodeProps = {
 
 export const CurrencyCodeInput = forwardRef<HTMLButtonElement, CurrencyCodeProps>(
   function CurrencyCodeInput({ label, value, onChange, disabled, name, form }) {
+    // Portal into the surrounding modal layer when there is one — see `usePortalContainer`.
+    const portalContainer = usePortalContainer();
     return (
       <div className="bottom-0 mt-6">
         {label && <Label className="sr-only">{label}</Label>}
@@ -37,7 +40,7 @@ export const CurrencyCodeInput = forwardRef<HTMLButtonElement, CurrencyCodeProps
           <SelectTrigger>
             <SelectValue placeholder="Currency" />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent container={portalContainer}>
             {CURRENCIES.map(currency => (
               <SelectItem key={currency} value={currency}>
                 {currency}
@@ -73,6 +76,10 @@ function CurrencySelect({
   form,
 }: CurrencyCodeFieldProps) {
   const [open, setOpen] = useState(false);
+  // Same modal-layer workaround as `ComboBox`: the currency search input is unusable and clicks on
+  // it close the surrounding drawer while the popover lives in `document.body`.
+  // See `usePortalContainer` and https://github.com/emilkowalski/vaul/issues/496
+  const portalContainer = usePortalContainer();
 
   return (
     <div className="w-1/2 min-w-[75px] mt-6">
@@ -95,7 +102,7 @@ function CurrencySelect({
             />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-40 p-0" align="start">
+        <PopoverContent className="w-40 p-0" align="start" container={portalContainer}>
           <Command>
             <CommandInput placeholder="Search currency..." form={form} />
             <CommandList>

--- a/packages/client/src/components/common/inputs/date-picker-input.tsx
+++ b/packages/client/src/components/common/inputs/date-picker-input.tsx
@@ -10,6 +10,7 @@ import {
   InputGroupInput,
 } from '@/components/ui/input-group.js';
 import { TIMELESS_DATE_REGEX, type TimelessDateString } from '@/helpers/index.js';
+import { usePortalContainer } from '../../../providers/portal-container.js';
 import { Calendar } from '../../ui/calendar.js';
 import { Popover, PopoverContent, PopoverTrigger } from '../../ui/popover.js';
 
@@ -35,6 +36,12 @@ export function DatePickerInput({ value: valueDate, onChange, disabled, id, ...p
   const generatedId = React.useId();
   const inputId = id ?? generatedId;
   const [open, setOpen] = React.useState(false);
+  // Inside a modal layer (e.g. the vaul Drawer used by PopUpDrawer) a popover portaled to
+  // `document.body` sits outside the dialog's focus scope, so the calendar's day buttons cannot be
+  // focused and clicking them counts as "outside" the drawer, closing it. Portal into the layer's
+  // own element instead, and make the popover modal so it stays interactive.
+  // See `usePortalContainer` and https://github.com/emilkowalski/vaul/issues/496
+  const portalContainer = usePortalContainer();
   const [date, setDate] = React.useState<TimelessDateString | undefined>(valueDate);
   const [month, setMonth] = React.useState<Date | undefined>(
     date ? timelessDateStringToDate(date) : undefined,
@@ -102,7 +109,7 @@ export function DatePickerInput({ value: valueDate, onChange, disabled, id, ...p
           }}
         />
         <InputGroupAddon align="inline-end">
-          <Popover open={open} onOpenChange={setOpen}>
+          <Popover open={open} onOpenChange={setOpen} modal={!!portalContainer}>
             <PopoverTrigger asChild>
               <InputGroupButton variant="ghost" size="icon-xs" aria-label="Select date">
                 <CalendarIcon />
@@ -114,6 +121,7 @@ export function DatePickerInput({ value: valueDate, onChange, disabled, id, ...p
               align="end"
               alignOffset={-8}
               sideOffset={10}
+              container={portalContainer}
             >
               <Calendar
                 mode="single"

--- a/packages/client/src/components/common/inputs/multi-select.tsx
+++ b/packages/client/src/components/common/inputs/multi-select.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { CheckIcon, ChevronDown, WandSparkles, XCircle, XIcon } from 'lucide-react';
 import { cn } from '../../../lib/utils.js';
+import { usePortalContainer } from '../../../providers/portal-container.js';
 import { Badge } from '../../ui/badge.js';
 import { Button } from '../../ui/button.js';
 import {
@@ -130,6 +131,14 @@ export const MultiSelect = React.forwardRef<HTMLButtonElement, MultiSelectProps>
     },
     ref,
   ) => {
+    // When rendered inside a modal layer (e.g. the vaul Drawer used by PopUpDrawer), the underlying
+    // Radix Dialog traps focus and blocks interaction with any element portaled to `document.body`,
+    // making the search input unusable and treating clicks on the popover as "outside" the drawer
+    // (which closes it). Such layers provide their content element via PortalContainerContext so the
+    // popover portals inside the dialog and stays focusable/clickable. Outside those layers the value
+    // is `null` and the popover keeps its default `document.body` portaling.
+    // See https://github.com/emilkowalski/vaul/issues/496
+    const portalContainer = usePortalContainer();
     const [selectedValues, setSelectedValues] = React.useState<string[]>(defaultValue);
     const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
     const [isAnimating, setIsAnimating] = React.useState(false);
@@ -198,7 +207,7 @@ export const MultiSelect = React.forwardRef<HTMLButtonElement, MultiSelectProps>
           }
           setIsPopoverOpen(open);
         }}
-        modal={modalPopover}
+        modal={modalPopover || !!portalContainer}
       >
         <PopoverTrigger asChild={asChild}>
           <Button
@@ -306,6 +315,7 @@ export const MultiSelect = React.forwardRef<HTMLButtonElement, MultiSelectProps>
         <PopoverContent
           className="w-auto p-0"
           align="start"
+          container={portalContainer}
           onEscapeKeyDown={() => setIsPopoverOpen(false)}
         >
           <Command>

--- a/packages/client/src/components/common/inputs/multi-select.tsx
+++ b/packages/client/src/components/common/inputs/multi-select.tsx
@@ -270,7 +270,10 @@ export const MultiSelect = React.forwardRef<HTMLButtonElement, MultiSelectProps>
                             {`+ ${selectedValues.length - maxCount} more`}
                           </span>
                         </TooltipTrigger>
-                        <TooltipContent className="flex flex-col gap-0.5">
+                        <TooltipContent
+                          className="flex flex-col gap-0.5"
+                          container={portalContainer}
+                        >
                           {selectedValues.slice(maxCount).map(value => {
                             const option = options.find(o => o.value === value);
                             return <span key={value}>{option?.label ?? value}</span>;

--- a/packages/client/src/components/ui/select.tsx
+++ b/packages/client/src/components/ui/select.tsx
@@ -45,10 +45,13 @@ function SelectContent({
   className,
   children,
   position = 'popper',
+  container,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+}: React.ComponentProps<typeof SelectPrimitive.Content> & {
+  container?: React.ComponentProps<typeof SelectPrimitive.Portal>['container'];
+}) {
   return (
-    <SelectPrimitive.Portal>
+    <SelectPrimitive.Portal container={container}>
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(

--- a/packages/client/src/components/ui/tooltip.tsx
+++ b/packages/client/src/components/ui/tooltip.tsx
@@ -33,10 +33,13 @@ function TooltipContent({
   className,
   sideOffset = 0,
   children,
+  container,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: React.ComponentProps<typeof TooltipPrimitive.Content> & {
+  container?: React.ComponentProps<typeof TooltipPrimitive.Portal>['container'];
+}) {
   return (
-    <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Portal container={container}>
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}


### PR DESCRIPTION
## Summary

Fixes the buggy Tags input in the Edit Charge modal (#4040) and, along the way, the same class of bug across several other inputs that live inside `PopUpDrawer` (Edit Charge / Edit Transaction / Edit Document modals):

- **Tags input** — the options list/search was unclickable, and clicking outside the options popover closed the whole edit drawer.
- **Date picker** — the calendar's day buttons couldn't be clicked and closed the drawer.
- **Currency inputs** — the currency `Select` and the currency search popover.
- **Financial-entity / document-type `Select`s** — in the Edit Transaction and document field forms.

## Root cause

These inputs render their overlay (Radix `Popover` / `Select` / `Tooltip`) via a portal to `document.body`. `PopUpDrawer` is a vaul `Drawer` whose underlying Radix `Dialog` is always modal and traps focus, so an overlay portaled to `document.body` lands *outside* that focus scope. As a result:

1. Its inputs/buttons can't receive focus or clicks.
2. Pointer interactions on the overlay are treated as "outside" the drawer, triggering its close.

`ComboBox` already solved this via `PortalContainerContext`: `PopUpDrawer` exposes its own content element through that context so overlays can portal *inside* the drawer's focus scope. These inputs simply never opted in.

## Changes

`packages/client/src/components/`:

- **`inputs/multi-select.tsx`** — portal the popover (and overflow tooltip) into the drawer container via `usePortalContainer()`, and make the popover modal when inside such a layer.
- **`inputs/date-picker-input.tsx`** — portal the calendar popover into the container and make it modal when present.
- **`inputs/currency-input.tsx`** — portal the currency `Select` and the currency search popover into the container.
- **`forms/edit-transaction.tsx`** and **`forms/modify-document-fields.tsx`** — pass the container to their `SelectContent`.
- **`ui/select.tsx`** and **`ui/tooltip.tsx`** — accept an optional `container` prop, forwarded to the Radix `Portal` (mirrors the existing `popover.tsx` API).

Outside a drawer the context value is `null`, so overlays keep their default `document.body` portaling and existing behavior is unchanged.

## Changeset

Added `.changeset/fix-inputs-portaling-in-drawer.md` (`@accounter/client`: patch).

## Testing notes

Dependency installation is blocked in this environment (the `xlsx`/sheetjs dependency is fetched from `cdn.sheetjs.com`, which returns 403 under the network policy), so `yarn lint`/`build` could not be run here. The changes are minimal and mirror the already-shipped `ComboBox` fix.

Fixes #4040

🤖 Generated with [Claude Code](https://claude.com/claude-code)