### PR TITLE
feat(ledger): notify when doc and transaction currencies differ

### DIFF
--- a/.changeset/charge-invoice-payment-currency-diff-error.md
+++ b/.changeset/charge-invoice-payment-currency-diff-error.md
@@ -1,0 +1,11 @@
+---
+'@accounter/server': patch
+---
+
+Notify when a charge's main document and main transaction settle in different currencies. The ledger
+`validate` resolver now surfaces an error (shown by the client's `ChargeErrors` component) when a
+charge's main financial document currency differs from its main transaction currency while the
+`invoice_payment_currency_diff` flag is off, prompting the user to turn on the "Invoice-Payment
+currency difference" switch. The check is display-only — it does not alter ledger record generation
+or storage, only fires when each side resolves to a single differing currency, and falls back to no
+extra errors if the underlying meta lookups fail.

--- a/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
@@ -73,18 +73,28 @@ async function getInvoicePaymentCurrencyDiffErrors(
     return [];
   }
 
-  const [{ documentsCurrency }, { transactionsCurrency }] = await Promise.all([
-    getChargeDocumentsMeta(charge, injector),
-    getChargeTransactionsMeta(charge, injector),
-  ]);
+  try {
+    const [{ documentsCurrency }, { transactionsCurrency }] = await Promise.all([
+      getChargeDocumentsMeta(charge, injector),
+      getChargeTransactionsMeta(charge, injector),
+    ]);
 
-  if (documentsCurrency && transactionsCurrency && documentsCurrency !== transactionsCurrency) {
-    return [
-      `Main document currency (${documentsCurrency}) differs from main transaction currency (${transactionsCurrency}). Turn on the "Invoice-Payment currency difference" switch for this charge.`,
-    ];
+    if (documentsCurrency && transactionsCurrency && documentsCurrency !== transactionsCurrency) {
+      return [
+        `Main document currency (${documentsCurrency}) differs from main transaction currency (${transactionsCurrency}). Turn on the "Invoice-Payment currency difference" switch for this charge.`,
+      ];
+    }
+
+    return [];
+  } catch (err) {
+    // This check is display-only; a loader/DB failure here must not turn the
+    // whole validation into an error. Log and fall back to no extra errors.
+    console.error(
+      `Failed to evaluate invoice/payment currency-diff for charge ID="${charge.id}"`,
+      err,
+    );
+    return [];
   }
-
-  return [];
 }
 
 export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'GeneratedLedgerRecords'> = {

--- a/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
@@ -12,8 +12,12 @@ import { formatFinancialAmount } from '../../../shared/helpers/index.js';
 import { degradeChargesAccountantApproval } from '../../accountant-approval/helpers/degrade-charges.helper.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
 import { ScopeProvider } from '../../auth/providers/scope.provider.js';
+import {
+  getChargeDocumentsMeta,
+  getChargeTransactionsMeta,
+} from '../../charges/helpers/common.helper.js';
 import { ChargesProvider } from '../../charges/providers/charges.provider.js';
-import { accountant_statusArray } from '../../charges/types.js';
+import { accountant_statusArray, type IGetChargesByIdsResult } from '../../charges/types.js';
 import { FinancialEntitiesProvider } from '../../financial-entities/providers/financial-entities.provider.js';
 import { IGetFinancialEntitiesByIdsResult } from '../../financial-entities/types.js';
 import {
@@ -55,6 +59,32 @@ async function recordLocalCurrency(
     .get(AdminContextProvider)
     .getVerifiedAdminContext();
   return defaultLocalCurrency;
+}
+
+// When the main financial document (usually the invoice) and the main
+// transaction settle in different currencies, the charge requires the dedicated
+// invoice/payment currency-diff handling. If that flag is off, surface an error
+// so the user knows to turn the "Invoice-Payment currency difference" switch on.
+async function getInvoicePaymentCurrencyDiffErrors(
+  charge: IGetChargesByIdsResult,
+  injector: Injector,
+): Promise<string[]> {
+  if (charge.invoice_payment_currency_diff) {
+    return [];
+  }
+
+  const [{ documentsCurrency }, { transactionsCurrency }] = await Promise.all([
+    getChargeDocumentsMeta(charge, injector),
+    getChargeTransactionsMeta(charge, injector),
+  ]);
+
+  if (documentsCurrency && transactionsCurrency && documentsCurrency !== transactionsCurrency) {
+    return [
+      `Main document currency (${documentsCurrency}) differs from main transaction currency (${transactionsCurrency}). Turn on the "Invoice-Payment currency difference" switch for this charge.`,
+    ];
+  }
+
+  return [];
 }
 
 export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'GeneratedLedgerRecords'> = {
@@ -493,6 +523,8 @@ export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'Generate
           errors: [],
         };
       }
+      const currencyDiffErrors = await getInvoicePaymentCurrencyDiffErrors(charge, injector);
+
       try {
         const generated = await ledgerGenerationByCharge(
           charge,
@@ -505,7 +537,7 @@ export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'Generate
             isValid: false,
             differences: [],
             matches: [],
-            errors: [],
+            errors: [...currencyDiffErrors],
           };
         }
 
@@ -515,10 +547,10 @@ export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'Generate
 
         if (fullMatching.isFullyMatched) {
           return {
-            isValid: true,
+            isValid: currencyDiffErrors.length === 0,
             differences: [],
             matches: Array.from(fullMatching.fullMatches.values()).filter(Boolean) as string[],
-            errors: generated.errors,
+            errors: [...generated.errors, ...currencyDiffErrors],
           };
         }
 
@@ -528,10 +560,13 @@ export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'Generate
         );
 
         return {
-          isValid: fullMatching.isFullyMatched && generated.errors.length === 0,
+          isValid:
+            fullMatching.isFullyMatched &&
+            generated.errors.length === 0 &&
+            currencyDiffErrors.length === 0,
           differences: toUpdate,
           matches: Array.from(fullMatching.fullMatches.values()).filter(Boolean) as string[],
-          errors: generated.errors,
+          errors: [...generated.errors, ...currencyDiffErrors],
         };
       } catch (err) {
         console.error(err);
@@ -539,7 +574,7 @@ export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'Generate
           isValid: false,
           differences: [],
           matches: [],
-          errors: [],
+          errors: [...currencyDiffErrors],
         };
       }
     },


### PR DESCRIPTION
## Problem

The `ChargeErrors` component (`packages/client/src/components/charges/charge-errors.tsx`) renders `ledger.validate.errors`. There was no error surfaced when a charge's main financial document (usually the invoice) and its main transaction settle in **different currencies** while the `invoice_payment_currency_diff` flag is off — so the user was never told to enable the special currency-diff handling.

Closes #3968

## Change

`packages/server/src/modules/ledger/resolvers/ledger.resolver.ts`

- Added a `getInvoicePaymentCurrencyDiffErrors(charge, injector)` helper that:
  - Returns nothing when `invoice_payment_currency_diff` is already on.
  - Otherwise compares `documentsCurrency` (from `getChargeDocumentsMeta`) and `transactionsCurrency` (from `getChargeTransactionsMeta`), and when **both resolve to a single, differing currency**, returns an error:
    > `Main document currency (X) differs from main transaction currency (Y). Turn on the "Invoice-Payment currency difference" switch for this charge.`
- Wired it into the `validate` resolver, merging the message into every returned `errors` array and marking `isValid` false when it fires.

## Why the `validate` resolver (not ledger generation)

`validate` is exactly what feeds `ledger.validate.errors` shown by `ChargeErrors`. Placing the check here makes it **display-only** — it does not short-circuit or alter ledger record generation/storage, avoiding any regression for the common "foreign invoice paid in local currency" flow that generates exchange-rate records.

The condition is conservative: it only fires when each side has an unambiguous single currency, so multi-currency / fee cases won't produce false positives. Once the user flips the existing "Is Invoice-Payment currency difference" switch (already present in `edit-charge.tsx`), the error clears on the next validation.

## Testing

`yarn install` could not complete in the CI-web environment (a dependency tarball host, `cdn.sheetjs.com`, is blocked by the network policy), so lint/build/tests were not run locally. The change is small, strictly typed against existing exported helpers/types, and mirrors surrounding patterns — please rely on CI for lint/typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRj7CCnYrXkrZQycUuTjf4

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRj7CCnYrXkrZQycUuTjf4)_