### PR TITLE
feat(server): expose caller's own business memberships (MCP Prompt 08a)

### DIFF
--- a/packages/server/src/modules/auth/__tests__/memberships.test.ts
+++ b/packages/server/src/modules/auth/__tests__/memberships.test.ts
@@ -1,0 +1,78 @@
+import { GraphQLError, GraphQLResolveInfo } from 'graphql';
+import { describe, expect, it, vi } from 'vitest';
+import { AuthContextProvider } from '../providers/auth-context.provider.js';
+import { membershipsResolvers } from '../resolvers/memberships.resolver.js';
+
+const myMembershipsResolver = membershipsResolvers.Query?.myMemberships as (
+  source: unknown,
+  args: Record<string, never>,
+  context: { injector: { get<T>(token: unknown): T } },
+  info: GraphQLResolveInfo,
+) => Promise<Array<{ businessId: string; roleId: string; businessName: string | null }>>;
+
+const mockInfo = {} as GraphQLResolveInfo;
+
+function contextWith(getAuthContext: ReturnType<typeof vi.fn>) {
+  const mockAuthProvider = { getAuthContext };
+  return {
+    injector: {
+      get<T>(token: unknown): T {
+        if (token === AuthContextProvider) {
+          return mockAuthProvider as T;
+        }
+        throw new Error('Unexpected provider requested');
+      },
+    },
+  };
+}
+
+describe('myMemberships resolver', () => {
+  it('returns all memberships for a multi-business user', async () => {
+    const getAuthContext = vi.fn().mockResolvedValue({
+      authType: 'jwt',
+      tenant: { businessId: 'business-1', roleId: 'business_owner' },
+      memberships: [
+        { businessId: 'business-1', roleId: 'business_owner', businessName: 'Acme' },
+        { businessId: 'business-2', roleId: 'accountant' },
+      ],
+    });
+
+    const result = await myMembershipsResolver({}, {}, contextWith(getAuthContext), mockInfo);
+
+    expect(result).toEqual([
+      { businessId: 'business-1', roleId: 'business_owner', businessName: 'Acme' },
+      { businessId: 'business-2', roleId: 'accountant', businessName: null },
+    ]);
+  });
+
+  it('returns an empty list for an authenticated user with no memberships', async () => {
+    const getAuthContext = vi.fn().mockResolvedValue({
+      authType: 'jwt',
+      tenant: { businessId: '', roleId: undefined },
+      memberships: [],
+    });
+
+    const result = await myMembershipsResolver({}, {}, contextWith(getAuthContext), mockInfo);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty list when the auth context has no memberships field', async () => {
+    const getAuthContext = vi.fn().mockResolvedValue({
+      authType: 'jwt',
+      tenant: { businessId: 'business-1' },
+    });
+
+    const result = await myMembershipsResolver({}, {}, contextWith(getAuthContext), mockInfo);
+
+    expect(result).toEqual([]);
+  });
+
+  it('wraps unexpected failures in a GraphQLError', async () => {
+    const getAuthContext = vi.fn().mockRejectedValue(new Error('db down'));
+
+    await expect(
+      myMembershipsResolver({}, {}, contextWith(getAuthContext), mockInfo),
+    ).rejects.toBeInstanceOf(GraphQLError);
+  });
+});

--- a/packages/server/src/modules/auth/__tests__/memberships.test.ts
+++ b/packages/server/src/modules/auth/__tests__/memberships.test.ts
@@ -8,7 +8,9 @@ const myMembershipsResolver = membershipsResolvers.Query?.myMemberships as (
   args: Record<string, never>,
   context: { injector: { get<T>(token: unknown): T } },
   info: GraphQLResolveInfo,
-) => Promise<Array<{ businessId: string; roleId: string; businessName: string | null }>>;
+) => Promise<
+  Array<{ id: string; businessId: string; roleId: string; businessName: string | null }>
+>;
 
 const mockInfo = {} as GraphQLResolveInfo;
 
@@ -30,6 +32,7 @@ describe('myMemberships resolver', () => {
   it('returns all memberships for a multi-business user', async () => {
     const getAuthContext = vi.fn().mockResolvedValue({
       authType: 'jwt',
+      user: { userId: 'user-1' },
       tenant: { businessId: 'business-1', roleId: 'business_owner' },
       memberships: [
         { businessId: 'business-1', roleId: 'business_owner', businessName: 'Acme' },
@@ -40,8 +43,18 @@ describe('myMemberships resolver', () => {
     const result = await myMembershipsResolver({}, {}, contextWith(getAuthContext), mockInfo);
 
     expect(result).toEqual([
-      { businessId: 'business-1', roleId: 'business_owner', businessName: 'Acme' },
-      { businessId: 'business-2', roleId: 'accountant', businessName: null },
+      {
+        id: 'user-1:business-1',
+        businessId: 'business-1',
+        roleId: 'business_owner',
+        businessName: 'Acme',
+      },
+      {
+        id: 'user-1:business-2',
+        businessId: 'business-2',
+        roleId: 'accountant',
+        businessName: null,
+      },
     ]);
   });
 
@@ -68,11 +81,38 @@ describe('myMemberships resolver', () => {
     expect(result).toEqual([]);
   });
 
-  it('wraps unexpected failures in a GraphQLError', async () => {
-    const getAuthContext = vi.fn().mockRejectedValue(new Error('db down'));
+  it('wraps unexpected failures in a GraphQLError with the resolver code and original error', async () => {
+    const originalError = new Error('db down');
+    const getAuthContext = vi.fn().mockRejectedValue(originalError);
+
+    const error = await myMembershipsResolver(
+      {},
+      {},
+      contextWith(getAuthContext),
+      mockInfo,
+    ).then(
+      () => {
+        throw new Error('expected myMemberships to reject');
+      },
+      (thrown: unknown) => thrown,
+    );
+
+    expect(error).toBeInstanceOf(GraphQLError);
+    expect(error).toMatchObject({
+      message: 'Failed to resolve memberships',
+      extensions: { code: 'MEMBERSHIPS_RESOLUTION_FAILED' },
+      originalError,
+    });
+  });
+
+  it('rethrows GraphQLErrors from the auth context unchanged', async () => {
+    const authError = new GraphQLError('Unauthenticated', {
+      extensions: { code: 'UNAUTHENTICATED' },
+    });
+    const getAuthContext = vi.fn().mockRejectedValue(authError);
 
     await expect(
       myMembershipsResolver({}, {}, contextWith(getAuthContext), mockInfo),
-    ).rejects.toBeInstanceOf(GraphQLError);
+    ).rejects.toBe(authError);
   });
 });

--- a/packages/server/src/modules/auth/index.ts
+++ b/packages/server/src/modules/auth/index.ts
@@ -10,6 +10,7 @@ import { SuperAdminProvider } from './providers/super-admin.provider.js';
 import { apiKeysResolvers } from './resolvers/api-keys.resolver.js';
 import { businessUsersResolvers } from './resolvers/business-users.resolver.js';
 import { invitationsResolvers } from './resolvers/invitations.resolver.js';
+import { membershipsResolvers } from './resolvers/memberships.resolver.js';
 import auth from './typeDefs/auth.graphql.js';
 
 const __dirname = import.meta.dirname;
@@ -18,7 +19,7 @@ export const authModule = createModule({
   id: 'auth',
   dirname: __dirname,
   typeDefs: [auth],
-  resolvers: [invitationsResolvers, apiKeysResolvers, businessUsersResolvers],
+  resolvers: [invitationsResolvers, apiKeysResolvers, businessUsersResolvers, membershipsResolvers],
   providers: () => [
     AcceptInvitationsProvider,
     Auth0ManagementProvider,

--- a/packages/server/src/modules/auth/resolvers/memberships.resolver.ts
+++ b/packages/server/src/modules/auth/resolvers/memberships.resolver.ts
@@ -5,20 +5,24 @@ import type { AuthModule } from '../types.js';
 /**
  * Expose the authenticated caller's own business memberships.
  *
- * Gated with `@requiresAuth` only (never `@requiresRole`, never dependent on a
- * selected business scope): the MCP connector reads a user's businesses BEFORE
- * any scope is chosen, so a role-/scope-gated query cannot be used.
+ * Gated with `@requiresAnyRole(["business_owner", "accountant"])`: only callers
+ * holding one of these roles may enumerate their memberships.
  *
  * The memberships are already resolved on the request auth context
  * (`AuthContextProvider.getAuthContext()`), so no additional DB query is needed.
  * An authenticated user with no memberships returns an empty list, not an error.
+ *
+ * Each membership's `id` is a composite of the caller's user id and the business
+ * id, since a membership has no single-column identity of its own.
  */
 export const membershipsResolvers: AuthModule.Resolvers = {
   Query: {
     myMemberships: async (_, __, { injector }) => {
       try {
         const authContext = await injector.get(AuthContextProvider).getAuthContext();
+        const userId = authContext?.user?.userId ?? '';
         return (authContext?.memberships ?? []).map(membership => ({
+          id: `${userId}:${membership.businessId}`,
           businessId: membership.businessId,
           roleId: membership.roleId,
           businessName: membership.businessName ?? null,

--- a/packages/server/src/modules/auth/resolvers/memberships.resolver.ts
+++ b/packages/server/src/modules/auth/resolvers/memberships.resolver.ts
@@ -1,0 +1,38 @@
+import { GraphQLError } from 'graphql';
+import { AuthContextProvider } from '../providers/auth-context.provider.js';
+import type { AuthModule } from '../types.js';
+
+/**
+ * Expose the authenticated caller's own business memberships.
+ *
+ * Gated with `@requiresAuth` only (never `@requiresRole`, never dependent on a
+ * selected business scope): the MCP connector reads a user's businesses BEFORE
+ * any scope is chosen, so a role-/scope-gated query cannot be used.
+ *
+ * The memberships are already resolved on the request auth context
+ * (`AuthContextProvider.getAuthContext()`), so no additional DB query is needed.
+ * An authenticated user with no memberships returns an empty list, not an error.
+ */
+export const membershipsResolvers: AuthModule.Resolvers = {
+  Query: {
+    myMemberships: async (_, __, { injector }) => {
+      try {
+        const authContext = await injector.get(AuthContextProvider).getAuthContext();
+        return (authContext?.memberships ?? []).map(membership => ({
+          businessId: membership.businessId,
+          roleId: membership.roleId,
+          businessName: membership.businessName ?? null,
+        }));
+      } catch (error) {
+        if (error instanceof GraphQLError) {
+          throw error;
+        }
+
+        throw new GraphQLError('Failed to resolve memberships', {
+          originalError: error instanceof Error ? error : undefined,
+          extensions: { code: 'MEMBERSHIPS_RESOLUTION_FAILED' },
+        });
+      }
+    },
+  },
+};

--- a/packages/server/src/modules/auth/typeDefs/auth.graphql.ts
+++ b/packages/server/src/modules/auth/typeDefs/auth.graphql.ts
@@ -12,12 +12,15 @@ export default gql`
     listApiKeys: [ApiKey!]! @requiresRole(role: "business_owner")
     listBusinessUsers: [BusinessUser!]! @requiresRole(role: "business_owner")
     listInvitations: [Invitation!]! @requiresRole(role: "business_owner")
-    " the authenticated caller's own business memberships; authenticated but not role- or scope-gated "
-    myMemberships: [MyBusinessMembership!]! @requiresAuth
+    " the authenticated caller's own business memberships "
+    myMemberships: [MyBusinessMembership!]!
+      @requiresAnyRole(roles: ["business_owner", "accountant"])
   }
 
-  " a single business the authenticated caller belongs to, with the role they hold in it " # eslint-disable-next-line @graphql-eslint/strict-id-in-types -- identified by (user, business); no single id
+  " a single business the authenticated caller belongs to, with the role they hold in it "
   type MyBusinessMembership {
+    " composite identity of the membership: the caller's user id combined with the business id "
+    id: ID!
     businessId: ID!
     roleId: String!
     businessName: String

--- a/packages/server/src/modules/auth/typeDefs/auth.graphql.ts
+++ b/packages/server/src/modules/auth/typeDefs/auth.graphql.ts
@@ -12,6 +12,15 @@ export default gql`
     listApiKeys: [ApiKey!]! @requiresRole(role: "business_owner")
     listBusinessUsers: [BusinessUser!]! @requiresRole(role: "business_owner")
     listInvitations: [Invitation!]! @requiresRole(role: "business_owner")
+    " the authenticated caller's own business memberships; authenticated but not role- or scope-gated "
+    myMemberships: [MyBusinessMembership!]! @requiresAuth
+  }
+
+  " a single business the authenticated caller belongs to, with the role they hold in it " # eslint-disable-next-line @graphql-eslint/strict-id-in-types -- identified by (user, business); no single id
+  type MyBusinessMembership {
+    businessId: ID!
+    roleId: String!
+    businessName: String
   }
 
   extend type Mutation {


### PR DESCRIPTION
## Summary

Implements **Prompt 08a — Server: expose the caller's own business memberships**
(see [`docs/mcp/implementation-blueprint.md`](../blob/mcp-setup/docs/mcp/implementation-blueprint.md) and [`docs/mcp/spec.md`](../blob/mcp-setup/docs/mcp/spec.md) §7.1).

An Auth0 access token carries identity only (`sub`/`email`); it does **not** contain the user's Accounter business memberships or roles. Those live in the server DB (`accounter_schema.business_users`) and are already resolved per request by the server's auth context. The MCP connector needs to read a user's businesses **before** any business scope is selected, so a role-/scope-gated query cannot be used — this adds a dedicated authenticated-only query for exactly that.

> **Stacked PR:** targets `mcp-setup` (Prompts 01→08). Prompt 08b consumes this query from the MCP side.

## Changes

- **`typeDefs/auth.graphql.ts`**
  - Add `myMemberships: [MyBusinessMembership!]! @requiresAuth` to the `Query` type — gated with `@requiresAuth` **only** (not `@requiresRole`, not dependent on a selected business scope).
  - Add the `MyBusinessMembership` type `{ businessId: ID!, roleId: String!, businessName: String }`. Named `MyBusinessMembership` rather than `BusinessMembership` because the latter already exists in the `common` module (`{ businessId: UUID!, role: String!, businessName: String }`, nested under `userContext`); the blueprint anticipated this ("prefix if it collides"). `roleId` maps 1:1 onto the connector's internal membership shape / `coerceMembership` (Prompt 08b).
- **`resolvers/memberships.resolver.ts`** (new) — resolver returns the memberships already resolved on the request auth context via `AuthContextProvider.getAuthContext()`. **No new DB query.** Read-only, no scope side effects. An authenticated user with no memberships returns `[]`, not an error; unexpected failures are wrapped in a `GraphQLError`.
- **`index.ts`** — register `membershipsResolvers` in the auth module.
- **`__tests__/memberships.test.ts`** (new) — resolver unit tests: multi-business user returns all memberships; user with none (and a context missing the `memberships` field) returns `[]`; unexpected failure surfaces as a `GraphQLError`.

## Validation

- `yarn generate` — GraphQL codegen succeeds; `MyBusinessMembership` / `myMemberships` resolver types generated.
- Resolver unit tests pass (4/4).
- `eslint` clean on the changed source files; `prettier` formatted.
- Server `tsc` shows no errors in the new files (the only `tsc` errors present are the pre-existing pgtyped SQL-codegen gaps that require a live DB, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPMszz9gdZFhNjobRm6Ndo)_