### PR TITLE
Clarify Prompt 08b upstream client and token forwarding requirements

### DIFF
--- a/docs/mcp/implementation-blueprint.md
+++ b/docs/mcp/implementation-blueprint.md
@@ -512,8 +512,10 @@ Validation:
 You are implementing Prompt 08b.
 
 Context:
-The MCP connector already forwards the caller's bearer token to the Accounter GraphQL server on
-every upstream call (the upstream client sets Authorization from the request context). So resolving
+This is the MCP's first upstream call to the Accounter GraphQL server: the current handler performs
+no upstream GraphQL calls. So the new MembershipSource must forward the caller's bearer token itself
+(setting Authorization from the request context on the upstream call) — that forwarding is a
+requirement of this prompt, not existing behavior. Once the token is forwarded, resolving
 memberships is just a normal authenticated query — no Auth0 custom claim and no shared service
 secret (unlike email-ingestion-gateway, which is unattended and uses an X-Gateway-CP-Token).
 
@@ -522,12 +524,16 @@ Resolve business memberships by calling the server's `myMemberships` query with 
 and make that the wired membership source.
 
 Requirements:
-- Implement an upstream MembershipSource that issues `myMemberships` using the existing upstream
-  client (reuse createReadOperation + UpstreamGraphQLClient in
-  packages/mcp-server/src/upstream/graphql-client.ts and getUpstreamClient()); map the result to the
-  internal BusinessMembership shape (reuse coerceMembership from auth/identity.ts).
-- Thread the caller's Authorization header + correlation id into the source, and wire it into
-  resolveAuthContext at packages/mcp-server/src/mcp/handler.ts, replacing the default claims source.
+- Introduce a minimal upstream GraphQL client as part of this prompt — do not assume one exists yet.
+  Create packages/mcp-server/src/upstream/graphql-client.ts exposing an UpstreamGraphQLClient, a
+  createReadOperation helper, and a getUpstreamClient() accessor. Keep it small; Prompt 12 later
+  generalizes and hardens this client with timeout/retry guardrails.
+- Implement an upstream MembershipSource that issues `myMemberships` through that client; map the
+  result to the internal BusinessMembership shape via a coerceMembership helper (add it, e.g. in
+  auth/identity.ts).
+- Thread the caller's Authorization header + correlation id into the source, and wire it into the
+  auth-context resolution in packages/mcp-server/src/mcp/handler.ts — introduce a resolveAuthContext
+  seam if one does not exist yet — replacing the default claims source.
 - Error semantics: throw on upstream/auth/infra failure (so the request surfaces 401/5xx, not a
   silent empty scope); return [] only when the server legitimately reports no memberships.
 

--- a/docs/mcp/spec.md
+++ b/docs/mcp/spec.md
@@ -136,13 +136,14 @@ If Claude Code support is added later, also support loopback callback patterns a
 
 ## 6.4 Token and Scope Model
 
-The Auth0 access token conveys **identity only** — the `sub` (stable user id) and `email`. It does
-**not** carry the user's Accounter business memberships or roles: those live in the Accounter
-server's database and are resolved at request time (see §7.1).
+The Auth0 access token conveys **identity only** — the `sub` (stable user id), plus `email` and
+`email_verified` when present (the `email` claim is optional and may be absent). It does **not**
+carry the user's Accounter business memberships or roles: those live in the Accounter server's
+database and are resolved at request time (see §7.1).
 
 The access token is used to:
 
-- authenticate the caller (identity: `sub`, `email`)
+- authenticate the caller (identity: `sub`, plus optional `email`/`email_verified`)
 - carry coarse OAuth transport scopes (not fine-grained business capability)
 
 Tenant/business memberships and roles are **not** read from token claims — they are resolved from


### PR DESCRIPTION
## Summary

Update implementation blueprint and spec documentation to clarify that Prompt 08b introduces a new upstream GraphQL client (rather than assuming one exists) and that bearer token forwarding is a new requirement, not existing behavior.

## Changes

- **implementation-blueprint.md**: Revise Prompt 08b context and requirements to:
  - Clarify that this is the MCP's first upstream GraphQL call, so the new MembershipSource must introduce token forwarding itself
  - Explicitly require creating a minimal `UpstreamGraphQLClient` in `packages/mcp-server/src/upstream/graphql-client.ts` as part of this prompt (not reusing an existing one)
  - Note that Prompt 12 will later generalize this client with timeout/retry guardrails
  - Clarify the need to introduce a `resolveAuthContext` seam in the handler if one doesn't exist yet

- **spec.md**: Refine §6.4 Token and Scope Model to:
  - Clarify that the Auth0 access token carries `sub` plus optional `email` and `email_verified` claims
  - Update authentication description to reflect that `email` is optional
  - Emphasize that memberships and roles are resolved from the Accounter database, not token claims

These changes improve clarity for implementers without altering the actual implementation approach.

https://claude.ai/code/session_017MqCVWqb56h8vjw8uyZ4rD