### PR TITLE
chore(mcp-server): fix lint errors in acceptance script

### DIFF
--- a/packages/mcp-server/scripts/acceptance.mjs
+++ b/packages/mcp-server/scripts/acceptance.mjs
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+/* eslint-disable no-undef */
+
+/* eslint-disable no-console */
 /**
  * Final acceptance gate for @accounter/mcp-server (blueprint Prompt 24).
  *


### PR DESCRIPTION
Disable no-undef and no-console for the Node acceptance script, matching the convention used by other .mjs scripts in scripts/.