### PR TITLE
fix(reports): exclude non-financial ("OTHER") documents from VAT report by-date logic

### DIFF
--- a/.changeset/vat-report-exclude-other-documents.md
+++ b/.changeset/vat-report-exclude-other-documents.md
@@ -1,0 +1,17 @@
+---
+'@accounter/server': patch
+---
+
+Exclude non-financial documents from the VAT report's by-date logic (issue #3375).
+
+Documents of type `OTHER` (and other non-financial documents) carry a `date`, so they were returned
+by the VAT report's date-filtered document query and registered their linked `charge_id` before the
+financial-document type check ran. That pulled unrelated charges into the report's `missingInfo` /
+`differentMonthDoc` / `businessTrips` buckets whenever a charge's only in-month tie was a hidden
+`OTHER`-document date.
+
+The report now registers a document's charge only after confirming it is a financial (invoice)
+document linked to a charge carrying both counterparties, via the new `isVatReportRelevantDocument`
+type guard in the vat-report helper (built on the canonical `isInvoice` definition). All callers of
+`getVatRecords` — the VAT report screen, PCN874 generation, monthly-VAT ledger validation and
+description suggestions — benefit from the corrected filtering.

--- a/packages/server/src/modules/reports/helpers/__tests__/vat-report.helper.test.ts
+++ b/packages/server/src/modules/reports/helpers/__tests__/vat-report.helper.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { Currency } from '../../../../shared/enums.js';
+import { Currency, DocumentType } from '../../../../shared/enums.js';
+import type { IGetDocumentsByFiltersResult } from '../../../documents/types.js';
 import {
   calculateMonthlyVatTotalAmount,
+  isVatReportRelevantDocument,
   isWithinMonthlyVatAmountTolerance,
   type RawVatReportRecord,
 } from '../vat-report.helper.js';
@@ -50,5 +52,47 @@ describe('vat-report helper monthly VAT utilities', () => {
     expect(isWithinMonthlyVatAmountTolerance(100, -100.009)).toBe(true);
     expect(isWithinMonthlyVatAmountTolerance(100, -100.02)).toBe(false);
     expect(isWithinMonthlyVatAmountTolerance(100, 100)).toBe(false);
+  });
+});
+
+function createDocument(
+  overrides: Partial<IGetDocumentsByFiltersResult> = {},
+): IGetDocumentsByFiltersResult {
+  return {
+    charge_id: 'charge-1',
+    creditor_id: 'creditor-1',
+    debtor_id: 'debtor-1',
+    type: DocumentType.Invoice,
+    ...overrides,
+  } as IGetDocumentsByFiltersResult;
+}
+
+describe('isVatReportRelevantDocument', () => {
+  it('accepts financial (invoice) documents linked to a charge with both counterparties', () => {
+    expect(isVatReportRelevantDocument(createDocument({ type: DocumentType.Invoice }))).toBe(true);
+    expect(
+      isVatReportRelevantDocument(createDocument({ type: DocumentType.InvoiceReceipt })),
+    ).toBe(true);
+    expect(
+      isVatReportRelevantDocument(createDocument({ type: DocumentType.CreditInvoice })),
+    ).toBe(true);
+  });
+
+  it('rejects "OTHER" documents even when they carry a date and counterparties (issue #3375)', () => {
+    expect(isVatReportRelevantDocument(createDocument({ type: DocumentType.Other }))).toBe(false);
+  });
+
+  it('rejects other non-financial document types', () => {
+    expect(isVatReportRelevantDocument(createDocument({ type: DocumentType.Receipt }))).toBe(false);
+    expect(isVatReportRelevantDocument(createDocument({ type: DocumentType.Proforma }))).toBe(false);
+    expect(
+      isVatReportRelevantDocument(createDocument({ type: DocumentType.Unprocessed })),
+    ).toBe(false);
+  });
+
+  it('rejects documents missing a charge or a counterparty', () => {
+    expect(isVatReportRelevantDocument(createDocument({ charge_id: null }))).toBe(false);
+    expect(isVatReportRelevantDocument(createDocument({ creditor_id: null }))).toBe(false);
+    expect(isVatReportRelevantDocument(createDocument({ debtor_id: null }))).toBe(false);
   });
 });

--- a/packages/server/src/modules/reports/helpers/vat-report.helper.ts
+++ b/packages/server/src/modules/reports/helpers/vat-report.helper.ts
@@ -56,11 +56,16 @@ export type RawVatReportRecord = {
  * `UNPROCESSED` — may still carry a date, counterparty or amount, yet they must never be included
  * in the report nor pull their charge into it via that date (issue #3375).
  *
- * Acts as a type guard so callers can safely treat `charge_id` as a non-null string.
+ * Acts as a type guard so callers can safely treat `charge_id`, `creditor_id` and `debtor_id`
+ * as non-null strings — all three are asserted present here.
  */
 export function isVatReportRelevantDocument(
   doc: IGetDocumentsByFiltersResult,
-): doc is IGetDocumentsByFiltersResult & { charge_id: string } {
+): doc is IGetDocumentsByFiltersResult & {
+  charge_id: string;
+  creditor_id: string;
+  debtor_id: string;
+} {
   if (!doc.charge_id || !doc.creditor_id || !doc.debtor_id) {
     return false;
   }

--- a/packages/server/src/modules/reports/helpers/vat-report.helper.ts
+++ b/packages/server/src/modules/reports/helpers/vat-report.helper.ts
@@ -10,6 +10,7 @@ import {
 } from '../../charges/helpers/common.helper.js';
 import type { IGetChargesByIdsResult } from '../../charges/types.js';
 import { DepreciationProvider } from '../../depreciation/providers/depreciation.provider.js';
+import { isInvoice } from '../../documents/helpers/common.helper.js';
 import type { IGetDocumentsByFiltersResult } from '../../documents/types.js';
 import { ExchangeProvider } from '../../exchange-rates/providers/exchange.provider.js';
 import type { IGetBusinessesByIdsResult } from '../../financial-entities/types.js';
@@ -46,6 +47,25 @@ export type RawVatReportRecord = {
   allocationNumber?: string | null;
   pcn874RecordType?: Pcn874RecordType;
 };
+
+/**
+ * Determines whether a document should be considered by the VAT report.
+ *
+ * Only financial (invoice) documents linked to a charge and carrying both counterparties are
+ * relevant. Non-financial documents — most notably `OTHER`, but also `RECEIPT`, `PROFORMA` and
+ * `UNPROCESSED` — may still carry a date, counterparty or amount, yet they must never be included
+ * in the report nor pull their charge into it via that date (issue #3375).
+ *
+ * Acts as a type guard so callers can safely treat `charge_id` as a non-null string.
+ */
+export function isVatReportRelevantDocument(
+  doc: IGetDocumentsByFiltersResult,
+): doc is IGetDocumentsByFiltersResult & { charge_id: string } {
+  if (!doc.charge_id || !doc.creditor_id || !doc.debtor_id) {
+    return false;
+  }
+  return isInvoice(doc.type);
+}
 
 export const MONTHLY_VAT_AMOUNT_TOLERANCE = 0.01;
 

--- a/packages/server/src/modules/reports/resolvers/get-vat-records.resolver.ts
+++ b/packages/server/src/modules/reports/resolvers/get-vat-records.resolver.ts
@@ -15,6 +15,7 @@ import { BusinessesProvider } from '../../financial-entities/providers/businesse
 import { isRefundCharge } from '../../ledger/helpers/common-charge-ledger.helper.js';
 import {
   adjustTaxRecord,
+  isVatReportRelevantDocument,
   type RawVatReportRecord,
   type VatReportRecordSources,
 } from '../helpers/vat-report.helper.js';
@@ -68,10 +69,6 @@ export const getVatRecords = async (
       })
       .then(documents =>
         documents.filter(doc => {
-          if (doc.charge_id) {
-            docsChargesIDs.add(doc.charge_id);
-          }
-
           // filter documents with vat_report_date_override outside of the date range
           if (doc.vat_report_date_override) {
             const isBeforeFromDate =
@@ -82,12 +79,15 @@ export const getVatRecords = async (
             }
           }
 
-          if (!doc.charge_id || !doc.creditor_id || !doc.debtor_id) {
-            // filter invoice documents with linked charge
+          // Only financial (invoice) documents linked to a charge are considered by the VAT
+          // report. Non-financial documents (e.g. "OTHER") may carry a date but must not be
+          // included nor register their charge via `docsChargesIDs` (issue #3375).
+          if (!isVatReportRelevantDocument(doc)) {
             return false;
           }
-          const isRelevantDoc = ['INVOICE', 'INVOICE_RECEIPT', 'CREDIT_INVOICE'].includes(doc.type);
-          return isRelevantDoc;
+
+          docsChargesIDs.add(doc.charge_id);
+          return true;
         }),
       );
 


### PR DESCRIPTION
## Summary

Fixes #3375 — documents of type `OTHER` were leaking into the VAT report.

The VAT report resolver (`get-vat-records.resolver.ts`) fetches documents whose effective VAT date falls in the report month via `DocumentsProvider.getDocumentsByFilters({ fromVatDate, toVatDate })`. `OTHER` (and other non-financial) documents carry a `date`, so they are returned by that query. The filter callback then registered every returned document's `charge_id` in `docsChargesIDs` **before** the financial-document type check:

```ts
if (doc.charge_id) {
  docsChargesIDs.add(doc.charge_id); // ran for OTHER docs too
}
```

`docsChargesIDs` is used to load additional charges (`moreDocsCharges`) that get pushed into `charges`, which in turn feeds the `missingInfo` / `differentMonthDoc` / `businessTrips` buckets shown on the VAT report screen. As a result, a charge whose only in-month tie was a hidden `OTHER`-document date was pulled into the report as an irrelevant charge.

## Change

Register a document's charge **only after** confirming it is a financial (invoice) document linked to a charge that carries both counterparties. The relevance rule is extracted into a small, reusable type guard in the vat-report helper:

```ts
export function isVatReportRelevantDocument(
  doc: IGetDocumentsByFiltersResult,
): doc is IGetDocumentsByFiltersResult & { charge_id: string } {
  if (!doc.charge_id || !doc.creditor_id || !doc.debtor_id) return false;
  return isInvoice(doc.type);
}
```

`isInvoice` (the existing canonical helper) covers exactly `INVOICE` / `INVOICE_RECEIPT` / `CREDIT_INVOICE` — the same set the resolver previously matched with an inline string array — so relevance is unchanged for financial docs, and the definition is now centralized. The guard also narrows `charge_id` to a non-null string for the caller.

All callers of the shared `getVatRecords` (VAT report screen, PCN874, monthly-VAT ledger validation, and description suggestions) benefit from the same fix.

## Files

- `modules/reports/helpers/vat-report.helper.ts` — new `isVatReportRelevantDocument` type guard.
- `modules/reports/resolvers/get-vat-records.resolver.ts` — use the guard; move the `docsChargesIDs.add` after the relevance check.
- `modules/reports/helpers/__tests__/vat-report.helper.test.ts` — unit tests for the guard (accepts invoice types; rejects `OTHER`/`RECEIPT`/`PROFORMA`/`UNPROCESSED` and docs missing a charge/counterparty).

## Testing

- Added unit tests for the new predicate.
- The predicate logic was verified standalone (invoice types accepted; `OTHER` and other non-financial types rejected). A full `yarn test` / typecheck could not be executed in the sandbox (SQL codegen needs a live Postgres, and one transitive package CDN host is blocked by the egress policy); CI generates the types and runs the suite.

## Note / possible follow-up (out of scope)

The issue mentions "multiple flows" and asks to *rethink* optional attributes on `OTHER` docs. This PR addresses the resolver flow the issue points at. There is a separate, broader path in the shared `getChargesByFilters` SQL where `documents_min_date`/`documents_max_date` fall back to *any* document date (`COALESCE(min_event_date, min_any_event_date)`), so a charge with only an `OTHER` doc (no financial docs) could still be date-matched by that `OTHER` date. Changing that touches app-wide charge date semantics and is intentionally left out of this focused fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp6doqCUURTfrKsC4hwLCw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qp6doqCUURTfrKsC4hwLCw)_