### PR TITLE
refactor(mcp-server): centralize TIMELESS_DATE date-validation primitives

### DIFF
--- a/.changeset/bumpy-jeans-fly.md
+++ b/.changeset/bumpy-jeans-fly.md
@@ -1,0 +1,9 @@
+---
+'@accounter/mcp-server': patch
+---
+
+- Added a shared `dates.ts` module exporting `TIMELESS_DATE`, `parseCalendarDate`, and `DAY_MS`.
+- Updated `tools/charges.ts` and `tools/reports.ts` to import those primitives from `./dates.js` and
+  removed their local copies.
+- Avoided per-call redefinition of `parseCalendarDate` in `reports.ts` by using the shared
+  implementation.

--- a/packages/mcp-server/src/tools/charges.ts
+++ b/packages/mcp-server/src/tools/charges.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { DAY_MS, parseCalendarDate, TIMELESS_DATE } from './dates.js';
 import { ToolInputError } from './execute.js';
 import { shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
@@ -16,8 +17,6 @@ export const SEARCH_CHARGES_TOOL_NAME = 'accounter_search_charges';
 export const MAX_PAGE_SIZE = 50;
 export const DEFAULT_PAGE_SIZE = 25;
 export const MAX_DATE_RANGE_DAYS = 366;
-
-const TIMELESS_DATE = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format');
 
 const searchChargesInput = z.object({
   businessIds: z
@@ -88,28 +87,6 @@ export interface NormalizedCharge {
   description: string | null;
   amount: { value: number; formatted: string; currency: string } | null;
   date: string | null;
-}
-
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-/**
- * Parse a strict `YYYY-MM-DD` string to a UTC timestamp, or `null` if it is not a
- * real calendar date. `Date.parse` alone is unsafe here: it silently rolls
- * impossible dates over (e.g. `2026-02-31` → `2026-03-03`) instead of failing, so
- * we verify the parsed components round-trip back to the input.
- */
-function parseCalendarDate(value: string): number | null {
-  const [year, month, day] = value.split('-').map(Number);
-  const timestamp = Date.UTC(year, month - 1, day);
-  const date = new Date(timestamp);
-  if (
-    date.getUTCFullYear() !== year ||
-    date.getUTCMonth() !== month - 1 ||
-    date.getUTCDate() !== day
-  ) {
-    return null;
-  }
-  return timestamp;
 }
 
 /** Reject an invalid, inverted, or too-wide date range before hitting upstream. */

--- a/packages/mcp-server/src/tools/dates.ts
+++ b/packages/mcp-server/src/tools/dates.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+/**
+ * Shared date-validation primitives for tool inputs.
+ *
+ * Several tools accept bounded `YYYY-MM-DD` date ranges and need the same
+ * format check and calendar-date parsing. Keeping these in one place avoids
+ * drift between tools (spec §9.1, §9.3).
+ */
+
+/** Milliseconds in a day — used to measure date-range widths. */
+export const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** A strict `YYYY-MM-DD` string. Format-only; use {@link parseCalendarDate} to
+ * confirm the value is a real calendar date. */
+export const TIMELESS_DATE = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format');
+
+/**
+ * Parse a strict `YYYY-MM-DD` string to a UTC timestamp, or `null` if it is not a
+ * real calendar date. `Date.parse` alone is unsafe here: it silently rolls
+ * impossible dates over (e.g. `2026-02-31` → `2026-03-03`) instead of failing, so
+ * we verify the parsed components round-trip back to the input.
+ */
+export function parseCalendarDate(value: string): number | null {
+  const [year, month, day] = value.split('-').map(Number);
+  const timestamp = Date.UTC(year, month - 1, day);
+  const date = new Date(timestamp);
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return timestamp;
+}

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { DAY_MS, parseCalendarDate, TIMELESS_DATE } from './dates.js';
 import { ToolInputError } from './execute.js';
 import { shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
@@ -16,8 +17,6 @@ export const BALANCE_REPORT_TOOL_NAME = 'accounter_balance_report';
 /** Bounds keeping the payload deterministic and small (spec §9.1, §9.3). */
 export const MAX_REPORT_DATE_RANGE_DAYS = 366;
 export const MAX_REPORT_ROWS = 500;
-
-const TIMELESS_DATE = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format');
 
 const balanceReportInput = z.object({
   businessId: z
@@ -61,22 +60,7 @@ interface RawBalanceRow {
   amount: { raw: number; formatted: string; currency: string };
 }
 
-const DAY_MS = 24 * 60 * 60 * 1000;
-
 function assertDateRange(input: BalanceReportInput): void {
-  const parseCalendarDate = (value: string): number | null => {
-    const [year, month, day] = value.split('-').map(Number);
-    const timestamp = Date.UTC(year, month - 1, day);
-    const date = new Date(timestamp);
-    if (
-      date.getUTCFullYear() !== year ||
-      date.getUTCMonth() !== month - 1 ||
-      date.getUTCDate() !== day
-    ) {
-      return null;
-    }
-    return timestamp;
-  };
   const from = parseCalendarDate(input.fromDate);
   const to = parseCalendarDate(input.toDate);
   if (from === null || to === null) {


### PR DESCRIPTION
## Summary

The MCP server's `charges` and `reports` tools each defined their own **identical** `TIMELESS_DATE` zod schema for `YYYY-MM-DD` input validation, along with duplicate `DAY_MS` and `parseCalendarDate` helpers. This centralizes those shared date-validation primitives into a single module.

## Changes

- **New** `packages/mcp-server/src/tools/dates.ts` — exports the shared primitives:
  - `TIMELESS_DATE` — strict `YYYY-MM-DD` zod string schema
  - `parseCalendarDate` — round-trip parse that rejects impossible calendar dates (e.g. `2026-02-31`)
  - `DAY_MS` — day-in-milliseconds constant used for range widths
- **`tools/charges.ts`** and **`tools/reports.ts`** — drop their local copies and import from `./dates.js`. In `reports.ts` this also removes a `parseCalendarDate` that was re-declared on every `assertDateRange` call.

## Notes

- **No behavioral change** — the extracted regex, parsing logic, and constant are byte-for-byte identical to the originals.
- The per-tool `assertDateRange` functions intentionally stay in place: their range rules differ (charges treats both dates as optional; reports requires both, with distinct error messages and its own max-range bound).

## Verification

Mechanical extraction verified by hand: the three primitives now live only in `dates.ts`, and both consumers reference them via import (`z` is still used by each file for its other schemas). Codegen/lint/tests could not be run in this environment because `yarn install` cannot complete — the pinned `xlsx@cdn.sheetjs.com` transitive dependency is blocked by the egress policy — an unrelated, pre-existing limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016EhrXtV2SMcWwhmnNiZdqN)_