### PR TITLE
feat(mcp-server): leverage GraphQL-Codegen for tool operation types

### DIFF
--- a/.changeset/new-ideas-search.md
+++ b/.changeset/new-ideas-search.md
@@ -1,0 +1,9 @@
+---
+'@accounter/mcp-server': patch
+---
+
+- Extend GraphQL codegen document discovery to include MCP server tool source files and generate
+  `typescript-operations` output for the MCP server.
+- Update MCP tool handlers (`charges`, `lookups`, `reports`) to use generated `Mcp*Query` /
+  `Mcp*QueryVariables` types instead of local `Raw*` interfaces.
+- Ensure the new generated MCP output directory is cleared as part of `generate:graphql:clear`.

--- a/codegen.ts
+++ b/codegen.ts
@@ -11,6 +11,7 @@ const config: CodegenConfig = {
     './packages/gmail-listener/src/server-requests.ts',
     './packages/scraper-app/src/server/graphql/mutations.ts',
     './packages/email-ingestion-gateway/src/graphql/mutations.ts',
+    './packages/mcp-server/src/tools/*.ts',
   ],
   emitLegacyCommonJSImports: false,
   generates: {
@@ -238,6 +239,36 @@ const config: CodegenConfig = {
         useTypeImports: true,
         rawRequest: true,
         scalars: {
+          UUID: {
+            input: 'string',
+            output: 'string',
+          },
+        },
+      },
+    },
+    // The MCP server calls the GraphQL API through its own read-only upstream
+    // client (not graphql-request), so it only needs the operation result and
+    // variables types — no SDK. `typescript-operations` is self-contained here:
+    // it emits the referenced input/enum types alongside inline operation types,
+    // giving tool handlers end-to-end inferred types in place of hand-written
+    // interfaces.
+    'packages/mcp-server/src/gql/index.ts': {
+      plugins: ['typescript-operations'],
+      config: {
+        enumType: 'const',
+        useTypeImports: true,
+        scalars: {
+          // The upstream client consumes the raw JSON response, where date
+          // scalars arrive as ISO strings — represent them as `string` rather
+          // than `Date`/`unknown` so tool handlers get the true runtime shape.
+          TimelessDate: {
+            input: 'string',
+            output: 'string',
+          },
+          DateTime: {
+            input: 'string',
+            output: 'string',
+          },
           UUID: {
             input: 'string',
             output: 'string',

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate": "concurrently -c blue,green -n GraphQL,SQL \"yarn generate:graphql\" \"yarn generate:sql\"",
     "generate:all": "yarn generate",
     "generate:graphql": "yarn generate:graphql:clear; graphql-codegen",
-    "generate:graphql:clear": "rimraf schema.graphql packages/server/**/__generated__/types.ts packages/client/src/gql/ packages/gmail-listener/src/gql/ packages/scraper-app/src/server/gql/ packages/email-ingestion-gateway/src/gql/",
+    "generate:graphql:clear": "rimraf schema.graphql packages/server/**/__generated__/types.ts packages/client/src/gql/ packages/gmail-listener/src/gql/ packages/scraper-app/src/server/gql/ packages/email-ingestion-gateway/src/gql/ packages/mcp-server/src/gql/",
     "generate:watch": "concurrently -c blue,green -n GraphQL,SQL \"yarn generate:graphql --watch\" \"yarn generate:sql:watch\"",
     "graphql:coverage": "yarn graphql-inspector coverage './packages/client/src/**/*.{ts,tsx}' './schema.graphql'",
     "graphql:validate": "yarn graphql-inspector validate './packages/client/src/**/*.{ts,tsx}' './schema.graphql'",

--- a/packages/mcp-server/src/tools/charges.ts
+++ b/packages/mcp-server/src/tools/charges.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { McpSearchChargesQuery, McpSearchChargesQueryVariables } from '../gql/index.js';
 import { DAY_MS, parseCalendarDate, TIMELESS_DATE } from './dates.js';
 import { ToolInputError } from './execute.js';
 import { shapeListResult } from './output.js';
@@ -62,24 +63,8 @@ const SEARCH_CHARGES_QUERY = /* GraphQL */ `
   }
 `;
 
-interface RawCharge {
-  id: string;
-  userDescription: string | null;
-  totalAmount: { raw: number; formatted: string; currency: string } | null;
-  minEventDate: string | null;
-}
-
-interface SearchChargesData {
-  allCharges: {
-    nodes: RawCharge[];
-    pageInfo: {
-      totalPages: number;
-      totalRecords: number;
-      currentPage: number | null;
-      pageSize: number | null;
-    };
-  };
-}
+/** A single charge node as returned by the generated `McpSearchCharges` query. */
+type RawCharge = McpSearchChargesQuery['allCharges']['nodes'][number];
 
 /** Normalized charge shape returned to the caller. */
 export interface NormalizedCharge {
@@ -119,15 +104,20 @@ function assertDateRange(input: SearchChargesInput): void {
   }
 }
 
-function buildFilters(input: SearchChargesInput, businessIds: readonly string[]) {
-  const filters: Record<string, unknown> = { chargesType: input.flow };
+function buildFilters(
+  input: SearchChargesInput,
+  businessIds: readonly string[],
+): NonNullable<McpSearchChargesQueryVariables['filters']> {
+  const filters: NonNullable<McpSearchChargesQueryVariables['filters']> = {
+    chargesType: input.flow,
+  };
   // Always scope to the authorized businesses.
   if (businessIds.length > 0) {
     filters.byBusinesses = [...businessIds];
   }
   if (input.fromDate) filters.fromDate = input.fromDate;
   if (input.toDate) filters.toDate = input.toDate;
-  if (input.tags && input.tags.length > 0) filters.byTags = input.tags;
+  if (input.tags && input.tags.length > 0) filters.byTags = [...input.tags];
   if (input.freeText) filters.freeText = input.freeText;
   return filters;
 }
@@ -153,18 +143,16 @@ async function handler(
 ): Promise<ToolResult> {
   assertDateRange(input);
 
-  const data = await context.client.query<SearchChargesData>(
-    {
-      query: SEARCH_CHARGES_QUERY,
-      variables: {
-        filters: buildFilters(input, context.readScope.businessIds),
-        // The tool exposes a 1-based `page`, but upstream `allCharges` is 0-based
-        // (it slices `[page * limit, (page + 1) * limit]`), so translate here —
-        // otherwise page 1 would skip the first page of results.
-        page: input.page - 1,
-        limit: input.pageSize,
-      },
-    },
+  const variables: McpSearchChargesQueryVariables = {
+    filters: buildFilters(input, context.readScope.businessIds),
+    // The tool exposes a 1-based `page`, but upstream `allCharges` is 0-based
+    // (it slices `[page * limit, (page + 1) * limit]`), so translate here —
+    // otherwise page 1 would skip the first page of results.
+    page: input.page - 1,
+    limit: input.pageSize,
+  };
+  const data = await context.client.query<McpSearchChargesQuery>(
+    { query: SEARCH_CHARGES_QUERY, variables },
     { correlationId: context.correlationId, authorization: context.authorization },
   );
 

--- a/packages/mcp-server/src/tools/lookups.ts
+++ b/packages/mcp-server/src/tools/lookups.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { McpListTagsQuery, McpListTaxCategoriesQuery } from '../gql/index.js';
 import { shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 
@@ -71,17 +72,11 @@ const LIST_TAGS_QUERY = /* GraphQL */ `
   }
 `;
 
-interface RawTag {
-  id: string;
-  name: string;
-  namePath: string[] | null;
-}
-
 async function listTagsHandler(
   input: ListTagsInput,
   context: ToolExecutionContext,
 ): Promise<ToolResult> {
-  const data = await context.client.query<{ allTags: RawTag[] }>(
+  const data = await context.client.query<McpListTagsQuery>(
     { query: LIST_TAGS_QUERY },
     { correlationId: context.correlationId, authorization: context.authorization },
   );
@@ -137,20 +132,11 @@ const LIST_TAX_CATEGORIES_QUERY = /* GraphQL */ `
   }
 `;
 
-interface RawTaxCategory {
-  id: string;
-  name: string;
-  irsCode: number | null;
-  isActive: boolean;
-  /** The bookkeeping (chart-of-accounts) sort code; null when unassigned. */
-  sortCode: { key: number; name: string | null } | null;
-}
-
 async function listTaxCategoriesHandler(
   input: ListTaxCategoriesInput,
   context: ToolExecutionContext,
 ): Promise<ToolResult> {
-  const data = await context.client.query<{ taxCategories: RawTaxCategory[] }>(
+  const data = await context.client.query<McpListTaxCategoriesQuery>(
     { query: LIST_TAX_CATEGORIES_QUERY },
     { correlationId: context.correlationId, authorization: context.authorization },
   );

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { McpBalanceReportQuery, McpBalanceReportQueryVariables } from '../gql/index.js';
 import { DAY_MS, parseCalendarDate, TIMELESS_DATE } from './dates.js';
 import { ToolInputError } from './execute.js';
 import { shapeListResult } from './output.js';
@@ -51,15 +52,6 @@ const BALANCE_REPORT_QUERY = /* GraphQL */ `
   }
 `;
 
-interface RawBalanceRow {
-  id: string;
-  chargeId: string;
-  date: string;
-  isFee: boolean;
-  description: string | null;
-  amount: { raw: number; formatted: string; currency: string };
-}
-
 function assertDateRange(input: BalanceReportInput): void {
   const from = parseCalendarDate(input.fromDate);
   const to = parseCalendarDate(input.toDate);
@@ -88,11 +80,13 @@ async function handler(
     throw new ToolInputError('No authorized business in scope for this report');
   }
 
-  const data = await context.client.query<{ transactionsForBalanceReport: RawBalanceRow[] }>(
-    {
-      query: BALANCE_REPORT_QUERY,
-      variables: { fromDate: input.fromDate, toDate: input.toDate, ownerId },
-    },
+  const variables: McpBalanceReportQueryVariables = {
+    fromDate: input.fromDate,
+    toDate: input.toDate,
+    ownerId,
+  };
+  const data = await context.client.query<McpBalanceReportQuery>(
+    { query: BALANCE_REPORT_QUERY, variables },
     { correlationId: context.correlationId, authorization: context.authorization },
   );
 


### PR DESCRIPTION
## Summary

The `@accounter/mcp-server` tools call the GraphQL API using inline query documents, but each result and variables shape was declared by hand as a local TypeScript `interface`. This wires those queries into the repo's existing `graphql-codegen` pipeline so the types are generated from the schema and stay in sync automatically — following the same approach already used by `packages/scraper-app` (`src/server/graphql/mutations.ts` + generated `gql/`).

## Changes

- **`codegen.ts`**
  - Add `./packages/mcp-server/src/tools/*.ts` to `documents` so the tool query documents are picked up.
  - New output `packages/mcp-server/src/gql/index.ts` using the `typescript-operations` plugin. Unlike `scraper-app`, the MCP server talks to the API through its own read-only `UpstreamGraphQLClient` (not `graphql-request`), so it needs only the operation result/variables types — **no SDK / no `graphql-request` dependency**. `typescript-operations` is self-contained here: it emits the referenced input/enum types alongside inline operation types.
  - Map `TimelessDate` / `DateTime` / `UUID` scalars to `string`, matching the raw JSON the upstream client actually consumes (date scalars arrive as ISO strings over the wire).
- **`package.json`**: add `packages/mcp-server/src/gql/` to `generate:graphql:clear` so the generated dir is cleaned on regeneration. (The dir is already covered by the repo's `**/gql/` gitignore.)
- **`tools/charges.ts`, `tools/reports.ts`, `tools/lookups.ts`**: remove the hand-written `Raw*` / `*Data` interfaces and drive the query calls, filter builder, and normalization from the generated `Mcp*Query` / `Mcp*QueryVariables` types.

`memberships.ts` is intentionally left as-is: it treats its payload as `unknown` for defensive runtime coercion, which conflicts with consuming a strict generated result type, so it is not part of the codegen documents.

## Verification

- `yarn generate:graphql` — generates cleanly, single self-contained output file.
- `yarn workspace @accounter/mcp-server typecheck` — passes.
- `yarn workspace @accounter/mcp-server test` — 273 tests pass.
- `yarn workspace @accounter/mcp-server lint` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ytMjL8eQTzfymZYrKMo6J)_