### PR TITLE
feat(tags): expose Tag.ownerId via extended_tags view (owner-scoping Phase 1)

### DIFF
--- a/docs/coherent-owner-scoping-for-mcp/plan.md
+++ b/docs/coherent-owner-scoping-for-mcp/plan.md
@@ -39,23 +39,72 @@ widening is visible rather than silent.
 
 ---
 
-## Phase 0 — pre-flight check (do this first, it can invalidate Phase 2 for tags)
+## Phase 0 — pre-flight check — ✅ **DONE (2026-08-01): PASS**
+
+**Outcome: `x-business-scope` will narrow `allTags` through `extended_tags`.** No `security_invoker`
+change and no resolver-side fallback are needed. **Phase 2 for tags proceeds as written.** Full
+write-up in
+[`packages/mcp-server/docs/connector-gaps-and-decisions.md`](../../packages/mcp-server/docs/connector-gaps-and-decisions.md).
 
 `extended_tags` is a **view**, and no view in this repo sets `security_invoker`, so views run with
-the view owner's privileges. If that owner is a superuser or has `BYPASSRLS`, `x-business-scope`
-will not narrow `allTags` at all (and `allTags` is leaking cross-tenant today):
+the view owner's privileges. If the view owner can escape RLS, `x-business-scope` will not narrow
+`allTags` at all.
+
+Verified against the **production** database (`accounter_prod_db`) — every link must hold, and all
+four do:
 
 ```sql
+-- 1. view owner → prod_group
 SELECT viewowner FROM pg_views WHERE schemaname='accounter_schema' AND viewname='extended_tags';
-SELECT rolname, rolsuper, rolbypassrls FROM pg_roles WHERE rolname = '<that owner>';
+
+-- 2. owner cannot bypass RLS → rolsuper=f, rolbypassrls=f
+SELECT rolname, rolsuper, rolbypassrls FROM pg_roles WHERE rolname = 'prod_group';
+
+-- 3. RLS is ENABLED *and FORCED* on the base table → tags: t / t
+--    (also charges: t/t, tax_categories: t/t)
+SELECT c.relname, pg_get_userbyid(c.relowner) AS owner,
+       c.relrowsecurity, c.relforcerowsecurity
+FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname='accounter_schema' AND c.relname IN ('tags','extended_tags');
+
+-- 4. policy resolves through a session GUC, not current_user
+SELECT policyname, qual FROM pg_policies
+WHERE schemaname='accounter_schema' AND tablename='tags';
+--   tenant_isolation: owner_id = ANY (accounter_schema.get_current_business_scope())
+--   → get_current_business_scope() reads current_setting('app.current_business_scope')
 ```
 
-`extended_charges` is also a view on the primary RLS-scoped read path, so this most likely already
-works. If it does not: `ALTER VIEW accounter_schema.extended_tags SET (security_invoker = true)` (PG
-15+), or add an explicit `WHERE owner_id = ANY($ownerIds)` to `TagsProvider.getAllTags` fed by
-`ScopeProvider.getReadScope()` — the canonical resolver-side pattern
+Two corrections to the original reasoning, both learned by running this:
+
+- **Step 3 is the load-bearing check, and was missing.** `prod_group` _owns_ `tags`, and a table
+  owner bypasses its own RLS policies unless `FORCE ROW LEVEL SECURITY` is set. Checking only
+  `rolsuper`/`rolbypassrls` is insufficient — had `relforcerowsecurity` been `f`, the view would
+  have escaped RLS with both of those still `f` and the check reporting green.
+- **`extended_charges` does not imply `extended_tags`.** They have _different_ owners
+  (`accounter_prod_user` vs `prod_group`), so the "the charges path works, therefore this most
+  likely works" inference does not transfer. Check each view's own owner.
+
+Also note that scope resolves through a session GUC rather than `current_user`, which is exactly why
+the absent `security_invoker` is harmless: the policy evaluates identically no matter which role
+executes the view.
+
+**Correction to the leak framing.** `allTags` is _not_ leaking cross-tenant today. With no
+`x-business-scope` header the server sets the scope to the caller's full membership list, so
+`allTags` returns a **union across the caller's own businesses** — untagged and indistinguishable
+(the actual problem this plan solves), but within the tenant boundary.
+`get_current_business_scope()` falls back to a single business id only when the GUC is unset
+entirely.
+
+If a future environment fails any of the four checks, the remedies are:
+`ALTER VIEW accounter_schema.extended_tags SET (security_invoker = true)` (PG 15+), or an explicit
+`WHERE owner_id = ANY($ownerIds)` in `TagsProvider.getAllTags` fed by `ScopeProvider.getReadScope()`
+— the canonical resolver-side pattern
 (`packages/server/src/modules/auth/providers/scope.provider.ts`). `taxCategories` queries base
 tables directly and is unaffected either way.
+
+> **Verified on production.** Ownership and role attributes are environment-specific, so re-run
+> these four queries against the local dev database before assuming dev behaves identically — dev is
+> the unverified environment here, not prod.
 
 ---
 
@@ -270,8 +319,8 @@ asserting `schema.graphql` contains `ownerId: UUID!` inside `type Tag`.
   self-describing-response contract.
 - `packages/mcp-server/docs/local-development.md` §6 Verify (line 106) — the end-to-end scope check
   below.
-- `packages/mcp-server/docs/connector-gaps-and-decisions.md` — record the Phase 0 view/RLS finding
-  and the stateless-vs-stateful decision.
+- `packages/mcp-server/docs/connector-gaps-and-decisions.md` — Phase 0 view/RLS finding ✅ recorded
+  (2026-08-01); still to add: the stateless-vs-stateful decision.
 - `packages/mcp-server/docs/submission-checklist.md:40` — tool list.
 
 ---

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -5,13 +5,12 @@ capabilities to Claude clients (Claude.ai / Claude Desktop).
 
 See the design docs:
 
-- [`docs/mcp/spec.md`](./docs/mcp/spec.md) — connector specification
-- [`docs/mcp/implementation-blueprint.md`](./docs/mcp/implementation-blueprint.md) — incremental
+- [`docs/spec.md`](./docs/spec.md) — connector specification
+- [`docs/implementation-blueprint.md`](./docs/implementation-blueprint.md) — incremental
   implementation plan
-- [`docs/mcp/operations-runbook.md`](./docs/mcp/operations-runbook.md) — incident handling, metrics,
-  log queries, rollback
-- [`docs/mcp/submission-checklist.md`](./docs/mcp/submission-checklist.md) — connector submission
-  readiness
+- [`docs/operations-runbook.md`](./docs/operations-runbook.md) — incident handling, metrics, log
+  queries, rollback
+- [`docs/submission-checklist.md`](./docs/submission-checklist.md) — connector submission readiness
 
 ## Status
 
@@ -151,8 +150,8 @@ a grace period).
 
 To connect this server to Claude Desktop as a custom connector — HTTPS tunnel, Auth0 application,
 connector fields, and a troubleshooting table — see
-[`docs/mcp/local-development.md`](./docs/mcp/local-development.md). Note that Claude requires an
-HTTPS connector URL, so `http://localhost:3100` cannot be used directly.
+[`docs/local-development.md`](./docs/local-development.md). Note that Claude requires an HTTPS
+connector URL, so `http://localhost:3100` cannot be used directly.
 
 ### MCP endpoint
 

--- a/packages/mcp-server/docs/connector-gaps-and-decisions.md
+++ b/packages/mcp-server/docs/connector-gaps-and-decisions.md
@@ -96,6 +96,52 @@ user-delegated grant on the Accounter API to the new app, update the connector's
 Claude Desktop, and restore the test application's original name. Best paired with any other change
 that already requires re-granting API access.
 
+## Owner-scoping pre-flight (Phase 0) — RLS reaches `extended_tags`
+
+Pre-flight check from
+[`../../../docs/coherent-owner-scoping-for-mcp/plan.md`](../../../docs/coherent-owner-scoping-for-mcp/plan.md)
+Phase 0, run on 2026-08-01 against the **production** database (`accounter_prod_db` on Azure — the
+target the repo root `.env` points at), read-only catalog queries only.
+
+**Result: PASS.** Forwarding `x-business-scope` _will_ narrow `allTags` through the `extended_tags`
+view. No `security_invoker` change and no resolver-side `WHERE owner_id = ANY(...)` fallback are
+needed, and Phase 2 for tags is not invalidated.
+
+Verified chain — every link must hold, and all four do:
+
+| Check                            | Result                                                          |
+| -------------------------------- | --------------------------------------------------------------- |
+| `extended_tags` view owner       | `prod_group`                                                    |
+| `prod_group` privileges          | `rolsuper = f`, `rolbypassrls = f` — cannot bypass RLS          |
+| `tags` table RLS                 | `relrowsecurity = t` **and `relforcerowsecurity = t`**          |
+| `tags` policy `tenant_isolation` | `owner_id = ANY(accounter_schema.get_current_business_scope())` |
+| `get_current_business_scope()`   | reads `current_setting('app.current_business_scope')`           |
+
+Two points worth keeping, because the plan's stated check alone is not sufficient:
+
+- **`FORCE ROW LEVEL SECURITY` is the load-bearing setting here.** `prod_group` owns `tags`, and a
+  table owner bypasses its own RLS policies _unless_ RLS is forced. The plan checks only
+  `rolsuper`/`rolbypassrls`; had `relforcerowsecurity` been `f`, the view would have escaped RLS
+  with both of those still `f`. `charges` and `tax_categories` are likewise `t`/`t`.
+- **Scope comes from a session GUC, not `current_user`.** Because the policy resolves through
+  `current_setting('app.current_business_scope')`, it evaluates identically regardless of which role
+  executes the view — which is precisely why the missing `security_invoker` is harmless here.
+  `extended_tags` has empty `reloptions` (no `security_invoker`), and it does not matter.
+
+Note that `extended_charges` is owned by a _different_ role (`accounter_prod_user`) than
+`extended_tags` (`prod_group`), so the plan's reasoning that "`extended_charges` works, therefore
+this most likely already works" does not transfer directly — the two were checked independently.
+
+On the current behavior the plan describes as a leak: with no `x-business-scope` header the server
+sets the scope to the caller's full membership list, so `allTags` returns a **union across the
+caller's own businesses** — untagged and indistinguishable, but not a cross-tenant leak.
+`get_current_business_scope()` falls back to a single business id only when the GUC is unset
+entirely.
+
+> Verified on **production**. Ownership and role attributes are environment-specific, so re-run
+> these queries against the local dev database before assuming dev behaves the same — dev is the
+> unverified environment here, not prod.
+
 ## Auth0 tenant changes made during debugging
 
 Applied to the dev tenant `dev-cnaunfqjwhwwd8ld` to get DCR-based connection working. Both exist

--- a/packages/migrations/src/actions/2026-08-01T10-00-00.extended-tags-owner-id.ts
+++ b/packages/migrations/src/actions/2026-08-01T10-00-00.extended-tags-owner-id.ts
@@ -1,0 +1,36 @@
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+export default {
+  name: '2026-08-01T10-00-00.extended-tags-owner-id.sql',
+  run: ({ sql }) => sql`
+    -- Expose tags.owner_id through the extended_tags view so Tag.ownerId can be
+    -- resolved (and rows can be attributed to a business).
+    --
+    -- CREATE OR REPLACE VIEW may append columns but never reorder or rename the
+    -- existing ones, so owner_id goes LAST in both the CTE column list and the
+    -- final SELECT.
+    create or replace view accounter_schema.extended_tags
+        (id, parent, name, names_path, ids_path, owner_id)
+    as
+    WITH RECURSIVE get_ancestor(id, parent, name, names_path, ids_path, owner_id
+        ) AS (SELECT t.id
+                , t.parent
+                , t.name
+                , NULL::TEXT[]
+                , NULL::UUID[]
+                , t.owner_id
+            FROM accounter_schema.tags t
+            WHERE parent IS NULL
+            UNION
+            SELECT t.id,
+                    t.parent,
+                    t.name,
+                    CASE WHEN g.names_path IS NULL THEN ARRAY[g.name] ELSE array_append(g.names_path, g.name) END,
+                    CASE WHEN g.ids_path IS NULL THEN ARRAY[g.id] ELSE array_append(g.ids_path, g.id) END,
+                    t.owner_id
+            FROM get_ancestor g
+                    JOIN accounter_schema.tags t ON t.parent = g.id)
+    SELECT *
+    FROM get_ancestor;
+  `,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -193,6 +193,7 @@ import migration_2026_06_22T10_00_00_add_email_ingestion_grant_business_id from 
 import migration_2026_07_06T17_00_00_enhance_conversion_recognition from './actions/2026-07-06T17-00-00.enhance-conversion-recognition.js';
 import migration_2026_07_07T13_00_00_extend_deel_table from './actions/2026-07-07T13-00-00.extend-deel-table.js';
 import migration_2026_07_08T17_00_00_poalim_ils_trigger_fix from './actions/2026-07-08T17-00-00.poalim-ils-trigger-fix.js';
+import migration_2026_08_01T10_00_00_extended_tags_owner_id from './actions/2026-08-01T10-00-00.extended-tags-owner-id.js';
 import { runMigrations } from './pg-migrator.js';
 
 export const MIGRATIONS = [
@@ -390,6 +391,7 @@ export const MIGRATIONS = [
   migration_2026_07_06T17_00_00_enhance_conversion_recognition,
   migration_2026_07_07T13_00_00_extend_deel_table,
   migration_2026_07_08T17_00_00_poalim_ils_trigger_fix,
+  migration_2026_08_01T10_00_00_extended_tags_owner_id,
 ] as const;
 
 export const LATEST_MIGRATION_NAME = MIGRATIONS[MIGRATIONS.length - 1]?.name;

--- a/packages/server/src/modules/tags/resolvers/tags.resolvers.ts
+++ b/packages/server/src/modules/tags/resolvers/tags.resolvers.ts
@@ -93,6 +93,7 @@ export const tagsResolvers: TagsModule.Resolvers = {
   Tag: {
     id: tag => tag.id!,
     name: tag => tag.name!,
+    ownerId: tag => tag.owner_id!,
     parent: (dbTag, _, { injector }) =>
       dbTag.parent
         ? injector

--- a/packages/server/src/modules/tags/typeDefs/tags.graphql.ts
+++ b/packages/server/src/modules/tags/typeDefs/tags.graphql.ts
@@ -82,6 +82,7 @@ export default gql`
   type Tag {
     name: String!
     id: UUID!
+    ownerId: UUID!
     parent: Tag
     namePath: [String!]
     fullPath: [Tag!]


### PR DESCRIPTION
Phase 1 of [`docs/coherent-owner-scoping-for-mcp/plan.md`](../blob/mcp-owner-scoping/docs/coherent-owner-scoping-for-mcp/plan.md). Prerequisite for owner-tagging MCP tool responses — `type Tag` currently has no owner field, so rows returned by `accounter_list_tags` are indistinguishable across businesses.

## Changes

- **Migration** `2026-08-01T10-00-00.extended-tags-owner-id.ts` — appends `owner_id` to `accounter_schema.extended_tags`. `CREATE OR REPLACE VIEW` may append but never reorder or rename existing columns, so `owner_id` goes **last** in both the recursive CTE column list and the final `SELECT`, and is added to the anchor *and* recursive branches.
- **Registered** in `run-pg-migrations.ts` — migrations are not auto-discovered.
- **Schema + resolver** — `Tag.ownerId: UUID!`. Non-null is correct: `accounter_schema.tags.owner_id` is `NOT NULL`. pgtyped infers the view column as `string | null`, so the resolver uses the same `!` the file already applies to `id`.
- **Docs** — records the Phase 0 RLS pre-flight result and carries MCP connector documentation from the local-connector bring-up.

## Phase 0 pre-flight (context)

Verified that forwarding `x-business-scope` will actually narrow `allTags` through the `extended_tags` view, which was a prerequisite for this direction being viable:

| Check | Result |
| --- | --- |
| `extended_tags` view owner | `prod_group` |
| `prod_group` privileges | `rolsuper=f`, `rolbypassrls=f` |
| `tags` RLS | `relrowsecurity=t` **and `relforcerowsecurity=t`** |
| policy | `owner_id = ANY(get_current_business_scope())` |
| scope source | `current_setting('app.current_business_scope')` |

`FORCE ROW LEVEL SECURITY` is the load-bearing setting — `prod_group` owns `tags`, and a table owner bypasses its own RLS policies without it.

## Verification

- `extended_tags` columns → `id, parent, name, names_path, ids_path, owner_id` (position 6, existing columns unchanged)
- `IGetAllTagsResult.owner_id: string | null`
- `schema.graphql` → `Tag.ownerId: UUID!`
- `yarn workspace @accounter/server build` → exit 0
- `yarn graphql:validate` → all documents valid
- `yarn test` → 2690 passed

Adding a field is non-breaking for existing client selections. The shared `Tag` mapper means `Tag.parent`, `Tag.fullPath`, and `Charge.tags` all pick the field up.

## Notes for review

- The migration has **not** been applied to production. It was applied to a local dev database only, for codegen.
- Codegen was run with explicit local DB overrides. Worth flagging separately: `yarn generate:sql` resolves `DATABASE_URL` from the repo-root `.env`, which currently points at the production database.
- `packages/server/src/modules/financial-entities/resolvers/tax-categories.resolver.ts` has unrelated in-progress work and is deliberately excluded from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)