### PR TITLE
fix(mcp-server): scope charges by owner and report on the requested business (owner-scoping Phase 3)

### DIFF
--- a/packages/mcp-server/src/tools/__tests__/charges.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/charges.test.ts
@@ -83,20 +83,31 @@ describe('searchChargesTool — successful read', () => {
     expect(structured.pagination.hasNextPage).toBe(false);
   });
 
-  it('scopes the query to the authorized businesses (byBusinesses)', async () => {
+  it('scopes the query to the authorized businesses (byOwners)', async () => {
     let sentBody: unknown;
     const client = clientReturning(oneCharge, body => (sentBody = body));
     await run(client, authContext(['b1', 'b2']), {});
-    const variables = (sentBody as { variables: { filters: { byBusinesses: string[] } } }).variables;
-    expect(variables.filters.byBusinesses).toEqual(['b1', 'b2']);
+    const variables = (sentBody as { variables: { filters: { byOwners: string[] } } }).variables;
+    expect(variables.filters.byOwners).toEqual(['b1', 'b2']);
   });
 
   it('narrows the scope to a requested subset', async () => {
     let sentBody: unknown;
     const client = clientReturning(oneCharge, body => (sentBody = body));
     await run(client, authContext(['b1', 'b2', 'b3']), { businessIds: ['b2'] });
-    const variables = (sentBody as { variables: { filters: { byBusinesses: string[] } } }).variables;
-    expect(variables.filters.byBusinesses).toEqual(['b2']);
+    const variables = (sentBody as { variables: { filters: { byOwners: string[] } } }).variables;
+    expect(variables.filters.byOwners).toEqual(['b2']);
+  });
+
+  // Regression guard: `byBusinesses` is the COUNTERPARTY predicate, and upstream
+  // strips the owner from `business_array`, so filtering by it returned only
+  // inter-company charges. Owner scoping must never go back to that field.
+  it('never sends byBusinesses — that is the counterparty predicate', async () => {
+    let sentBody: unknown;
+    const client = clientReturning(oneCharge, body => (sentBody = body));
+    await run(client, authContext(['b1', 'b2']), {});
+    const { filters } = (sentBody as { variables: { filters: Record<string, unknown> } }).variables;
+    expect('byBusinesses' in filters).toBe(false);
   });
 
   it('requests the first upstream page (0-based) for the default page', async () => {

--- a/packages/mcp-server/src/tools/__tests__/reports.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/reports.test.ts
@@ -65,6 +65,38 @@ const run = (client: UpstreamGraphQLClient, auth: McpAuthContext, rawArgs: unkno
 const validArgs = { businessId: 'b1', fromDate: '2026-01-01', toDate: '2026-03-01' };
 
 describe('balanceReportTool — valid report', () => {
+  // Regression guard for the owner source. Driven through the handler directly
+  // rather than `executeRegisteredTool`, because the policy narrows `readScope`
+  // to exactly `[input.businessId]` (execute.ts honors the singular field), so
+  // via the normal path the scope-derived owner and the requested owner always
+  // agree and the two are indistinguishable.
+  //
+  // The bug is therefore latent, not live — but it goes live the moment the
+  // resolved scope can hold more than one business, at which point deriving the
+  // owner from `readScope.businessIds[0]` silently reports on the wrong one.
+  it('takes the owner from input.businessId, not from the first id in scope', async () => {
+    let sent: unknown;
+    const client = clientReturning([row('t1')], body => (sent = body));
+    const auth = authContext(['b1', 'b2']);
+    const result = await balanceReportTool.handler(
+      { businessId: 'b2', fromDate: '2026-01-01', toDate: '2026-03-01', reportType: 'BALANCE' },
+      {
+        auth,
+        // Deliberately wider than one business, and ordered so that
+        // `businessIds[0]` is NOT the requested business.
+        readScope: { businessIds: ['b1', 'b2'] },
+        correlationId: 'c',
+        client,
+        authorization: 'Bearer t',
+        upstream: { correlationId: 'c', authorization: 'Bearer t', businessScope: ['b1', 'b2'] },
+      },
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect((sent as { variables: { ownerId: string } }).variables.ownerId).toBe('b2');
+    expect((result.structuredContent as { businessId: string }).businessId).toBe('b2');
+  });
+
   it('returns normalized rows scoped to the requested business (ownerId)', async () => {
     let sent: unknown;
     const client = clientReturning([row('t1')], body => (sent = body));

--- a/packages/mcp-server/src/tools/charges.ts
+++ b/packages/mcp-server/src/tools/charges.ts
@@ -144,9 +144,20 @@ function assertDateRange(input: SearchChargesInput): void {
 
 function buildFilters(input: SearchChargesInput, businessIds: readonly string[]) {
   const filters: Record<string, unknown> = { chargesType: input.flow };
-  // Always scope to the authorized businesses.
+  // Always scope to the authorized businesses — by OWNER, not counterparty.
+  //
+  // `byOwners` is the owner predicate (`c.owner_id IN $ownerIds`). `byBusinesses`
+  // is the *counterparty* predicate (`ec.business_array && $ids`), and upstream
+  // builds that array as `array_remove(base.business_array, fc.owner_id)` — the
+  // owner is explicitly removed from it. Filtering by `byBusinesses` therefore
+  // matched only charges where an authorized business appears as the *other*
+  // party, i.e. inter-company charges: a small and wrong slice of the results.
+  //
+  // Kept as an explicit predicate even though `x-business-scope` now narrows via
+  // RLS upstream: defence in depth, and the tool stays correct if upstream ever
+  // runs under a scope-bypassing role.
   if (businessIds.length > 0) {
-    filters.byBusinesses = [...businessIds];
+    filters.byOwners = [...businessIds];
   }
   if (input.fromDate) filters.fromDate = input.fromDate;
   if (input.toDate) filters.toDate = input.toDate;

--- a/packages/mcp-server/src/tools/charges.ts
+++ b/packages/mcp-server/src/tools/charges.ts
@@ -154,7 +154,7 @@ function buildFilters(input: SearchChargesInput, businessIds: readonly string[])
   // party, i.e. inter-company charges: a small and wrong slice of the results.
   //
   // Kept as an explicit predicate even though `x-business-scope` now narrows via
-  // RLS upstream: defence in depth, and the tool stays correct if upstream ever
+  // RLS upstream: defense in depth, and the tool stays correct if upstream ever
   // runs under a scope-bypassing role.
   if (businessIds.length > 0) {
     filters.byOwners = [...businessIds];

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -96,11 +96,17 @@ async function handler(
 ): Promise<ToolResult> {
   assertDateRange(input);
 
-  // Policy has already confirmed the requested business is within scope; use the
-  // narrowed scope as the single owner. Assert defensively — a business-scoped
-  // tool must never reach upstream without a concrete owner.
-  const ownerId = context.readScope.businessIds[0];
-  if (!ownerId) {
+  // Report on the business the caller actually asked for. Deriving the owner
+  // from the scope instead (`readScope.businessIds[0]`) happens to agree today
+  // only because the policy narrows the scope to exactly this one business — it
+  // would silently report on the wrong business the moment the scope can hold
+  // more than one entry.
+  //
+  // The membership check is defense in depth: the policy has already verified
+  // this business is in scope, so a mismatch means the two disagree, and a
+  // business-scoped tool must never reach upstream with an unauthorized owner.
+  const ownerId = input.businessId;
+  if (!context.readScope.businessIds.includes(ownerId)) {
     throw new ToolInputError('No authorized business in scope for this report');
   }
 


### PR DESCRIPTION
Phase 3 of `docs/coherent-owner-scoping-for-mcp/plan.md` — the two scoping bugs. Follows #4089 (Phase 1) and #4091 (Phase 2).

## 1. `charges.ts` — `byBusinesses` → `byOwners` (live bug)

`byBusinesses` is the **counterparty** predicate (`ec.business_array && $ids`), and upstream builds that array as `array_remove(base.business_array, fc.owner_id)` — the owner is explicitly removed from it. Scoping by owner through that field therefore matched only charges where an authorized business appeared as the *other* party: inter-company charges, a small and wrong slice of the results.

`byOwners` is the owner predicate (`c.owner_id IN $ownerIds`).

The explicit filter is kept alongside the RLS narrowing added in Phase 2 — defence in depth, and the tool stays correct if upstream ever runs under a scope-bypassing role.

## 2. `reports.ts` — owner from `input.businessId` (latent bug)

The handler took the owner from `readScope.businessIds[0]` while ignoring the `businessId` the caller asked for, and now takes it from the input with the membership asserted defensively.

**This one is latent, not live.** `execute.ts` honors the singular `businessId` for scope narrowing, so the policy resolves `readScope` to exactly `[input.businessId]` and both sources agree today. It goes live the moment the resolved scope can hold more than one business — at which point the report would silently cover the wrong one.

## Tests

- charges: the two scope assertions move to `byOwners`, plus a new guard that `byBusinesses` is **never** sent.
- reports: a guard that the owner comes from the input. It drives `balanceReportTool.handler` **directly** rather than going through `executeRegisteredTool`, because the policy's narrowing makes the two owner sources indistinguishable via the normal path — a test written the obvious way passes against the buggy code.

Both fixes were verified by mutation: reverting each one fails the corresponding tests (charges → 3 failures, reports → 1).

## Verification

```
build      exit 0
eslint     clean
prettier   clean
tests      28 files, 284 passed
```

Rebased onto `mcp-owner-scoping` after Phases 1 and 2 merged; the duplicate Phase 2 commit was skipped as already applied, so this branch is a single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)