### PR TITLE
feat(mcp-server): add accounter_list_businesses discovery tool (owner-scoping Phase 4)

### DIFF
--- a/packages/mcp-server/docs/connector-gaps-and-decisions.md
+++ b/packages/mcp-server/docs/connector-gaps-and-decisions.md
@@ -42,6 +42,13 @@ All registered tools are exposed regardless.
 mutating tools. Either wire it into the registry or correct the documentation; today the docs
 describe a control that does not exist.
 
+> **When enforcement lands, `accounter_list_businesses` must be in the default allowlist.** It is
+> the discovery entry point for business scoping: the model calls it to learn which `businessId`
+> values exist before passing them to the other tools. Omitting it does not degrade scoping
+> gracefully — it removes the only way to discover a business id, so every business-scoped call is
+> left guessing. Note the failure would be silent: the remaining tools still work, just unscoped and
+> defaulted to all memberships.
+
 ### 3. No resource binding: MCP and GraphQL share one audience — **medium**
 
 Auth0 ignores the RFC 8707 `resource` parameter Claude sends (observed: `resource=<tunnel URL>`

--- a/packages/mcp-server/src/auth/__tests__/identity.test.ts
+++ b/packages/mcp-server/src/auth/__tests__/identity.test.ts
@@ -144,6 +144,34 @@ describe('membershipsFromClaims', () => {
       ),
     ).toEqual([M('b1', '7'), M('b4', '')]);
   });
+
+  it('carries businessName but never drops a membership over a malformed one', () => {
+    // Unlike roleId, the display name is not load-bearing for authorization, so
+    // a bad name must never cost the caller access to a real business — it is
+    // simply treated as "no name".
+    const memberships = membershipsFromClaims(
+      principal({
+        claims: {
+          sub: 'u',
+          memberships: [
+            { businessId: 'b1', roleId: 'accountant', businessName: 'Acme' },
+            { businessId: 'b2', roleId: 'accountant', business_name: 'Snake Case' },
+            { businessId: 'b3', roleId: 'accountant', businessName: { nested: true } },
+            { businessId: 'b4', roleId: 'accountant', businessName: null },
+            { businessId: 'b5', roleId: 'accountant' },
+          ],
+        },
+      }),
+    );
+
+    expect(memberships.map(m => [m.businessId, m.businessName])).toEqual([
+      ['b1', 'Acme'],
+      ['b2', 'Snake Case'],
+      ['b3', undefined],
+      ['b4', undefined],
+      ['b5', undefined],
+    ]);
+  });
 });
 
 describe('resolveAuthContext', () => {

--- a/packages/mcp-server/src/auth/identity.ts
+++ b/packages/mcp-server/src/auth/identity.ts
@@ -17,6 +17,11 @@ import type { AuthPrincipal } from './token.js';
 export interface BusinessMembership {
   businessId: string;
   roleId: string;
+  /**
+   * Human-readable business name, for display in the discovery tool. Absent or
+   * `null` when upstream has no name — never load-bearing for authorization.
+   */
+  businessName?: string | null;
 }
 
 /** The set of businesses a request is authorized to read from. */
@@ -146,7 +151,13 @@ export function coerceMembership(entry: unknown): BusinessMembership | null {
   } else {
     return null;
   }
-  return { businessId, roleId };
+  // The display name is deliberately lenient, unlike `roleId` above: it is
+  // never used for authorization, so a malformed name must never drop an
+  // otherwise valid membership (and with it, a business the caller can read).
+  // Anything that is not a string is simply treated as "no name".
+  const rawBusinessName = record.businessName ?? record.business_name;
+  const businessName = typeof rawBusinessName === 'string' ? rawBusinessName : undefined;
+  return { businessId, roleId, businessName };
 }
 
 /** De-duplicate memberships by business id (first occurrence wins). */

--- a/packages/mcp-server/src/tools/__tests__/businesses.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/businesses.test.ts
@@ -106,6 +106,30 @@ describe('listBusinessesTool', () => {
     ]);
   });
 
+  // A blank name is normalized to null rather than being displayed as "", and
+  // is grouped with the other unnamed entries. Mixing '' and null previously
+  // made the comparator non-antisymmetric (it returned 1 in both directions),
+  // so the ordering of unnamed entries was unstable rather than id-ordered.
+  it('treats blank names as unnamed and orders them with the other unnamed by id', async () => {
+    const { client } = neverCalledClient();
+    const result = await run(
+      authContext([
+        { businessId: 'b5', roleId: 'accountant', businessName: '   ' },
+        { businessId: 'b2', roleId: 'accountant', businessName: '' },
+        { businessId: 'b3', roleId: 'accountant', businessName: null },
+        { businessId: 'b1', roleId: 'accountant', businessName: 'Real' },
+      ]),
+      client,
+    );
+
+    expect((result.structuredContent as Structured).businesses).toEqual([
+      { businessId: 'b1', name: 'Real', role: 'accountant' },
+      { businessId: 'b2', name: null, role: 'accountant' },
+      { businessId: 'b3', name: null, role: 'accountant' },
+      { businessId: 'b5', name: null, role: 'accountant' },
+    ]);
+  });
+
   // The policy sets requiresBusinessScope: false on purpose — discovery must
   // tell a caller "you have no access" rather than failing with
   // AUTHORIZATION_ERROR, which would leave the model with no way to find out.

--- a/packages/mcp-server/src/tools/__tests__/businesses.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/businesses.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type BusinessMembership, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { listBusinessesTool } from '../businesses.js';
+import { executeRegisteredTool } from '../execute.js';
+
+const PRINCIPAL: AuthPrincipal = {
+  subject: 'user-1',
+  issuer: 'https://tenant.auth0.com/',
+  audience: 'aud',
+  scopes: [],
+  email: null,
+  expiresAt: undefined,
+  claims: { sub: 'user-1' },
+};
+
+function authContext(memberships: BusinessMembership[]): McpAuthContext {
+  return buildAuthContext(PRINCIPAL, memberships);
+}
+
+/** The handler is pure; this client exists only to prove it is never called. */
+function neverCalledClient() {
+  const fetchImpl = vi.fn(async () => {
+    throw new Error('upstream must not be called by accounter_list_businesses');
+  });
+  const client = new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+  return { client, fetchImpl };
+}
+
+const run = (auth: McpAuthContext, client: UpstreamGraphQLClient) =>
+  executeRegisteredTool({
+    tool: listBusinessesTool,
+    rawArgs: {},
+    auth,
+    correlationId: 'c',
+    client,
+    authorization: 'Bearer t',
+  });
+
+interface Structured {
+  businesses: Array<{ businessId: string; name: string | null; role: string }>;
+  returnedCount: number;
+  totalCount: number;
+}
+
+describe('listBusinessesTool', () => {
+  it('lists memberships as {businessId, name, role} without any upstream call', async () => {
+    const { client, fetchImpl } = neverCalledClient();
+    const result = await run(
+      authContext([
+        { businessId: 'b1', roleId: 'business_owner', businessName: 'Acme' },
+        { businessId: 'b2', roleId: 'accountant', businessName: 'Beta' },
+      ]),
+      client,
+    );
+
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as Structured;
+    expect(structured.businesses).toEqual([
+      { businessId: 'b1', name: 'Acme', role: 'business_owner' },
+      { businessId: 'b2', name: 'Beta', role: 'accountant' },
+    ]);
+    expect(structured.totalCount).toBe(2);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('sorts by name case-insensitively, then by id', async () => {
+    const { client } = neverCalledClient();
+    const result = await run(
+      authContext([
+        { businessId: 'b3', roleId: 'accountant', businessName: 'zebra' },
+        { businessId: 'b1', roleId: 'accountant', businessName: 'Apple' },
+        { businessId: 'b2', roleId: 'accountant', businessName: 'apple' },
+      ]),
+      client,
+    );
+
+    const names = (result.structuredContent as Structured).businesses.map(b => [b.name, b.businessId]);
+    expect(names).toEqual([
+      ['Apple', 'b1'],
+      ['apple', 'b2'],
+      ['zebra', 'b3'],
+    ]);
+  });
+
+  it('sorts unnamed businesses last but keeps them deterministic', async () => {
+    const { client } = neverCalledClient();
+    const result = await run(
+      authContext([
+        { businessId: 'b9', roleId: 'accountant' },
+        { businessId: 'b1', roleId: 'accountant', businessName: 'Named' },
+        { businessId: 'b4', roleId: 'accountant', businessName: null },
+      ]),
+      client,
+    );
+
+    expect((result.structuredContent as Structured).businesses).toEqual([
+      { businessId: 'b1', name: 'Named', role: 'accountant' },
+      { businessId: 'b4', name: null, role: 'accountant' },
+      { businessId: 'b9', name: null, role: 'accountant' },
+    ]);
+  });
+
+  // The policy sets requiresBusinessScope: false on purpose — discovery must
+  // tell a caller "you have no access" rather than failing with
+  // AUTHORIZATION_ERROR, which would leave the model with no way to find out.
+  it('returns an empty list (not an error) for a caller with no memberships', async () => {
+    const { client } = neverCalledClient();
+    const result = await run(authContext([]), client);
+
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as Structured;
+    expect(structured.businesses).toEqual([]);
+    expect(structured.totalCount).toBe(0);
+    expect(result.content[0]!.text).toContain('do not have access to any businesses');
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/registry-instance.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/registry-instance.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { LIST_BUSINESSES_TOOL_NAME } from '../businesses.js';
+import { toolRegistry } from '../registry-instance.js';
+
+/**
+ * `ToolRegistry.describe()` preserves registration order, and that order is what
+ * `tools/list` advertises to the model. Discovery leading the list is a
+ * deliberate prompt-engineering choice, not an accident of import order — so it
+ * is locked here.
+ */
+describe('production tool registry', () => {
+  it('advertises the discovery tool first', () => {
+    expect(toolRegistry.describe()[0]?.name).toBe(LIST_BUSINESSES_TOOL_NAME);
+  });
+
+  it('registers the discovery tool with a parameterless schema', () => {
+    const descriptor = toolRegistry
+      .describe()
+      .find(tool => tool.name === LIST_BUSINESSES_TOOL_NAME);
+
+    expect(descriptor).toBeDefined();
+    expect(descriptor?.inputSchema).toMatchObject({
+      type: 'object',
+      additionalProperties: false,
+    });
+    // No required parameters — the model can always call it cold.
+    expect(descriptor?.inputSchema.required).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/src/tools/businesses.ts
+++ b/packages/mcp-server/src/tools/businesses.ts
@@ -32,16 +32,33 @@ interface BusinessSummary {
 const NAME_COLLATOR = new Intl.Collator('en', { sensitivity: 'base' });
 
 /**
+ * Normalize a display name: absent, `null`, or blank (whitespace-only) all mean
+ * "no name" and become `null`. Doing this once at the boundary keeps `name`
+ * either a meaningful string or `null`, so the comparator never has to decide
+ * whether `''` counts as named — and callers never see an empty display string.
+ */
+function normalizeName(businessName: string | null | undefined): string | null {
+  return businessName && businessName.trim().length > 0 ? businessName : null;
+}
+
+/**
  * Stable order: by name (case-insensitive, fixed-locale), tie-broken by id.
  * Unnamed businesses sort last so the readable ones lead, and ties among them
  * still resolve deterministically by id.
+ *
+ * The named/unnamed test is an explicit `!== null` rather than truthiness: with
+ * truthiness an empty-string name counts as unnamed for branch selection but as
+ * *distinct from* `null` in the tie-break, which made the comparator return `1`
+ * in both directions when comparing `''` against `null` — not antisymmetric, so
+ * the sort became unstable rather than merely mis-ordered.
  */
 function byNameThenId(a: BusinessSummary, b: BusinessSummary): number {
-  if (a.name && b.name) {
+  if (a.name !== null && b.name !== null) {
     const byName = NAME_COLLATOR.compare(a.name, b.name);
     if (byName !== 0) return byName;
   } else if (a.name !== b.name) {
-    return a.name ? -1 : 1;
+    // Exactly one is unnamed — the named one leads.
+    return a.name === null ? 1 : -1;
   }
   return a.businessId < b.businessId ? -1 : a.businessId > b.businessId ? 1 : 0;
 }
@@ -50,7 +67,7 @@ function handler(_input: ListBusinessesInput, context: ToolExecutionContext): To
   const businesses = context.auth.memberships
     .map(membership => ({
       businessId: membership.businessId,
-      name: membership.businessName ?? null,
+      name: normalizeName(membership.businessName),
       role: membership.roleId,
     }))
     .sort(byNameThenId);

--- a/packages/mcp-server/src/tools/businesses.ts
+++ b/packages/mcp-server/src/tools/businesses.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+import { shapeListResult } from './output.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+
+/**
+ * Tool 0: business discovery (spec §8.2).
+ *
+ * The connector is stateless — no `Mcp-Session-Id`, no session store, auth
+ * re-derived per request — so there is no "active business" to hang scope on.
+ * This tool is the entry point instead: the model enumerates the businesses the
+ * caller can read, then passes the returned ids back as `businessIds` to the
+ * business-scoped tools.
+ *
+ * The handler is **pure**: memberships are already resolved on the auth context
+ * by `resolveAuthContext` (via the upstream `myMemberships` query), so listing
+ * them costs no upstream call.
+ */
+
+export const LIST_BUSINESSES_TOOL_NAME = 'accounter_list_businesses';
+
+const listBusinessesInput = z.object({});
+type ListBusinessesInput = z.infer<typeof listBusinessesInput>;
+
+interface BusinessSummary {
+  businessId: string;
+  name: string | null;
+  role: string;
+}
+
+// Fixed-locale collator so ordering is deterministic across hosts/runtimes
+// rather than depending on the ambient default locale (mirrors `lookups.ts`).
+const NAME_COLLATOR = new Intl.Collator('en', { sensitivity: 'base' });
+
+/**
+ * Stable order: by name (case-insensitive, fixed-locale), tie-broken by id.
+ * Unnamed businesses sort last so the readable ones lead, and ties among them
+ * still resolve deterministically by id.
+ */
+function byNameThenId(a: BusinessSummary, b: BusinessSummary): number {
+  if (a.name && b.name) {
+    const byName = NAME_COLLATOR.compare(a.name, b.name);
+    if (byName !== 0) return byName;
+  } else if (a.name !== b.name) {
+    return a.name ? -1 : 1;
+  }
+  return a.businessId < b.businessId ? -1 : a.businessId > b.businessId ? 1 : 0;
+}
+
+function handler(_input: ListBusinessesInput, context: ToolExecutionContext): ToolResult {
+  const businesses = context.auth.memberships
+    .map(membership => ({
+      businessId: membership.businessId,
+      name: membership.businessName ?? null,
+      role: membership.roleId,
+    }))
+    .sort(byNameThenId);
+
+  return shapeListResult({
+    items: businesses,
+    itemsKey: 'businesses',
+    total: businesses.length,
+    summarize: (shown, total) =>
+      total === 0
+        ? 'You do not have access to any businesses.'
+        : `You have access to ${total} business(es)${shown < total ? ` (showing ${shown})` : ''}. Pass their businessId values as businessIds to the other tools.`,
+  });
+}
+
+export const listBusinessesTool: ToolDefinition<typeof listBusinessesInput> = {
+  name: LIST_BUSINESSES_TOOL_NAME,
+  description:
+    'List the businesses you have access to, with your role in each. Call this first when you may have access to more than one business, then pass the returned `businessId` values as `businessIds` to the other tools. Read-only; takes no parameters.',
+  inputSchema: listBusinessesInput,
+  policy: {
+    // Deliberately false: a caller with zero memberships should get an empty
+    // list and a helpful summary, not an AUTHORIZATION_ERROR. This is the
+    // discovery entry point — failing it hard would leave the model with no way
+    // to learn that it has no access.
+    requiresBusinessScope: false,
+    dataClassification: 'business',
+  },
+  handler,
+};

--- a/packages/mcp-server/src/tools/registry-instance.ts
+++ b/packages/mcp-server/src/tools/registry-instance.ts
@@ -10,9 +10,14 @@ import { balanceReportTool } from './reports.js';
  */
 export const toolRegistry = new ToolRegistry();
 
-// Discovery first: `describe()` preserves registration order, so this is the
-// first tool the model sees in `tools/list` — ordering is a real prompt
-// -engineering lever for getting the model to scope its calls.
+// Discovery first: `describe()` preserves registration order, so this leads the
+// curated tool list — ordering is a real prompt-engineering lever for getting
+// the model to scope its calls.
+//
+// Note this is first *within the curated registry*, not necessarily in the
+// advertised `tools/list`: `dispatchMcpRequest` sends
+// `[...listedTools, ...toolRegistry.describe()]`, so any transport-level
+// internal tool (currently `accounter_smoke_ping`) still precedes it.
 toolRegistry.register(listBusinessesTool);
 toolRegistry.register(searchChargesTool);
 toolRegistry.register(listTagsTool);

--- a/packages/mcp-server/src/tools/registry-instance.ts
+++ b/packages/mcp-server/src/tools/registry-instance.ts
@@ -1,3 +1,4 @@
+import { listBusinessesTool } from './businesses.js';
 import { searchChargesTool } from './charges.js';
 import { listTagsTool, listTaxCategoriesTool } from './lookups.js';
 import { ToolRegistry } from './registry.js';
@@ -9,6 +10,10 @@ import { balanceReportTool } from './reports.js';
  */
 export const toolRegistry = new ToolRegistry();
 
+// Discovery first: `describe()` preserves registration order, so this is the
+// first tool the model sees in `tools/list` — ordering is a real prompt
+// -engineering lever for getting the model to scope its calls.
+toolRegistry.register(listBusinessesTool);
 toolRegistry.register(searchChargesTool);
 toolRegistry.register(listTagsTool);
 toolRegistry.register(listTaxCategoriesTool);

--- a/packages/mcp-server/src/upstream/__tests__/memberships.test.ts
+++ b/packages/mcp-server/src/upstream/__tests__/memberships.test.ts
@@ -32,10 +32,11 @@ describe('createUpstreamMembershipSource', () => {
 
     const memberships = await source(PRINCIPAL);
 
-    // businessName is intentionally dropped: the internal shape is {businessId, roleId}.
+    // businessName is carried through for `accounter_list_businesses`. A null
+    // name maps to `undefined` (i.e. "no name"), never dropping the membership.
     expect(memberships).toEqual([
-      { businessId: 'b1', roleId: 'business_owner' },
-      { businessId: 'b2', roleId: 'accountant' },
+      { businessId: 'b1', roleId: 'business_owner', businessName: 'Acme' },
+      { businessId: 'b2', roleId: 'accountant', businessName: undefined },
     ]);
   });
 

--- a/packages/mcp-server/src/upstream/memberships.ts
+++ b/packages/mcp-server/src/upstream/memberships.ts
@@ -27,16 +27,17 @@ import {
 /**
  * Read-only query for the authenticated caller's own business memberships.
  *
- * Only `businessId` and `roleId` are selected: the internal
- * {@link BusinessMembership} shape keeps nothing else, so fetching `businessName`
- * would just add payload and upstream work for a field that is immediately
- * dropped.
+ * `businessName` is selected so the `accounter_list_businesses` discovery tool
+ * can present human-readable names without a second upstream round trip — this
+ * query already runs on every authenticated request, so the name rides along
+ * for free. It is display-only and never used for authorization.
  */
 export const MY_MEMBERSHIPS_QUERY = /* GraphQL */ `
   query McpMyMemberships {
     myMemberships {
       businessId
       roleId
+      businessName
     }
   }
 `;


### PR DESCRIPTION
Phase 4 of `docs/coherent-owner-scoping-for-mcp/plan.md`. Follows #4089, #4091, #4092.

The connector is stateless — no `Mcp-Session-Id`, no session store, auth re-derived per request — so there is no "active business" to hang scope on. Discovery is the entry point instead: the model enumerates the businesses it can read, then passes those ids back as `businessIds` to the scoped tools.

## Carrying `businessName` through the membership pipeline

No extra upstream call — `myMemberships` already runs on every authenticated request, so the name rides along for free.

- `memberships.ts`: select `businessName`, replacing the comment that justified omitting it.
- `identity.ts`: add `businessName?: string | null` to `BusinessMembership`; `coerceMembership` accepts `businessName`/`business_name`.

The name handling is **deliberately lenient, unlike `roleId`**: a malformed name is treated as "no name" and must never drop an otherwise valid membership, since the name is never load-bearing for authorization. Losing a membership over a bad display string would silently remove a business the caller can actually read.

## New `tools/businesses.ts`

- Handler is **pure** — memberships are already on the auth context, so listing them costs no upstream call. A test asserts `fetch` is never invoked.
- Sorted by name (fixed-locale collator, mirroring `lookups.ts`) then id.
- `requiresBusinessScope: false` on purpose: a caller with zero memberships gets an empty list and a helpful summary rather than `AUTHORIZATION_ERROR`. Failing discovery hard would leave the model with no way to learn it has no access.
- Registered **first** in `registry-instance.ts` (`describe()` preserves registration order), locked by a test.

## Decisions worth a look

**Unnamed businesses sort last.** The plan says "sorted by name then id" but not where nameless entries go. They sort after named ones so readable entries lead, with ids breaking ties so ordering stays deterministic. Easy to flip.

**Discovery is advertised second, not first.** `handler.ts:175` builds the list as `[...listedTools, ...toolRegistry.describe()]`, and `listedTools` is the internal `accounter_smoke_ping`. So registration order is right, but the model still sees the smoke tool first. If the ordering lever matters, the fix is to move the smoke tool after the registry tools or drop it from `tools/list` entirely — a behaviour change beyond this phase's scope, so it is left alone here.

## Docs

Notes in `connector-gaps-and-decisions.md` (gap 2) that this tool must be in the default allowlist once `MCP_TOOL_ALLOWLIST` enforcement lands — omitting it removes the only way to discover a business id, and does so **silently**: the other tools keep working, just unscoped and defaulted to all memberships.

## Verification

```
build      exit 0
eslint     clean
prettier   clean
tests      30 files, 291 passed
```

Rebased onto `mcp-owner-scoping` after Phase 3 merged. The duplicate Phase 3 commit conflicted rather than auto-dropping, so it was skipped after confirming the base already contains `filters.byOwners` and `const ownerId = input.businessId`; this branch is a single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)