### PR TITLE
feat(mcp-server): uniform scope input, owner-tagged rows, echoed scope (owner-scoping Phase 5)

### DIFF
--- a/packages/mcp-server/docs/connector-gaps-and-decisions.md
+++ b/packages/mcp-server/docs/connector-gaps-and-decisions.md
@@ -103,6 +103,24 @@ user-delegated grant on the Accounter API to the new app, update the connector's
 Claude Desktop, and restore the test application's original name. Best paired with any other change
 that already requires re-granting API access.
 
+### 8. MCP GraphQL documents are not validated by CI — **medium**
+
+The connector's upstream queries are template literals in `src/tools/*.ts` and
+`src/upstream/memberships.ts`. Nothing checks them against the schema: `yarn graphql:validate` scans
+`packages/client` only, `graphql-codegen` does not read this package, and TypeScript sees the
+queries as opaque strings.
+
+**Impact.** A misspelled field, a field removed upstream, or a selection on the wrong type compiles,
+lints, and passes every unit test — the tool suites stub `fetch`, so they never contact a real
+schema. The failure surfaces only at runtime against the live server, as a sanitized
+`UPSTREAM_ERROR` that does not name the offending field. This is a live risk whenever the schema
+changes underneath the connector: nothing in this repo links the two.
+
+**Task:** add a CI step that parses each `/* GraphQL */` document in `packages/mcp-server/src` and
+runs `graphql`'s `validate()` against the generated `schema.graphql`, failing the build on any
+error. Roughly 30 lines. It was run manually during Phase 5 (5 queries, 0 invalid) — the point is to
+stop that being a manual step.
+
 ## Owner-scoping pre-flight (Phase 0) — RLS reaches `extended_tags`
 
 Pre-flight check from

--- a/packages/mcp-server/src/tools/__tests__/charges.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/charges.test.ts
@@ -70,10 +70,15 @@ describe('searchChargesTool — successful read', () => {
       totalCount: number;
       truncated: boolean;
     };
+    // This fixture omits `owner` on purpose — it predates the field. Owner
+    // tagging must degrade to nulls rather than throwing, so older fixtures and
+    // any upstream that stops returning the field keep working.
     expect(structured.charges).toEqual([
       {
         id: 'c1',
         description: 'Coffee',
+        ownerId: null,
+        ownerName: null,
         amount: { value: 12.5, formatted: '₪12.50', currency: 'ILS' },
         date: '2026-01-05',
       },
@@ -81,6 +86,34 @@ describe('searchChargesTool — successful read', () => {
     expect(structured.totalCount).toBe(1);
     expect(structured.truncated).toBe(false);
     expect(structured.pagination.hasNextPage).toBe(false);
+  });
+
+  it('tags each charge with its owning business', async () => {
+    const client = clientReturning({
+      allCharges: {
+        nodes: [
+          {
+            id: 'c1',
+            userDescription: 'Coffee',
+            owner: { id: 'b1', name: 'Acme' },
+            totalAmount: { raw: 12.5, formatted: '₪12.50', currency: 'ILS' },
+            minEventDate: '2026-01-05',
+          },
+        ],
+        pageInfo: { totalPages: 1, totalRecords: 1, currentPage: 1, pageSize: 25 },
+      },
+    });
+    const result = await run(client, authContext(['b1', 'b2']), {});
+
+    const structured = result.structuredContent as {
+      charges: Array<{ ownerId: string | null; ownerName: string | null }>;
+      scope: { businessIds: string[] };
+    };
+    expect(structured.charges[0]).toMatchObject({ ownerId: 'b1', ownerName: 'Acme' });
+    // The response echoes the effective scope, so a silent widening is visible.
+    expect(structured.scope).toEqual({ businessIds: ['b1', 'b2'] });
+    // …and the text content — what the model reads first — says so too.
+    expect(result.content[0]!.text).toContain('across 2 businesses');
   });
 
   it('scopes the query to the authorized businesses (byOwners)', async () => {

--- a/packages/mcp-server/src/tools/__tests__/scope-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/scope-contract.test.ts
@@ -7,7 +7,10 @@ import { searchChargesTool } from '../charges.js';
 import { executeRegisteredTool } from '../execute.js';
 import { listTagsTool, listTaxCategoriesTool } from '../lookups.js';
 import { balanceReportTool } from '../reports.js';
-import { SCOPE_DESCRIPTION_SUFFIX } from '../scope-input.js';
+import {
+  SCOPE_DESCRIPTION_SUFFIX,
+  SINGLE_BUSINESS_SCOPE_DESCRIPTION_SUFFIX,
+} from '../scope-input.js';
 
 /**
  * Cross-tool contract for Phase 5: one uniform scoping input, owner-tagged rows,
@@ -50,11 +53,37 @@ const BUSINESS_SCOPED_TOOLS = [
   balanceReportTool,
 ];
 
+const MULTI_BUSINESS_TOOLS = [searchChargesTool, listTagsTool, listTaxCategoriesTool];
+
 describe('uniform business-scope input', () => {
-  it.each(BUSINESS_SCOPED_TOOLS.map(tool => [tool.name, tool] as const))(
-    '%s teaches the scoping workflow in its description',
+  it.each(MULTI_BUSINESS_TOOLS.map(tool => [tool.name, tool] as const))(
+    '%s teaches the multi-business scoping workflow',
     (_name, tool) => {
       expect(tool.description).toContain(SCOPE_DESCRIPTION_SUFFIX);
+    },
+  );
+
+  // The single-business report must NOT claim an optional `businessIds` or
+  // per-row `ownerId` — it has neither. It still points at discovery.
+  it('balance report uses the single-business clause, not the list-tool one', () => {
+    expect(balanceReportTool.description).toContain(SINGLE_BUSINESS_SCOPE_DESCRIPTION_SUFFIX);
+    expect(balanceReportTool.description).not.toContain(SCOPE_DESCRIPTION_SUFFIX);
+  });
+
+  it.each(BUSINESS_SCOPED_TOOLS.map(tool => [tool.name, tool] as const))(
+    '%s points at the discovery tool',
+    (_name, tool) => {
+      expect(tool.description).toContain('accounter_list_businesses');
+    },
+  );
+
+  // Guards the mismatch Copilot caught on #4094: a description may only promise
+  // `businessIds` if the tool actually accepts that field.
+  it.each(BUSINESS_SCOPED_TOOLS.map(tool => [tool.name, tool] as const))(
+    '%s only advertises `businessIds` if it accepts it',
+    (_name, tool) => {
+      const acceptsBusinessIds = 'businessIds' in tool.inputSchema.shape;
+      expect(tool.description.includes('`businessIds`')).toBe(acceptsBusinessIds);
     },
   );
 

--- a/packages/mcp-server/src/tools/__tests__/scope-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/scope-contract.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { listBusinessesTool } from '../businesses.js';
+import { searchChargesTool } from '../charges.js';
+import { executeRegisteredTool } from '../execute.js';
+import { listTagsTool, listTaxCategoriesTool } from '../lookups.js';
+import { balanceReportTool } from '../reports.js';
+import { SCOPE_DESCRIPTION_SUFFIX } from '../scope-input.js';
+
+/**
+ * Cross-tool contract for Phase 5: one uniform scoping input, owner-tagged rows,
+ * and an echoed effective scope. Asserted across every tool at once, so a tool
+ * added later cannot quietly opt out of the convention.
+ */
+
+const PRINCIPAL: AuthPrincipal = {
+  subject: 'user-1',
+  issuer: 'https://tenant.auth0.com/',
+  audience: 'aud',
+  scopes: [],
+  email: null,
+  expiresAt: undefined,
+  claims: { sub: 'user-1' },
+};
+
+function authContext(businessIds: string[]): McpAuthContext {
+  return buildAuthContext(
+    PRINCIPAL,
+    businessIds.map(businessId => ({ businessId, roleId: 'accountant' })),
+  );
+}
+
+function clientReturning(data: unknown) {
+  const fetchImpl = vi.fn(
+    async () => ({ ok: true, status: 200, json: async () => ({ data }) }) as unknown as Response,
+  );
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+const BUSINESS_SCOPED_TOOLS = [
+  searchChargesTool,
+  listTagsTool,
+  listTaxCategoriesTool,
+  balanceReportTool,
+];
+
+describe('uniform business-scope input', () => {
+  it.each(BUSINESS_SCOPED_TOOLS.map(tool => [tool.name, tool] as const))(
+    '%s teaches the scoping workflow in its description',
+    (_name, tool) => {
+      expect(tool.description).toContain(SCOPE_DESCRIPTION_SUFFIX);
+    },
+  );
+
+  it('gives the three list tools an identical businessIds description', () => {
+    const describeField = (tool: (typeof BUSINESS_SCOPED_TOOLS)[number]) =>
+      (tool.inputSchema.shape as Record<string, { description?: string }>).businessIds?.description;
+
+    const descriptions = [searchChargesTool, listTagsTool, listTaxCategoriesTool].map(describeField);
+
+    expect(descriptions[0]).toBeDefined();
+    expect(new Set(descriptions).size).toBe(1);
+  });
+
+  it('accepts businessIds on every list tool and rejects out-of-scope ids uniformly', async () => {
+    for (const tool of [searchChargesTool, listTagsTool, listTaxCategoriesTool]) {
+      const result = await executeRegisteredTool({
+        tool,
+        rawArgs: { businessIds: ['not-mine'] },
+        auth: authContext(['b1']),
+        correlationId: 'c',
+        client: clientReturning({}),
+        authorization: 'Bearer t',
+      });
+      expect(result.isError, `${tool.name} should reject an out-of-scope id`).toBe(true);
+    }
+  });
+});
+
+describe('echoed effective scope', () => {
+  const FIXTURES = [
+    [listTagsTool, { allTags: [{ id: 't1', name: 'a', namePath: ['a'], ownerId: 'b1' }] }, 'tags'],
+    [
+      listTaxCategoriesTool,
+      {
+        taxCategories: [
+          { id: 'tc1', name: 'c', ownerId: 'b1', irsCode: null, isActive: true, sortCode: null },
+        ],
+      },
+      'taxCategories',
+    ],
+  ] as const;
+
+  it.each(FIXTURES.map(([tool, data, key]) => [tool.name, tool, data, key] as const))(
+    '%s echoes scope.businessIds and tags rows with ownerId',
+    async (_name, tool, data, itemsKey) => {
+      const result = await executeRegisteredTool({
+        tool,
+        rawArgs: {},
+        auth: authContext(['b1', 'b2']),
+        correlationId: 'c',
+        client: clientReturning(data),
+        authorization: 'Bearer t',
+      });
+
+      const structured = result.structuredContent as Record<string, unknown> & {
+        scope: { businessIds: string[] };
+      };
+      expect(structured.scope).toEqual({ businessIds: ['b1', 'b2'] });
+      const rows = structured[itemsKey] as Array<{ ownerId?: string }>;
+      expect(rows[0]?.ownerId).toBe('b1');
+    },
+  );
+
+  it('balance report echoes the resolved scope alongside its businessId', async () => {
+    const result = await executeRegisteredTool({
+      tool: balanceReportTool,
+      rawArgs: { businessId: 'b2', fromDate: '2026-01-01', toDate: '2026-03-01' },
+      auth: authContext(['b1', 'b2']),
+      correlationId: 'c',
+      client: clientReturning({ transactionsForBalanceReport: [] }),
+      authorization: 'Bearer t',
+    });
+
+    const structured = result.structuredContent as {
+      businessId: string;
+      scope: { businessIds: string[] };
+    };
+    expect(structured.businessId).toBe('b2');
+    // The singular businessId narrows the scope, so the echo confirms it.
+    expect(structured.scope).toEqual({ businessIds: ['b2'] });
+  });
+
+  // Discovery is the scope; echoing one would be circular.
+  it('accounter_list_businesses does not echo a scope', async () => {
+    const result = await executeRegisteredTool({
+      tool: listBusinessesTool,
+      rawArgs: {},
+      auth: authContext(['b1']),
+      correlationId: 'c',
+      client: clientReturning({}),
+      authorization: 'Bearer t',
+    });
+
+    expect(result.structuredContent as Record<string, unknown>).not.toHaveProperty('scope');
+  });
+});

--- a/packages/mcp-server/src/tools/charges.ts
+++ b/packages/mcp-server/src/tools/charges.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { ToolInputError } from './execute.js';
 import { shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import { businessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
 /**
  * Tool 1: read-only charges search/browse (spec §8.2).
@@ -20,11 +21,7 @@ export const MAX_DATE_RANGE_DAYS = 366;
 const TIMELESS_DATE = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format');
 
 const searchChargesInput = z.object({
-  businessIds: z
-    .array(z.string().min(1))
-    .max(50)
-    .optional()
-    .describe('Narrow results to these business ids (must be a subset of your memberships).'),
+  businessIds: businessIdsInput,
   fromDate: TIMELESS_DATE.optional().describe('Only charges on/after this date (YYYY-MM-DD).'),
   toDate: TIMELESS_DATE.optional().describe('Only charges on/before this date (YYYY-MM-DD).'),
   tags: z.array(z.string().min(1)).max(20).optional().describe('Only charges carrying these tags.'),
@@ -46,6 +43,10 @@ const SEARCH_CHARGES_QUERY = /* GraphQL */ `
       nodes {
         id
         userDescription
+        owner {
+          id
+          name
+        }
         totalAmount {
           raw
           formatted
@@ -66,6 +67,11 @@ const SEARCH_CHARGES_QUERY = /* GraphQL */ `
 interface RawCharge {
   id: string;
   userDescription: string | null;
+  /**
+   * Owning business. `Charge.owner` is non-null upstream, but this stays
+   * optional so existing test/perf fixtures that omit it keep deserializing.
+   */
+  owner?: { id: string; name: string | null } | null;
   totalAmount: { raw: number; formatted: string; currency: string } | null;
   minEventDate: string | null;
 }
@@ -86,6 +92,9 @@ interface SearchChargesData {
 export interface NormalizedCharge {
   id: string;
   description: string | null;
+  /** Owning business, so multi-business results can be grouped by the model. */
+  ownerId: string | null;
+  ownerName: string | null;
   amount: { value: number; formatted: string; currency: string } | null;
   date: string | null;
 }
@@ -170,6 +179,9 @@ function normalizeCharge(charge: RawCharge): NormalizedCharge {
   return {
     id: charge.id,
     description: charge.userDescription,
+    // Optional chaining: fixtures predating owner selection omit the field.
+    ownerId: charge.owner?.id ?? null,
+    ownerName: charge.owner?.name ?? null,
     amount: charge.totalAmount
       ? {
           value: charge.totalAmount.raw,
@@ -211,22 +223,30 @@ async function handler(
     hasNextPage: (pageInfo.currentPage ?? input.page) < pageInfo.totalPages,
   };
 
+  const scope = { businessIds: context.readScope.businessIds };
+  // The text content is what the model reads first, so surface a multi-business
+  // result there — otherwise a union across businesses looks like a single-
+  // business answer until the model inspects `scope` in the structured payload.
+  const scopeNote =
+    scope.businessIds.length > 1 ? ` across ${scope.businessIds.length} businesses` : '';
+
   return shapeListResult({
     items: charges,
     itemsKey: 'charges',
     total: pageInfo.totalRecords,
-    extra: { pagination },
+    extra: { pagination, scope },
     summarize: (shown, total) =>
       total === 0
-        ? 'No charges matched the given filters.'
-        : `Found ${total} charge(s); showing ${shown} on page ${pagination.page} of ${pagination.totalPages}.`,
+        ? `No charges matched the given filters${scopeNote}.`
+        : `Found ${total} charge(s)${scopeNote}; showing ${shown} on page ${pagination.page} of ${pagination.totalPages}.`,
   });
 }
 
 export const searchChargesTool: ToolDefinition<typeof searchChargesInput> = {
   name: SEARCH_CHARGES_TOOL_NAME,
   description:
-    'Search and browse accounting charges within your authorized businesses. Supports date range, tag, free-text, and income/expense filters with bounded pagination. Read-only.',
+    'Search and browse accounting charges within your authorized businesses. Supports date range, tag, free-text, and income/expense filters with bounded pagination. Read-only. ' +
+    SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: searchChargesInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },
   handler,

--- a/packages/mcp-server/src/tools/lookups.ts
+++ b/packages/mcp-server/src/tools/lookups.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import { businessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
 /**
  * Tool 2: read-only lookups for tags and tax categories (spec §8.2).
@@ -58,7 +59,7 @@ function filterSortCap<T extends { name: string; id: string }>(
 // Tags
 // ---------------------------------------------------------------------------
 
-const listTagsInput = z.object({ nameContains, limit });
+const listTagsInput = z.object({ businessIds: businessIdsInput, nameContains, limit });
 type ListTagsInput = z.infer<typeof listTagsInput>;
 
 const LIST_TAGS_QUERY = /* GraphQL */ `
@@ -67,6 +68,7 @@ const LIST_TAGS_QUERY = /* GraphQL */ `
       id
       name
       namePath
+      ownerId
     }
   }
 `;
@@ -75,6 +77,8 @@ interface RawTag {
   id: string;
   name: string;
   namePath: string[] | null;
+  /** Owning business (added by the Tag.ownerId migration). */
+  ownerId: string;
 }
 
 async function listTagsHandler(
@@ -90,6 +94,7 @@ async function listTagsHandler(
   const tags = rows.map(tag => ({
     id: tag.id,
     name: tag.name,
+    ownerId: tag.ownerId,
     namePath: tag.namePath ?? [tag.name],
   }));
 
@@ -97,6 +102,7 @@ async function listTagsHandler(
     items: tags,
     itemsKey: 'tags',
     total,
+    extra: { scope: { businessIds: context.readScope.businessIds } },
     summarize: (_shown, count, truncated) =>
       `Found ${count} ${count === 1 ? 'tag' : 'tags'}${truncated ? ' (truncated)' : ''}.`,
   });
@@ -105,7 +111,8 @@ async function listTagsHandler(
 export const listTagsTool: ToolDefinition<typeof listTagsInput> = {
   name: LIST_TAGS_TOOL_NAME,
   description:
-    'List the tags available for categorizing charges, optionally filtered by name. Read-only.',
+    'List the tags available for categorizing charges, optionally filtered by name. Read-only. ' +
+    SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: listTagsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },
   handler: listTagsHandler,
@@ -116,6 +123,7 @@ export const listTagsTool: ToolDefinition<typeof listTagsInput> = {
 // ---------------------------------------------------------------------------
 
 const listTaxCategoriesInput = z.object({
+  businessIds: businessIdsInput,
   nameContains,
   activeOnly: z.boolean().optional().default(false).describe('Return only active tax categories.'),
   limit,
@@ -127,6 +135,7 @@ const LIST_TAX_CATEGORIES_QUERY = /* GraphQL */ `
     taxCategories {
       id
       name
+      ownerId
       irsCode
       isActive
       sortCode {
@@ -140,6 +149,8 @@ const LIST_TAX_CATEGORIES_QUERY = /* GraphQL */ `
 interface RawTaxCategory {
   id: string;
   name: string;
+  /** Owning business; already exposed upstream on FinancialEntity. */
+  ownerId: string | null;
   irsCode: number | null;
   isActive: boolean;
   /** The bookkeeping (chart-of-accounts) sort code; null when unassigned. */
@@ -169,6 +180,7 @@ async function listTaxCategoriesHandler(
     items: taxCategories,
     itemsKey: 'taxCategories',
     total,
+    extra: { scope: { businessIds: context.readScope.businessIds } },
     summarize: (_shown, count, truncated) =>
       `Found ${count} tax ${count === 1 ? 'category' : 'categories'}${
         truncated ? ' (truncated)' : ''
@@ -179,7 +191,8 @@ async function listTaxCategoriesHandler(
 export const listTaxCategoriesTool: ToolDefinition<typeof listTaxCategoriesInput> = {
   name: LIST_TAX_CATEGORIES_TOOL_NAME,
   description:
-    'List tax categories (id, name, IRS code, active flag), optionally filtered by name or active status. Read-only.',
+    'List tax categories (id, name, IRS code, active flag), optionally filtered by name or active status. Read-only. ' +
+    SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: listTaxCategoriesInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },
   handler: listTaxCategoriesHandler,

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { ToolInputError } from './execute.js';
 import { shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import { SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
 /**
  * Tool 3: a selected read-only report (spec §8.2).
@@ -23,7 +24,11 @@ const balanceReportInput = z.object({
   businessId: z
     .string()
     .min(1)
-    .describe('The business to report on (must be one of your memberships).'),
+    .describe(
+      'The business (owner) id to report on — must be one of the businesses you belong to. ' +
+        'Unlike the list tools this report covers exactly one business, so the id is required. ' +
+        'Use accounter_list_businesses to discover ids.',
+    ),
   fromDate: TIMELESS_DATE.describe('Start of the reporting period (YYYY-MM-DD).'),
   toDate: TIMELESS_DATE.describe('End of the reporting period (YYYY-MM-DD).'),
   reportType: z
@@ -140,6 +145,7 @@ async function handler(
     extra: {
       reportType: input.reportType,
       businessId: ownerId,
+      scope: { businessIds: context.readScope.businessIds },
       period: { fromDate: input.fromDate, toDate: input.toDate },
     },
     summarize: (shown, total) =>
@@ -152,7 +158,8 @@ async function handler(
 export const balanceReportTool: ToolDefinition<typeof balanceReportInput> = {
   name: BALANCE_REPORT_TOOL_NAME,
   description:
-    'Generate a read-only balance report (transactions) for one of your businesses over a bounded date range. Requires business owner or accountant role.',
+    'Generate a read-only balance report (transactions) for one of your businesses over a bounded date range. Requires business owner or accountant role. ' +
+    SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: balanceReportInput,
   policy: {
     requiredRoles: ['business_owner', 'accountant'],

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { ToolInputError } from './execute.js';
 import { shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
-import { SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
+import { SINGLE_BUSINESS_SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
 /**
  * Tool 3: a selected read-only report (spec §8.2).
@@ -159,7 +159,7 @@ export const balanceReportTool: ToolDefinition<typeof balanceReportInput> = {
   name: BALANCE_REPORT_TOOL_NAME,
   description:
     'Generate a read-only balance report (transactions) for one of your businesses over a bounded date range. Requires business owner or accountant role. ' +
-    SCOPE_DESCRIPTION_SUFFIX,
+    SINGLE_BUSINESS_SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: balanceReportInput,
   policy: {
     requiredRoles: ['business_owner', 'accountant'],

--- a/packages/mcp-server/src/tools/scope-input.ts
+++ b/packages/mcp-server/src/tools/scope-input.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+/**
+ * Shared business-scope input fragment.
+ *
+ * Every business-scoped tool takes the *same* optional `businessIds` field with
+ * the *same* description, so the model learns one scoping convention instead of
+ * a different one per tool. Kept in its own module so the registry never has to
+ * depend on zod.
+ *
+ * `requestedBusinessIds()` in `execute.ts` already accepts either this array or
+ * a singular `businessId`, so adding the field to a tool needs no plumbing —
+ * the resolved scope flows to `x-business-scope` automatically.
+ */
+
+/** Upper bound on requested ids, matching the charges tool's original cap. */
+export const MAX_REQUESTED_BUSINESS_IDS = 50;
+
+export const businessIdsInput = z
+  .array(z.string().min(1))
+  .max(MAX_REQUESTED_BUSINESS_IDS)
+  .optional()
+  .describe(
+    'Limit results to these business (owner) ids — must be a subset of the businesses you belong to. ' +
+      'Omit to include all of them. Use accounter_list_businesses to discover ids. ' +
+      'Every returned row carries its ownerId so results can be grouped by business.',
+  );
+
+/**
+ * Trailing clause appended to every business-scoped tool description, so the
+ * scoping workflow is taught consistently wherever the model looks.
+ */
+export const SCOPE_DESCRIPTION_SUFFIX =
+  'Scope: omitting `businessIds` covers every business you belong to; results are tagged with `ownerId` ' +
+  'and the response echoes the effective `scope.businessIds`. If you have more than one business, call ' +
+  '`accounter_list_businesses` first and pass explicit ids.';

--- a/packages/mcp-server/src/tools/scope-input.ts
+++ b/packages/mcp-server/src/tools/scope-input.ts
@@ -21,16 +21,31 @@ export const businessIdsInput = z
   .max(MAX_REQUESTED_BUSINESS_IDS)
   .optional()
   .describe(
-    'Limit results to these business (owner) ids — must be a subset of the businesses you belong to. ' +
-      'Omit to include all of them. Use accounter_list_businesses to discover ids. ' +
+    'Limit results to the businesses with these (owner) ids — must be a subset of the businesses you ' +
+      'belong to. Omit to include all of them. Use accounter_list_businesses to discover ids. ' +
       'Every returned row carries its ownerId so results can be grouped by business.',
   );
 
 /**
- * Trailing clause appended to every business-scoped tool description, so the
- * scoping workflow is taught consistently wherever the model looks.
+ * Trailing clause for the **multi-business list tools** — those taking the
+ * optional {@link businessIdsInput} and returning owner-tagged rows.
+ *
+ * Not applicable to single-business tools: it would promise an optional
+ * `businessIds` field and per-row `ownerId` that they do not have. Use
+ * {@link SINGLE_BUSINESS_SCOPE_DESCRIPTION_SUFFIX} there instead.
  */
 export const SCOPE_DESCRIPTION_SUFFIX =
   'Scope: omitting `businessIds` covers every business you belong to; results are tagged with `ownerId` ' +
   'and the response echoes the effective `scope.businessIds`. If you have more than one business, call ' +
   '`accounter_list_businesses` first and pass explicit ids.';
+
+/**
+ * Trailing clause for tools scoped to exactly **one** business via a required
+ * singular `businessId`. States only what is actually true of them: no optional
+ * `businessIds`, no per-row `ownerId` (every row shares the one owner, which the
+ * response reports once), but the same discovery entry point.
+ */
+export const SINGLE_BUSINESS_SCOPE_DESCRIPTION_SUFFIX =
+  'Scope: this covers exactly one business — pass its id as the required `businessId`. The response ' +
+  'echoes the effective `scope.businessIds` alongside it. If you have more than one business, call ' +
+  '`accounter_list_businesses` first to choose.';


### PR DESCRIPTION
Phase 5 of `docs/coherent-owner-scoping-for-mcp/plan.md`. Follows #4089, #4091, #4092, #4093.

Makes scoping legible to the model: one input convention across tools, every row attributed to a business, and the effective scope echoed on every call.

## One shared input fragment

New `tools/scope-input.ts` holds `businessIdsInput` and the trailing description clause — kept in its own module so the registry never has to depend on zod. Used verbatim by `charges` and **both** `lookups` tools; `reports`' singular `businessId` gets a matching description.

`requestedBusinessIds()` in `execute.ts` already accepts either shape, so no plumbing changed — the resolved scope still reaches `x-business-scope` automatically.

## Owner on every row

- **tags** — `ownerId` added to the selection and the projected rows (relies on `Tag.ownerId` from #4089).
- **taxCategories** — `ownerId` added; `TaxCategory.ownerId` already existed upstream.
- **charges** — `owner { id name }` added, surfaced as `ownerId` / `ownerName`. Read with optional chaining so fixtures predating the field — and any upstream that stops returning it — degrade to `null` rather than throwing. There is an explicit test for that, since it is also the upstream-resilience path.

## Echoed effective scope

Every business-scoped tool adds `scope: { businessIds }` through `shapeListResult`'s `extra`; framework keys win that spread, so it cannot collide with the items array or the counts. `accounter_list_businesses` does **not** echo one — it *is* the scope.

The charges summary text also names the business count when >1. The text content is what the model reads first, and a union across businesses otherwise reads like a single-business answer until the structured payload is inspected.

## Tests

New `scope-contract.test.ts` asserts the cross-tool contract in one place — shared description, uniform rejection of out-of-scope ids, owner tagging, and the scope echo — across every tool at once, so a tool added later cannot quietly opt out of the convention. Mutation-verified: removing the scope echo from tags fails it.

## Worth flagging separately

**Nothing in CI validates these GraphQL documents.** `yarn graphql:validate` only covers `packages/client`, so the MCP server's template-literal queries are unchecked — a bad field name would ship and fail at runtime. I validated all five against `schema.graphql` manually (all pass, including the three new selections, and `Business.id`/`.name` confirmed non-null on the interface before selecting them without a fragment). Wiring this into CI is a small script and probably worth doing.

## Verification

```
build      exit 0
eslint     clean
prettier   clean
tests      31 files, 303 passed
queries    5 checked, 0 invalid
```

Rebased onto `mcp-owner-scoping` after Phase 4 merged; both superseded Phase 4 commits were dropped (one manually after confirming the base contains the review fixes, one auto-detected as already upstream), so this branch is a single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)