### PR TITLE
test(mcp-server): scope-forwarding guard + stop advertising the smoke tool (owner-scoping Phase 6)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -160,8 +160,9 @@ bearer token in the `Authorization` header. The token is verified (signature via
 plus `issuer`, `audience`, and expiry). A request with no token gets a `401` pointing at the
 protected-resource metadata document; a request with an invalid/expired token gets a `401` with
 `error="invalid_token"`. Supported methods: `initialize`, `ping`, `tools/list`, and `tools/call`
-(the four curated tools plus the internal `accounter_smoke_ping` tool). Unknown methods return a
-deterministic JSON-RPC `-32601` error; notifications receive `202 Accepted` with no body.
+(the curated tools; the internal `accounter_smoke_ping` tool is still dispatchable by name but is no
+longer advertised by `tools/list`). Unknown methods return a deterministic JSON-RPC `-32601` error;
+notifications receive `202 Accepted` with no body.
 
 ```bash
 curl -sX POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
@@ -215,7 +216,8 @@ curl -s http://localhost:3100/.well-known/oauth-protected-resource
 curl -si -X POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | grep -i -E 'HTTP/|www-authenticate'
 
-# 4. Authenticated tool list → the four curated tools (+ the smoke tool)
+# 4. Authenticated tool list → the curated tools, accounter_list_businesses first
+#    (accounter_smoke_ping is dispatchable but intentionally not listed)
 TOKEN=<a valid Auth0 access token for AUTH0_AUDIENCE>
 curl -s -X POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $TOKEN" \

--- a/packages/mcp-server/src/__tests__/mcp-e2e.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-e2e.test.ts
@@ -60,7 +60,11 @@ function upstreamData(query: string, authorization?: string): unknown {
     // none. (Keeps the suite honest if role gating ever moves from token scopes
     // to membership roles.)
     if (authorization === 'Bearer owner-token') {
-      return { myMemberships: [{ businessId: AUTHORIZED_BUSINESS, roleId: 'business_owner' }] };
+      return {
+        myMemberships: [
+          { businessId: AUTHORIZED_BUSINESS, roleId: 'business_owner', businessName: 'Acme Ltd' },
+        ],
+      };
     }
     return { myMemberships: [] };
   }
@@ -71,6 +75,7 @@ function upstreamData(query: string, authorization?: string): unknown {
           {
             id: 'charge-1',
             userDescription: 'Coffee supplies',
+            owner: { id: AUTHORIZED_BUSINESS, name: 'Acme Ltd' },
             totalAmount: { raw: -12.5, formatted: '-12.50', currency: 'ILS' },
             minEventDate: '2026-01-05',
           },
@@ -80,10 +85,23 @@ function upstreamData(query: string, authorization?: string): unknown {
     };
   }
   if (query.includes('allTags')) {
-    return { allTags: [{ id: 'tag-1', name: 'food', namePath: ['food'] }] };
+    return {
+      allTags: [{ id: 'tag-1', name: 'food', namePath: ['food'], ownerId: AUTHORIZED_BUSINESS }],
+    };
   }
   if (query.includes('taxCategories')) {
-    return { taxCategories: [{ id: 'tc-1', name: 'Income', irsCode: 100, isActive: true }] };
+    return {
+      taxCategories: [
+        {
+          id: 'tc-1',
+          name: 'Income',
+          ownerId: AUTHORIZED_BUSINESS,
+          irsCode: 100,
+          isActive: true,
+          sortCode: null,
+        },
+      ],
+    };
   }
   if (query.includes('transactionsForBalanceReport')) {
     return {
@@ -102,9 +120,22 @@ function upstreamData(query: string, authorization?: string): unknown {
   throw new Error(`unexpected upstream query: ${query}`);
 }
 
+/**
+ * Records the business scope forwarded on each upstream call, so the e2e can
+ * assert that tool calls carry `x-business-scope` while the membership
+ * bootstrap — the query that *discovers* the scope — carries none.
+ */
+const forwardedScopes: Array<{ query: string; businessScope?: readonly string[] }> = [];
+
 const fakeUpstreamClient = {
-  query: vi.fn(async (request: { query: string }, context: { authorization?: string }) =>
-    upstreamData(request.query, context.authorization),
+  query: vi.fn(
+    async (
+      request: { query: string },
+      context: { authorization?: string; businessScope?: readonly string[] },
+    ) => {
+      forwardedScopes.push({ query: request.query, businessScope: context.businessScope });
+      return upstreamData(request.query, context.authorization);
+    },
   ),
 };
 
@@ -217,20 +248,63 @@ describe('authenticated tool invocation', () => {
     ).result.tools.map(t => t.name);
     expect(tools).toEqual(
       expect.arrayContaining([
+        'accounter_list_businesses',
         'accounter_search_charges',
         'accounter_list_tags',
         'accounter_list_tax_categories',
         'accounter_balance_report',
       ]),
     );
+    // Discovery leads the list, and the internal smoke tool is not advertised.
+    expect(tools[0]).toBe('accounter_list_businesses');
+    expect(tools).not.toContain('accounter_smoke_ping');
   });
 
   it('runs a charges search scoped to the caller and returns structured results', async () => {
     const result = await callTool('accounter_search_charges', { fromDate: '2026-01-01' }, 'owner-token');
     expect(result.isError).toBeUndefined();
-    const { charges } = result.structuredContent as { charges: Array<{ id: string }> };
+    const { charges, scope } = result.structuredContent as {
+      charges: Array<{ id: string; ownerId: string | null; ownerName: string | null }>;
+      scope: { businessIds: string[] };
+    };
     expect(charges).toHaveLength(1);
     expect(charges[0].id).toBe('charge-1');
+    // Rows are owner-tagged and the response echoes the effective scope.
+    expect(charges[0].ownerId).toBe(AUTHORIZED_BUSINESS);
+    expect(charges[0].ownerName).toBe('Acme Ltd');
+    expect(scope).toEqual({ businessIds: [AUTHORIZED_BUSINESS] });
+  });
+
+  it('forwards x-business-scope on tool calls but never on the membership bootstrap', async () => {
+    forwardedScopes.length = 0;
+    await callTool('accounter_list_tags', {}, 'owner-token');
+
+    const bootstrap = forwardedScopes.filter(c => c.query.includes('myMemberships'));
+    const toolCalls = forwardedScopes.filter(c => !c.query.includes('myMemberships'));
+
+    expect(bootstrap.length).toBeGreaterThan(0);
+    // Scoping the scope-discovery query would be circular; it must stay unscoped.
+    for (const call of bootstrap) {
+      expect(call.businessScope).toBeUndefined();
+    }
+    expect(toolCalls.length).toBeGreaterThan(0);
+    for (const call of toolCalls) {
+      expect(call.businessScope).toEqual([AUTHORIZED_BUSINESS]);
+    }
+  });
+
+  it('lists the caller businesses without any upstream call', async () => {
+    forwardedScopes.length = 0;
+    const result = await callTool('accounter_list_businesses', {}, 'owner-token');
+
+    const { businesses } = result.structuredContent as {
+      businesses: Array<{ businessId: string; name: string | null; role: string }>;
+    };
+    expect(businesses).toEqual([
+      { businessId: AUTHORIZED_BUSINESS, name: 'Acme Ltd', role: 'business_owner' },
+    ]);
+    // Only the membership bootstrap talks upstream; the handler itself is pure.
+    expect(forwardedScopes.every(c => c.query.includes('myMemberships'))).toBe(true);
   });
 
   it('runs a role-gated balance report for a caller who holds the role', async () => {

--- a/packages/mcp-server/src/__tests__/perf.test.ts
+++ b/packages/mcp-server/src/__tests__/perf.test.ts
@@ -41,6 +41,9 @@ const CHARGES_RESPONSE = {
         {
           id: 'charge-1',
           userDescription: 'Coffee',
+          // Owner is selected since Phase 5; keep the fixture representative so
+          // the latency budget is measured against the real payload shape.
+          owner: { id: BUSINESS, name: 'Acme Ltd' },
           totalAmount: { raw: -12.5, formatted: '-12.50', currency: 'ILS' },
           minEventDate: '2026-01-05',
         },

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -52,11 +52,12 @@ describe('handleMcpBody — method dispatch', () => {
     expect(res.result).toEqual({});
   });
 
-  it('lists the smoke tool', () => {
+  // The smoke tool is dispatchable but no longer advertised: it is an internal
+  // diagnostic, and it short-circuits dispatch before the curated pipeline.
+  it('advertises no transport-level tools', () => {
     const res = handleMcpBody(rpc('tools/list')) as JsonRpcSuccess;
     const result = res.result as { tools: Array<{ name: string }> };
-    expect(result.tools).toHaveLength(1);
-    expect(result.tools[0].name).toBe(SMOKE_TOOL_NAME);
+    expect(result.tools).toEqual([]);
   });
 
   it('calls the smoke tool and echoes the message', () => {
@@ -147,7 +148,9 @@ describe('mcpHttpHandler', () => {
 
     expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
     const body = JSON.parse(res.end.mock.calls[0][0] as string);
-    expect(body.result.tools[0].name).toBe(SMOKE_TOOL_NAME);
+    const names = (body.result.tools as Array<{ name: string }>).map(t => t.name);
+    expect(names[0]).toBe('accounter_list_businesses');
+    expect(names).not.toContain(SMOKE_TOOL_NAME);
   });
 
   it('responds 202 with no body for a notification', async () => {
@@ -256,14 +259,25 @@ describe('dispatchMcpRequest — registry integration', () => {
     [],
   );
 
-  it('lists the smoke tool alongside the registered production tools', async () => {
+  it('lists the curated tools with discovery first, and hides the smoke tool', async () => {
     const response = (await dispatchMcpRequest(
       { jsonrpc: '2.0', id: 1, method: 'tools/list' },
       { auth, correlationId: 'c' },
     )) as JsonRpcSuccess;
     const names = (response.result as { tools: Array<{ name: string }> }).tools.map(t => t.name);
-    expect(names).toContain(SMOKE_TOOL_NAME);
+    // Discovery leads: tools/list ordering steers how the model scopes calls.
+    expect(names[0]).toBe('accounter_list_businesses');
     expect(names).toContain('accounter_search_charges');
+    expect(names).not.toContain(SMOKE_TOOL_NAME);
+  });
+
+  // Unadvertised, but still routable — the documented smoke test relies on it.
+  it('still dispatches the smoke tool by name', async () => {
+    const response = (await dispatchMcpRequest(
+      { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: SMOKE_TOOL_NAME, arguments: { message: 'hi' } } },
+      { auth, correlationId: 'c' },
+    )) as JsonRpcSuccess;
+    expect(response.result).toEqual({ content: [{ type: 'text', text: 'pong: hi' }], isError: false });
   });
 
   it('returns InvalidParams for an unknown tool name', async () => {

--- a/packages/mcp-server/src/mcp/tools.ts
+++ b/packages/mcp-server/src/mcp/tools.ts
@@ -52,8 +52,24 @@ export const smokeTool: ToolDescriptor = {
   },
 };
 
-/** Tools advertised by `tools/list` in the current (skeleton) phase. */
-export const listedTools: readonly ToolDescriptor[] = [smokeTool];
+/**
+ * Transport-level tools advertised by `tools/list`, *in addition to* the curated
+ * registry. Deliberately empty.
+ *
+ * The smoke tool stays dispatchable — `tools/call` still routes
+ * `accounter_smoke_ping` (see `handler.ts`), so connectivity checks and the
+ * documented smoke test keep working — but it is no longer advertised to the
+ * model. Two reasons:
+ *
+ *  - It is an internal diagnostic that echoes a string. Advertising it spends
+ *    the first slot in `tools/list` (ordering is a prompt-engineering lever) on
+ *    a non-capability, ahead of `accounter_list_businesses`, which is the
+ *    intended entry point for business scoping.
+ *  - It short-circuits dispatch *before* the curated pipeline — no policy
+ *    evaluation, rate limiting, or metrics. Harmless for an echo, but not
+ *    something to put in front of the model as if it were a normal tool.
+ */
+export const listedTools: readonly ToolDescriptor[] = [];
 
 /** Execute the smoke tool. Pure and side-effect free — no upstream calls. */
 export function runSmokeTool(args: unknown): ToolCallResult {

--- a/packages/mcp-server/src/tools/__tests__/byte-budget.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/byte-budget.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { executeRegisteredTool } from '../execute.js';
+import { listTagsTool, MAX_LOOKUP_RESULTS } from '../lookups.js';
+import { MAX_TOOL_RESULT_BYTES } from '../output.js';
+
+/**
+ * Payload-size guard at the cap. Every row now carries `ownerId` (Phase 5), so a
+ * full 500-row lookup is meaningfully larger than before — this pins the
+ * behaviour at the boundary rather than assuming the extra field is free.
+ *
+ * The contract when the guard trips: whole trailing items are dropped (never
+ * invalid JSON), `truncated` is true, and the continuation hint says the payload
+ * size — not the result cap — is what stopped it.
+ */
+
+const B1 = 'aa000000-0000-4000-8000-000000000001';
+
+function authContext(): McpAuthContext {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: [],
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+  return buildAuthContext(principal, [{ businessId: B1, roleId: 'accountant' }]);
+}
+
+function clientReturning(data: unknown) {
+  const fetchImpl = vi.fn(
+    async () => ({ ok: true, status: 200, json: async () => ({ data }) }) as unknown as Response,
+  );
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+/** 500 owner-tagged tags with names long enough to blow the byte budget. */
+function manyTags(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `tag-${String(i).padStart(4, '0')}`,
+    name: `Tag ${String(i).padStart(4, '0')} ${'x'.repeat(120)}`,
+    namePath: [`Tag ${String(i).padStart(4, '0')}`],
+    ownerId: B1,
+  }));
+}
+
+describe('payload byte budget with owner-tagged rows', () => {
+  it('caps a full lookup at the byte budget, keeping valid JSON', async () => {
+    const result = await executeRegisteredTool({
+      tool: listTagsTool,
+      rawArgs: {},
+      auth: authContext(),
+      correlationId: 'c',
+      client: clientReturning({ allTags: manyTags(MAX_LOOKUP_RESULTS) }),
+      authorization: 'Bearer t',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as {
+      tags: Array<{ id: string; ownerId: string }>;
+      returnedCount: number;
+      totalCount: number;
+      truncated: boolean;
+      continuation?: { reason: string };
+    };
+
+    expect(structured.totalCount).toBe(MAX_LOOKUP_RESULTS);
+    expect(structured.truncated).toBe(true);
+    expect(structured.continuation?.reason).toBe('payload_size');
+
+    // Whole items only — the guard must never emit a half-serialized row.
+    expect(structured.returnedCount).toBe(structured.tags.length);
+    expect(structured.returnedCount).toBeLessThan(MAX_LOOKUP_RESULTS);
+    for (const tag of structured.tags) {
+      expect(tag.ownerId).toBe(B1);
+    }
+
+    // Serializable, and within the advertised budget.
+    const serialized = JSON.stringify(structured);
+    expect(() => JSON.parse(serialized)).not.toThrow();
+    expect(serialized.length).toBeLessThanOrEqual(MAX_TOOL_RESULT_BYTES);
+  });
+
+  it('does not truncate when the same row count fits the budget', async () => {
+    const result = await executeRegisteredTool({
+      tool: listTagsTool,
+      rawArgs: {},
+      auth: authContext(),
+      correlationId: 'c',
+      // Short names: 500 rows well inside the budget.
+      client: clientReturning({
+        allTags: Array.from({ length: MAX_LOOKUP_RESULTS }, (_, i) => ({
+          id: `t${i}`,
+          name: `n${i}`,
+          namePath: [`n${i}`],
+          ownerId: B1,
+        })),
+      }),
+    });
+
+    const structured = result.structuredContent as {
+      returnedCount: number;
+      truncated: boolean;
+      continuation?: unknown;
+    };
+    expect(structured.truncated).toBe(false);
+    expect(structured.returnedCount).toBe(MAX_LOOKUP_RESULTS);
+    expect(structured.continuation).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/lookups.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/lookups.test.ts
@@ -21,10 +21,11 @@ function authContext(businessIds: string[]): McpAuthContext {
   );
 }
 
-function clientReturning(data: unknown) {
-  const fetchImpl = vi.fn(
-    async () => ({ ok: true, status: 200, json: async () => ({ data }) }) as unknown as Response,
-  );
+function clientReturning(data: unknown, capture?: (init: RequestInit) => void) {
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    capture?.(init);
+    return { ok: true, status: 200, json: async () => ({ data }) } as unknown as Response;
+  });
   return new UpstreamGraphQLClient({
     endpoint: 'http://localhost:4000/graphql',
     timeoutMs: 1000,
@@ -137,5 +138,55 @@ describe('listTaxCategoriesTool', () => {
     });
     const rows = (result.structuredContent as { taxCategories: Array<{ name: string }> }).taxCategories;
     expect(rows.map(r => r.name)).toEqual(['Income']);
+  });
+});
+
+describe('lookups — business scoping', () => {
+  const TAGS = { allTags: [{ id: '1', name: 'a', namePath: ['a'], ownerId: 'b2' }] };
+  const TAX_CATEGORIES = {
+    taxCategories: [
+      { id: '1', name: 'a', ownerId: 'b2', irsCode: null, isActive: true, sortCode: null },
+    ],
+  };
+
+  it.each([
+    ['accounter_list_tags', listTagsTool, TAGS, 'tags'],
+    ['accounter_list_tax_categories', listTaxCategoriesTool, TAX_CATEGORIES, 'taxCategories'],
+  ] as const)('%s narrows to a requested subset and reflects it in scope', async (
+    _name,
+    tool,
+    data,
+    itemsKey,
+  ) => {
+    let sentHeaders: Record<string, string> | undefined;
+    const client = clientReturning(data, init => {
+      sentHeaders = init.headers as Record<string, string>;
+    });
+
+    const result = await runTool(tool, client, authContext(['b1', 'b2']), {
+      businessIds: ['b2'],
+    });
+
+    expect(result.isError).toBeUndefined();
+    // The header is the only way these argument-less queries can be narrowed.
+    expect(sentHeaders?.['x-business-scope']).toBe('b2');
+    const structured = result.structuredContent as Record<string, unknown> & {
+      scope: { businessIds: string[] };
+    };
+    expect(structured.scope).toEqual({ businessIds: ['b2'] });
+    // ownerId passes straight through so rows stay attributable.
+    expect((structured[itemsKey] as Array<{ ownerId?: string }>)[0]?.ownerId).toBe('b2');
+  });
+
+  it.each([
+    ['accounter_list_tags', listTagsTool, TAGS],
+    ['accounter_list_tax_categories', listTaxCategoriesTool, TAX_CATEGORIES],
+  ] as const)('%s denies ids outside the caller memberships', async (_name, tool, data) => {
+    const result = await runTool(tool, clientReturning(data), authContext(['b1']), {
+      businessIds: ['b9'],
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('AUTHORIZATION_ERROR');
   });
 });

--- a/packages/mcp-server/src/tools/__tests__/schema-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/schema-contract.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -12,21 +12,41 @@ import { describe, expect, it } from 'vitest';
  */
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../..');
+const SCHEMA_PATH = resolve(REPO_ROOT, 'schema.graphql');
+
+/**
+ * `schema.graphql` is generated and git-ignored, so a fresh checkout has none
+ * until `yarn generate:graphql` runs. Read it lazily — inside the test rather
+ * than at collection time — and fail with the command to run; otherwise this
+ * surfaces as a bare `ENOENT` while collecting, which says nothing about the fix
+ * and takes the whole file's tests down with it.
+ *
+ * Deliberately a failure rather than a skip: skipping would leave the contract
+ * unchecked in exactly the situation where codegen has not run, so the guard
+ * would be absent precisely when it is most likely to be needed.
+ */
+function loadSchema(): string {
+  if (!existsSync(SCHEMA_PATH)) {
+    throw new Error(
+      `schema.graphql not found at ${SCHEMA_PATH}. It is generated and git-ignored — run ` +
+        '`yarn generate:graphql` from the repo root before running this suite.',
+    );
+  }
+  return readFileSync(SCHEMA_PATH, 'utf8');
+}
+
+function typeBlock(schema: string, name: string): string {
+  const match = schema.match(new RegExp(`^type ${name} [^{]*\\{[^}]*\\}`, 'm'));
+  if (!match) throw new Error(`type ${name} not found in schema.graphql`);
+  return match[0];
+}
 
 describe('generated schema contract', () => {
-  const schema = readFileSync(resolve(REPO_ROOT, 'schema.graphql'), 'utf8');
-
-  const typeBlock = (name: string): string => {
-    const match = schema.match(new RegExp(`^type ${name} [^{]*\\{[^}]*\\}`, 'm'));
-    if (!match) throw new Error(`type ${name} not found in schema.graphql`);
-    return match[0];
-  };
-
   it('Tag exposes a non-null ownerId', () => {
-    expect(typeBlock('Tag')).toContain('ownerId: UUID!');
+    expect(typeBlock(loadSchema(), 'Tag')).toContain('ownerId: UUID!');
   });
 
   it('TaxCategory exposes ownerId', () => {
-    expect(typeBlock('TaxCategory')).toMatch(/ownerId: UUID!?/);
+    expect(typeBlock(loadSchema(), 'TaxCategory')).toMatch(/ownerId: UUID!?/);
   });
 });

--- a/packages/mcp-server/src/tools/__tests__/schema-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/schema-contract.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Phase 1 (`Tag.ownerId`) has no server-side unit test — the tags module has no
+ * suite — so it is covered by typecheck + codegen. This pins the one field the
+ * MCP tools actually depend on: `accounter_list_tags` selects `ownerId`, and if
+ * the field were dropped upstream the failure would surface only at runtime as
+ * a sanitized UPSTREAM_ERROR that does not name the field.
+ */
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../..');
+
+describe('generated schema contract', () => {
+  const schema = readFileSync(resolve(REPO_ROOT, 'schema.graphql'), 'utf8');
+
+  const typeBlock = (name: string): string => {
+    const match = schema.match(new RegExp(`^type ${name} [^{]*\\{[^}]*\\}`, 'm'));
+    if (!match) throw new Error(`type ${name} not found in schema.graphql`);
+    return match[0];
+  };
+
+  it('Tag exposes a non-null ownerId', () => {
+    expect(typeBlock('Tag')).toContain('ownerId: UUID!');
+  });
+
+  it('TaxCategory exposes ownerId', () => {
+    expect(typeBlock('TaxCategory')).toMatch(/ownerId: UUID!?/);
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/scope-forwarding.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/scope-forwarding.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { BUSINESS_SCOPE_HEADER, UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { LIST_BUSINESSES_TOOL_NAME } from '../businesses.js';
+import { executeRegisteredTool } from '../execute.js';
+import { toolRegistry } from '../registry-instance.js';
+
+/**
+ * The cross-cutting guard: iterate the *production registry* rather than a
+ * hand-listed set, so a tool added later cannot silently regress.
+ *
+ * Every registered tool that talks upstream must send `x-business-scope` with
+ * the resolved ids and echo `scope.businessIds`. Asserting on the outbound HTTP
+ * headers (not the context object) means a handler that hand-builds
+ * `{ correlationId, authorization }` and drops the scope fails here.
+ */
+
+const B1 = 'aa000000-0000-4000-8000-000000000001';
+const B2 = 'aa000000-0000-4000-8000-000000000002';
+
+const PRINCIPAL: AuthPrincipal = {
+  subject: 'user-1',
+  issuer: 'https://tenant.auth0.com/',
+  audience: 'aud',
+  scopes: [],
+  email: null,
+  expiresAt: undefined,
+  claims: { sub: 'user-1' },
+};
+
+function authContext(): McpAuthContext {
+  return buildAuthContext(PRINCIPAL, [
+    { businessId: B1, roleId: 'business_owner' },
+    { businessId: B2, roleId: 'business_owner' },
+  ]);
+}
+
+/** Upstream payloads keyed by the operation each tool issues. */
+function dataFor(query: string): unknown {
+  if (query.includes('allCharges')) {
+    return {
+      allCharges: {
+        nodes: [],
+        pageInfo: { totalPages: 1, totalRecords: 0, currentPage: 1, pageSize: 25 },
+      },
+    };
+  }
+  if (query.includes('allTags')) return { allTags: [] };
+  if (query.includes('taxCategories')) return { taxCategories: [] };
+  if (query.includes('transactionsForBalanceReport')) return { transactionsForBalanceReport: [] };
+  return {};
+}
+
+function capturingClient() {
+  const headersSeen: Array<Record<string, string>> = [];
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    headersSeen.push(init.headers as Record<string, string>);
+    const body = JSON.parse(init.body as string) as { query: string };
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: dataFor(body.query) }),
+    } as unknown as Response;
+  });
+  const client = new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+  return { client, headersSeen };
+}
+
+/** Minimal valid arguments per tool; everything else is optional. */
+const ARGS_BY_TOOL: Record<string, unknown> = {
+  accounter_balance_report: { businessId: B1, fromDate: '2026-01-01', toDate: '2026-03-01' },
+};
+
+describe('registry-wide business-scope forwarding', () => {
+  const tools = toolRegistry.list();
+
+  it('has tools registered (guards against an empty-registry false pass)', () => {
+    expect(tools.length).toBeGreaterThan(0);
+  });
+
+  it.each(tools.map(tool => [tool.name, tool] as const))(
+    '%s forwards the resolved scope and echoes it',
+    async (name, tool) => {
+      const { client, headersSeen } = capturingClient();
+      const result = await executeRegisteredTool({
+        tool,
+        rawArgs: ARGS_BY_TOOL[name] ?? {},
+        auth: authContext(),
+        correlationId: 'c',
+        client,
+        authorization: 'Bearer t',
+      });
+
+      expect(result.isError, `${name} should succeed`).toBeUndefined();
+      const structured = result.structuredContent as Record<string, unknown>;
+
+      if (name === LIST_BUSINESSES_TOOL_NAME) {
+        // Discovery is pure and *is* the scope — no upstream call, no echo.
+        expect(headersSeen).toHaveLength(0);
+        expect(structured).not.toHaveProperty('scope');
+        return;
+      }
+
+      expect(headersSeen.length, `${name} should call upstream`).toBeGreaterThan(0);
+      // The balance report narrows to its single businessId; the rest keep both.
+      const expectedScope = name === 'accounter_balance_report' ? [B1] : [B1, B2];
+      for (const headers of headersSeen) {
+        expect(headers[BUSINESS_SCOPE_HEADER]).toBe(expectedScope.join(','));
+      }
+      expect(structured.scope).toEqual({ businessIds: expectedScope });
+    },
+  );
+});

--- a/packages/mcp-server/src/tools/registry-instance.ts
+++ b/packages/mcp-server/src/tools/registry-instance.ts
@@ -14,10 +14,9 @@ export const toolRegistry = new ToolRegistry();
 // curated tool list — ordering is a real prompt-engineering lever for getting
 // the model to scope its calls.
 //
-// Note this is first *within the curated registry*, not necessarily in the
-// advertised `tools/list`: `dispatchMcpRequest` sends
-// `[...listedTools, ...toolRegistry.describe()]`, so any transport-level
-// internal tool (currently `accounter_smoke_ping`) still precedes it.
+// `dispatchMcpRequest` sends `[...listedTools, ...toolRegistry.describe()]`, and
+// `listedTools` is now empty (the internal smoke tool is dispatchable but no
+// longer advertised), so this is genuinely the first tool the model sees.
 toolRegistry.register(listBusinessesTool);
 toolRegistry.register(searchChargesTool);
 toolRegistry.register(listTagsTool);


### PR DESCRIPTION
Phase 6 of `docs/coherent-owner-scoping-for-mcp/plan.md`, plus a small `tools/list` change agreed during Phase 5 review. Follows #4089, #4091, #4092, #4093, #4094.

Two commits, reviewable independently.

---

## 1. `refactor(mcp-server)`: stop advertising the internal smoke tool

`accounter_smoke_ping` came from the transport skeleton — its own module header says it should be *"removed or folded into that registry at wiring time"*, which never happened. It stayed in `listedTools`, which `tools/list` prepends to the curated registry, so the model saw an internal echo tool **ahead of** `accounter_list_businesses`. That spent the first slot on a non-capability and partly defeated registering discovery first in #4093.

It also short-circuits `tools/call` before the curated pipeline — no policy evaluation, rate limiting, or metrics. Harmless for an echo, but not something to present to the model as a normal tool.

`listedTools` is now empty. **Dispatch is unchanged**: `accounter_smoke_ping` is still routable by name, so connectivity checks and the documented smoke test keep working. It is simply no longer advertised, and discovery is now genuinely first — asserted in both the handler tests and e2e.

README updated where it described the smoke tool as listed (the broader README work is Phase 7).

---

## 2. `test(mcp-server)`: Phase 6

Most of the plan's "update" list landed alongside the code in Phases 2–5 — the `byOwners` retarget and `byBusinesses` absence guard (#4092), the `x-business-scope` header cases (#4091), `businessName` coercion (#4093), the membership bootstrap staying unscoped (#4091). This adds what remained.

**`scope-forwarding.test.ts` — the cross-cutting guard.** Iterates `toolRegistry.list()` rather than a hand-listed set, so a tool added later cannot silently regress, and asserts on the **outbound HTTP headers** rather than the context object, so a handler that hand-builds `{ correlationId, authorization }` fails here. Includes a non-empty-registry assertion so an empty list can't produce a false pass. Mutation-verified: dropping `context.upstream` in one tool fails it by name.

**`byte-budget.test.ts`** — 500 owner-tagged tags still yield valid JSON with whole trailing items dropped, `truncated: true`, and `continuation.reason === 'payload_size'`, plus the negative case at the same row count.

**`mcp-e2e.test.ts`** — fixtures gain `businessName`, charge `owner`, and tags/tax-category `ownerId`. New assertions: discovery leads `tools/list` and the smoke tool is absent; charge rows are owner-tagged and echo `scope`; `x-business-scope` is forwarded on tool calls but **never** on the membership bootstrap; discovery makes no upstream call of its own.

**`lookups.test.ts`** — the client helper now captures the request so headers can be asserted; adds subset narrowing reflected in `scope`, `ownerId` passthrough, and uniform denial of out-of-scope ids on both tools.

**`schema-contract.test.ts`** — pins `Tag.ownerId: UUID!` and `TaxCategory.ownerId` in the generated schema. The tags server module has no test suite, so this is the only thing linking the MCP selection to the schema it depends on.

**`perf.test.ts`** — the charge fixture gains `owner`. Worth calling out: the plan suggested re-running to confirm `P95_TARGET_MS` holds "with the larger payload", but the fixture lacked the field, so a re-run wouldn't have exercised it at all. The budget is now measured against the real payload shape. P95 still holds.

---

## Verification

```
build      exit 0
eslint     clean
prettier   clean
tests      34 files, 328 passed
```

Rebased onto `mcp-owner-scoping` after Phase 5 merged; all three superseded Phase 5 commits were dropped (one skipped manually after confirming the base contains the review fixes, two auto-detected as already upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)