### PR TITLE
docs(mcp-server): document the business-scoping contract (owner-scoping Phase 7)

### DIFF
--- a/docs/coherent-owner-scoping-for-mcp/plan.md
+++ b/docs/coherent-owner-scoping-for-mcp/plan.md
@@ -319,8 +319,8 @@ asserting `schema.graphql` contains `ownerId: UUID!` inside `type Tag`.
   self-describing-response contract.
 - `packages/mcp-server/docs/local-development.md` §6 Verify (line 106) — the end-to-end scope check
   below.
-- `packages/mcp-server/docs/connector-gaps-and-decisions.md` — Phase 0 view/RLS finding ✅ recorded
-  (2026-08-01); still to add: the stateless-vs-stateful decision.
+- `packages/mcp-server/docs/connector-gaps-and-decisions.md` — ✅ Phase 0 view/RLS finding and the
+  stateless-vs-stateful decision both recorded (2026-08-01).
 - `packages/mcp-server/docs/submission-checklist.md:40` — tool list.
 
 ---

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -18,12 +18,13 @@ Phase 1 (read-only) is feature-complete. The server provides: strict startup env
 transport with `/health`, `/metrics`, the OAuth protected-resource metadata endpoint, and the MCP
 route (`POST /mcp`, JSON-RPC 2.0) with graceful shutdown; Auth0 bearer-token verification; identity
 mapping to an internal user + business-membership context with memberships resolved from the
-Accounter GraphQL server; a curated registry of four read-only tools (`accounter_search_charges`,
-`accounter_list_tags`, `accounter_list_tax_categories`, `accounter_balance_report`) each gated by
-strict input validation, a per-tool authorization policy, and business-scope narrowing; a hardened
-upstream GraphQL client (timeout, bounded retries, header propagation, sanitized errors); a unified
-error taxonomy; per-`tools/call` rate limiting; and operational telemetry (request/outcome counters,
-a latency histogram, auth-failure counters, tracing spans) exposed at `GET /metrics`.
+Accounter GraphQL server; a curated registry of five read-only tools (`accounter_list_businesses`,
+`accounter_search_charges`, `accounter_list_tags`, `accounter_list_tax_categories`,
+`accounter_balance_report`) each gated by strict input validation, a per-tool authorization policy,
+and business-scope narrowing forwarded upstream as `x-business-scope`; a hardened upstream GraphQL
+client (timeout, bounded retries, header propagation, sanitized errors); a unified error taxonomy;
+per-`tools/call` rate limiting; and operational telemetry (request/outcome counters, a latency
+histogram, auth-failure counters, tracing spans) exposed at `GET /metrics`.
 
 Phase 2 (write scope) is **not** implemented — see
 [Known limitations & phase 2](#known-limitations--phase-2-write-scope).
@@ -48,27 +49,56 @@ by **user + business scope + tool**, enforced before any upstream call. Exceedin
 a `RATE_LIMIT_ERROR` with `retryAfterMs`. Limits are configured via `MCP_RATE_LIMIT_CONFIG`
 (`{"windowMs":60000,"max":60}` by default).
 
+### Business scoping contract
+
+Every business-scoped tool follows one convention, so the model learns it once:
+
+- **Discover, then scope.** `accounter_list_businesses` returns `{ businessId, name, role }`. Pass
+  those ids back as `businessIds` (or, for the balance report, the singular required `businessId`).
+- **`businessIds` is optional and means "narrow".** Omitting it covers every business the caller
+  belongs to. Any id outside the caller's memberships is **rejected**, never silently dropped.
+- **The resolved scope is forwarded upstream** as `x-business-scope`, so RLS on the Accounter server
+  is the actual enforcement point (see [Identity & tenant scope](#identity--tenant-scope)).
+- **Rows are owner-tagged.** List rows carry `ownerId` (charges also carry `ownerName`), so results
+  spanning several businesses can be grouped rather than silently merged.
+- **The response echoes `scope.businessIds`.** A widened scope is visible in the payload instead of
+  being inferred, and the charges summary text names the business count when it is greater than one.
+
+`accounter_list_businesses` is the one exception: it takes no parameters and echoes no scope,
+because it _is_ the scope.
+
+- **`accounter_list_businesses`** — list the businesses the caller can access, with their role in
+  each. Sorted by name (fixed-locale, case-insensitive) then id, with unnamed businesses last. Pure:
+  memberships are already on the auth context, so it makes no upstream call. A caller with no
+  memberships gets an empty list, not an error.
 - **`accounter_search_charges`** — read-only charges search/browse within the caller's authorized
   businesses. Optional `businessIds` (subset of memberships), `fromDate`/`toDate` (bounded to 366
   days), `tags`, `freeText`, and `flow` (`ALL`/`INCOME`/`EXPENSE`), with bounded pagination
-  (`pageSize` ≤ 50). Returns normalized charges plus pagination metadata.
-- **`accounter_list_tags`** — list tags for categorizing charges, optionally filtered by name.
-  Deterministically sorted (name, then id) and size-capped (≤ 500).
-- **`accounter_list_tax_categories`** — list tax categories (id, name, IRS code, bookkeeping sort
-  code, active flag), optionally filtered by name or active status. Same deterministic sort + cap.
-- **`accounter_balance_report`** — read-only balance report (transactions) for one of your
-  businesses over a bounded date range (≤ 366 days). Requires `business_owner`/`accountant` role;
-  rows are capped at 500 with a `truncated` flag.
+  (`pageSize` ≤ 50). Returns normalized charges — each carrying `ownerId`/`ownerName` — plus
+  pagination metadata and the echoed `scope`. Scoping uses the `byOwners` predicate upstream (the
+  owner), never `byBusinesses` (the counterparty).
+- **`accounter_list_tags`** — list tags for categorizing charges, optionally filtered by name and by
+  `businessIds`. Rows carry `ownerId`. Deterministically sorted (name, then id) and size-capped (≤
+  500).
+- **`accounter_list_tax_categories`** — list tax categories (id, name, `ownerId`, IRS code,
+  bookkeeping sort code, active flag), optionally filtered by name, active status, or `businessIds`.
+  Same deterministic sort + cap.
+- **`accounter_balance_report`** — read-only balance report (transactions) for **exactly one** of
+  your businesses over a bounded date range (≤ 366 days), selected by the required singular
+  `businessId`. Requires `business_owner`/`accountant` role; rows are capped at 500 with a
+  `truncated` flag. Rows are not individually owner-tagged — they all share the one owner, which the
+  response reports once alongside the echoed `scope`.
 
 ## Upstream GraphQL client
 
 Tool handlers talk to the Accounter GraphQL server through a single hardened client
 (`src/upstream/graphql-client.ts`): a strict per-request **timeout** with cancellation, **bounded
 retries** for idempotent read failures only (network errors, timeouts, and 5xx — never 4xx
-auth/validation errors or GraphQL-level errors), **header propagation** of the correlation id and
-the caller's `Authorization` bearer token, and **sanitized** upstream errors (no stack traces or
-internal details). Phase 1 is read-only: mutations/subscriptions are refused, and there is **no**
-generic "execute anything" surface — tools use typed read-only wrappers via `createReadOperation`.
+auth/validation errors or GraphQL-level errors), **header propagation** of the correlation id, the
+caller's `Authorization` bearer token, and the resolved read scope as `x-business-scope`, and
+**sanitized** upstream errors (no stack traces or internal details). Phase 1 is read-only:
+mutations/subscriptions are refused, and there is **no** generic "execute anything" surface — tools
+use typed read-only wrappers via `createReadOperation`.
 
 ## Identity & tenant scope
 
@@ -81,6 +111,27 @@ seam (`MembershipSource`) for testing. Requested scope narrowing is validated ag
 memberships: any business id outside them is rejected rather than silently dropped. These shapes and
 rules mirror the server package's tenant-isolation model
 (`packages/server/src/shared/helpers/auth-scope.ts`).
+
+**RLS upstream is the enforcement point.** The resolved read scope is forwarded on every tool call
+as the `x-business-scope` header, which the Accounter server turns into `app.current_business_scope`
+and applies through row-level security. MCP-side narrowing is the _first_ gate, not the only one: it
+rejects out-of-scope ids early with a legible `AUTHORIZATION_ERROR`, but the database is what
+actually constrains the rows. This matters for the argument-less upstream queries (`allTags`,
+`taxCategories`), which have no filter arguments to narrow — the header is the only mechanism
+available to them.
+
+The context is built once in `execute.ts`, where the resolved scope is known, and handlers receive
+it as `context.upstream`. A handler therefore cannot forget to forward the scope; a registry-wide
+test asserts every registered tool sends the header.
+
+Two deliberate exceptions:
+
+- **The membership bootstrap is never scoped.** `myMemberships` is the query that _discovers_ the
+  scope, so scoping it would be circular, and a stale or unknown id would fail the whole request at
+  authentication time rather than returning an empty list.
+- **An empty scope sends no header at all.** Upstream reads an absent `x-business-scope` as "all of
+  the caller's memberships", so emitting an empty header would widen the scope rather than narrow it
+  — the exact opposite of the intent.
 
 ## OAuth discovery
 
@@ -223,13 +274,25 @@ curl -s -X POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 
-# 5. Authenticated tool call
+# 5. Discover the businesses you can read → [{ businessId, name, role }]
 curl -s -X POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $TOKEN" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"accounter_list_tags","arguments":{}}}'
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"accounter_list_businesses","arguments":{}}}'
+
+# 6. Authenticated tool call, scoped to one of those ids.
+#    The response echoes scope.businessIds and every row carries ownerId.
+curl -s -X POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"accounter_list_tags","arguments":{"businessIds":["<businessId from step 5>"]}}}'
+
+# 7. Negative check: an id outside your memberships must be REJECTED, not ignored.
+#    Expect isError: true and code AUTHORIZATION_ERROR.
+curl -s -X POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"accounter_list_tags","arguments":{"businessIds":["00000000-0000-4000-8000-000000000000"]}}}'
 ```
 
-The automated equivalent of steps 1–5 (with the Auth0 verifier and upstream mocked) lives in
+The automated equivalent of steps 1–7 (with the Auth0 verifier and upstream mocked) lives in
 `src/__tests__/mcp-e2e.test.ts` and runs with `yarn workspace @accounter/mcp-server test`.
 
 ## Troubleshooting

--- a/packages/mcp-server/docs/connector-gaps-and-decisions.md
+++ b/packages/mcp-server/docs/connector-gaps-and-decisions.md
@@ -205,6 +205,29 @@ returned to the original four `*:users` scopes. These credentials are the root `
 process itself. `read:logs` is read-only and worth keeping — it was the single most useful
 diagnostic in this work.
 
+## Decided: stateless connector, self-describing responses
+
+**Decision (2026-08-01): the connector stays stateless; business scope is carried per call, never
+held as session state.**
+
+There is no `Mcp-Session-Id`, no session store, and auth is re-derived per request — so there is
+nowhere to hang an "active business" even if we wanted one. The alternative considered was a
+stateful `set_active_business`-style tool with server-side stickiness.
+
+**Why stateless.** A sticky active business is invisible to the model between calls: it cannot see
+what scope a result was produced under, so a silently-widened or stale scope looks identical to a
+correct one. It would also need a session store, an expiry policy, and a cross-request invalidation
+story when memberships change mid-session — all to avoid passing an id the model already has.
+
+**What replaces stickiness.** The feedback loop that session state would have provided is delivered
+on _every_ call instead: a discovery tool enumerates businesses, every business-scoped tool takes a
+uniform optional `businessIds`, the resolved scope is forwarded as `x-business-scope` (RLS enforces
+it), and each response echoes `scope.businessIds` with every row owner-tagged.
+
+**Cost accepted.** The model must pass ids explicitly on each call, and omitting them means "all my
+businesses" — a wider default than a sticky single business would give. That widening is made
+visible rather than silent, which is the trade: the response says which businesses it covered.
+
 ## Open decisions
 
 1. **Audience strategy.** Accept the shared `https://api.accounter.com` audience for MCP and GraphQL

--- a/packages/mcp-server/docs/local-development.md
+++ b/packages/mcp-server/docs/local-development.md
@@ -119,6 +119,26 @@ curl -s http://localhost:3100/metrics # after a tool call
 `resource` must equal the origin exactly — not `.../mcp`. A healthy connector shows entries under
 `requestsTotal` (e.g. `accounter_search_charges|success`) and nothing new in `authFailuresTotal`.
 
+### End-to-end business scoping
+
+Worth checking once from a real client, because a broken scope still returns plausible-looking data
+— it is just the wrong (wider) set. Ask Claude to run the three steps below and inspect the replies.
+
+1. **Discover** — "list the businesses I have access to". Should return one row per business with
+   `businessId`, `name`, and your role.
+2. **Scope a call** — "list tags for `<businessId>`". In the structured reply, `scope.businessIds`
+   must equal exactly the id you asked for, and every row's `ownerId` must match it. If `scope`
+   contains more ids than you asked for, narrowing is not reaching the server.
+3. **Negative check** — ask for a business id you do not belong to (any random UUID). It must come
+   back as an error with code `AUTHORIZATION_ERROR`. A successful reply, or an empty-but-successful
+   one, means ids are being silently dropped instead of rejected — the failure mode scope validation
+   exists to prevent.
+
+To confirm the header itself is doing the work rather than the MCP-side filter, tail the GraphQL
+server and check `app.current_business_scope` is set per request. Note that
+`parseBusinessScopeHeader` requires strict UUIDs upstream, so a dev database seeded with non-UUID
+business ids will fail every scoped tool call with an `UPSTREAM_ERROR`.
+
 ## 7. Shutting down
 
 Stop `cloudflared` when you are not actively testing — the quick tunnel publishes your local server

--- a/packages/mcp-server/docs/spec.md
+++ b/packages/mcp-server/docs/spec.md
@@ -204,6 +204,47 @@ Rules:
 - Requested scope outside memberships => forbidden
 - Empty requested scope => default authorized read scope
 
+### 7.3.1 Forwarding rule
+
+The resolved read scope MUST be forwarded to the Accounter GraphQL server on every tool call as the
+`x-business-scope` header (comma-joined business ids). The server maps it to
+`app.current_business_scope`, and **row-level security is the enforcement point**. MCP-side
+narrowing is the first gate — it rejects out-of-scope ids early with a legible `AUTHORIZATION_ERROR`
+— but it is not the only one.
+
+This is mandatory rather than best-effort because the argument-less upstream queries (`allTags`,
+`taxCategories`) have no filter arguments capable of expressing a scope; the header is their only
+narrowing mechanism.
+
+Two rules constrain how the header is emitted:
+
+- **An empty or absent scope MUST NOT send the header.** The server reads an absent
+  `x-business-scope` as "all of the caller's memberships", so an empty header would _widen_ the
+  scope rather than narrow it.
+- **Ids MUST NOT be filtered before joining.** Silently dropping an id is precisely the failure mode
+  scope validation exists to prevent; an unusable id is a rejected request, not a smaller scope.
+
+The scope-discovery query (`myMemberships`, §7.1) is the one call that MUST NOT carry the header:
+scoping the query that resolves the scope is circular, and a stale or not-yet-known id would fail
+the whole request at authentication time instead of returning an empty membership list.
+
+To make omission structurally impossible, the upstream request context is built once where the
+resolved scope is known and handed to handlers, rather than assembled per handler.
+
+### 7.3.2 Self-describing response contract
+
+Scope handling MUST be visible in the response, not inferred by the caller:
+
+- Every business-scoped tool echoes the effective scope as `scope.businessIds`.
+- Every returned row carries its owning business (`ownerId`; charges also carry `ownerName`), so
+  results spanning several businesses can be grouped rather than silently merged.
+- Text summaries surface a multi-business result, since the text content is what a model reads
+  first.
+
+The discovery tool (`accounter_list_businesses`) is exempt from both: it takes no scope input and
+echoes no scope, because it _is_ the scope. A single-business tool reports its one owner once
+(alongside the echoed scope) instead of tagging every row.
+
 ## 8) Tool Exposure Strategy
 
 ## 8.1 Selection Framework

--- a/packages/mcp-server/docs/spec.md
+++ b/packages/mcp-server/docs/spec.md
@@ -221,8 +221,20 @@ Two rules constrain how the header is emitted:
 - **An empty or absent scope MUST NOT send the header.** The server reads an absent
   `x-business-scope` as "all of the caller's memberships", so an empty header would _widen_ the
   scope rather than narrow it.
-- **Ids MUST NOT be filtered before joining.** Silently dropping an id is precisely the failure mode
-  scope validation exists to prevent; an unusable id is a rejected request, not a smaller scope.
+- **Business ids MUST NOT be silently dropped.** An id outside the caller's memberships is a
+  **rejected request** (`AUTHORIZATION_ERROR` at the policy gate), never a quietly smaller scope —
+  silently narrowing is precisely the failure mode scope validation exists to prevent.
+
+  This constrains _meaningful_ ids. Blank entries are removed before joining, because an empty
+  string denotes no business and would otherwise emit a trailing or doubled comma, which upstream
+  rejects outright with `FORBIDDEN`. Dropping them therefore changes no caller's access.
+
+  These two rules interact in one edge case: if every entry were blank, the filter would empty the
+  scope and the rule above would then omit the header — which upstream reads as "all memberships", a
+  widening. That case is unreachable by construction rather than by guard: membership coercion
+  rejects an empty `businessId` (§7.1), and both the default and narrowed read scopes are built only
+  from accepted memberships, so a blank id cannot reach the client. A future change that relaxes
+  membership coercion MUST also make this case fail closed.
 
 The scope-discovery query (`myMemberships`, §7.1) is the one call that MUST NOT carry the header:
 scoping the query that resolves the scope is circular, and a stale or not-yet-known id would fail

--- a/packages/mcp-server/docs/submission-checklist.md
+++ b/packages/mcp-server/docs/submission-checklist.md
@@ -37,8 +37,15 @@ code satisfies them.
 
 ## Tools & responses
 
-- [x] Curated tool set: `accounter_search_charges`, `accounter_list_tags`,
-      `accounter_list_tax_categories`, `accounter_balance_report`.
+- [x] Curated tool set: `accounter_list_businesses`, `accounter_search_charges`,
+      `accounter_list_tags`, `accounter_list_tax_categories`, `accounter_balance_report`. Discovery
+      is registered first so it leads `tools/list`; the internal `accounter_smoke_ping` is
+      dispatchable but deliberately not advertised.
+- [x] Uniform business scoping: optional `businessIds` (singular required `businessId` on the
+      single-business report), out-of-scope ids rejected rather than dropped, resolved scope
+      forwarded upstream as `x-business-scope` with RLS as the enforcement point.
+- [x] Self-describing responses: rows carry `ownerId` (charges also `ownerName`) and every
+      business-scoped tool echoes `scope.businessIds`.
 - [x] Strict input schemas (unknown fields rejected); advertised JSON Schema matches runtime
       validation (`additionalProperties: false`).
 - [x] Bounded, deterministic responses (date-range ≤ 366 days, page size ≤ 50, list caps 500,


### PR DESCRIPTION
Phase 7 of `docs/coherent-owner-scoping-for-mcp/plan.md` — brings the docs in line with the behaviour shipped in Phases 1–6. Docs only; no source changes.

> **Stacked on #4095.** Based on `mcp-owner-scoping-phase-6` so the diff is just the docs commit; basing on `mcp-owner-scoping` would re-include Phase 6's two commits and duplicate that review. GitHub retargets this to `mcp-owner-scoping` automatically when #4095 merges.

## README

- Four curated tools → five, with the `accounter_list_businesses` bullet.
- New **Business scoping contract** section stating the convention once: discover then scope; `businessIds` optional and meaning *narrow*; out-of-scope ids rejected rather than dropped; scope forwarded upstream; rows owner-tagged; scope echoed. Notes the discovery tool is the one exception, since it *is* the scope.
- Per-tool bullets note `ownerId`/`ownerName`, the echoed `scope`, `byOwners` vs `byBusinesses` on charges, and that the single-business report reports its owner once rather than tagging every row.
- Upstream client section lists `x-business-scope` in header propagation.
- Identity section documents **RLS upstream as the enforcement point**, with MCP-side narrowing as the first gate, plus the two deliberate exceptions.
- Smoke test gains discovery as a step, a scoped call, and a negative check.

## `docs/spec.md` §7.3

Adds **7.3.1 Forwarding rule** and **7.3.2 Self-describing response contract**.

Both non-obvious rules are documented with their reasons, not just as rules — they are the two things most likely to be "simplified" into a bug later:

- an empty scope must send **no header**, because upstream reads an absent `x-business-scope` as "all memberships", so an empty one would *widen* rather than narrow;
- ids must **not** be filtered before joining, because silently dropping an id is exactly the failure mode scope validation exists to prevent.

## `docs/local-development.md` §6

An end-to-end scope check. It leads with the **negative** case deliberately: a broken scope does not error, it returns plausible-looking data from a wider set, so the only reliable signal is that an out-of-scope id must be *rejected*. Also notes that `parseBusinessScopeHeader` requires strict UUIDs upstream, so a dev database seeded with non-UUID business ids fails every scoped call with an opaque `UPSTREAM_ERROR`.

## `docs/submission-checklist.md`

Tool list updated, with uniform scoping and self-describing responses as their own line items.

## `docs/connector-gaps-and-decisions.md`

Records the **stateless-vs-stateful decision** the plan still owed — why there is no session-held "active business", what replaces the stickiness, and the cost accepted: omitting `businessIds` means "all my businesses", wider than a sticky single business would be, but the widening is visible in the echoed scope rather than silent.

## Verification

```
build      exit 0
tests      34 files, 328 passed
prettier   clean
links      12/12 relative doc links resolve
```

(`packages/mcp-server/bench/summary.md` fails prettier but is gitignored perf-run output, untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)