### PR TITLE
fix(mcp-server): tolerate a trailing slash on the /mcp route (I4)

### DIFF
--- a/.changeset/mcp-server-trailing-slash-route.md
+++ b/.changeset/mcp-server-trailing-slash-route.md
@@ -1,0 +1,11 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Tolerate a trailing slash on the MCP transport route. Previously only the exact
+path `/mcp` was routed, so `POST /mcp/` — a correct-looking URL — fell through
+to a `404` that was raised before the auth layer, so `/metrics` recorded nothing
+and the failure looked like an outage rather than a typo. Route lookup now
+normalizes the request path (stripping a trailing slash, preserving the root
+`/`), so `/mcp/` reaches the same handler, auth layer, and metrics as `/mcp`.
+`context.route` still carries the raw pathname for logging fidelity.

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -12,6 +12,7 @@ const {
   requestHandler,
   getServiceVersion,
   createShutdownHandler,
+  normalizeRoutePath,
   SERVICE_NAME,
 } = await import('../server.js');
 
@@ -131,6 +132,63 @@ describe('MCP kill-switch (MCP_ENABLED=0)', () => {
         meta,
       );
       expect(meta.writeHead).toHaveBeenCalledWith(404, { 'Content-Type': 'application/json' });
+    });
+  });
+});
+
+describe('normalizeRoutePath', () => {
+  it('strips a trailing slash so /mcp/ routes as /mcp', () => {
+    expect(normalizeRoutePath('/mcp/')).toBe('/mcp');
+  });
+
+  it('collapses repeated trailing slashes', () => {
+    expect(normalizeRoutePath('/mcp///')).toBe('/mcp');
+  });
+
+  it('leaves a canonical path untouched', () => {
+    expect(normalizeRoutePath('/mcp')).toBe('/mcp');
+    expect(normalizeRoutePath('/health')).toBe('/health');
+  });
+
+  it('preserves the root path', () => {
+    expect(normalizeRoutePath('/')).toBe('/');
+  });
+});
+
+describe('trailing-slash tolerance on the MCP route', () => {
+  async function withMcpEnv(run: () => Promise<void>) {
+    vi.stubEnv('MCP_PUBLIC_BASE_URL', 'https://mcp.example.com');
+    vi.stubEnv('AUTH0_ISSUER_URL', 'https://tenant.auth0.com/');
+    vi.stubEnv('AUTH0_AUDIENCE', 'aud');
+    vi.stubEnv('GRAPHQL_UPSTREAM_URL', 'http://localhost:4000/graphql');
+    const { resetEnvCache } = await import('../config/env.js');
+    resetEnvCache();
+    try {
+      await run();
+    } finally {
+      vi.unstubAllEnvs();
+      resetEnvCache();
+    }
+  }
+
+  it('routes GET /mcp/ to the same 405 as GET /mcp (not a 404)', async () => {
+    await withMcpEnv(async () => {
+      const res = mockRes();
+      await requestHandler(mockReq({ method: 'GET', url: '/mcp/' }), res);
+      expect(res.writeHead).toHaveBeenCalledWith(405, {
+        'Content-Type': 'application/json',
+        Allow: 'POST',
+      });
+    });
+  });
+
+  it('lets POST /mcp/ reach the auth layer (401), not a silent 404', async () => {
+    await withMcpEnv(async () => {
+      const res = mockRes();
+      // No Authorization header → the MCP handler must challenge with 401.
+      // A 404 here would mean the trailing slash never reached auth.
+      await requestHandler(mockReq({ method: 'POST', url: '/mcp/' }), res);
+      expect(res.writeHead).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
     });
   });
 });

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -36,6 +36,20 @@ type RouteHandler = (req: IncomingMessage, res: ServerResponse) => void | Promis
 
 export const MCP_ROUTE_PATH = '/mcp';
 
+/**
+ * Normalize a request path for routing: strip a single-or-repeated trailing
+ * slash so a correct-looking URL such as `/mcp/` matches the `/mcp` route
+ * instead of silently 404ing. The root path `/` is preserved as-is.
+ *
+ * This runs before route lookup so a trailing slash reaches the same handler
+ * (and, for `/mcp`, the auth layer and metrics) as the canonical path — a
+ * trailing-slash 404 never reaches auth, so it records nothing and looks like
+ * an outage rather than a typo.
+ */
+export function normalizeRoutePath(route: string): string {
+  return route.length > 1 ? route.replace(/\/+$/, '') || '/' : route;
+}
+
 export const routes: Record<string, Record<string, RouteHandler>> = {
   GET: {
     '/health': (_req, res) => {
@@ -88,13 +102,16 @@ export async function requestHandler(req: IncomingMessage, res: ServerResponse):
   });
 
   try {
+    // Tolerate a trailing slash (e.g. `/mcp/`) so the request is dispatched to
+    // the same handler as its canonical path. `context.route` keeps the raw
+    // pathname for logging fidelity; only routing uses the normalized form.
+    const route = normalizeRoutePath(context.route);
     // Kill-switch: when MCP is disabled the server serves health only, so the
     // MCP transport and its OAuth resource-metadata discovery route are treated
     // as absent (404) rather than being advertised/served.
-    const isMcpRoute =
-      context.route === MCP_ROUTE_PATH || context.route === PROTECTED_RESOURCE_METADATA_PATH;
+    const isMcpRoute = route === MCP_ROUTE_PATH || route === PROTECTED_RESOURCE_METADATA_PATH;
     const handler =
-      isMcpRoute && !env.server.enabled ? undefined : routes[context.method]?.[context.route];
+      isMcpRoute && !env.server.enabled ? undefined : routes[context.method]?.[route];
     if (handler) {
       await handler(req, res);
     } else {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -110,8 +110,7 @@ export async function requestHandler(req: IncomingMessage, res: ServerResponse):
     // MCP transport and its OAuth resource-metadata discovery route are treated
     // as absent (404) rather than being advertised/served.
     const isMcpRoute = route === MCP_ROUTE_PATH || route === PROTECTED_RESOURCE_METADATA_PATH;
-    const handler =
-      isMcpRoute && !env.server.enabled ? undefined : routes[context.method]?.[route];
+    const handler = isMcpRoute && !env.server.enabled ? undefined : routes[context.method]?.[route];
     if (handler) {
       await handler(req, res);
     } else {


### PR DESCRIPTION
## What & why

Implements **I4** from [`packages/mcp-server/docs/todo.md`](../blob/main/packages/mcp-server/docs/todo.md).

Only the exact path `/mcp` was routed, so `POST /mcp/` — a correct-looking URL — fell through to a `404`. Worse, that `404` was raised _before_ the auth layer, so `/metrics` recorded nothing and the failure looked like an outage rather than a typo. Per the connector gap notes, this "cost real debugging time."

## Change

- Add `normalizeRoutePath()` in `server.ts` — strips a trailing slash (and collapses repeated ones) for **routing lookup only**, preserving the root path `/`.
- Route lookup and the MCP kill-switch check now use the normalized path, so `/mcp/` reaches the same handler, auth layer, and metrics as `/mcp`.
- `context.route` still carries the raw pathname, so logging fidelity is unchanged.

## Tests

- Unit tests for `normalizeRoutePath` (trailing slash, repeated slashes, canonical paths, root).
- `GET /mcp/` now returns the same `405` as `GET /mcp` (not `404`).
- `POST /mcp/` with no token now reaches the auth layer (`401`) instead of a silent `404`.

Full `@accounter/mcp-server` suite passes (the only failures in this environment are the two `schema-contract` tests that require a generated `schema.graphql`, unrelated to this change).

## Stack

This is the base of a 3-PR stack addressing the MCP server implementation gaps (I4 → I1 → I2). The other two target this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR6Y1hUhqFGNqAjUg1Qhtn)_