### PR TITLE
feat(mcp-server): enforce MCP_TOOL_ALLOWLIST (I1)

### DIFF
--- a/.changeset/mcp-server-enforce-tool-allowlist.md
+++ b/.changeset/mcp-server-enforce-tool-allowlist.md
@@ -1,0 +1,14 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Enforce `MCP_TOOL_ALLOWLIST`. The parsed allowlist was previously never read, so
+every registered tool was advertised and dispatchable regardless — harmless
+while phase 1 is read-only, but a real control gap once mutating tools land.
+`tools/list` now filters advertised tools through the allowlist and `tools/call`
+rejects an excluded tool as `Unknown tool` (indistinguishable from a nonexistent
+one, so the allowlist does not leak which capabilities exist). Semantics: an
+empty allowlist imposes no restriction (every tool exposed); a non-empty
+allowlist restricts to exactly the named tools. When narrowing, keep
+`accounter_list_businesses` in the set — it is the discovery entry point for
+business scoping.

--- a/packages/mcp-server/src/config/env.ts
+++ b/packages/mcp-server/src/config/env.ts
@@ -19,7 +19,7 @@ import zod from 'zod';
  * | GRAPHQL_UPSTREAM_URL        | yes      | —                        | Base URL of the Accounter GraphQL server the tools call.          |
  * | MCP_SERVER_PORT             | no       | 3100                     | TCP port the HTTP transport listens on.                           |
  * | MCP_ENABLED                 | no       | 1                        | Master kill-switch (`1` on / `0` off).                            |
- * | MCP_TOOL_ALLOWLIST          | no       | '' (none)                | Comma-separated tool names allowed in production (least priv).    |
+ * | MCP_TOOL_ALLOWLIST          | no       | '' (all tools)           | Comma-separated allowed tool names; empty ⇒ no restriction.       |
  * | AUTH0_JWKS_URL              | no       | derived from issuer      | JWKS endpoint; defaults to `<issuer>/.well-known/jwks.json`.      |
  * | GRAPHQL_UPSTREAM_TIMEOUT_MS | no       | 10000                    | Upstream GraphQL request timeout budget in milliseconds.          |
  * | MCP_RATE_LIMIT_CONFIG       | no       | '' (defaults applied)    | Optional rate-limit override spec (parsed by the limiter later).  |
@@ -56,8 +56,11 @@ export const envSchema = zod.object({
     zod.coerce.number().int().positive().max(65_535).optional().default(3100),
   ),
   MCP_ENABLED: booleanFlag('1'),
-  // Least-privilege default: empty allowlist means no tools are exposed unless
-  // explicitly enabled. The registry enforces this in later prompts.
+  // Tool allowlist: an empty value imposes no restriction (every registered
+  // tool is exposed); a non-empty value restricts `tools/list` and `tools/call`
+  // to exactly the named tools. Enforced in `mcp/handler.ts` via
+  // `tools/allowlist.ts`. When narrowing, keep `accounter_list_businesses` in
+  // the set — it is the discovery entry point for business scoping.
   MCP_TOOL_ALLOWLIST: emptyStringAsUndefined(zod.string().optional().default('')),
   AUTH0_JWKS_URL: emptyStringAsUndefined(
     zod.url({ message: 'AUTH0_JWKS_URL must be a valid URL' }).optional(),
@@ -77,7 +80,7 @@ export interface AppConfig {
     /** Public origin without a trailing slash. */
     publicBaseUrl: string;
     enabled: boolean;
-    /** Parsed tool allowlist; empty array means "no tools exposed". */
+    /** Parsed tool allowlist; empty array means "no restriction" (all tools). */
     toolAllowlist: readonly string[];
   };
   auth0: {

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -276,7 +276,7 @@ describe('dispatchMcpRequest — registry integration', () => {
   it('lists the curated tools with discovery first, and hides the smoke tool', async () => {
     const response = (await dispatchMcpRequest(
       { jsonrpc: '2.0', id: 1, method: 'tools/list' },
-      { auth, correlationId: 'c' },
+      { auth, correlationId: 'c', allowlist: [] },
     )) as JsonRpcSuccess;
     const names = (response.result as { tools: Array<{ name: string }> }).tools.map(t => t.name);
     // Discovery leads: tools/list ordering steers how the model scopes calls.
@@ -289,7 +289,7 @@ describe('dispatchMcpRequest — registry integration', () => {
   it('still dispatches the smoke tool by name', async () => {
     const response = (await dispatchMcpRequest(
       { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: SMOKE_TOOL_NAME, arguments: { message: 'hi' } } },
-      { auth, correlationId: 'c' },
+      { auth, correlationId: 'c', allowlist: [] },
     )) as JsonRpcSuccess;
     expect(response.result).toEqual({ content: [{ type: 'text', text: 'pong: hi' }], isError: false });
   });
@@ -297,7 +297,7 @@ describe('dispatchMcpRequest — registry integration', () => {
   it('returns InvalidParams for an unknown tool name', async () => {
     const response = (await dispatchMcpRequest(
       { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'nope' } },
-      { auth, correlationId: 'c' },
+      { auth, correlationId: 'c', allowlist: [] },
     )) as JsonRpcErrorResponse;
     expect(response.error.code).toBe(JsonRpcErrorCode.InvalidParams);
   });

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildAuthContext } from '../../auth/identity.js';
 import { TokenVerificationError } from '../../auth/token.js';
 import { verifyAccessToken } from '../../auth/verifier.js';
@@ -136,10 +136,24 @@ function mockRes() {
 }
 
 describe('mcpHttpHandler', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     // A valid bearer token resolves to a principal by default.
     mockVerify.mockReset();
     mockVerify.mockResolvedValue(PRINCIPAL);
+    // The handler reads env at the HTTP boundary (public base URL for 401
+    // challenges, tool allowlist for dispatch), so provide a valid config.
+    vi.stubEnv('MCP_PUBLIC_BASE_URL', 'https://mcp.example.com');
+    vi.stubEnv('AUTH0_ISSUER_URL', 'https://tenant.auth0.com/');
+    vi.stubEnv('AUTH0_AUDIENCE', 'aud');
+    vi.stubEnv('GRAPHQL_UPSTREAM_URL', 'http://localhost:4000/graphql');
+    const { resetEnvCache } = await import('../../config/env.js');
+    resetEnvCache();
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    const { resetEnvCache } = await import('../../config/env.js');
+    resetEnvCache();
   });
 
   it('responds 200 with the JSON-RPC result for a request', async () => {
@@ -286,6 +300,54 @@ describe('dispatchMcpRequest — registry integration', () => {
       { auth, correlationId: 'c' },
     )) as JsonRpcErrorResponse;
     expect(response.error.code).toBe(JsonRpcErrorCode.InvalidParams);
+  });
+
+  it('lists every registered tool when the allowlist is empty', async () => {
+    const response = (await dispatchMcpRequest(
+      { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      { auth, correlationId: 'c', allowlist: [] },
+    )) as JsonRpcSuccess;
+    const names = (response.result as { tools: Array<{ name: string }> }).tools.map(t => t.name);
+    expect(names).toContain('accounter_list_businesses');
+    expect(names).toContain('accounter_search_charges');
+    expect(names).toContain('accounter_balance_report');
+  });
+
+  it('lists only allowlisted tools when the allowlist is non-empty', async () => {
+    const response = (await dispatchMcpRequest(
+      { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      { auth, correlationId: 'c', allowlist: ['accounter_list_businesses'] },
+    )) as JsonRpcSuccess;
+    const names = (response.result as { tools: Array<{ name: string }> }).tools.map(t => t.name);
+    expect(names).toEqual(['accounter_list_businesses']);
+  });
+
+  it('reports an allowlisted-out tool as unknown on tools/call (no capability leak)', async () => {
+    const response = (await dispatchMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'accounter_search_charges', arguments: {} },
+      },
+      { auth, correlationId: 'c', allowlist: ['accounter_list_businesses'] },
+    )) as JsonRpcErrorResponse;
+    // Excluded tool is indistinguishable from a nonexistent one.
+    expect(response.error.code).toBe(JsonRpcErrorCode.InvalidParams);
+    expect(response.error.message).toContain('Unknown tool');
+  });
+
+  it('still dispatches the smoke tool even under a restrictive allowlist', async () => {
+    const response = (await dispatchMcpRequest(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: SMOKE_TOOL_NAME, arguments: { message: 'hi' } },
+      },
+      { auth, correlationId: 'c', allowlist: ['accounter_list_businesses'] },
+    )) as JsonRpcSuccess;
+    expect(response.result).toEqual({ content: [{ type: 'text', text: 'pong: hi' }], isError: false });
   });
 });
 

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -21,6 +21,7 @@ import { protectedResourceMetadataUrl } from '../oauth/metadata.js';
 import { getMetrics } from '../observability/metrics.js';
 import { withSpan } from '../observability/tracing.js';
 import { getRateLimiter } from '../rate-limit/default-limiter.js';
+import { isToolAllowed } from '../tools/allowlist.js';
 import { executeRegisteredTool } from '../tools/execute.js';
 import { toolRegistry } from '../tools/registry-instance.js';
 import { getUpstreamClient } from '../upstream/default-client.js';
@@ -155,6 +156,12 @@ export interface McpDispatchContext {
   correlationId: string;
   /** Caller's Authorization header value, forwarded upstream (never logged). */
   authorization?: string;
+  /**
+   * `MCP_TOOL_ALLOWLIST`, resolved at the HTTP boundary. Empty/omitted ⇒ no
+   * restriction (every registered tool is exposed); non-empty ⇒ `tools/list`
+   * and `tools/call` are limited to exactly these tool names.
+   */
+  allowlist?: readonly string[];
 }
 
 /**
@@ -171,8 +178,17 @@ export async function dispatchMcpRequest(
   }
   const id = request.id ?? null;
 
+  // `MCP_TOOL_ALLOWLIST` enforcement: an empty allowlist exposes every tool; a
+  // non-empty one restricts both discovery and dispatch to the named subset.
+  // The list is threaded in via the dispatch context (built at the HTTP
+  // boundary) so this function stays env-free and directly unit-testable.
+  const allowlist = context.allowlist ?? [];
+
   if (request.method === 'tools/list') {
-    return success(id, { tools: [...listedTools, ...toolRegistry.describe()] });
+    const registered = toolRegistry
+      .describe()
+      .filter(descriptor => isToolAllowed(allowlist, descriptor.name));
+    return success(id, { tools: [...listedTools, ...registered] });
   }
 
   if (request.method === 'tools/call') {
@@ -181,7 +197,10 @@ export async function dispatchMcpRequest(
     if (name === SMOKE_TOOL_NAME) {
       return success(id, runSmokeTool(params.arguments));
     }
-    const tool = toolRegistry.get(name);
+    // A tool that exists but is excluded by the allowlist is reported as
+    // unknown — indistinguishable from a nonexistent one, so the allowlist does
+    // not leak which capabilities the server could otherwise offer.
+    const tool = isToolAllowed(allowlist, name) ? toolRegistry.get(name) : undefined;
     if (!tool) {
       return failure(id, JsonRpcErrorCode.InvalidParams, `Unknown tool: ${name}`);
     }
@@ -350,6 +369,7 @@ export async function mcpHttpHandler(req: IncomingMessage, res: ServerResponse):
     correlationId: getRequestContext(req)?.correlationId ?? '',
     authorization:
       typeof req.headers.authorization === 'string' ? req.headers.authorization : undefined,
+    allowlist: env.server.toolAllowlist,
   });
 
   if (response === null) {

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -157,11 +157,15 @@ export interface McpDispatchContext {
   /** Caller's Authorization header value, forwarded upstream (never logged). */
   authorization?: string;
   /**
-   * `MCP_TOOL_ALLOWLIST`, resolved at the HTTP boundary. Empty/omitted ⇒ no
-   * restriction (every registered tool is exposed); non-empty ⇒ `tools/list`
-   * and `tools/call` are limited to exactly these tool names.
+   * `MCP_TOOL_ALLOWLIST`, resolved at the HTTP boundary. Empty ⇒ no restriction
+   * (every registered tool is exposed); non-empty ⇒ `tools/list` and
+   * `tools/call` are limited to exactly these tool names.
+   *
+   * Required — not optional — precisely because it is a security control:
+   * making every caller pass it (even the empty, unrestricted case) means a new
+   * call site cannot silently bypass enforcement by forgetting the field.
    */
-  allowlist?: readonly string[];
+  allowlist: readonly string[];
 }
 
 /**
@@ -182,7 +186,7 @@ export async function dispatchMcpRequest(
   // non-empty one restricts both discovery and dispatch to the named subset.
   // The list is threaded in via the dispatch context (built at the HTTP
   // boundary) so this function stays env-free and directly unit-testable.
-  const allowlist = context.allowlist ?? [];
+  const { allowlist } = context;
 
   if (request.method === 'tools/list') {
     const registered = toolRegistry

--- a/packages/mcp-server/src/tools/__tests__/allowlist.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/allowlist.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isToolAllowed } from '../allowlist.js';
+
+describe('isToolAllowed', () => {
+  it('permits every tool when the allowlist is empty (no restriction)', () => {
+    expect(isToolAllowed([], 'accounter_list_businesses')).toBe(true);
+    expect(isToolAllowed([], 'anything_at_all')).toBe(true);
+  });
+
+  it('permits only named tools when the allowlist is non-empty', () => {
+    const allowlist = ['accounter_list_businesses', 'accounter_search_charges'];
+    expect(isToolAllowed(allowlist, 'accounter_list_businesses')).toBe(true);
+    expect(isToolAllowed(allowlist, 'accounter_search_charges')).toBe(true);
+    expect(isToolAllowed(allowlist, 'accounter_balance_report')).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/tools/allowlist.ts
+++ b/packages/mcp-server/src/tools/allowlist.ts
@@ -1,0 +1,33 @@
+/**
+ * Tool allowlist enforcement (`MCP_TOOL_ALLOWLIST`).
+ *
+ * The allowlist is a comma-separated set of tool names parsed into
+ * `env.server.toolAllowlist`. Until now it was parsed and never read — every
+ * registered tool was advertised and dispatchable regardless. That is harmless
+ * while phase 1 is read-only, but a real control gap the moment mutating tools
+ * land, so enforcement is wired in here at the transport boundary.
+ *
+ * **Semantics.** An *empty* allowlist means "no restriction" — every registered
+ * tool is exposed. A *non-empty* allowlist restricts both `tools/list` and
+ * `tools/call` to exactly the named tools. This is the conventional
+ * unset-allowlist reading and, deliberately, the one that keeps phase 1 working
+ * out of the box: an operator opts into least-privilege by naming the subset
+ * they want, rather than the server refusing to serve any tool until configured.
+ *
+ * A caveat worth stating loudly (see the note on I1 in the connector todo): when
+ * an operator *does* set an allowlist, `accounter_list_businesses` should almost
+ * always be in it. It is the discovery entry point for business scoping — the
+ * model calls it to learn which `businessId` values exist before passing them to
+ * the other tools. Omitting it does not degrade gracefully: the remaining tools
+ * still work, just with no way to discover a business id. Enforcement here makes
+ * an omitted tool genuinely absent (hidden from `tools/list` *and* rejected by
+ * `tools/call`) rather than silently unscoped, which is the safer failure.
+ */
+
+/**
+ * Whether `toolName` is permitted by `allowlist`. An empty allowlist permits
+ * every tool; a non-empty allowlist permits only its members.
+ */
+export function isToolAllowed(allowlist: readonly string[], toolName: string): boolean {
+  return allowlist.length === 0 || allowlist.includes(toolName);
+}


### PR DESCRIPTION
## What & why

Implements **I1** from [`packages/mcp-server/docs/todo.md`](../blob/main/packages/mcp-server/docs/todo.md) — _"Enforce `MCP_TOOL_ALLOWLIST` (high before phase 2)"_.

`env.server.toolAllowlist` was parsed and **never read**: every registered tool was advertised (`tools/list`) and dispatchable (`tools/call`) regardless of the allowlist. Harmless while phase 1 is read-only, but a real control gap the moment phase 2 adds mutating tools.

## Change

- New `tools/allowlist.ts` with a small pure `isToolAllowed(allowlist, name)`.
- `tools/list` filters advertised descriptors through it; `tools/call` rejects an excluded tool as `Unknown tool` — **indistinguishable from a nonexistent one**, so the allowlist never leaks which capabilities exist.
- The list is threaded through `McpDispatchContext.allowlist` (resolved from env in `mcpHttpHandler`), keeping `dispatchMcpRequest` env-free and directly unit-testable, consistent with how the rate limiter and metrics are already injected.
- The internal smoke tool short-circuits before the gate, so connectivity checks keep working under any allowlist.

## Decision (D3)

This resolves decision **D3** in favor of _implementing enforcement_, with these semantics:

| `MCP_TOOL_ALLOWLIST` | Behavior |
| --- | --- |
| empty / unset | **no restriction** — every registered tool exposed (phase-1 compatible) |
| non-empty | restricted to exactly the named tools, for both `tools/list` and `tools/call` |

An operator opts into least-privilege by naming the subset they want, rather than the server refusing to serve any tool until configured. The env docs — which previously claimed "empty ⇒ no tools exposed" for a control that did not exist — are corrected to match, including the caveat from the todo that **`accounter_list_businesses`** (the business-scoping discovery entry point) should stay in any non-empty allowlist.

## Tests

- Pure `isToolAllowed` (empty ⇒ all; non-empty ⇒ subset).
- Dispatch: empty allowlist lists all tools; non-empty lists only the subset; an excluded tool returns `Unknown tool` on `tools/call`; the smoke tool still dispatches under a restrictive allowlist.
- Existing `mcpHttpHandler` tests updated to provide a valid env at the HTTP boundary.

## Stack

Stacked on **#4103 (I4)**. Base branch is `claude/mcp-server-gaps-jnvn1t`; review/merge that first. The diff against `main` will shrink to just this change once #4103 merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR6Y1hUhqFGNqAjUg1Qhtn)_