### PR TITLE
fix(mcp-server): key the rate limiter on user+tool, not business scope (I2)

### DIFF
--- a/.changeset/mcp-server-rate-limit-key.md
+++ b/.changeset/mcp-server-rate-limit-key.md
@@ -1,0 +1,13 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Key the rate limiter on `userId|toolName` instead of
+`userId|sortedScope|toolName`. Sorting already defeated permutation abuse, but
+distinct business-scope *subsets* still mapped to distinct buckets, so a caller
+with N businesses could address up to 2^N−1 buckets per tool and multiply their
+effective quota — now that two tools accept a `businessIds` input. Every subset
+is already authorized, so scope in the key protected nothing and only fragmented
+the quota it is meant to bound. Tenant isolation is unaffected: it is enforced
+upstream by RLS via the forwarded `x-business-scope` header, not by the
+rate-limit key.

--- a/packages/mcp-server/src/rate-limit/__tests__/limiter.test.ts
+++ b/packages/mcp-server/src/rate-limit/__tests__/limiter.test.ts
@@ -7,14 +7,15 @@ import {
 } from '../limiter.js';
 
 describe('rateLimitKey', () => {
-  it('scopes the key to identity + sorted business scope + tool', () => {
-    expect(rateLimitKey({ userId: 'u1', toolName: 't', businessIds: ['b2', 'b1'] })).toBe(
-      'u1|b1,b2|t',
-    );
+  it('scopes the key to identity + tool', () => {
+    expect(rateLimitKey({ userId: 'u1', toolName: 't' })).toBe('u1|t');
   });
 
-  it('uses "none" when there is no business scope', () => {
-    expect(rateLimitKey({ userId: 'u1', toolName: 't', businessIds: [] })).toBe('u1|none|t');
+  it('is independent of business scope, so scope subsets share one bucket', () => {
+    // A caller must not be able to multiply their quota by addressing distinct
+    // scope subsets — every subset maps to the same identity|tool bucket.
+    const key = rateLimitKey({ userId: 'u1', toolName: 't' });
+    expect(rateLimitKey({ userId: 'u1', toolName: 't' })).toBe(key);
   });
 });
 

--- a/packages/mcp-server/src/rate-limit/limiter.ts
+++ b/packages/mcp-server/src/rate-limit/limiter.ts
@@ -1,9 +1,9 @@
 /**
  * In-memory rate limiter (spec §11.4).
  *
- * A fixed-window counter keyed by authenticated identity + business scope +
- * tool. Enforced before expensive upstream calls. Phase 1 uses an in-process
- * store; a shared store can replace it later without changing callers.
+ * A fixed-window counter keyed by authenticated identity + tool. Enforced
+ * before expensive upstream calls. Phase 1 uses an in-process store; a shared
+ * store can replace it later without changing callers.
  */
 
 export interface RateLimitConfig {
@@ -40,14 +40,19 @@ interface Bucket {
 /** How many `check` calls between opportunistic sweeps of expired buckets. */
 const SWEEP_EVERY = 1000;
 
-/** Build a limiter key scoped to identity + business scope + tool. */
-export function rateLimitKey(params: {
-  userId: string;
-  toolName: string;
-  businessIds: readonly string[];
-}): string {
-  const scope = params.businessIds.length > 0 ? [...params.businessIds].sort().join(',') : 'none';
-  return `${params.userId}|${scope}|${params.toolName}`;
+/**
+ * Build a limiter key scoped to identity + tool.
+ *
+ * Deliberately **not** keyed by business scope. Every scope subset a caller can
+ * request is already authorized, so scope in the key would only fragment the
+ * quota: a caller with N businesses could address up to 2^N−1 distinct buckets
+ * per tool (one per subset) and multiply their effective budget. Keying on
+ * `userId|toolName` gives one bucket per caller per tool, which is what the
+ * quota is meant to bound. Tenant isolation is enforced upstream by RLS via the
+ * forwarded `x-business-scope` header, not by the rate-limit key.
+ */
+export function rateLimitKey(params: { userId: string; toolName: string }): string {
+  return `${params.userId}|${params.toolName}`;
 }
 
 export class RateLimiter implements RateLimiterLike {

--- a/packages/mcp-server/src/tools/__tests__/rate-limit.execute.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/rate-limit.execute.test.ts
@@ -68,12 +68,14 @@ describe('executeRegisteredTool — rate limiting', () => {
     expect(structured.retryAfterMs).toBe(1000);
   });
 
-  it('keys the limit by tool + business scope (different scope is independent)', async () => {
+  it('keys the limit by user + tool, independent of business scope (I2)', async () => {
     const limiter = new RateLimiter({ windowMs: 1000, max: 1 }, () => 0);
+    // Same user + tool but a different business scope must NOT get a fresh
+    // bucket — otherwise a caller with N businesses could address 2^N−1 buckets
+    // per tool and multiply their quota.
     expect((await run(limiter, authContext(['b1']))).isError).toBeUndefined();
-    // Same user + tool but a different business scope → separate bucket.
-    expect((await run(limiter, authContext(['b2']))).isError).toBeUndefined();
-    // Repeat of the first scope is now limited.
+    // Different scope subset, same user + tool → same bucket, already exhausted.
+    expect((await run(limiter, authContext(['b2']))).isError).toBe(true);
     expect((await run(limiter, authContext(['b1']))).isError).toBe(true);
   });
 });

--- a/packages/mcp-server/src/tools/execute.ts
+++ b/packages/mcp-server/src/tools/execute.ts
@@ -137,14 +137,15 @@ async function runTool(params: ExecuteToolParams): Promise<ToolResult> {
     );
   }
 
-  // 3. Rate limit (before any expensive upstream call), keyed by
-  // identity + business scope + tool.
+  // 3. Rate limit (before any expensive upstream call), keyed by identity +
+  // tool. Business scope is intentionally left out of the key — every subset is
+  // already authorized, so keying on it would let a caller multiply their quota
+  // across scope subsets (see `rateLimitKey`).
   if (limiter) {
     const outcome = limiter.check(
       rateLimitKey({
         userId: auth.userId,
         toolName: tool.name,
-        businessIds: decision.readScope.businessIds,
       }),
     );
     if (!outcome.allowed) {


### PR DESCRIPTION
## What & why

Implements **I2** from [`packages/mcp-server/docs/todo.md`](../blob/main/packages/mcp-server/docs/todo.md) — _"Rate-limit quota multiplies with scope subsets"_.

`rateLimitKey` was `userId|sortedScope|toolName`. Sorting defeated permutation abuse, but distinct scope **subsets** still mapped to distinct buckets. Since phase 5 gave two more tools a `businessIds` input, a caller with N businesses can address up to **2^N−1 buckets per tool** and multiply their effective quota.

This is not a tenant-isolation issue — every subset is already authorized. Scope in the key protects nothing; it only fragments the quota it is meant to bound, on exactly the tools that now push RLS-scoped work upstream.

## Change

- `rateLimitKey` now returns `userId|toolName` (business scope dropped from the key).
- `execute.ts` no longer passes `businessIds` into the key.
- Tenant isolation is untouched — it is enforced upstream by RLS via the forwarded `x-business-scope` header, not by the rate-limit key.

## Decision (D6)

Resolves decision **D6** in favor of _keying on `userId|toolName`_ (one bucket per caller per tool), over accepting the multiplication or adding a separate per-user aggregate ceiling.

## Tests

- `rateLimitKey` unit test updated: key is `u1|t`, independent of business scope.
- `executeRegisteredTool` rate-limit test updated: a second call under a **different** scope subset now hits the **same** (exhausted) bucket instead of a fresh one.

## Stack

Top of the stack: **#4103 (I4)** → **#4104 (I1)** → this PR. Base branch is `claude/mcp-i1-allowlist`; merge the two below first, and this PR's diff against `main` collapses to just the rate-limit change.

## Not in this stack (I3, I5)

The remaining I-series items are **not repository code changes** and have no PR:
- **I3** — replace the Auth0 test application: Auth0 tenant/dashboard configuration (create a Regular Web App, move the user-delegated grant, update Claude Desktop credentials).
- **I5** — stable named tunnel / production origin: infrastructure/ops setup, gated on hosting decision D4.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR6Y1hUhqFGNqAjUg1Qhtn)_