### PR TITLE
Add OpenTelemetry tracing to MCP server

### DIFF
--- a/.changeset/@accounter_client-4107-dependencies.md
+++ b/.changeset/@accounter_client-4107-dependencies.md
@@ -1,5 +1,0 @@
----
-"@accounter/client": patch
----
-dependencies updates:
-  - Updated dependency [`lucide-react@1.28.0` ↗︎](https://www.npmjs.com/package/lucide-react/v/1.28.0) (from `1.27.0`, in `dependencies`)

--- a/.changeset/@accounter_client-4107-dependencies.md
+++ b/.changeset/@accounter_client-4107-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`lucide-react@1.28.0` ↗︎](https://www.npmjs.com/package/lucide-react/v/1.28.0) (from `1.27.0`, in `dependencies`)

--- a/.changeset/mcp-server-opentelemetry-tracing.md
+++ b/.changeset/mcp-server-opentelemetry-tracing.md
@@ -1,0 +1,19 @@
+---
+'@accounter/mcp-server': minor
+'@accounter/server': patch
+---
+
+Export MCP server traces to OpenTelemetry (Grafana Tempo) and link them with the backend.
+
+The MCP server's tracing was previously a dependency-free stub. It now emits real OpenTelemetry
+spans over OTLP/HTTP to the same Grafana Tempo backend as the main server, using the same `OTEL_*`
+configuration (disabled by default; enable with `OTEL_ENABLED=1` and an
+`OTEL_EXPORTER_OTLP_ENDPOINT`). Spans come from Node auto-instrumentation (incoming `POST /mcp`, and
+the outbound `fetch` to the upstream GraphQL API) plus the existing `withSpan` units of work
+(`auth:verify`, `tool:<name>`, `upstream:graphql`), each tagged with an `accounter.correlation_id`
+attribute.
+
+MCP and backend traces are linked two ways: the outbound `fetch` propagates the W3C `traceparent`
+header, so the Accounter server continues the same distributed trace; and a new `correlationIdPlugin`
+on the server records an inbound `X-Correlation-Id` as the `accounter.correlation_id` span
+attribute, so both services' traces are searchable by the same business-level id in Grafana.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -24,8 +24,9 @@ Accounter GraphQL server; a curated registry of eight read-only tools (`accounte
 `accounter_balance_report`) each gated by strict input validation, a per-tool authorization policy,
 and business-scope narrowing forwarded upstream as `x-business-scope`; a hardened upstream GraphQL
 client (timeout, bounded retries, header propagation, sanitized errors); a unified error taxonomy;
-per-`tools/call` rate limiting; and operational telemetry (request/outcome counters, a latency
-histogram, auth-failure counters, tracing spans) exposed at `GET /metrics`.
+per-`tools/call` rate limiting; in-process operational metrics (request/outcome counters, a latency
+histogram, auth-failure counters) exposed at `GET /metrics`; and OpenTelemetry tracing exported to
+Grafana Tempo (opt-in), correlated with the backend via `traceparent` and `X-Correlation-Id`.
 
 Phase 2 (write scope) is **not** implemented — see
 [Known limitations & phase 2](#known-limitations--phase-2-write-scope).
@@ -194,13 +195,40 @@ A snapshot is exposed at `GET /metrics`:
 curl http://localhost:3100/metrics
 ```
 
-### Tracing spans
+### Tracing (OpenTelemetry → Grafana Tempo)
 
-Lightweight tracing spans (`src/observability/tracing.ts`) wrap the key units of work — token
-verification (`auth:verify`), tool execution (`tool:<name>`), and each upstream GraphQL call
-(`upstream:graphql`) — emitting structured `span start`/`span end` debug logs carrying the
-correlation id and span duration. The implementation is deliberately dependency-free so it can be
-swapped for OpenTelemetry later without touching call sites.
+The MCP server emits OpenTelemetry traces over OTLP/HTTP to the same Grafana Tempo backend as the
+main Accounter server, using the same `OTEL_*` configuration conventions (see
+[Configuration](#configuration)). Tracing is **off by default** and enabled with `OTEL_ENABLED=1`
+plus an `OTEL_EXPORTER_OTLP_ENDPOINT`.
+
+Spans come from two sources:
+
+- **Auto-instrumentation** (`@opentelemetry/auto-instrumentations-node`): the incoming `POST /mcp`
+  HTTP server span, and the outbound `fetch` client spans for upstream GraphQL calls (via the
+  `undici` instrumentation).
+- **Manual spans** (`src/observability/tracing.ts`, `withSpan`): token verification (`auth:verify`),
+  tool execution (`tool:<name>`), and each upstream GraphQL call (`upstream:graphql`). Each carries
+  the business-level `accounter.correlation_id` attribute. The `withSpan` signature is unchanged, so
+  call sites did not move — and when OTEL is disabled it resolves to the API's no-op tracer at
+  effectively zero cost.
+
+The SDK is started from a `--import` preload (`src/bootstrap-telemetry.ts`) so instrumentation
+patches `node:http`/`fetch` before the app loads, and flushed on graceful shutdown.
+
+#### Linking MCP traces to the backend
+
+Two mechanisms tie an MCP request to the backend work it triggers:
+
+1. **W3C `traceparent` propagation (the distributed-trace join).** The upstream `fetch` is
+   auto-instrumented, so `traceparent` is injected on every upstream GraphQL call and the Accounter
+   server's HTTP instrumentation continues the **same trace**. A single Grafana trace therefore
+   spans `POST /mcp` → `tool:<name>` → `upstream:graphql` → the backend HTTP/GraphQL/Postgres spans.
+2. **`X-Correlation-Id` as a shared, searchable attribute.** The correlation id (inherited from the
+   inbound header or generated) is set as `accounter.correlation_id` on the MCP spans and forwarded
+   upstream as `X-Correlation-Id`; the backend records the same attribute on its spans (via its
+   `correlationIdPlugin`). This lets you pivot from an MCP log line to the backend trace and search
+   Tempo by the business-level id.
 
 ## Running locally
 
@@ -254,6 +282,15 @@ process to exit immediately with a clear error. Secrets are supplied via the env
 | `AUTH0_JWKS_URL`              | no       | derived from issuer | JWKS endpoint; defaults to `<issuer>/.well-known/jwks.json`     |
 | `GRAPHQL_UPSTREAM_TIMEOUT_MS` | no       | `10000`             | Upstream GraphQL request timeout budget (ms)                    |
 | `MCP_RATE_LIMIT_CONFIG`       | no       | `''` (defaults)     | Optional rate-limit override spec (parsed by the limiter later) |
+| `OTEL_ENABLED`                | no       | `0`                 | Enable OpenTelemetry tracing (`1` on / `0` off)                 |
+| `OTEL_SERVICE_NAME`           | no       | `accounter-mcp-server` | `service.name` resource attribute                            |
+| `OTEL_SERVICE_NAMESPACE`      | no       | `accounter`         | `service.namespace` resource attribute                          |
+| `OTEL_DEPLOYMENT_ENV`         | no       | `NODE_ENV`/`development` | `deployment.environment.name` resource attribute            |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | if OTEL  | —                   | OTLP/HTTP traces endpoint (e.g. `http://localhost:4318/v1/traces`) |
+| `OTEL_EXPORTER_OTLP_HEADERS`  | no       | —                   | OTLP exporter headers as `key=value,key=value`                  |
+| `OTEL_TRACES_SAMPLER`         | no       | `always_on`         | Sampler strategy (`always_on`, `parentbased_traceidratio`, …)   |
+| `OTEL_TRACES_SAMPLER_ARG`     | if ratio | —                   | Ratio `0`–`1` for the ratio-based samplers                      |
+| `OTEL_STARTUP_STRICT`         | no       | —                   | `true` ⇒ abort the process on a telemetry startup failure       |
 
 ## Scripts
 
@@ -333,7 +370,8 @@ Phase 1 is intentionally **read-only** and single-purpose:
   rather than streamed in full.
 - Rate limiting and metrics are **in-process** (per replica); there is no shared/Redis-backed
   limiter or Prometheus exposition yet (the limiter and metrics are behind swappable seams).
-- Tracing is a dependency-free stub emitting structured span logs; it is not wired to OpenTelemetry.
+- Tracing is exported to OpenTelemetry/Grafana Tempo (opt-in via `OTEL_ENABLED=1`), but metrics
+  remain in-process (`GET /metrics`) and are not yet exported over OTLP.
 
 **Phase 2 (write scope)** — not implemented — will add mutating tools (e.g. tagging/updating
 charges) behind: per-tool write policies and role checks reusing the server's authorization model;

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -270,27 +270,27 @@ Environment variables are validated at startup with a strict schema
 ([`src/config/env.ts`](src/config/env.ts)). Missing required variables or malformed values cause the
 process to exit immediately with a clear error. Secrets are supplied via the environment only.
 
-| Variable                      | Required | Default             | Description                                                     |
-| ----------------------------- | -------- | ------------------- | --------------------------------------------------------------- |
-| `MCP_PUBLIC_BASE_URL`         | yes      | —                   | Public HTTPS origin of this MCP server (used in OAuth metadata) |
-| `AUTH0_ISSUER_URL`            | yes      | —                   | Auth0 issuer/tenant URL used to validate access tokens          |
-| `AUTH0_AUDIENCE`              | yes      | —                   | Expected `aud` claim for incoming access tokens                 |
-| `GRAPHQL_UPSTREAM_URL`        | yes      | —                   | Base URL of the Accounter GraphQL server the tools call         |
-| `MCP_SERVER_PORT`             | no       | `3100`              | TCP port the HTTP transport listens on                          |
-| `MCP_ENABLED`                 | no       | `1`                 | Master kill-switch (`1` on / `0` off)                           |
-| `MCP_TOOL_ALLOWLIST`          | no       | `''` (none)         | Comma-separated tool names allowed (empty = least privilege)    |
-| `AUTH0_JWKS_URL`              | no       | derived from issuer | JWKS endpoint; defaults to `<issuer>/.well-known/jwks.json`     |
-| `GRAPHQL_UPSTREAM_TIMEOUT_MS` | no       | `10000`             | Upstream GraphQL request timeout budget (ms)                    |
-| `MCP_RATE_LIMIT_CONFIG`       | no       | `''` (defaults)     | Optional rate-limit override spec (parsed by the limiter later) |
-| `OTEL_ENABLED`                | no       | `0`                 | Enable OpenTelemetry tracing (`1` on / `0` off)                 |
-| `OTEL_SERVICE_NAME`           | no       | `accounter-mcp-server` | `service.name` resource attribute                            |
-| `OTEL_SERVICE_NAMESPACE`      | no       | `accounter`         | `service.namespace` resource attribute                          |
-| `OTEL_DEPLOYMENT_ENV`         | no       | `NODE_ENV`/`development` | `deployment.environment.name` resource attribute            |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | if OTEL  | —                   | OTLP/HTTP traces endpoint (e.g. `http://localhost:4318/v1/traces`) |
-| `OTEL_EXPORTER_OTLP_HEADERS`  | no       | —                   | OTLP exporter headers as `key=value,key=value`                  |
-| `OTEL_TRACES_SAMPLER`         | no       | `always_on`         | Sampler strategy (`always_on`, `parentbased_traceidratio`, …)   |
-| `OTEL_TRACES_SAMPLER_ARG`     | if ratio | —                   | Ratio `0`–`1` for the ratio-based samplers                      |
-| `OTEL_STARTUP_STRICT`         | no       | —                   | `true` ⇒ abort the process on a telemetry startup failure       |
+| Variable                      | Required | Default                  | Description                                                        |
+| ----------------------------- | -------- | ------------------------ | ------------------------------------------------------------------ |
+| `MCP_PUBLIC_BASE_URL`         | yes      | —                        | Public HTTPS origin of this MCP server (used in OAuth metadata)    |
+| `AUTH0_ISSUER_URL`            | yes      | —                        | Auth0 issuer/tenant URL used to validate access tokens             |
+| `AUTH0_AUDIENCE`              | yes      | —                        | Expected `aud` claim for incoming access tokens                    |
+| `GRAPHQL_UPSTREAM_URL`        | yes      | —                        | Base URL of the Accounter GraphQL server the tools call            |
+| `MCP_SERVER_PORT`             | no       | `3100`                   | TCP port the HTTP transport listens on                             |
+| `MCP_ENABLED`                 | no       | `1`                      | Master kill-switch (`1` on / `0` off)                              |
+| `MCP_TOOL_ALLOWLIST`          | no       | `''` (none)              | Comma-separated tool names allowed (empty = least privilege)       |
+| `AUTH0_JWKS_URL`              | no       | derived from issuer      | JWKS endpoint; defaults to `<issuer>/.well-known/jwks.json`        |
+| `GRAPHQL_UPSTREAM_TIMEOUT_MS` | no       | `10000`                  | Upstream GraphQL request timeout budget (ms)                       |
+| `MCP_RATE_LIMIT_CONFIG`       | no       | `''` (defaults)          | Optional rate-limit override spec (parsed by the limiter later)    |
+| `OTEL_ENABLED`                | no       | `0`                      | Enable OpenTelemetry tracing (`1` on / `0` off)                    |
+| `OTEL_SERVICE_NAME`           | no       | `accounter-mcp-server`   | `service.name` resource attribute                                  |
+| `OTEL_SERVICE_NAMESPACE`      | no       | `accounter`              | `service.namespace` resource attribute                             |
+| `OTEL_DEPLOYMENT_ENV`         | no       | `NODE_ENV`/`development` | `deployment.environment.name` resource attribute                   |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | if OTEL  | —                        | OTLP/HTTP traces endpoint (e.g. `http://localhost:4318/v1/traces`) |
+| `OTEL_EXPORTER_OTLP_HEADERS`  | no       | —                        | OTLP exporter headers as `key=value,key=value`                     |
+| `OTEL_TRACES_SAMPLER`         | no       | `always_on`              | Sampler strategy (`always_on`, `parentbased_traceidratio`, …)      |
+| `OTEL_TRACES_SAMPLER_ARG`     | if ratio | —                        | Ratio `0`–`1` for the ratio-based samplers                         |
+| `OTEL_STARTUP_STRICT`         | no       | —                        | `true` ⇒ abort the process on a telemetry startup failure          |
 
 ## Scripts
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -32,14 +32,20 @@
   "scripts": {
     "benchmark": "cd ../.. && vitest run --project unit packages/mcp-server/src/__tests__/perf.test.ts",
     "build": "tsc",
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --import ./src/bootstrap-telemetry.ts src/index.ts",
     "lint": "eslint './src/**/*.{js,ts,tsx}' --quiet",
-    "start": "node dist/index.js",
+    "start": "node --import ./dist/bootstrap-telemetry.js dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/auto-instrumentations-node": "0.79.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.221.0",
+    "@opentelemetry/resources": "2.10.0",
+    "@opentelemetry/sdk-node": "0.221.0",
+    "@opentelemetry/semantic-conventions": "1.43.0",
     "dotenv": "17.4.2",
     "jose": "6.2.7",
     "zod": "4.4.3"

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -246,7 +246,7 @@ describe('createShutdownHandler', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
-  it('closes the server and exits 0 on clean shutdown', () => {
+  it('closes the server and exits 0 on clean shutdown', async () => {
     const exit = vi.fn();
     const server = {
       close: vi.fn((cb: (err?: Error) => void) => cb()),
@@ -256,7 +256,9 @@ describe('createShutdownHandler', () => {
     handler('SIGTERM');
 
     expect(server.close).toHaveBeenCalledTimes(1);
-    expect(exit).toHaveBeenCalledWith(0);
+    // Exit is deferred until telemetry has flushed (a resolved no-op when OTEL
+    // is disabled), so it lands on a later microtask.
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0));
   });
 
   it('closes idle keep-alive connections to avoid stalling shutdown', () => {
@@ -273,7 +275,7 @@ describe('createShutdownHandler', () => {
     expect(closeIdleConnections).toHaveBeenCalledTimes(1);
   });
 
-  it('exits 1 when close reports an error', () => {
+  it('exits 1 when close reports an error', async () => {
     const exit = vi.fn();
     const server = {
       close: vi.fn((cb: (err?: Error) => void) => cb(new Error('close failed'))),
@@ -282,7 +284,7 @@ describe('createShutdownHandler', () => {
     const handler = createShutdownHandler({ server, exit, graceMs: 1000 });
     handler('SIGINT');
 
-    expect(exit).toHaveBeenCalledWith(1);
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1));
   });
 
   it('ignores repeated signals (idempotent)', () => {

--- a/packages/mcp-server/src/bootstrap-telemetry.ts
+++ b/packages/mcp-server/src/bootstrap-telemetry.ts
@@ -1,0 +1,16 @@
+import { log } from './logger.js';
+import { startTelemetry } from './telemetry/index.js';
+
+/**
+ * Telemetry preload hook.
+ *
+ * Loaded via Node's `--import` before the application modules so the OTEL
+ * auto-instrumentation can patch `node:http` and global `fetch` (undici) before
+ * they are first required. Mirrors `packages/server/src/bootstrap-telemetry.ts`.
+ */
+try {
+  await startTelemetry();
+} catch (error) {
+  log('error', 'OpenTelemetry bootstrap failed.', { error: String(error) });
+  process.exit(1);
+}

--- a/packages/mcp-server/src/config/__tests__/env.test.ts
+++ b/packages/mcp-server/src/config/__tests__/env.test.ts
@@ -124,6 +124,72 @@ describe('parseEnv — invalid configuration', () => {
   });
 });
 
+describe('parseEnv — OpenTelemetry configuration', () => {
+  it('defaults OTEL to disabled with the MCP service identity', () => {
+    const config = parseEnv(validEnv);
+    expect(config.otel.enabled).toBe(false);
+    expect(config.otel.serviceName).toBe('accounter-mcp-server');
+    expect(config.otel.serviceNamespace).toBe('accounter');
+    expect(config.otel.tracesSampler).toBe('always_on');
+    expect(config.otel.exporterEndpoint).toBeUndefined();
+    expect(config.otel.tracesSamplerArg).toBeUndefined();
+    expect(config.otel.startupStrict).toBe(false);
+  });
+
+  it('requires an exporter endpoint when OTEL is enabled', () => {
+    expect(() => parseEnv({ ...validEnv, OTEL_ENABLED: '1' })).toThrow(EnvValidationError);
+  });
+
+  it('parses an enabled configuration', () => {
+    const config = parseEnv({
+      ...validEnv,
+      OTEL_ENABLED: '1',
+      OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318/v1/traces',
+      OTEL_EXPORTER_OTLP_HEADERS: 'x-api-key=secret',
+      OTEL_SERVICE_NAME: 'mcp-prod',
+      OTEL_STARTUP_STRICT: 'true',
+    });
+    expect(config.otel.enabled).toBe(true);
+    expect(config.otel.exporterEndpoint).toBe('http://localhost:4318/v1/traces');
+    expect(config.otel.exporterHeaders).toBe('x-api-key=secret');
+    expect(config.otel.serviceName).toBe('mcp-prod');
+    expect(config.otel.startupStrict).toBe(true);
+  });
+
+  it('requires a valid ratio arg for ratio-based samplers', () => {
+    expect(() =>
+      parseEnv({
+        ...validEnv,
+        OTEL_ENABLED: '1',
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318/v1/traces',
+        OTEL_TRACES_SAMPLER: 'parentbased_traceidratio',
+      }),
+    ).toThrow(EnvValidationError);
+
+    expect(() =>
+      parseEnv({
+        ...validEnv,
+        OTEL_ENABLED: '1',
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318/v1/traces',
+        OTEL_TRACES_SAMPLER: 'traceidratio',
+        OTEL_TRACES_SAMPLER_ARG: '2',
+      }),
+    ).toThrow(EnvValidationError);
+  });
+
+  it('coerces a valid ratio sampler arg to a number', () => {
+    const config = parseEnv({
+      ...validEnv,
+      OTEL_ENABLED: '1',
+      OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318/v1/traces',
+      OTEL_TRACES_SAMPLER: 'parentbased_traceidratio',
+      OTEL_TRACES_SAMPLER_ARG: '0.25',
+    });
+    expect(config.otel.tracesSampler).toBe('parentbased_traceidratio');
+    expect(config.otel.tracesSamplerArg).toBe(0.25);
+  });
+});
+
 describe('loadEnv — fail-fast startup', () => {
   // Point dotenv at a nonexistent file so no real .env leaks into the source.
   const missingEnvFile = resolve(tmpdir(), 'accounter-mcp-nonexistent.env');

--- a/packages/mcp-server/src/config/env.ts
+++ b/packages/mcp-server/src/config/env.ts
@@ -23,6 +23,15 @@ import zod from 'zod';
  * | AUTH0_JWKS_URL              | no       | derived from issuer      | JWKS endpoint; defaults to `<issuer>/.well-known/jwks.json`.      |
  * | GRAPHQL_UPSTREAM_TIMEOUT_MS | no       | 10000                    | Upstream GraphQL request timeout budget in milliseconds.          |
  * | MCP_RATE_LIMIT_CONFIG       | no       | '' (defaults applied)    | Optional rate-limit override spec (parsed by the limiter later).  |
+ * | OTEL_ENABLED                | no       | 0                        | Master switch for OpenTelemetry tracing (`1` on / `0` off).       |
+ * | OTEL_SERVICE_NAME           | no       | accounter-mcp-server     | `service.name` resource attribute.                                |
+ * | OTEL_SERVICE_NAMESPACE      | no       | accounter                | `service.namespace` resource attribute.                           |
+ * | OTEL_DEPLOYMENT_ENV         | no       | NODE_ENV or development  | `deployment.environment.name` resource attribute.                 |
+ * | OTEL_EXPORTER_OTLP_ENDPOINT | if OTEL  | —                        | OTLP/HTTP traces endpoint (required when OTEL_ENABLED=1).          |
+ * | OTEL_EXPORTER_OTLP_HEADERS  | no       | —                        | OTLP exporter headers as `key=value,key=value`.                   |
+ * | OTEL_TRACES_SAMPLER         | no       | always_on                | Sampler strategy (see builder.ts).                                |
+ * | OTEL_TRACES_SAMPLER_ARG     | if ratio | —                        | Ratio 0–1, required for the ratio-based samplers.                 |
+ * | OTEL_STARTUP_STRICT         | no       | —                        | `true` ⇒ a telemetry startup failure aborts the process.          |
  *
  * Secrets are never embedded here; they are supplied via the environment only.
  */
@@ -69,6 +78,73 @@ export const envSchema = zod.object({
     zod.coerce.number().int().positive().max(120_000).optional().default(10_000),
   ),
   MCP_RATE_LIMIT_CONFIG: emptyStringAsUndefined(zod.string().optional().default('')),
+
+  // --- OpenTelemetry (traces exported over OTLP/HTTP to Grafana Tempo) ---
+  // Mirrors the main server's OTEL_* configuration so both services share one
+  // Grafana backend and the same conventions. Disabled by default; when enabled
+  // the exporter endpoint is required. See `../telemetry/builder.ts`.
+  OTEL_ENABLED: booleanFlag('0'),
+  OTEL_SERVICE_NAME: emptyStringAsUndefined(
+    zod.string().optional().default('accounter-mcp-server'),
+  ),
+  OTEL_SERVICE_NAMESPACE: emptyStringAsUndefined(zod.string().optional().default('accounter')),
+  OTEL_DEPLOYMENT_ENV: emptyStringAsUndefined(
+    zod
+      .string()
+      .optional()
+      .default(process.env.NODE_ENV ?? 'development'),
+  ),
+  OTEL_EXPORTER_OTLP_ENDPOINT: emptyStringAsUndefined(zod.string().optional()),
+  OTEL_EXPORTER_OTLP_HEADERS: emptyStringAsUndefined(zod.string().optional()),
+  OTEL_TRACES_SAMPLER: emptyStringAsUndefined(
+    zod
+      .enum([
+        'parentbased_traceidratio',
+        'always_on',
+        'always_off',
+        'traceidratio',
+        'parentbased_always_on',
+        'parentbased_always_off',
+      ])
+      .optional()
+      .default('always_on'),
+  ),
+  OTEL_TRACES_SAMPLER_ARG: emptyStringAsUndefined(zod.string().optional()),
+  OTEL_STARTUP_STRICT: emptyStringAsUndefined(
+    zod.union([zod.literal('true'), zod.literal('false')]).optional(),
+  ),
+}).superRefine((data, ctx) => {
+  if (data.OTEL_ENABLED === '1' && !data.OTEL_EXPORTER_OTLP_ENDPOINT) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['OTEL_EXPORTER_OTLP_ENDPOINT'],
+      message: 'OTEL_EXPORTER_OTLP_ENDPOINT is required when OTEL_ENABLED is "1".',
+    });
+  }
+
+  const usesRatioSampler =
+    data.OTEL_TRACES_SAMPLER === 'parentbased_traceidratio' ||
+    data.OTEL_TRACES_SAMPLER === 'traceidratio';
+
+  if (usesRatioSampler) {
+    if (data.OTEL_TRACES_SAMPLER_ARG === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['OTEL_TRACES_SAMPLER_ARG'],
+        message:
+          'OTEL_TRACES_SAMPLER_ARG is required when OTEL_TRACES_SAMPLER is a ratio sampler ("traceidratio" or "parentbased_traceidratio").',
+      });
+    } else {
+      const num = Number(data.OTEL_TRACES_SAMPLER_ARG);
+      if (!Number.isFinite(num) || num < 0 || num > 1) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['OTEL_TRACES_SAMPLER_ARG'],
+          message: 'OTEL_TRACES_SAMPLER_ARG must be a numeric string between 0 and 1.',
+        });
+      }
+    }
+  }
 });
 
 export type RawEnv = zod.infer<typeof envSchema>;
@@ -95,6 +171,32 @@ export interface AppConfig {
   rateLimit: {
     /** Raw config spec; parsed by the rate limiter in a later prompt. */
     raw: string;
+  };
+  otel: {
+    /** Master switch; when false the telemetry SDK is never started. */
+    enabled: boolean;
+    /** `service.name` resource attribute. */
+    serviceName: string;
+    /** `service.namespace` resource attribute. */
+    serviceNamespace: string;
+    /** `deployment.environment.name` resource attribute. */
+    deploymentEnv: string;
+    /** OTLP/HTTP traces endpoint (e.g. `http://localhost:4318/v1/traces`). */
+    exporterEndpoint: string | undefined;
+    /** OTLP exporter headers as a raw `key=value,key=value` string. */
+    exporterHeaders: string | undefined;
+    /** Trace sampler strategy. */
+    tracesSampler:
+      | 'parentbased_traceidratio'
+      | 'always_on'
+      | 'always_off'
+      | 'traceidratio'
+      | 'parentbased_always_on'
+      | 'parentbased_always_off';
+    /** Ratio (0–1) for the ratio-based samplers; undefined otherwise. */
+    tracesSamplerArg: number | undefined;
+    /** When true, a telemetry startup failure aborts the process. */
+    startupStrict: boolean;
   };
 }
 
@@ -145,6 +247,22 @@ export function parseEnv(source: NodeJS.ProcessEnv): AppConfig {
     },
     rateLimit: {
       raw: raw.MCP_RATE_LIMIT_CONFIG,
+    },
+    otel: {
+      enabled: raw.OTEL_ENABLED === '1',
+      serviceName: raw.OTEL_SERVICE_NAME,
+      serviceNamespace: raw.OTEL_SERVICE_NAMESPACE,
+      deploymentEnv: raw.OTEL_DEPLOYMENT_ENV,
+      exporterEndpoint: raw.OTEL_EXPORTER_OTLP_ENDPOINT,
+      exporterHeaders: raw.OTEL_EXPORTER_OTLP_HEADERS,
+      tracesSampler: raw.OTEL_TRACES_SAMPLER,
+      tracesSamplerArg:
+        (raw.OTEL_TRACES_SAMPLER === 'parentbased_traceidratio' ||
+          raw.OTEL_TRACES_SAMPLER === 'traceidratio') &&
+        raw.OTEL_TRACES_SAMPLER_ARG !== undefined
+          ? Number(raw.OTEL_TRACES_SAMPLER_ARG)
+          : undefined,
+      startupStrict: raw.OTEL_STARTUP_STRICT === 'true',
     },
   };
 }

--- a/packages/mcp-server/src/config/env.ts
+++ b/packages/mcp-server/src/config/env.ts
@@ -53,99 +53,101 @@ const booleanFlag = (defaultValue: '0' | '1') =>
  * NOT used here because the ambient environment contains many unrelated
  * variables; instead we only read the keys we know about.
  */
-export const envSchema = zod.object({
-  // --- Required (no safe default) ---
-  MCP_PUBLIC_BASE_URL: zod.url({ message: 'MCP_PUBLIC_BASE_1URL must be a valid URL' }),
-  AUTH0_ISSUER_URL: zod.url({ message: 'AUTH0_ISSUER_URL must be a valid URL' }),
-  AUTH0_AUDIENCE: zod.string().min(1, { message: 'AUTH0_AUDIENCE must be a non-empty string' }),
-  GRAPHQL_UPSTREAM_URL: zod.url({ message: 'GRAPHQL_UPSTREAM_URL must be a valid URL' }),
+export const envSchema = zod
+  .object({
+    // --- Required (no safe default) ---
+    MCP_PUBLIC_BASE_URL: zod.url({ message: 'MCP_PUBLIC_BASE_1URL must be a valid URL' }),
+    AUTH0_ISSUER_URL: zod.url({ message: 'AUTH0_ISSUER_URL must be a valid URL' }),
+    AUTH0_AUDIENCE: zod.string().min(1, { message: 'AUTH0_AUDIENCE must be a non-empty string' }),
+    GRAPHQL_UPSTREAM_URL: zod.url({ message: 'GRAPHQL_UPSTREAM_URL must be a valid URL' }),
 
-  // --- Optional with secure defaults ---
-  MCP_SERVER_PORT: emptyStringAsUndefined(
-    zod.coerce.number().int().positive().max(65_535).optional().default(3100),
-  ),
-  MCP_ENABLED: booleanFlag('1'),
-  // Tool allowlist: an empty value imposes no restriction (every registered
-  // tool is exposed); a non-empty value restricts `tools/list` and `tools/call`
-  // to exactly the named tools. Enforced in `mcp/handler.ts` via
-  // `tools/allowlist.ts`. When narrowing, keep `accounter_list_businesses` in
-  // the set — it is the discovery entry point for business scoping.
-  MCP_TOOL_ALLOWLIST: emptyStringAsUndefined(zod.string().optional().default('')),
-  AUTH0_JWKS_URL: emptyStringAsUndefined(
-    zod.url({ message: 'AUTH0_JWKS_URL must be a valid URL' }).optional(),
-  ),
-  GRAPHQL_UPSTREAM_TIMEOUT_MS: emptyStringAsUndefined(
-    zod.coerce.number().int().positive().max(120_000).optional().default(10_000),
-  ),
-  MCP_RATE_LIMIT_CONFIG: emptyStringAsUndefined(zod.string().optional().default('')),
+    // --- Optional with secure defaults ---
+    MCP_SERVER_PORT: emptyStringAsUndefined(
+      zod.coerce.number().int().positive().max(65_535).optional().default(3100),
+    ),
+    MCP_ENABLED: booleanFlag('1'),
+    // Tool allowlist: an empty value imposes no restriction (every registered
+    // tool is exposed); a non-empty value restricts `tools/list` and `tools/call`
+    // to exactly the named tools. Enforced in `mcp/handler.ts` via
+    // `tools/allowlist.ts`. When narrowing, keep `accounter_list_businesses` in
+    // the set — it is the discovery entry point for business scoping.
+    MCP_TOOL_ALLOWLIST: emptyStringAsUndefined(zod.string().optional().default('')),
+    AUTH0_JWKS_URL: emptyStringAsUndefined(
+      zod.url({ message: 'AUTH0_JWKS_URL must be a valid URL' }).optional(),
+    ),
+    GRAPHQL_UPSTREAM_TIMEOUT_MS: emptyStringAsUndefined(
+      zod.coerce.number().int().positive().max(120_000).optional().default(10_000),
+    ),
+    MCP_RATE_LIMIT_CONFIG: emptyStringAsUndefined(zod.string().optional().default('')),
 
-  // --- OpenTelemetry (traces exported over OTLP/HTTP to Grafana Tempo) ---
-  // Mirrors the main server's OTEL_* configuration so both services share one
-  // Grafana backend and the same conventions. Disabled by default; when enabled
-  // the exporter endpoint is required. See `../telemetry/builder.ts`.
-  OTEL_ENABLED: booleanFlag('0'),
-  OTEL_SERVICE_NAME: emptyStringAsUndefined(
-    zod.string().optional().default('accounter-mcp-server'),
-  ),
-  OTEL_SERVICE_NAMESPACE: emptyStringAsUndefined(zod.string().optional().default('accounter')),
-  OTEL_DEPLOYMENT_ENV: emptyStringAsUndefined(
-    zod
-      .string()
-      .optional()
-      .default(process.env.NODE_ENV ?? 'development'),
-  ),
-  OTEL_EXPORTER_OTLP_ENDPOINT: emptyStringAsUndefined(zod.string().optional()),
-  OTEL_EXPORTER_OTLP_HEADERS: emptyStringAsUndefined(zod.string().optional()),
-  OTEL_TRACES_SAMPLER: emptyStringAsUndefined(
-    zod
-      .enum([
-        'parentbased_traceidratio',
-        'always_on',
-        'always_off',
-        'traceidratio',
-        'parentbased_always_on',
-        'parentbased_always_off',
-      ])
-      .optional()
-      .default('always_on'),
-  ),
-  OTEL_TRACES_SAMPLER_ARG: emptyStringAsUndefined(zod.string().optional()),
-  OTEL_STARTUP_STRICT: emptyStringAsUndefined(
-    zod.union([zod.literal('true'), zod.literal('false')]).optional(),
-  ),
-}).superRefine((data, ctx) => {
-  if (data.OTEL_ENABLED === '1' && !data.OTEL_EXPORTER_OTLP_ENDPOINT) {
-    ctx.addIssue({
-      code: 'custom',
-      path: ['OTEL_EXPORTER_OTLP_ENDPOINT'],
-      message: 'OTEL_EXPORTER_OTLP_ENDPOINT is required when OTEL_ENABLED is "1".',
-    });
-  }
-
-  const usesRatioSampler =
-    data.OTEL_TRACES_SAMPLER === 'parentbased_traceidratio' ||
-    data.OTEL_TRACES_SAMPLER === 'traceidratio';
-
-  if (usesRatioSampler) {
-    if (data.OTEL_TRACES_SAMPLER_ARG === undefined) {
+    // --- OpenTelemetry (traces exported over OTLP/HTTP to Grafana Tempo) ---
+    // Mirrors the main server's OTEL_* configuration so both services share one
+    // Grafana backend and the same conventions. Disabled by default; when enabled
+    // the exporter endpoint is required. See `../telemetry/builder.ts`.
+    OTEL_ENABLED: booleanFlag('0'),
+    OTEL_SERVICE_NAME: emptyStringAsUndefined(
+      zod.string().optional().default('accounter-mcp-server'),
+    ),
+    OTEL_SERVICE_NAMESPACE: emptyStringAsUndefined(zod.string().optional().default('accounter')),
+    OTEL_DEPLOYMENT_ENV: emptyStringAsUndefined(
+      zod
+        .string()
+        .optional()
+        .default(process.env.NODE_ENV ?? 'development'),
+    ),
+    OTEL_EXPORTER_OTLP_ENDPOINT: emptyStringAsUndefined(zod.string().optional()),
+    OTEL_EXPORTER_OTLP_HEADERS: emptyStringAsUndefined(zod.string().optional()),
+    OTEL_TRACES_SAMPLER: emptyStringAsUndefined(
+      zod
+        .enum([
+          'parentbased_traceidratio',
+          'always_on',
+          'always_off',
+          'traceidratio',
+          'parentbased_always_on',
+          'parentbased_always_off',
+        ])
+        .optional()
+        .default('always_on'),
+    ),
+    OTEL_TRACES_SAMPLER_ARG: emptyStringAsUndefined(zod.string().optional()),
+    OTEL_STARTUP_STRICT: emptyStringAsUndefined(
+      zod.union([zod.literal('true'), zod.literal('false')]).optional(),
+    ),
+  })
+  .superRefine((data, ctx) => {
+    if (data.OTEL_ENABLED === '1' && !data.OTEL_EXPORTER_OTLP_ENDPOINT) {
       ctx.addIssue({
         code: 'custom',
-        path: ['OTEL_TRACES_SAMPLER_ARG'],
-        message:
-          'OTEL_TRACES_SAMPLER_ARG is required when OTEL_TRACES_SAMPLER is a ratio sampler ("traceidratio" or "parentbased_traceidratio").',
+        path: ['OTEL_EXPORTER_OTLP_ENDPOINT'],
+        message: 'OTEL_EXPORTER_OTLP_ENDPOINT is required when OTEL_ENABLED is "1".',
       });
-    } else {
-      const num = Number(data.OTEL_TRACES_SAMPLER_ARG);
-      if (!Number.isFinite(num) || num < 0 || num > 1) {
+    }
+
+    const usesRatioSampler =
+      data.OTEL_TRACES_SAMPLER === 'parentbased_traceidratio' ||
+      data.OTEL_TRACES_SAMPLER === 'traceidratio';
+
+    if (usesRatioSampler) {
+      if (data.OTEL_TRACES_SAMPLER_ARG === undefined) {
         ctx.addIssue({
           code: 'custom',
           path: ['OTEL_TRACES_SAMPLER_ARG'],
-          message: 'OTEL_TRACES_SAMPLER_ARG must be a numeric string between 0 and 1.',
+          message:
+            'OTEL_TRACES_SAMPLER_ARG is required when OTEL_TRACES_SAMPLER is a ratio sampler ("traceidratio" or "parentbased_traceidratio").',
         });
+      } else {
+        const num = Number(data.OTEL_TRACES_SAMPLER_ARG);
+        if (!Number.isFinite(num) || num < 0 || num > 1) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['OTEL_TRACES_SAMPLER_ARG'],
+            message: 'OTEL_TRACES_SAMPLER_ARG must be a numeric string between 0 and 1.',
+          });
+        }
       }
     }
-  }
-});
+  });
 
 export type RawEnv = zod.infer<typeof envSchema>;
 

--- a/packages/mcp-server/src/observability/__tests__/tracing.test.ts
+++ b/packages/mcp-server/src/observability/__tests__/tracing.test.ts
@@ -1,9 +1,22 @@
+import { type Span, SpanStatusCode, type Tracer, trace } from '@opentelemetry/api';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import * as logger from '../../logger.js';
-import { withSpan } from '../tracing.js';
+import { CORRELATION_ID_ATTRIBUTE, withSpan } from '../tracing.js';
 
-function spyLog() {
-  return vi.spyOn(logger, 'log').mockImplementation(() => {});
+function fakeSpan() {
+  return {
+    setAttribute: vi.fn(),
+    setStatus: vi.fn(),
+    recordException: vi.fn(),
+    end: vi.fn(),
+  };
+}
+
+/** Stub `trace.getTracer` with a tracer whose active span is `span`. */
+function stubTracer(span: ReturnType<typeof fakeSpan>) {
+  const tracer = {
+    startActiveSpan: (_name: string, fn: (s: Span) => unknown) => fn(span as unknown as Span),
+  } as unknown as Tracer;
+  return vi.spyOn(trace, 'getTracer').mockReturnValue(tracer);
 }
 
 afterEach(() => {
@@ -12,26 +25,25 @@ afterEach(() => {
 
 describe('withSpan', () => {
   it('returns the wrapped function result', async () => {
-    spyLog();
+    stubTracer(fakeSpan());
     await expect(withSpan('work', 'corr-1', async () => 42)).resolves.toBe(42);
   });
 
-  it('emits a start and a successful end span carrying the correlation id', async () => {
-    const log = spyLog();
+  it('sets the correlation-id attribute, marks the span OK, and ends it', async () => {
+    const span = fakeSpan();
+    stubTracer(span);
+
     await withSpan('tool:search', 'corr-1', async () => 'ok');
 
-    expect(log).toHaveBeenCalledTimes(2);
-    expect(log).toHaveBeenNthCalledWith(1, 'debug', 'span start', {
-      span: 'tool:search',
-      correlationId: 'corr-1',
-    });
-    const [, , endFields] = log.mock.calls[1];
-    expect(endFields).toMatchObject({ span: 'tool:search', correlationId: 'corr-1', ok: true });
-    expect(typeof (endFields as { durationMs: number }).durationMs).toBe('number');
+    expect(span.setAttribute).toHaveBeenCalledWith(CORRELATION_ID_ATTRIBUTE, 'corr-1');
+    expect(span.setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.OK });
+    expect(span.recordException).not.toHaveBeenCalled();
+    expect(span.end).toHaveBeenCalledTimes(1);
   });
 
-  it('logs a failed end span and re-throws the error', async () => {
-    const log = spyLog();
+  it('records the exception, marks the span errored, ends it, and re-throws', async () => {
+    const span = fakeSpan();
+    stubTracer(span);
     const boom = new TypeError('nope');
 
     await expect(
@@ -40,12 +52,34 @@ describe('withSpan', () => {
       }),
     ).rejects.toBe(boom);
 
-    const [, , endFields] = log.mock.calls[1];
-    expect(endFields).toMatchObject({
-      span: 'auth:verify',
-      correlationId: 'corr-2',
-      ok: false,
-      error: 'TypeError',
+    expect(span.setAttribute).toHaveBeenCalledWith(CORRELATION_ID_ATTRIBUTE, 'corr-2');
+    expect(span.recordException).toHaveBeenCalledWith(boom);
+    expect(span.setStatus).toHaveBeenCalledWith({
+      code: SpanStatusCode.ERROR,
+      message: 'TypeError',
     });
+    expect(span.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the correlation attribute when no correlation id is given', async () => {
+    const span = fakeSpan();
+    stubTracer(span);
+
+    await withSpan('work', '', async () => undefined);
+
+    expect(span.setAttribute).not.toHaveBeenCalled();
+    expect(span.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('works with the global no-op tracer (OTEL disabled) — result and re-throw preserved', async () => {
+    // No stub: with no registered provider, the API returns a no-op tracer, so
+    // withSpan must still run the work and propagate results/errors unchanged.
+    await expect(withSpan('work', 'corr', async () => 'value')).resolves.toBe('value');
+    const boom = new Error('boom');
+    await expect(
+      withSpan('work', 'corr', async () => {
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
   });
 });

--- a/packages/mcp-server/src/observability/tracing.ts
+++ b/packages/mcp-server/src/observability/tracing.ts
@@ -1,4 +1,4 @@
-import { type Span, SpanStatusCode, trace } from '@opentelemetry/api';
+import { SpanStatusCode, trace, type Span } from '@opentelemetry/api';
 import { getServiceVersion, SERVICE_NAME } from '../version.js';
 
 /**

--- a/packages/mcp-server/src/observability/tracing.ts
+++ b/packages/mcp-server/src/observability/tracing.ts
@@ -1,37 +1,59 @@
-import { log } from '../logger.js';
+import { type Span, SpanStatusCode, trace } from '@opentelemetry/api';
+import { getServiceVersion, SERVICE_NAME } from '../version.js';
 
 /**
- * Minimal tracing spans (spec §11.3).
+ * OpenTelemetry span helper (spec §11.3).
  *
- * Wraps a unit of work (auth validation, an upstream call, tool execution) and
- * emits structured start/end debug logs carrying the correlation id and the
- * span duration. Deliberately lightweight — no external tracer dependency — so
- * it can be swapped for OpenTelemetry later without touching call sites.
+ * Wraps a unit of work (auth validation, an upstream call, tool execution) in a
+ * real OTEL span. The span is started as the *active* span, so:
+ *  - nested `withSpan` calls (e.g. `upstream:graphql` inside `tool:<name>`) are
+ *    parented correctly, and
+ *  - the undici (fetch) instrumentation picks up the active context and injects
+ *    the W3C `traceparent` header on the upstream call — which is what links a
+ *    trace across the MCP server and the Accounter backend.
+ *
+ * The business-level `correlationId` (inherited from / echoed as the
+ * `X-Correlation-Id` header) is attached as a span attribute so a trace can be
+ * found in Grafana from an MCP log line, and cross-referenced with the same
+ * attribute set on the backend spans.
+ *
+ * When OTEL is disabled, `trace.getTracer` returns the API's no-op tracer, so
+ * this stays effectively zero-cost and the call sites need no changes.
  */
+
+/** Span attribute carrying the business-level correlation id. */
+export const CORRELATION_ID_ATTRIBUTE = 'accounter.correlation_id';
+
+function tracer() {
+  return trace.getTracer(SERVICE_NAME, getServiceVersion());
+}
+
 export async function withSpan<T>(
   name: string,
   correlationId: string,
   fn: () => Promise<T>,
 ): Promise<T> {
-  const start = performance.now();
-  log('debug', 'span start', { span: name, correlationId });
-  try {
-    const result = await fn();
-    log('debug', 'span end', {
-      span: name,
-      correlationId,
-      durationMs: Math.round(performance.now() - start),
-      ok: true,
-    });
-    return result;
-  } catch (error) {
-    log('debug', 'span end', {
-      span: name,
-      correlationId,
-      durationMs: Math.round(performance.now() - start),
-      ok: false,
-      error: error instanceof Error ? error.name : 'unknown',
-    });
-    throw error;
-  }
+  return tracer().startActiveSpan(name, async (span: Span) => {
+    if (correlationId) {
+      span.setAttribute(CORRELATION_ID_ATTRIBUTE, correlationId);
+    }
+    try {
+      const result = await fn();
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (error) {
+      // Record the exception on the span (name/message only — no secrets flow
+      // through here) and mark it errored, then re-throw unchanged.
+      const exception =
+        error instanceof Error ? error : { name: 'unknown', message: String(error) };
+      span.recordException(exception);
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error instanceof Error ? error.name : 'unknown',
+      });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
 }

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,4 +1,5 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { trace } from '@opentelemetry/api';
 import { env } from './config/env.js';
 import { createRequestContext, elapsedMs, setRequestContext } from './context.js';
 import { completionFields, createRequestLogger, log } from './logger.js';
@@ -8,6 +9,8 @@ import {
   PROTECTED_RESOURCE_METADATA_PATH,
 } from './oauth/metadata.js';
 import { getMetrics } from './observability/metrics.js';
+import { CORRELATION_ID_ATTRIBUTE } from './observability/tracing.js';
+import { shutdownTelemetry } from './telemetry/index.js';
 import { getServiceVersion, SERVICE_NAME } from './version.js';
 
 /**
@@ -91,6 +94,16 @@ export async function requestHandler(req: IncomingMessage, res: ServerResponse):
   setRequestContext(req, context);
   const logger = createRequestLogger(context);
 
+  // Tag the auto-instrumented incoming HTTP span with the business-level
+  // correlation id (and request id) so this MCP trace — and, via `traceparent`
+  // propagation, the backend trace it triggers — are both searchable by the
+  // same `X-Correlation-Id` in Grafana. A no-op when telemetry is disabled.
+  const activeSpan = trace.getActiveSpan();
+  if (activeSpan) {
+    activeSpan.setAttribute(CORRELATION_ID_ATTRIBUTE, context.correlationId);
+    activeSpan.setAttribute('accounter.request_id', context.requestId);
+  }
+
   // Echo the correlation id so callers can tie their logs to ours.
   res.setHeader('X-Correlation-Id', context.correlationId);
 
@@ -165,13 +178,17 @@ export function createShutdownHandler({
 
     server.close(error => {
       clearTimeout(forceTimer);
-      if (error) {
-        log('error', 'error during shutdown', { error: String(error) });
-        exit(1);
-        return;
-      }
-      log('info', 'shutdown complete', { signal });
-      exit(0);
+      // Flush pending spans before exiting so in-flight traces are not dropped.
+      // A no-op when telemetry was never started (OTEL disabled).
+      void shutdownTelemetry().finally(() => {
+        if (error) {
+          log('error', 'error during shutdown', { error: String(error) });
+          exit(1);
+          return;
+        }
+        log('info', 'shutdown complete', { signal });
+        exit(0);
+      });
     });
 
     // `server.close()` stops accepting new connections but leaves idle

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -177,10 +177,12 @@ export function createShutdownHandler({
     forceTimer.unref?.();
 
     server.close(error => {
-      clearTimeout(forceTimer);
       // Flush pending spans before exiting so in-flight traces are not dropped.
-      // A no-op when telemetry was never started (OTEL disabled).
+      // A no-op when telemetry was never started (OTEL disabled). Keep the grace
+      // timer armed across the flush so a stalled exporter can't hang shutdown
+      // indefinitely — clear it only once we're actually about to exit.
       void shutdownTelemetry().finally(() => {
+        clearTimeout(forceTimer);
         if (error) {
           log('error', 'error during shutdown', { error: String(error) });
           exit(1);

--- a/packages/mcp-server/src/telemetry/__tests__/builder.test.ts
+++ b/packages/mcp-server/src/telemetry/__tests__/builder.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { buildOtelSdk } from '../builder.js';
+
+// Prevent dotenv from loading any .env file during tests.
+vi.mock('dotenv', () => ({ config: vi.fn() }));
+
+// ---------- Mutable env stub ----------
+const mockOtelConfig = vi.hoisted(() => ({
+  enabled: false,
+  serviceName: 'test-mcp',
+  serviceNamespace: 'test-ns',
+  deploymentEnv: 'test-env',
+  exporterEndpoint: undefined as string | undefined,
+  exporterHeaders: undefined as string | undefined,
+  tracesSampler: 'always_on' as 'always_on' | 'always_off' | 'parentbased_traceidratio',
+  tracesSamplerArg: undefined as number | undefined,
+  startupStrict: false,
+}));
+
+vi.mock('../../config/env.js', () => ({
+  env: { otel: mockOtelConfig },
+}));
+
+vi.mock('../../version.js', () => ({
+  SERVICE_NAME: '@accounter/mcp-server',
+  getServiceVersion: () => '1.2.3',
+}));
+
+// ---------- NodeSDK + tracing mock ----------
+const MockNodeSDK = vi.hoisted(() =>
+  vi.fn().mockImplementation(function () {
+    return { start: vi.fn(), shutdown: vi.fn() };
+  }),
+);
+
+const mockSamplers = vi.hoisted(() => ({
+  AlwaysOnSampler: vi.fn().mockImplementation(function () {
+    return { _type: 'AlwaysOnSampler' };
+  }),
+  AlwaysOffSampler: vi.fn().mockImplementation(function () {
+    return { _type: 'AlwaysOffSampler' };
+  }),
+  ParentBasedSampler: vi.fn().mockImplementation(function (config: unknown) {
+    return { _type: 'ParentBasedSampler', _config: config };
+  }),
+  TraceIdRatioBasedSampler: vi.fn().mockImplementation(function (ratio: number) {
+    return { _type: 'TraceIdRatioBasedSampler', _ratio: ratio };
+  }),
+}));
+
+const mockResource = vi.hoisted(() => ({ _type: 'resource' }));
+const mockResourceFromAttributes = vi.hoisted(() => vi.fn().mockReturnValue(mockResource));
+
+vi.mock('@opentelemetry/sdk-node', () => ({
+  NodeSDK: MockNodeSDK,
+  tracing: mockSamplers,
+  resources: {
+    resourceFromAttributes: mockResourceFromAttributes,
+  },
+}));
+
+// ---------- OTLPTraceExporter mock ----------
+const MockOTLPTraceExporter = vi.hoisted(() =>
+  vi.fn().mockImplementation(function (config: unknown) {
+    return { _exporterConfig: config };
+  }),
+);
+
+vi.mock('@opentelemetry/exporter-trace-otlp-http', () => ({
+  OTLPTraceExporter: MockOTLPTraceExporter,
+}));
+
+// ---------- auto-instrumentations mock ----------
+const mockInstrumentationBundle = vi.hoisted(() => ({}));
+vi.mock('@opentelemetry/auto-instrumentations-node', () => ({
+  getNodeAutoInstrumentations: vi.fn().mockReturnValue(mockInstrumentationBundle),
+}));
+
+describe('buildOtelSdk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockOtelConfig.enabled = false;
+    mockOtelConfig.serviceName = 'test-mcp';
+    mockOtelConfig.serviceNamespace = 'test-ns';
+    mockOtelConfig.deploymentEnv = 'test-env';
+    mockOtelConfig.exporterEndpoint = undefined;
+    mockOtelConfig.exporterHeaders = undefined;
+    mockOtelConfig.tracesSampler = 'always_on';
+    mockOtelConfig.tracesSamplerArg = undefined;
+
+    mockResourceFromAttributes.mockReturnValue(mockResource);
+  });
+
+  describe('when OTEL is disabled', () => {
+    it('returns null and constructs nothing', () => {
+      expect(buildOtelSdk()).toBeNull();
+      expect(MockNodeSDK).not.toHaveBeenCalled();
+      expect(MockOTLPTraceExporter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when OTEL is enabled', () => {
+    beforeEach(() => {
+      mockOtelConfig.enabled = true;
+      mockOtelConfig.exporterEndpoint = 'http://localhost:4318/v1/traces';
+    });
+
+    it('returns a NodeSDK instance', () => {
+      expect(buildOtelSdk()).not.toBeNull();
+      expect(MockNodeSDK).toHaveBeenCalledOnce();
+    });
+
+    it('builds resource with service identity including version', () => {
+      buildOtelSdk();
+      expect(mockResourceFromAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'service.name': 'test-mcp',
+          'service.namespace': 'test-ns',
+          'service.version': '1.2.3',
+          'deployment.environment.name': 'test-env',
+        }),
+      );
+    });
+
+    it('configures OTLPTraceExporter with the endpoint', () => {
+      buildOtelSdk();
+      expect(MockOTLPTraceExporter).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'http://localhost:4318/v1/traces' }),
+      );
+    });
+
+    it('disables graphql instrumentation (no GraphQL layer in this process)', () => {
+      buildOtelSdk();
+      expect(getNodeAutoInstrumentations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          '@opentelemetry/instrumentation-fs': expect.objectContaining({ enabled: false }),
+          '@opentelemetry/instrumentation-http': expect.objectContaining({
+            ignoreIncomingRequestHook: expect.any(Function),
+          }),
+          '@opentelemetry/instrumentation-graphql': expect.objectContaining({ enabled: false }),
+        }),
+      );
+    });
+
+    describe('sampler configuration', () => {
+      it('uses AlwaysOnSampler for always_on', () => {
+        mockOtelConfig.tracesSampler = 'always_on';
+        buildOtelSdk();
+        expect(mockSamplers.AlwaysOnSampler).toHaveBeenCalledOnce();
+      });
+
+      it('uses AlwaysOffSampler for always_off', () => {
+        mockOtelConfig.tracesSampler = 'always_off';
+        buildOtelSdk();
+        expect(mockSamplers.AlwaysOffSampler).toHaveBeenCalledOnce();
+      });
+
+      it('wraps TraceIdRatioBasedSampler in ParentBasedSampler for parentbased_traceidratio', () => {
+        mockOtelConfig.tracesSampler = 'parentbased_traceidratio';
+        mockOtelConfig.tracesSamplerArg = 0.5;
+        buildOtelSdk();
+        expect(mockSamplers.TraceIdRatioBasedSampler).toHaveBeenCalledWith(0.5);
+        expect(mockSamplers.ParentBasedSampler).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe('headers configuration', () => {
+      it('parses key=value pairs into a headers record', () => {
+        mockOtelConfig.exporterHeaders = 'Authorization=Bearer token,X-Custom=value';
+        buildOtelSdk();
+        expect(MockOTLPTraceExporter).toHaveBeenCalledWith(
+          expect.objectContaining({
+            headers: { Authorization: 'Bearer token', 'X-Custom': 'value' },
+          }),
+        );
+      });
+
+      it('passes undefined headers when unset', () => {
+        mockOtelConfig.exporterHeaders = undefined;
+        buildOtelSdk();
+        expect(MockOTLPTraceExporter).toHaveBeenCalledWith(
+          expect.objectContaining({ headers: undefined }),
+        );
+      });
+    });
+  });
+});

--- a/packages/mcp-server/src/telemetry/__tests__/index.test.ts
+++ b/packages/mcp-server/src/telemetry/__tests__/index.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('dotenv', () => ({ config: vi.fn() }));
+
+const mockOtelConfig = vi.hoisted(() => ({
+  startupStrict: false,
+}));
+
+const mockBuildOtelSdk = vi.hoisted(() => vi.fn());
+const mockLog = vi.hoisted(() => vi.fn());
+
+vi.mock('../../config/env.js', () => ({
+  env: { otel: mockOtelConfig },
+}));
+
+vi.mock('../../logger.js', () => ({
+  log: mockLog,
+}));
+
+vi.mock('../builder.js', () => ({
+  buildOtelSdk: mockBuildOtelSdk,
+}));
+
+type MockSdk = {
+  start: ReturnType<typeof vi.fn>;
+  shutdown: ReturnType<typeof vi.fn>;
+};
+
+function createMockSdk(): MockSdk {
+  return {
+    start: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('telemetry lifecycle', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockOtelConfig.startupStrict = false;
+  });
+
+  describe('startTelemetry', () => {
+    it('no-ops when the SDK is disabled (builder returns null)', async () => {
+      mockBuildOtelSdk.mockReturnValueOnce(null);
+      const { startTelemetry } = await import('../index.js');
+      await expect(startTelemetry()).resolves.toBeUndefined();
+    });
+
+    it('throws startup errors in strict mode', async () => {
+      mockOtelConfig.startupStrict = true;
+      const sdk = createMockSdk();
+      sdk.start.mockRejectedValueOnce(new Error('startup failed'));
+      mockBuildOtelSdk.mockReturnValueOnce(sdk);
+
+      const { startTelemetry } = await import('../index.js');
+      await expect(startTelemetry()).rejects.toThrow('startup failed');
+    });
+
+    it('logs startup errors and continues in non-strict mode', async () => {
+      const sdk = createMockSdk();
+      sdk.start.mockRejectedValueOnce(new Error('startup failed'));
+      mockBuildOtelSdk.mockReturnValueOnce(sdk);
+
+      const { startTelemetry } = await import('../index.js');
+      await expect(startTelemetry()).resolves.toBeUndefined();
+      expect(mockLog).toHaveBeenCalledWith(
+        'error',
+        'OpenTelemetry startup failed, continuing without tracing.',
+        expect.objectContaining({ error: expect.stringContaining('startup failed') }),
+      );
+    });
+
+    it('reuses the same in-flight startup for concurrent calls', async () => {
+      const startDeferred = createDeferred<void>();
+      const sdk = createMockSdk();
+      sdk.start.mockImplementationOnce(() => startDeferred.promise);
+      mockBuildOtelSdk.mockReturnValue(sdk);
+
+      const { startTelemetry } = await import('../index.js');
+      const first = startTelemetry();
+      const second = startTelemetry();
+
+      expect(mockBuildOtelSdk).toHaveBeenCalledOnce();
+      expect(sdk.start).toHaveBeenCalledOnce();
+
+      startDeferred.resolve();
+      await Promise.all([first, second]);
+      await startTelemetry();
+
+      expect(mockBuildOtelSdk).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('shutdownTelemetry', () => {
+    it('no-ops when telemetry was never started', async () => {
+      const { shutdownTelemetry } = await import('../index.js');
+      await expect(shutdownTelemetry()).resolves.toBeUndefined();
+    });
+
+    it('waits for an in-flight startup before shutting down the SDK', async () => {
+      const startDeferred = createDeferred<void>();
+      const sdk = createMockSdk();
+      sdk.start.mockImplementationOnce(() => startDeferred.promise);
+      mockBuildOtelSdk.mockReturnValueOnce(sdk);
+
+      const { shutdownTelemetry, startTelemetry } = await import('../index.js');
+      const start = startTelemetry();
+      const shutdown = shutdownTelemetry();
+
+      expect(sdk.shutdown).not.toHaveBeenCalled();
+      startDeferred.resolve();
+      await start;
+      await shutdown;
+
+      expect(sdk.shutdown).toHaveBeenCalledOnce();
+    });
+
+    it('logs shutdown success', async () => {
+      const sdk = createMockSdk();
+      mockBuildOtelSdk.mockReturnValueOnce(sdk);
+
+      const { startTelemetry, shutdownTelemetry } = await import('../index.js');
+      await startTelemetry();
+      await shutdownTelemetry();
+
+      expect(sdk.shutdown).toHaveBeenCalledOnce();
+      expect(mockLog).toHaveBeenCalledWith('info', 'OpenTelemetry shutdown completed.');
+    });
+
+    it('logs shutdown failure without throwing', async () => {
+      const sdk = createMockSdk();
+      sdk.shutdown.mockRejectedValueOnce(new Error('shutdown failed'));
+      mockBuildOtelSdk.mockReturnValueOnce(sdk);
+
+      const { startTelemetry, shutdownTelemetry } = await import('../index.js');
+      await startTelemetry();
+      await expect(shutdownTelemetry()).resolves.toBeUndefined();
+
+      expect(mockLog).toHaveBeenCalledWith(
+        'error',
+        'OpenTelemetry shutdown failed.',
+        expect.objectContaining({ error: expect.stringContaining('shutdown failed') }),
+      );
+    });
+  });
+});

--- a/packages/mcp-server/src/telemetry/builder.ts
+++ b/packages/mcp-server/src/telemetry/builder.ts
@@ -1,0 +1,144 @@
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { NodeSDK, resources, tracing } from '@opentelemetry/sdk-node';
+import {
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_NAMESPACE,
+  ATTR_SERVICE_VERSION,
+} from '@opentelemetry/semantic-conventions';
+import { env } from '../config/env.js';
+import { getServiceVersion } from '../version.js';
+
+/**
+ * OpenTelemetry SDK builder for the MCP server.
+ *
+ * Mirrors `packages/server/src/telemetry/builder.ts` so both services export to
+ * the same Grafana Tempo backend with identical conventions. Tracing relies on
+ * auto-instrumentation:
+ *  - `instrumentation-http` produces the incoming `POST /mcp` server span.
+ *  - `instrumentation-undici` instruments global `fetch` (used by the upstream
+ *    GraphQL client) and injects the W3C `traceparent` header, so the upstream
+ *    Accounter server continues the SAME distributed trace.
+ *
+ * There is no GraphQL/Postgres layer in this process, so those instrumentations
+ * stay off.
+ */
+
+const ATTR_DEPLOYMENT_ENVIRONMENT_NAME = 'deployment.environment.name';
+// Endpoints that must never generate spans (liveness/metrics scrapes).
+const HEALTH_CHECK_PATHS = new Set(['/health', '/metrics']);
+
+function shouldIgnoreIncomingRequest(url: string | undefined): boolean {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    const pathname = new URL(url, 'http://localhost').pathname;
+    return HEALTH_CHECK_PATHS.has(pathname);
+  } catch {
+    const pathname = url.split('?')[0] ?? '';
+    return HEALTH_CHECK_PATHS.has(pathname);
+  }
+}
+
+/**
+ * Parses an OTLP header string of the form "key1=value1,key2=value2" into a
+ * Record<string, string>. Returns undefined when the input is absent or empty.
+ */
+function parseHeaders(headersStr: string | undefined): Record<string, string> | undefined {
+  if (!headersStr) return undefined;
+  const result: Record<string, string> = {};
+  for (const part of headersStr.split(',')) {
+    const eqIdx = part.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = part.slice(0, eqIdx).trim();
+    const value = part.slice(eqIdx + 1).trim();
+    if (key) result[key] = value;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function buildSampler(
+  samplerType:
+    | 'always_on'
+    | 'always_off'
+    | 'parentbased_traceidratio'
+    | 'traceidratio'
+    | 'parentbased_always_on'
+    | 'parentbased_always_off',
+  arg: number | undefined,
+) {
+  switch (samplerType) {
+    case 'always_off':
+      return new tracing.AlwaysOffSampler();
+    case 'parentbased_traceidratio': {
+      const ratio = arg ?? 1.0;
+      return new tracing.ParentBasedSampler({
+        root: new tracing.TraceIdRatioBasedSampler(ratio),
+      });
+    }
+    case 'traceidratio': {
+      const ratio = arg ?? 1.0;
+      return new tracing.TraceIdRatioBasedSampler(ratio);
+    }
+    case 'parentbased_always_on':
+      return new tracing.ParentBasedSampler({
+        root: new tracing.AlwaysOnSampler(),
+      });
+    case 'parentbased_always_off':
+      return new tracing.ParentBasedSampler({
+        root: new tracing.AlwaysOffSampler(),
+      });
+    default:
+      return new tracing.AlwaysOnSampler();
+  }
+}
+
+/**
+ * Builds and returns a configured (but not yet started) NodeSDK instance using
+ * the OTEL settings from `env`. Returns null when OTEL is disabled.
+ */
+export function buildOtelSdk(): NodeSDK | null {
+  const otel = env.otel;
+
+  if (!otel.enabled) {
+    return null;
+  }
+
+  const resource = resources.resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: otel.serviceName,
+    [ATTR_SERVICE_NAMESPACE]: otel.serviceNamespace,
+    [ATTR_SERVICE_VERSION]: getServiceVersion(),
+    [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]: otel.deploymentEnv,
+  });
+
+  const traceExporter = new OTLPTraceExporter({
+    url: otel.exporterEndpoint,
+    headers: parseHeaders(otel.exporterHeaders),
+  });
+
+  const sampler = buildSampler(otel.tracesSampler, otel.tracesSamplerArg);
+
+  return new NodeSDK({
+    resource,
+    traceExporter,
+    sampler,
+    instrumentations: [
+      getNodeAutoInstrumentations({
+        '@opentelemetry/instrumentation-fs': {
+          enabled: false,
+        },
+        '@opentelemetry/instrumentation-http': {
+          ignoreIncomingRequestHook: request => shouldIgnoreIncomingRequest(request.url),
+        },
+        // This process has no GraphQL or Postgres layer of its own — only an
+        // outbound GraphQL-over-HTTP client, covered by the undici (fetch)
+        // instrumentation — so leave those server instrumentations off.
+        '@opentelemetry/instrumentation-graphql': {
+          enabled: false,
+        },
+      }),
+    ],
+  });
+}

--- a/packages/mcp-server/src/telemetry/index.ts
+++ b/packages/mcp-server/src/telemetry/index.ts
@@ -1,0 +1,77 @@
+import type { NodeSDK } from '@opentelemetry/sdk-node';
+import { env } from '../config/env.js';
+import { log } from '../logger.js';
+import { buildOtelSdk } from './builder.js';
+
+/**
+ * Telemetry lifecycle for the MCP server.
+ *
+ * Mirrors `packages/server/src/telemetry/index.ts`: a single, idempotent,
+ * concurrency-safe start (so `--import` preload and any defensive call converge
+ * on one SDK) plus a graceful shutdown that flushes pending spans. When OTEL is
+ * disabled the SDK is never built and both calls are no-ops.
+ */
+
+let sdk: NodeSDK | null = null;
+let startPromise: Promise<void> | null = null;
+
+export async function startTelemetry(): Promise<void> {
+  if (sdk) {
+    return;
+  }
+
+  if (startPromise) {
+    await startPromise;
+    return;
+  }
+
+  startPromise = (async () => {
+    try {
+      const builtSdk = buildOtelSdk();
+      if (!builtSdk) {
+        return;
+      }
+
+      await builtSdk.start();
+      sdk = builtSdk;
+    } catch (error) {
+      sdk = null;
+
+      if (env.otel.startupStrict) {
+        throw error;
+      }
+
+      log('error', 'OpenTelemetry startup failed, continuing without tracing.', {
+        error: String(error),
+      });
+    } finally {
+      startPromise = null;
+    }
+  })();
+
+  await startPromise;
+}
+
+export async function shutdownTelemetry(): Promise<void> {
+  if (startPromise) {
+    try {
+      await startPromise;
+    } catch {
+      // Start failures leave no initialized SDK to shut down.
+    }
+  }
+
+  if (!sdk) {
+    return;
+  }
+
+  const currentSdk = sdk;
+  sdk = null;
+
+  try {
+    await currentSdk.shutdown();
+    log('info', 'OpenTelemetry shutdown completed.');
+  } catch (error) {
+    log('error', 'OpenTelemetry shutdown failed.', { error: String(error) });
+  }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -14,6 +14,7 @@ import { createGraphQLApp } from './modules-app.js';
 import { DBProvider } from './modules/app-providers/db.provider.js';
 import { Auth0ManagementProvider } from './modules/auth/providers/auth0-management.provider.js';
 import { authPlugin } from './plugins/auth-plugin.js';
+import { correlationIdPlugin } from './plugins/correlation-id-plugin.js';
 import { dbCleanupPlugin } from './plugins/db-cleanup-plugin.js';
 import { AccounterContext } from './shared/types/index.js';
 
@@ -88,6 +89,7 @@ async function main() {
 
   const yoga = createYoga({
     plugins: [
+      correlationIdPlugin(),
       dbCleanupPlugin(),
       authPlugin(),
       useGraphQLModules(application),

--- a/packages/server/src/plugins/__tests__/correlation-id-plugin.test.ts
+++ b/packages/server/src/plugins/__tests__/correlation-id-plugin.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type Span, trace } from '@opentelemetry/api';
+import {
+  CORRELATION_ID_ATTRIBUTE,
+  CORRELATION_ID_HEADER,
+  correlationIdPlugin,
+} from '../correlation-id-plugin.js';
+
+/** Minimal `onRequest` payload with only the header lookup the plugin uses. */
+function onRequestArg(headerValue: string | null) {
+  return {
+    request: {
+      headers: { get: (name: string) => (name === CORRELATION_ID_HEADER ? headerValue : null) },
+    },
+  } as unknown as Parameters<NonNullable<ReturnType<typeof correlationIdPlugin>['onRequest']>>[0];
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('correlationIdPlugin', () => {
+  it('sets the correlation id as an attribute on the active span', () => {
+    const setAttribute = vi.fn();
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue({ setAttribute } as unknown as Span);
+
+    const plugin = correlationIdPlugin();
+    plugin.onRequest?.(onRequestArg('corr-123'));
+
+    expect(setAttribute).toHaveBeenCalledWith(CORRELATION_ID_ATTRIBUTE, 'corr-123');
+  });
+
+  it('trims the header value', () => {
+    const setAttribute = vi.fn();
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue({ setAttribute } as unknown as Span);
+
+    correlationIdPlugin().onRequest?.(onRequestArg('  corr-abc  '));
+
+    expect(setAttribute).toHaveBeenCalledWith(CORRELATION_ID_ATTRIBUTE, 'corr-abc');
+  });
+
+  it('is a no-op when the header is absent', () => {
+    const getActiveSpan = vi.spyOn(trace, 'getActiveSpan');
+
+    correlationIdPlugin().onRequest?.(onRequestArg(null));
+
+    // Returns before ever touching the tracer when there is nothing to record.
+    expect(getActiveSpan).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the header is blank', () => {
+    const getActiveSpan = vi.spyOn(trace, 'getActiveSpan');
+
+    correlationIdPlugin().onRequest?.(onRequestArg('   '));
+
+    expect(getActiveSpan).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when there is no active span (OTEL disabled)', () => {
+    vi.spyOn(trace, 'getActiveSpan').mockReturnValue(undefined);
+
+    expect(() => correlationIdPlugin().onRequest?.(onRequestArg('corr-1'))).not.toThrow();
+  });
+});

--- a/packages/server/src/plugins/correlation-id-plugin.ts
+++ b/packages/server/src/plugins/correlation-id-plugin.ts
@@ -1,0 +1,41 @@
+import { Plugin } from 'graphql-yoga';
+import { trace } from '@opentelemetry/api';
+
+/**
+ * Request header carrying a business-level correlation id across service hops.
+ * The MCP server (`@accounter/mcp-server`) mints/inherits this id and forwards
+ * it on every upstream GraphQL call.
+ */
+export const CORRELATION_ID_HEADER = 'x-correlation-id';
+
+/**
+ * Span attribute name for the correlation id. Kept identical to the attribute
+ * the MCP server sets on its own spans (`accounter.correlation_id`) so a single
+ * Grafana/Tempo query surfaces the matching spans on both services.
+ */
+export const CORRELATION_ID_ATTRIBUTE = 'accounter.correlation_id';
+
+/**
+ * CorrelationIdPlugin — bridges an inbound `X-Correlation-Id` header onto the
+ * current OpenTelemetry trace.
+ *
+ * The actual MCP↔backend trace linkage rides the W3C `traceparent` header
+ * (auto-propagated by the MCP server's fetch instrumentation and extracted by
+ * this server's HTTP instrumentation). This plugin adds the human-friendly
+ * correlation id as a searchable attribute on the active (HTTP server) span, so
+ * an operator can pivot from an MCP log line to the backend trace, and search
+ * traces by the business-level id.
+ *
+ * A no-op when the header is absent or when OTEL is disabled (no active span).
+ */
+export function correlationIdPlugin(): Plugin {
+  return {
+    onRequest({ request }) {
+      const correlationId = request.headers.get(CORRELATION_ID_HEADER)?.trim();
+      if (!correlationId) {
+        return;
+      }
+      trace.getActiveSpan()?.setAttribute(CORRELATION_ID_ATTRIBUTE, correlationId);
+    },
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,6 +268,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@accounter/mcp-server@workspace:packages/mcp-server"
   dependencies:
+    "@opentelemetry/api": "npm:1.9.1"
+    "@opentelemetry/auto-instrumentations-node": "npm:0.79.0"
+    "@opentelemetry/exporter-trace-otlp-http": "npm:0.221.0"
+    "@opentelemetry/resources": "npm:2.10.0"
+    "@opentelemetry/sdk-node": "npm:0.221.0"
+    "@opentelemetry/semantic-conventions": "npm:1.43.0"
     "@types/node": "npm:25.9.5"
     dotenv: "npm:17.4.2"
     jose: "npm:6.2.7"


### PR DESCRIPTION
Implements distributed tracing for the MCP server using OpenTelemetry, exporting traces to Grafana Tempo. Mirrors the main server's telemetry setup to enable end-to-end trace correlation across services.

## Key Changes

- **OpenTelemetry SDK builder** (`src/telemetry/builder.ts`): Configures NodeSDK with OTLP/HTTP exporter, auto-instrumentation (HTTP, undici/fetch), and sampler strategies. Disables fs and GraphQL instrumentations (not applicable to this process).

- **Telemetry lifecycle** (`src/telemetry/index.ts`): Idempotent, concurrency-safe startup and graceful shutdown. Supports strict mode (fail-fast on startup errors) and non-strict mode (log and continue).

- **Span instrumentation** (`src/observability/tracing.ts`): Refactored from lightweight debug-log spans to real OpenTelemetry spans. `withSpan()` now uses the active span context, enabling proper parent-child relationships and automatic `traceparent` header injection on upstream calls.

- **Environment configuration** (`src/config/env.ts`): Added `OTEL_*` variables (enabled, service identity, exporter endpoint/headers, sampler strategy, startup mode). Validation ensures exporter endpoint is required when enabled, and ratio samplers have valid 0–1 arguments.

- **Bootstrap preload** (`src/bootstrap-telemetry.ts`): Node `--import` hook to start telemetry before application modules load, allowing auto-instrumentation to patch `node:http` and global `fetch` early.

- **Server integration** (`src/server.ts`): Tags the auto-instrumented HTTP span with business-level correlation id and request id for searchability in Grafana.

- **Backend correlation plugin** (`packages/server/src/plugins/correlation-id-plugin.ts`): New GraphQL Yoga plugin that bridges inbound `X-Correlation-Id` header onto the active span, enabling trace pivoting from MCP logs to backend traces.

- **Tests**: Comprehensive test suites for builder, lifecycle, and tracing behavior; updated existing tracing tests to verify OTEL span attributes and status codes.

- **Documentation** (`README.md`): Updated to describe OpenTelemetry tracing, configuration, and trace correlation via `traceparent` and `X-Correlation-Id`.

## Implementation Details

- Tracing is **disabled by default**; opt-in via `OTEL_ENABLED=1` + `OTEL_EXPORTER_OTLP_ENDPOINT`.
- Spans are started as *active* spans so nested calls (e.g., `tool:<name>` → `upstream:graphql`) are parented correctly and undici auto-instrumentation picks up the context to inject `traceparent`.
- Business-level `correlationId` is attached as `accounter.correlation_id` span attribute on both MCP and backend spans for unified searchability.
- When OTEL is disabled, `trace.getTracer()` returns the API's no-op tracer, keeping call sites zero-cost and unchanged.
- Mirrors `packages/server/src/telemetry/` conventions for consistency across services.

https://claude.ai/code/session_019ov6G23TZohvEmp4ypZUEN