### PR TITLE
feat(mcp-server): add by-id detail tools for charges, transactions, and documents

### DIFF
--- a/.changeset/mcp-server-detail-tools-filters.md
+++ b/.changeset/mcp-server-detail-tools-filters.md
@@ -1,0 +1,17 @@
+---
+'@accounter/mcp-server': patch
+---
+
+- Enrich detail tools to support filter-based retrieval in addition to by-id retrieval:
+  - `accounter_get_charges` supports full `ChargeFilter` input.
+  - `accounter_get_transactions` supports `transactionsByFilters` predicates.
+  - `accounter_get_documents` supports `documentsByFilters` predicates.
+- Allow combining ids and filters in detail tools (ids + filters), and treat empty array inputs as
+  undefined to match backend semantics.
+- Refactor detail-tool GraphQL documents to use shared fragments and one multi-operation document per
+  tool, selecting operations with `operationName` to keep result structures consistent and reduce
+  duplicate selection sets.
+- Normalize specific upstream not-found GraphQL errors from `chargesByIDs` / `transactionsByIDs` to
+  empty successful results so out-of-scope or missing ids behave consistently with tool summaries.
+- Tighten `RawDocument.charge.owner` typing to match selected fields (`owner { id }`) and avoid
+  accidental reliance on unselected `name` fields.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -18,8 +18,9 @@ Phase 1 (read-only) is feature-complete. The server provides: strict startup env
 transport with `/health`, `/metrics`, the OAuth protected-resource metadata endpoint, and the MCP
 route (`POST /mcp`, JSON-RPC 2.0) with graceful shutdown; Auth0 bearer-token verification; identity
 mapping to an internal user + business-membership context with memberships resolved from the
-Accounter GraphQL server; a curated registry of five read-only tools (`accounter_list_businesses`,
-`accounter_search_charges`, `accounter_list_tags`, `accounter_list_tax_categories`,
+Accounter GraphQL server; a curated registry of eight read-only tools (`accounter_list_businesses`,
+`accounter_search_charges`, `accounter_get_charges`, `accounter_get_transactions`,
+`accounter_get_documents`, `accounter_list_tags`, `accounter_list_tax_categories`,
 `accounter_balance_report`) each gated by strict input validation, a per-tool authorization policy,
 and business-scope narrowing forwarded upstream as `x-business-scope`; a hardened upstream GraphQL
 client (timeout, bounded retries, header propagation, sanitized errors); a unified error taxonomy;
@@ -77,6 +78,20 @@ because it _is_ the scope.
   (`pageSize` ≤ 50). Returns normalized charges — each carrying `ownerId`/`ownerName` — plus
   pagination metadata and the echoed `scope`. Scoping uses the `byOwners` predicate upstream (the
   owner), never `byBusinesses` (the counterparty).
+- **`accounter_get_charges`** — read-only charge **detail** by id (1–25 `chargeIds`). Returns each
+  charge with owner, counterparty, amounts (total, VAT, withholding), the full set of dates, tags,
+  and `metadata` counts, plus — by default — its linked `transactions` and `documents` nested inline
+  (toggle with `includeTransactions` / `includeDocuments`). This is the drill-down for
+  `accounter_search_charges`. A charge whose `owner` falls outside the resolved scope is dropped as
+  defense-in-depth on top of RLS.
+- **`accounter_get_transactions`** — read-only bank/card **transactions** by id (1–50
+  `transactionIds`). Each row carries direction, amount, event/effective dates, source description,
+  `isFee`, `chargeId`, counterparty, and account. Scope is enforced upstream by RLS (transactions
+  carry no owner field for a client-side filter).
+- **`accounter_get_documents`** — read-only **documents** by id (1–50 `documentIds`). Each row
+  carries `documentType`, serial number, date, amount, VAT, creditor/debtor, `chargeId`, and
+  `file`/`image` links. A document whose owning charge falls outside the resolved scope is dropped
+  as defense-in-depth on top of RLS.
 - **`accounter_list_tags`** — list tags for categorizing charges, optionally filtered by name and by
   `businessIds`. Rows carry `ownerId`. Deterministically sorted (name, then id) and size-capped (≤
   500).

--- a/packages/mcp-server/docs/spec.md
+++ b/packages/mcp-server/docs/spec.md
@@ -274,6 +274,10 @@ Expose only capabilities that pass all checks:
 Recommended initial groups:
 
 - Charges browse/search (read-only)
+- Charge / transaction / document detail by id (read-only): `accounter_get_charges` (charges with
+  their transactions and documents nested inline), `accounter_get_transactions`,
+  `accounter_get_documents`. These narrow to the caller's businesses via RLS (`x-business-scope`),
+  with an owner-scope filter as defense-in-depth where an owner is resolvable.
 - Tags and tax-category lookups
 - Counterparty/business entity lookups
 - Selected report generation queries (read-only)

--- a/packages/mcp-server/src/tools/__tests__/detail-tools.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/detail-tools.test.ts
@@ -46,6 +46,22 @@ function clientReturning(data: unknown, capture?: (body: unknown) => void) {
   });
 }
 
+function clientGraphQLErrors(messages: string[], capture?: (body: unknown) => void) {
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    capture?.(JSON.parse(init.body as string));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ errors: messages.map(message => ({ message })) }),
+    } as unknown as Response;
+  });
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
 function run(
   tool: ToolDefinition,
   client: UpstreamGraphQLClient,
@@ -305,6 +321,14 @@ describe('getChargesTool', () => {
     expect(result.content[0]!.text).toMatch(/No charges/);
   });
 
+  it('normalizes upstream chargesByIDs not-found error to empty result', async () => {
+    const client = clientGraphQLErrors(['Charge ID="missing" not found']);
+    const result = await run(getChargesTool, client, authContext([B1]), { chargeIds: ['missing'] });
+    expect(result.isError).toBeUndefined();
+    expect((result.structuredContent as { charges: unknown[] }).charges).toEqual([]);
+    expect(result.content[0]!.text).toMatch(/No charges/);
+  });
+
   it('rejects an empty id list', async () => {
     const client = clientReturning(chargeFixture);
     const result = await run(getChargesTool, client, authContext([B1]), { chargeIds: [] });
@@ -401,6 +425,16 @@ describe('getTransactionsTool', () => {
     const result = await run(getTransactionsTool, client, authContext([B1]), {
       transactionIds: ['missing'],
     });
+    expect((result.structuredContent as { transactions: unknown[] }).transactions).toEqual([]);
+    expect(result.content[0]!.text).toMatch(/No transactions/);
+  });
+
+  it('normalizes upstream transactionsByIDs not-found error to empty result', async () => {
+    const client = clientGraphQLErrors(['Transaction ID="missing" not found']);
+    const result = await run(getTransactionsTool, client, authContext([B1]), {
+      transactionIds: ['missing'],
+    });
+    expect(result.isError).toBeUndefined();
     expect((result.structuredContent as { transactions: unknown[] }).transactions).toEqual([]);
     expect(result.content[0]!.text).toMatch(/No transactions/);
   });

--- a/packages/mcp-server/src/tools/__tests__/detail-tools.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/detail-tools.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { getChargesTool, MAX_CHARGE_IDS } from '../charge-details.js';
+import { getDocumentsTool } from '../document-details.js';
+import { MAX_DETAIL_IDS } from '../entity-shapes.js';
+import { executeRegisteredTool } from '../execute.js';
+import type { ToolDefinition } from '../registry.js';
+import { getTransactionsTool } from '../transaction-details.js';
+
+/**
+ * Unit coverage for the by-id detail tools: get_charges, get_transactions,
+ * get_documents. Mirrors the harness in `charges.test.ts` — a fake upstream
+ * client returns fixtures and the executor drives validation + policy + handler.
+ */
+
+const B1 = 'aa000000-0000-4000-8000-000000000001';
+const B2 = 'aa000000-0000-4000-8000-000000000002';
+
+function authContext(businessIds: string[]): McpAuthContext {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: [],
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+  return buildAuthContext(
+    principal,
+    businessIds.map(businessId => ({ businessId, roleId: 'accountant' })),
+  );
+}
+
+function clientReturning(data: unknown, capture?: (body: unknown) => void) {
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    capture?.(JSON.parse(init.body as string));
+    return { ok: true, status: 200, json: async () => ({ data }) } as unknown as Response;
+  });
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+function run(
+  tool: ToolDefinition,
+  client: UpstreamGraphQLClient,
+  auth: McpAuthContext,
+  rawArgs: unknown,
+) {
+  return executeRegisteredTool({
+    tool,
+    rawArgs,
+    auth,
+    correlationId: 'corr-1',
+    client,
+    authorization: 'Bearer tok',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// get_charges
+// ---------------------------------------------------------------------------
+
+const chargeFixture = {
+  chargesByIDs: [
+    {
+      id: 'c1',
+      userDescription: 'Coffee supplies',
+      owner: { id: B1, name: 'Acme' },
+      counterparty: { id: 'cp1', name: 'Beans Ltd' },
+      totalAmount: { raw: -120, formatted: '₪-120.00', currency: 'ILS' },
+      vat: { raw: -17, formatted: '₪-17.00', currency: 'ILS' },
+      withholdingTax: null,
+      minEventDate: '2026-01-05',
+      maxEventDate: '2026-01-05',
+      minDebitDate: null,
+      maxDebitDate: null,
+      minDocumentsDate: '2026-01-04',
+      maxDocumentsDate: '2026-01-04',
+      tags: [{ id: 't1', name: 'office' }],
+      metadata: {
+        createdAt: '2026-01-06',
+        updatedAt: '2026-01-07',
+        invoicesCount: 1,
+        receiptsCount: 0,
+        documentsCount: 1,
+        transactionsCount: 1,
+        ledgerCount: 2,
+        miscExpensesCount: 0,
+        openDocuments: false,
+        invalidLedger: 'VALID',
+      },
+      transactions: [
+        {
+          __typename: 'CommonTransaction',
+          id: 'tx1',
+          chargeId: 'c1',
+          eventDate: '2026-01-05',
+          effectiveDate: '2026-01-06',
+          direction: 'DEBIT',
+          amount: { raw: -120, formatted: '₪-120.00', currency: 'ILS' },
+          sourceDescription: 'CARD 1234',
+          isFee: false,
+          counterparty: { id: 'cp1', name: 'Beans Ltd' },
+          account: { id: 'acc1', name: 'Main card' },
+        },
+      ],
+      additionalDocuments: [
+        {
+          __typename: 'Invoice',
+          id: 'd1',
+          documentType: 'INVOICE',
+          serialNumber: 'INV-1',
+          date: '2026-01-04',
+          amount: { raw: -120, formatted: '₪-120.00', currency: 'ILS' },
+          vat: { raw: -17, formatted: '₪-17.00', currency: 'ILS' },
+          creditor: { id: 'cp1', name: 'Beans Ltd' },
+          debtor: { id: B1, name: 'Acme' },
+          description: 'Monthly beans',
+          file: 'https://files/d1.pdf',
+          image: null,
+          charge: { id: 'c1' },
+        },
+      ],
+    },
+  ],
+};
+
+describe('getChargesTool', () => {
+  it('normalizes a charge with nested transactions and documents', async () => {
+    const client = clientReturning(chargeFixture);
+    const result = await run(getChargesTool, client, authContext([B1]), { chargeIds: ['c1'] });
+
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as {
+      charges: Array<{
+        id: string;
+        ownerId: string;
+        counterparty: { id: string; name: string };
+        totalAmount: { value: number };
+        tags: Array<{ id: string; name: string }>;
+        transactions: Array<{ id: string; account: { name: string }; type: string }>;
+        documents: Array<{ id: string; serialNumber: string; fileUrl: string; type: string }>;
+      }>;
+      scope: { businessIds: string[] };
+    };
+    const charge = structured.charges[0]!;
+    expect(charge.id).toBe('c1');
+    expect(charge.ownerId).toBe(B1);
+    expect(charge.counterparty).toEqual({ id: 'cp1', name: 'Beans Ltd' });
+    expect(charge.totalAmount).toEqual({ value: -120, formatted: '₪-120.00', currency: 'ILS' });
+    expect(charge.tags).toEqual([{ id: 't1', name: 'office' }]);
+    expect(charge.transactions[0]).toMatchObject({
+      id: 'tx1',
+      type: 'CommonTransaction',
+      direction: 'DEBIT',
+      account: { id: 'acc1', name: 'Main card' },
+    });
+    expect(charge.documents[0]).toMatchObject({
+      id: 'd1',
+      type: 'Invoice',
+      serialNumber: 'INV-1',
+      fileUrl: 'https://files/d1.pdf',
+    });
+    expect(structured.scope).toEqual({ businessIds: [B1] });
+  });
+
+  it('forwards include flags and charge ids to upstream', async () => {
+    let sentBody: unknown;
+    const client = clientReturning(chargeFixture, body => (sentBody = body));
+    await run(getChargesTool, client, authContext([B1]), {
+      chargeIds: ['c1', 'c2'],
+      includeDocuments: false,
+    });
+    const variables = (
+      sentBody as {
+        variables: { chargeIDs: string[]; includeTransactions: boolean; includeDocuments: boolean };
+      }
+    ).variables;
+    expect(variables.chargeIDs).toEqual(['c1', 'c2']);
+    expect(variables.includeTransactions).toBe(true);
+    expect(variables.includeDocuments).toBe(false);
+  });
+
+  it('drops a charge whose owner is outside the resolved scope (defense-in-depth)', async () => {
+    const client = clientReturning(chargeFixture);
+    // Caller is authorized for B2 only; the fixture charge is owned by B1.
+    const result = await run(getChargesTool, client, authContext([B2]), { chargeIds: ['c1'] });
+    const structured = result.structuredContent as { charges: unknown[] };
+    expect(structured.charges).toEqual([]);
+    expect(result.content[0]!.text).toMatch(/No charges/);
+  });
+
+  it('rejects an empty id list', async () => {
+    const client = clientReturning(chargeFixture);
+    const result = await run(getChargesTool, client, authContext([B1]), { chargeIds: [] });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects more than the id cap', async () => {
+    const client = clientReturning(chargeFixture);
+    const chargeIds = Array.from({ length: MAX_CHARGE_IDS + 1 }, (_, i) => `c${i}`);
+    const result = await run(getChargesTool, client, authContext([B1]), { chargeIds });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects an unknown field', async () => {
+    const client = clientReturning(chargeFixture);
+    const result = await run(getChargesTool, client, authContext([B1]), {
+      chargeIds: ['c1'],
+      bogus: true,
+    });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_transactions
+// ---------------------------------------------------------------------------
+
+describe('getTransactionsTool', () => {
+  const fixture = {
+    transactionsByIDs: [
+      {
+        __typename: 'CommonTransaction',
+        id: 'tx1',
+        chargeId: 'c1',
+        eventDate: '2026-01-05',
+        effectiveDate: '2026-01-06',
+        direction: 'DEBIT',
+        amount: { raw: -120, formatted: '₪-120.00', currency: 'ILS' },
+        sourceDescription: 'CARD 1234',
+        isFee: false,
+        counterparty: { id: 'cp1', name: 'Beans Ltd' },
+        account: { id: 'acc1', name: 'Main card' },
+      },
+    ],
+  };
+
+  it('normalizes transactions and echoes scope', async () => {
+    const client = clientReturning(fixture);
+    const result = await run(getTransactionsTool, client, authContext([B1, B2]), {
+      transactionIds: ['tx1'],
+    });
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as {
+      transactions: Array<{ id: string; chargeId: string; counterparty: { name: string } }>;
+      scope: { businessIds: string[] };
+    };
+    expect(structured.transactions[0]).toMatchObject({
+      id: 'tx1',
+      chargeId: 'c1',
+      direction: 'DEBIT',
+      counterparty: { id: 'cp1', name: 'Beans Ltd' },
+    });
+    expect(structured.scope).toEqual({ businessIds: [B1, B2] });
+  });
+
+  it('forwards ids to upstream', async () => {
+    let sentBody: unknown;
+    const client = clientReturning(fixture, body => (sentBody = body));
+    await run(getTransactionsTool, client, authContext([B1]), { transactionIds: ['tx1', 'tx2'] });
+    const variables = (sentBody as { variables: { transactionIDs: string[] } }).variables;
+    expect(variables.transactionIDs).toEqual(['tx1', 'tx2']);
+  });
+
+  it('reports no matches for an empty upstream result', async () => {
+    const client = clientReturning({ transactionsByIDs: [] });
+    const result = await run(getTransactionsTool, client, authContext([B1]), {
+      transactionIds: ['missing'],
+    });
+    expect((result.structuredContent as { transactions: unknown[] }).transactions).toEqual([]);
+    expect(result.content[0]!.text).toMatch(/No transactions/);
+  });
+
+  it('rejects more than the id cap', async () => {
+    const client = clientReturning(fixture);
+    const transactionIds = Array.from({ length: MAX_DETAIL_IDS + 1 }, (_, i) => `tx${i}`);
+    const result = await run(getTransactionsTool, client, authContext([B1]), { transactionIds });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_documents
+// ---------------------------------------------------------------------------
+
+describe('getDocumentsTool', () => {
+  function doc(overrides: Record<string, unknown> = {}) {
+    return {
+      __typename: 'Invoice',
+      id: 'd1',
+      documentType: 'INVOICE',
+      serialNumber: 'INV-1',
+      date: '2026-01-04',
+      amount: { raw: -120, formatted: '₪-120.00', currency: 'ILS' },
+      vat: { raw: -17, formatted: '₪-17.00', currency: 'ILS' },
+      creditor: { id: 'cp1', name: 'Beans Ltd' },
+      debtor: { id: B1, name: 'Acme' },
+      description: 'Monthly beans',
+      file: 'https://files/d1.pdf',
+      image: null,
+      charge: { id: 'c1', owner: { id: B1 } },
+      ...overrides,
+    };
+  }
+
+  it('normalizes documents and echoes scope', async () => {
+    const client = clientReturning({ documentsByIds: [doc()] });
+    const result = await run(getDocumentsTool, client, authContext([B1]), { documentIds: ['d1'] });
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as {
+      documents: Array<{
+        id: string;
+        documentType: string;
+        vat: { value: number };
+        creditor: { name: string };
+        chargeId: string;
+        fileUrl: string;
+      }>;
+    };
+    expect(structured.documents[0]).toMatchObject({
+      id: 'd1',
+      documentType: 'INVOICE',
+      type: 'Invoice',
+      serialNumber: 'INV-1',
+      chargeId: 'c1',
+      fileUrl: 'https://files/d1.pdf',
+    });
+    expect(structured.documents[0]!.vat).toEqual({ value: -17, formatted: '₪-17.00', currency: 'ILS' });
+  });
+
+  it('drops a document whose owning charge is outside scope', async () => {
+    const client = clientReturning({
+      documentsByIds: [doc({ charge: { id: 'c9', owner: { id: B2 } } })],
+    });
+    const result = await run(getDocumentsTool, client, authContext([B1]), { documentIds: ['d1'] });
+    expect((result.structuredContent as { documents: unknown[] }).documents).toEqual([]);
+    expect(result.content[0]!.text).toMatch(/No documents/);
+  });
+
+  it('keeps a document with no resolvable charge owner (RLS already scoped it)', async () => {
+    const client = clientReturning({ documentsByIds: [doc({ charge: null })] });
+    const result = await run(getDocumentsTool, client, authContext([B1]), { documentIds: ['d1'] });
+    const structured = result.structuredContent as { documents: Array<{ id: string; chargeId: null }> };
+    expect(structured.documents[0]).toMatchObject({ id: 'd1', chargeId: null });
+  });
+
+  it('forwards ids to upstream', async () => {
+    let sentBody: unknown;
+    const client = clientReturning({ documentsByIds: [doc()] }, body => (sentBody = body));
+    await run(getDocumentsTool, client, authContext([B1]), { documentIds: ['d1', 'd2'] });
+    const variables = (sentBody as { variables: { documentIds: string[] } }).variables;
+    expect(variables.documentIds).toEqual(['d1', 'd2']);
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/detail-tools.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/detail-tools.test.ts
@@ -132,6 +132,13 @@ const chargeFixture = {
 };
 
 describe('getChargesTool', () => {
+  const filteredChargeFixture = {
+    allCharges: {
+      nodes: chargeFixture.chargesByIDs,
+      pageInfo: { totalPages: 1, totalRecords: 1, currentPage: 0, pageSize: 100 },
+    },
+  };
+
   it('normalizes a charge with nested transactions and documents', async () => {
     const client = clientReturning(chargeFixture);
     const result = await run(getChargesTool, client, authContext([B1]), { chargeIds: ['c1'] });
@@ -187,6 +194,108 @@ describe('getChargesTool', () => {
     expect(variables.includeDocuments).toBe(false);
   });
 
+  it('forwards all available filters to allCharges', async () => {
+    let sentBody: unknown;
+    const client = clientReturning(filteredChargeFixture, body => (sentBody = body));
+    const result = await run(getChargesTool, client, authContext([B1]), {
+      filters: {
+        accountantStatus: ['APPROVED', 'PENDING'],
+        businessTrip: 'bt1',
+        byBusinessTrips: ['bt1', 'bt2'],
+        byBusinesses: ['biz1'],
+        byChargeTypes: ['COMMON', 'BUSINESS_TRIP'],
+        byFinancialAccounts: ['fa1'],
+        byOwners: [B1, B2],
+        byTags: ['office', 'vat'],
+        chargesType: 'EXPENSE',
+        freeText: 'coffee',
+        fromAnyDate: '2026-01-01',
+        fromDate: '2026-01-01',
+        sortBy: { field: 'DATE', asc: false },
+        toAnyDate: '2026-01-31',
+        toDate: '2026-01-31',
+        unbalanced: true,
+        withMissingCounterparty: false,
+        withOpenDocuments: true,
+        withoutDocuments: false,
+        withoutInvoice: false,
+        withoutLedger: false,
+        withoutReceipt: false,
+        withoutTransactions: false,
+      },
+      includeTransactions: false,
+      includeDocuments: true,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const variables = (
+      sentBody as {
+        variables: {
+          filters: Record<string, unknown>;
+          includeTransactions: boolean;
+          includeDocuments: boolean;
+          page: number;
+          limit: number;
+        };
+      }
+    ).variables;
+
+    expect(variables.filters).toEqual({
+      accountantStatus: ['APPROVED', 'PENDING'],
+      businessTrip: 'bt1',
+      byBusinessTrips: ['bt1', 'bt2'],
+      byBusinesses: ['biz1'],
+      byChargeTypes: ['COMMON', 'BUSINESS_TRIP'],
+      byFinancialAccounts: ['fa1'],
+      byOwners: [B1],
+      byTags: ['office', 'vat'],
+      chargesType: 'EXPENSE',
+      freeText: 'coffee',
+      fromAnyDate: '2026-01-01',
+      fromDate: '2026-01-01',
+      sortBy: { field: 'DATE', asc: false },
+      toAnyDate: '2026-01-31',
+      toDate: '2026-01-31',
+      unbalanced: true,
+      withMissingCounterparty: false,
+      withOpenDocuments: true,
+      withoutDocuments: false,
+      withoutInvoice: false,
+      withoutLedger: false,
+      withoutReceipt: false,
+      withoutTransactions: false,
+    });
+    expect(variables.includeTransactions).toBe(false);
+    expect(variables.includeDocuments).toBe(true);
+    expect(variables.page).toBe(0);
+    expect(variables.limit).toBe(100);
+  });
+
+  it('combines chargeIds with filters and keeps only requested ids', async () => {
+    const client = clientReturning({
+      allCharges: {
+        nodes: [
+          ...chargeFixture.chargesByIDs,
+          {
+            ...chargeFixture.chargesByIDs[0],
+            id: 'c2',
+          },
+        ],
+        pageInfo: { totalPages: 1, totalRecords: 2, currentPage: 0, pageSize: 100 },
+      },
+    });
+
+    const result = await run(getChargesTool, client, authContext([B1]), {
+      chargeIds: ['c1'],
+      filters: { freeText: 'coffee' },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as { charges: Array<{ id: string }> };
+    expect(structured.charges).toHaveLength(1);
+    expect(structured.charges[0]?.id).toBe('c1');
+  });
+
   it('drops a charge whose owner is outside the resolved scope (defense-in-depth)', async () => {
     const client = clientReturning(chargeFixture);
     // Caller is authorized for B2 only; the fixture charge is owned by B1.
@@ -201,6 +310,21 @@ describe('getChargesTool', () => {
     const result = await run(getChargesTool, client, authContext([B1]), { chargeIds: [] });
     expect(result.isError).toBe(true);
     expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('treats empty chargeIds as undefined when filters are provided', async () => {
+    let sentBody: unknown;
+    const client = clientReturning(filteredChargeFixture, body => (sentBody = body));
+    const result = await run(getChargesTool, client, authContext([B1]), {
+      chargeIds: [],
+      filters: { byTags: ['office'] },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const variables = (sentBody as { variables: { filters: Record<string, unknown> } }).variables
+      .filters;
+    expect('byIds' in variables).toBe(false);
+    expect(variables.byTags).toEqual(['office']);
   });
 
   it('rejects more than the id cap', async () => {
@@ -288,6 +412,114 @@ describe('getTransactionsTool', () => {
     expect(result.isError).toBe(true);
     expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
   });
+
+  it('forwards all filters to transactionsByFilters and normalizes the result', async () => {
+    let sentBody: unknown;
+    const client = clientReturning(
+      {
+        transactionsByFilters: [
+          {
+            __typename: 'CommonTransaction',
+            id: 'tx2',
+            chargeId: 'c2',
+            eventDate: '2026-02-01',
+            effectiveDate: '2026-02-02',
+            direction: 'CREDIT',
+            amount: { raw: 50, formatted: '₪50.00', currency: 'ILS' },
+            sourceDescription: 'Bank transfer',
+            isFee: false,
+            counterparty: { id: 'cp2', name: 'Client Ltd' },
+            account: { id: 'acc2', name: 'Main bank' },
+          },
+        ],
+      },
+      body => (sentBody = body),
+    );
+
+    const result = await run(getTransactionsTool, client, authContext([B1]), {
+      filters: {
+        byIds: ['tx2'],
+        byChargeIds: ['c2'],
+        byOwners: [B1, B2],
+        fromEventDate: '2026-02-01',
+        toEventDate: '2026-02-10',
+        fromDebitDate: '2026-02-01',
+        toDebitDate: '2026-02-10',
+        fromAnyDate: '2026-02-01',
+        toAnyDate: '2026-02-10',
+        byCounterparties: ['cp2'],
+        withMissingCounterparty: false,
+        withMissingInfo: false,
+        freeText: 'Bank',
+      },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const variables = (sentBody as { variables: { filters: Record<string, unknown> } }).variables
+      .filters;
+    expect(variables).toEqual({
+      byIds: ['tx2'],
+      byChargeIds: ['c2'],
+      byOwners: [B1],
+      fromEventDate: '2026-02-01',
+      toEventDate: '2026-02-10',
+      fromDebitDate: '2026-02-01',
+      toDebitDate: '2026-02-10',
+      fromAnyDate: '2026-02-01',
+      toAnyDate: '2026-02-10',
+      byCounterparties: ['cp2'],
+      withMissingCounterparty: false,
+      withMissingInfo: false,
+      freeText: 'Bank',
+    });
+
+    const structured = result.structuredContent as {
+      transactions: Array<{ id: string; chargeId: string; direction: string }>;
+    };
+    expect(structured.transactions[0]).toMatchObject({
+      id: 'tx2',
+      chargeId: 'c2',
+      direction: 'CREDIT',
+    });
+  });
+
+  it('combines transactionIds with filters (no dropped filters)', async () => {
+    let sentBody: unknown;
+    const client = clientReturning({ transactionsByFilters: fixture.transactionsByIDs }, body => (sentBody = body));
+    const result = await run(getTransactionsTool, client, authContext([B1]), {
+      transactionIds: ['tx1'],
+      filters: { byOwners: [B1], withMissingInfo: false },
+    });
+    expect(result.isError).toBeUndefined();
+    const variables = (sentBody as { variables: { filters: Record<string, unknown> } }).variables
+      .filters;
+    expect(variables).toMatchObject({
+      byIds: ['tx1'],
+      byOwners: [B1],
+      withMissingInfo: false,
+    });
+  });
+
+  it('rejects when neither transactionIds nor filters is provided', async () => {
+    const client = clientReturning(fixture);
+    const result = await run(getTransactionsTool, client, authContext([B1]), {});
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('treats empty transactionIds as undefined (backend-compatible)', async () => {
+    let sentBody: unknown;
+    const client = clientReturning({ transactionsByFilters: fixture.transactionsByIDs }, body => (sentBody = body));
+    const result = await run(getTransactionsTool, client, authContext([B1]), {
+      transactionIds: [],
+      filters: { byOwners: [B1] },
+    });
+    expect(result.isError).toBeUndefined();
+    const variables = (sentBody as { variables: { filters: Record<string, unknown> } }).variables
+      .filters;
+    expect('byIds' in variables).toBe(false);
+    expect(variables.byOwners).toEqual([B1]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -361,5 +593,86 @@ describe('getDocumentsTool', () => {
     await run(getDocumentsTool, client, authContext([B1]), { documentIds: ['d1', 'd2'] });
     const variables = (sentBody as { variables: { documentIds: string[] } }).variables;
     expect(variables.documentIds).toEqual(['d1', 'd2']);
+  });
+
+  it('forwards all filters to documentsByFilters and normalizes the result', async () => {
+    let sentBody: unknown;
+    const client = clientReturning({ documentsByFilters: [doc()] }, body => (sentBody = body));
+
+    const result = await run(getDocumentsTool, client, authContext([B1]), {
+      filters: {
+        businessIds: ['biz-1'],
+        ownerIds: [B1, B2],
+        chargeIds: ['c1'],
+        fromDate: '2026-01-01',
+        toDate: '2026-01-31',
+        unmatched: false,
+        type: ['INVOICE', 'RECEIPT'],
+        missingCounterparty: false,
+        missingInfo: false,
+        freeText: 'beans',
+      },
+    });
+
+    expect(result.isError).toBeUndefined();
+    const variables = (sentBody as { variables: { filters: Record<string, unknown> } }).variables
+      .filters;
+    expect(variables).toEqual({
+      businessIDs: ['biz-1'],
+      ownerIDs: [B1],
+      chargeIDs: ['c1'],
+      fromDate: '2026-01-01',
+      toDate: '2026-01-31',
+      unmatched: false,
+      type: ['INVOICE', 'RECEIPT'],
+      missingCounterparty: false,
+      missingInfo: false,
+      freeText: 'beans',
+    });
+
+    const structured = result.structuredContent as { documents: Array<{ id: string; chargeId: string }> };
+    expect(structured.documents[0]).toMatchObject({ id: 'd1', chargeId: 'c1' });
+  });
+
+  it('combines documentIds with filters (no dropped filters)', async () => {
+    let sentBody: unknown;
+    const client = clientReturning({ documentsByFilters: [doc()] }, body => (sentBody = body));
+    const result = await run(getDocumentsTool, client, authContext([B1]), {
+      documentIds: ['d1'],
+      filters: { type: ['INVOICE'], missingInfo: false },
+    });
+    expect(result.isError).toBeUndefined();
+    const variables = (sentBody as { variables: { filters: Record<string, unknown> } }).variables
+      .filters;
+    expect(variables).toMatchObject({
+      ownerIDs: [B1],
+      type: ['INVOICE'],
+      missingInfo: false,
+    });
+    const structured = result.structuredContent as { documents: Array<{ id: string }> };
+    expect(structured.documents).toHaveLength(1);
+    expect(structured.documents[0]?.id).toBe('d1');
+  });
+
+  it('rejects when neither documentIds nor filters is provided', async () => {
+    const client = clientReturning({ documentsByIds: [doc()] });
+    const result = await run(getDocumentsTool, client, authContext([B1]), {});
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('treats empty documentIds as undefined (backend-compatible)', async () => {
+    let sentBody: unknown;
+    const client = clientReturning({ documentsByFilters: [doc()] }, body => (sentBody = body));
+    const result = await run(getDocumentsTool, client, authContext([B1]), {
+      documentIds: [],
+      filters: { ownerIds: [B1] },
+    });
+    expect(result.isError).toBeUndefined();
+    const variables = (sentBody as { variables: { filters: Record<string, unknown> } }).variables
+      .filters;
+    expect(variables.ownerIDs).toEqual([B1]);
+    const structured = result.structuredContent as { documents: Array<{ id: string }> };
+    expect(structured.documents).toHaveLength(1);
   });
 });

--- a/packages/mcp-server/src/tools/__tests__/scope-forwarding.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/scope-forwarding.test.ts
@@ -46,6 +46,9 @@ function dataFor(query: string): unknown {
       },
     };
   }
+  if (query.includes('chargesByIDs')) return { chargesByIDs: [] };
+  if (query.includes('transactionsByIDs')) return { transactionsByIDs: [] };
+  if (query.includes('documentsByIds')) return { documentsByIds: [] };
   if (query.includes('allTags')) return { allTags: [] };
   if (query.includes('taxCategories')) return { taxCategories: [] };
   if (query.includes('transactionsForBalanceReport')) return { transactionsForBalanceReport: [] };
@@ -74,6 +77,9 @@ function capturingClient() {
 /** Minimal valid arguments per tool; everything else is optional. */
 const ARGS_BY_TOOL: Record<string, unknown> = {
   accounter_balance_report: { businessId: B1, fromDate: '2026-01-01', toDate: '2026-03-01' },
+  accounter_get_charges: { chargeIds: ['c1'] },
+  accounter_get_transactions: { transactionIds: ['t1'] },
+  accounter_get_documents: { documentIds: ['d1'] },
 };
 
 describe('registry-wide business-scope forwarding', () => {

--- a/packages/mcp-server/src/tools/charge-details.ts
+++ b/packages/mcp-server/src/tools/charge-details.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
-import type { McpGetChargesQuery, McpGetChargesQueryVariables } from '../gql/index.js';
+import type {
+  McpGetChargesByFiltersQuery,
+  McpGetChargesByFiltersQueryVariables,
+  McpGetChargesQuery,
+  McpGetChargesQueryVariables,
+} from '../gql/index.js';
+import { TIMELESS_DATE } from './dates.js';
 import {
   normalizeAmount,
   normalizeDocument,
@@ -35,47 +41,156 @@ export const GET_CHARGES_TOOL_NAME = 'accounter_get_charges';
 /** Lower than the flat detail tools because each charge nests its children. */
 export const MAX_CHARGE_IDS = 25;
 
-const getChargesInput = z.object({
-  chargeIds: z
-    .array(z.string().min(1))
-    .min(1)
-    .max(MAX_CHARGE_IDS)
-    .describe(
-      `The charge ids to fetch (1–${MAX_CHARGE_IDS}). Discover ids via accounter_search_charges.`,
-    ),
-  businessIds: businessIdsInput,
-  includeTransactions: z
-    .boolean()
-    .optional()
-    .default(true)
-    .describe('Include each charge’s linked transactions (default true).'),
-  includeDocuments: z
-    .boolean()
-    .optional()
-    .default(true)
-    .describe('Include each charge’s linked documents (default true).'),
-});
+const CHARGE_FILTER_IDS_CAP = 100;
+const CHARGE_FILTER_TAGS_CAP = 50;
+const CHARGE_FILTER_TEXT_MAX = 200;
+const MAX_FILTERED_CHARGES = 100;
+
+function optionalNonEmptyStringArray(max: number) {
+  return z.preprocess(
+    value => (Array.isArray(value) && value.length === 0 ? undefined : value),
+    z.array(z.string().min(1)).min(1).max(max).optional(),
+  );
+}
+
+const chargeSortByInput = z
+  .object({
+    field: z.enum(['DATE', 'AMOUNT', 'ABS_AMOUNT']),
+    asc: z.boolean().optional(),
+  })
+  .strict();
+
+const chargeFiltersInput = z
+  .object({
+    accountantStatus: z
+      .preprocess(
+        value => (Array.isArray(value) && value.length === 0 ? undefined : value),
+        z
+          .array(z.enum(['APPROVED', 'PENDING', 'UNAPPROVED']))
+          .min(1)
+          .max(3)
+          .optional(),
+      )
+      .optional(),
+    businessTrip: z.string().min(1).optional(),
+    byBusinessTrips: optionalNonEmptyStringArray(CHARGE_FILTER_IDS_CAP).optional(),
+    byBusinesses: optionalNonEmptyStringArray(CHARGE_FILTER_IDS_CAP).optional(),
+    byChargeTypes: z
+      .preprocess(
+        value => (Array.isArray(value) && value.length === 0 ? undefined : value),
+        z
+          .array(
+            z.enum([
+              'COMMON',
+              'CONVERSION',
+              'PAYROLL',
+              'INTERNAL',
+              'DIVIDEND',
+              'BUSINESS_TRIP',
+              'VAT',
+              'BANK_DEPOSIT',
+              'FOREIGN_SECURITIES',
+              'CREDITCARD_BANK',
+              'FINANCIAL',
+            ]),
+          )
+          .min(1)
+          .max(11)
+          .optional(),
+      )
+      .optional(),
+    byFinancialAccounts: optionalNonEmptyStringArray(CHARGE_FILTER_IDS_CAP).optional(),
+    byOwners: optionalNonEmptyStringArray(CHARGE_FILTER_IDS_CAP).optional(),
+    byTags: optionalNonEmptyStringArray(CHARGE_FILTER_TAGS_CAP).optional(),
+    chargesType: z.enum(['ALL', 'INCOME', 'EXPENSE']).optional(),
+    freeText: z.string().min(1).max(CHARGE_FILTER_TEXT_MAX).optional(),
+    fromAnyDate: TIMELESS_DATE.optional(),
+    fromDate: TIMELESS_DATE.optional(),
+    sortBy: chargeSortByInput.optional(),
+    toAnyDate: TIMELESS_DATE.optional(),
+    toDate: TIMELESS_DATE.optional(),
+    unbalanced: z.boolean().optional(),
+    withMissingCounterparty: z.boolean().optional(),
+    withOpenDocuments: z.boolean().optional(),
+    withoutDocuments: z.boolean().optional(),
+    withoutInvoice: z.boolean().optional(),
+    withoutLedger: z.boolean().optional(),
+    withoutReceipt: z.boolean().optional(),
+    withoutTransactions: z.boolean().optional(),
+  })
+  .strict();
+
+const getChargesInput = z
+  .object({
+    chargeIds: optionalNonEmptyStringArray(MAX_CHARGE_IDS)
+      .optional()
+      .describe(
+        `The charge ids to fetch (1–${MAX_CHARGE_IDS}). Discover ids via accounter_search_charges.`,
+      ),
+    filters: chargeFiltersInput
+      .optional()
+      .describe('Filter charges by any supported ChargeFilter predicate.'),
+    businessIds: businessIdsInput,
+    includeTransactions: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe('Include each charge’s linked transactions (default true).'),
+    includeDocuments: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe('Include each charge’s linked documents (default true).'),
+  })
+  .superRefine((value, context) => {
+    const hasIds = value.chargeIds !== undefined && value.chargeIds.length > 0;
+    const hasFilters =
+      value.filters !== undefined &&
+      Object.values(value.filters).some(filterValue => filterValue !== undefined);
+    if (!hasIds && !hasFilters) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['chargeIds'],
+        message: 'Provide chargeIds, filters, or both.',
+      });
+    }
+  });
 
 type GetChargesInput = z.infer<typeof getChargesInput>;
 
-const GET_CHARGES_QUERY = /* GraphQL */ `
-  query McpGetCharges(
-    $chargeIDs: [UUID!]!
-    $includeTransactions: Boolean!
-    $includeDocuments: Boolean!
-  ) {
-    chargesByIDs(chargeIDs: $chargeIDs) {
+const CHARGES_QUERY_DOCUMENT = /* GraphQL */ `
+  fragment McpChargeDetailTransactionFields on Transaction {
+    __typename
+    id
+    chargeId
+    eventDate
+    effectiveDate
+    direction
+    amount {
+      raw
+      formatted
+      currency
+    }
+    sourceDescription
+    isFee
+    counterparty {
       id
-      userDescription
-      owner {
-        id
-        name
-      }
-      counterparty {
-        id
-        name
-      }
-      totalAmount {
+      name
+    }
+    account {
+      id
+      name
+    }
+  }
+
+  fragment McpChargeDetailDocumentFields on Document {
+    __typename
+    id
+    documentType
+    ... on FinancialDocument {
+      serialNumber
+      date
+      amount {
         raw
         formatted
         currency
@@ -85,136 +200,202 @@ const GET_CHARGES_QUERY = /* GraphQL */ `
         formatted
         currency
       }
-      withholdingTax {
+      creditor {
+        id
+        name
+      }
+      debtor {
+        id
+        name
+      }
+    }
+    ... on Unprocessed {
+      serialNumber
+      date
+      amount {
         raw
         formatted
         currency
       }
-      minEventDate
-      maxEventDate
-      minDebitDate
-      maxDebitDate
-      minDocumentsDate
-      maxDocumentsDate
-      tags {
+      vat {
+        raw
+        formatted
+        currency
+      }
+      creditor {
         id
         name
       }
-      metadata {
-        createdAt
-        updatedAt
-        invoicesCount
-        receiptsCount
-        documentsCount
-        transactionsCount
-        ledgerCount
-        miscExpensesCount
-        openDocuments
-        invalidLedger
-      }
-      transactions @include(if: $includeTransactions) {
-        __typename
+      debtor {
         id
-        chargeId
-        eventDate
-        effectiveDate
-        direction
-        amount {
-          raw
-          formatted
-          currency
-        }
-        sourceDescription
-        isFee
-        counterparty {
-          id
-          name
-        }
-        account {
-          id
-          name
-        }
+        name
       }
-      additionalDocuments @include(if: $includeDocuments) {
-        __typename
+    }
+    ... on OtherDocument {
+      serialNumber
+      date
+      amount {
+        raw
+        formatted
+        currency
+      }
+      vat {
+        raw
+        formatted
+        currency
+      }
+      creditor {
         id
-        documentType
-        ... on FinancialDocument {
-          serialNumber
-          date
-          amount {
-            raw
-            formatted
-            currency
-          }
-          vat {
-            raw
-            formatted
-            currency
-          }
-          creditor {
-            id
-            name
-          }
-          debtor {
-            id
-            name
-          }
-        }
-        ... on Unprocessed {
-          serialNumber
-          date
-          amount {
-            raw
-            formatted
-            currency
-          }
-          vat {
-            raw
-            formatted
-            currency
-          }
-          creditor {
-            id
-            name
-          }
-          debtor {
-            id
-            name
-          }
-        }
-        ... on OtherDocument {
-          serialNumber
-          date
-          amount {
-            raw
-            formatted
-            currency
-          }
-          vat {
-            raw
-            formatted
-            currency
-          }
-          creditor {
-            id
-            name
-          }
-          debtor {
-            id
-            name
-          }
-        }
-        description
-        file
-        image
-        charge {
-          id
-        }
+        name
+      }
+      debtor {
+        id
+        name
+      }
+    }
+    description
+    file
+    image
+    charge {
+      id
+    }
+  }
+
+  fragment McpChargeDetailFields on Charge {
+    id
+    userDescription
+    owner {
+      id
+      name
+    }
+    counterparty {
+      id
+      name
+    }
+    totalAmount {
+      raw
+      formatted
+      currency
+    }
+    vat {
+      raw
+      formatted
+      currency
+    }
+    withholdingTax {
+      raw
+      formatted
+      currency
+    }
+    minEventDate
+    maxEventDate
+    minDebitDate
+    maxDebitDate
+    minDocumentsDate
+    maxDocumentsDate
+    tags {
+      id
+      name
+    }
+    metadata {
+      createdAt
+      updatedAt
+      invoicesCount
+      receiptsCount
+      documentsCount
+      transactionsCount
+      ledgerCount
+      miscExpensesCount
+      openDocuments
+      invalidLedger
+    }
+    transactions @include(if: $includeTransactions) {
+      ...McpChargeDetailTransactionFields
+    }
+    additionalDocuments @include(if: $includeDocuments) {
+      ...McpChargeDetailDocumentFields
+    }
+  }
+
+  query McpGetCharges(
+    $chargeIDs: [UUID!]!
+    $includeTransactions: Boolean!
+    $includeDocuments: Boolean!
+  ) {
+    chargesByIDs(chargeIDs: $chargeIDs) {
+      ...McpChargeDetailFields
+    }
+  }
+
+  query McpGetChargesByFilters(
+    $filters: ChargeFilter
+    $page: Int!
+    $limit: Int!
+    $includeTransactions: Boolean!
+    $includeDocuments: Boolean!
+  ) {
+    allCharges(filters: $filters, page: $page, limit: $limit) {
+      nodes {
+        ...McpChargeDetailFields
+      }
+      pageInfo {
+        totalPages
+        totalRecords
+        currentPage
+        pageSize
       }
     }
   }
 `;
+
+type ChargeFiltersInput = z.infer<typeof chargeFiltersInput>;
+
+function intersectOwners(
+  requested: readonly string[] | undefined,
+  scopeBusinessIds: readonly string[],
+): string[] {
+  const scopeSet = new Set(scopeBusinessIds);
+  if (!requested || requested.length === 0) {
+    return [...scopeBusinessIds];
+  }
+  return requested.filter(id => scopeSet.has(id));
+}
+
+function buildChargeFilters(
+  input: ChargeFiltersInput,
+  scopeBusinessIds: readonly string[],
+): NonNullable<McpGetChargesByFiltersQueryVariables['filters']> {
+  const filters: NonNullable<McpGetChargesByFiltersQueryVariables['filters']> = {
+    byOwners: intersectOwners(input.byOwners, scopeBusinessIds),
+  };
+  if (input.accountantStatus) filters.accountantStatus = [...input.accountantStatus];
+  if (input.businessTrip) filters.businessTrip = input.businessTrip;
+  if (input.byBusinessTrips) filters.byBusinessTrips = [...input.byBusinessTrips];
+  if (input.byBusinesses) filters.byBusinesses = [...input.byBusinesses];
+  if (input.byChargeTypes) filters.byChargeTypes = [...input.byChargeTypes];
+  if (input.byFinancialAccounts) filters.byFinancialAccounts = [...input.byFinancialAccounts];
+  if (input.byTags) filters.byTags = [...input.byTags];
+  if (input.chargesType) filters.chargesType = input.chargesType;
+  if (input.freeText) filters.freeText = input.freeText;
+  if (input.fromAnyDate) filters.fromAnyDate = input.fromAnyDate;
+  if (input.fromDate) filters.fromDate = input.fromDate;
+  if (input.sortBy) filters.sortBy = { ...input.sortBy };
+  if (input.toAnyDate) filters.toAnyDate = input.toAnyDate;
+  if (input.toDate) filters.toDate = input.toDate;
+  if (input.unbalanced !== undefined) filters.unbalanced = input.unbalanced;
+  if (input.withMissingCounterparty !== undefined) {
+    filters.withMissingCounterparty = input.withMissingCounterparty;
+  }
+  if (input.withOpenDocuments !== undefined) filters.withOpenDocuments = input.withOpenDocuments;
+  if (input.withoutDocuments !== undefined) filters.withoutDocuments = input.withoutDocuments;
+  if (input.withoutInvoice !== undefined) filters.withoutInvoice = input.withoutInvoice;
+  if (input.withoutLedger !== undefined) filters.withoutLedger = input.withoutLedger;
+  if (input.withoutReceipt !== undefined) filters.withoutReceipt = input.withoutReceipt;
+  if (input.withoutTransactions !== undefined) {
+    filters.withoutTransactions = input.withoutTransactions;
+  }
+  return filters;
+}
 
 type RawCharge = McpGetChargesQuery['chargesByIDs'][number];
 
@@ -270,18 +451,52 @@ function normalizeCharge(charge: RawCharge): NormalizedCharge {
 }
 
 async function handler(input: GetChargesInput, context: ToolExecutionContext): Promise<ToolResult> {
-  const variables: McpGetChargesQueryVariables = {
-    chargeIDs: input.chargeIds,
-    includeTransactions: input.includeTransactions,
-    includeDocuments: input.includeDocuments,
-  };
-  const data = await context.client.query<McpGetChargesQuery>(
-    { query: GET_CHARGES_QUERY, variables },
-    context.upstream,
-  );
+  const hasChargeIds = input.chargeIds !== undefined && input.chargeIds.length > 0;
+  const hasFilters =
+    input.filters !== undefined &&
+    Object.values(input.filters).some(filterValue => filterValue !== undefined);
+  const usingIds = hasChargeIds && !hasFilters;
+
+  const byIdsData = usingIds
+    ? await context.client.query<McpGetChargesQuery>(
+        {
+          query: CHARGES_QUERY_DOCUMENT,
+          operationName: 'McpGetCharges',
+          variables: {
+            chargeIDs: input.chargeIds!,
+            includeTransactions: input.includeTransactions,
+            includeDocuments: input.includeDocuments,
+          } satisfies McpGetChargesQueryVariables,
+        },
+        context.upstream,
+      )
+    : null;
+
+  const filteredData = usingIds
+    ? null
+    : await context.client.query<McpGetChargesByFiltersQuery>(
+        {
+          query: CHARGES_QUERY_DOCUMENT,
+          operationName: 'McpGetChargesByFilters',
+          variables: {
+            filters: buildChargeFilters(input.filters ?? {}, context.readScope.businessIds),
+            page: 0,
+            limit: MAX_FILTERED_CHARGES,
+            includeTransactions: input.includeTransactions,
+            includeDocuments: input.includeDocuments,
+          } satisfies McpGetChargesByFiltersQueryVariables,
+        },
+        context.upstream,
+      );
+
+  const rawCharges = usingIds
+    ? (byIdsData?.chargesByIDs ?? [])
+    : (filteredData?.allCharges.nodes ?? []);
+  const requestedChargeIds = hasChargeIds ? new Set(input.chargeIds) : null;
 
   const scopeIds = new Set(context.readScope.businessIds);
-  const charges = (data.chargesByIDs ?? [])
+  const charges = rawCharges
+    .filter(charge => requestedChargeIds === null || requestedChargeIds.has(charge.id))
     // Defense-in-depth owner filter (see `charges.ts`): keep a charge only when
     // its owner is in the resolved read scope. A charge with no resolvable owner
     // is kept — RLS already returned it and there is no owner to reject it by.
@@ -291,14 +506,23 @@ async function handler(input: GetChargesInput, context: ToolExecutionContext): P
     })
     .map(normalizeCharge);
 
+  const total =
+    charges.length === 0
+      ? 0
+      : !usingIds && !hasChargeIds
+        ? (filteredData?.allCharges.pageInfo.totalRecords ?? charges.length)
+        : charges.length;
+
   return shapeListResult({
     items: charges,
     itemsKey: 'charges',
-    total: charges.length,
+    total,
     extra: { scope: { businessIds: context.readScope.businessIds } },
     summarize: (shown, total) =>
       total === 0
-        ? 'No charges were found for the given ids (they may be outside your authorized businesses).'
+        ? usingIds
+          ? 'No charges were found for the given ids (they may be outside your authorized businesses).'
+          : 'No charges matched the given filters.'
         : `Found ${total} charge(s)${shown < total ? ` (showing ${shown})` : ''}.`,
   });
 }
@@ -306,7 +530,7 @@ async function handler(input: GetChargesInput, context: ToolExecutionContext): P
 export const getChargesTool: ToolDefinition<typeof getChargesInput> = {
   name: GET_CHARGES_TOOL_NAME,
   description:
-    'Fetch charges by id with their full detail: owner, counterparty, amounts (total, VAT, withholding), dates, tags, metadata counts, and — by default — their linked transactions and documents. Read-only. ' +
+    'Fetch charges by id and/or by filters (all ChargeFilter fields), with full detail: owner, counterparty, amounts (total, VAT, withholding), dates, tags, metadata counts, and — by default — linked transactions and documents. Read-only. ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: getChargesInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/charge-details.ts
+++ b/packages/mcp-server/src/tools/charge-details.ts
@@ -1,0 +1,314 @@
+import { z } from 'zod';
+import type { McpGetChargesQuery, McpGetChargesQueryVariables } from '../gql/index.js';
+import {
+  normalizeAmount,
+  normalizeDocument,
+  normalizeEntity,
+  normalizeTransaction,
+  type NormalizedDocument,
+  type NormalizedTransaction,
+  type RawDocument,
+  type RawTransaction,
+} from './entity-shapes.js';
+import { shapeListResult } from './output.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import { businessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
+
+/**
+ * Detail tool: fetch charges by id with their transactions and documents
+ * (spec §8.2).
+ *
+ * Read-only. Results are narrowed to the caller's authorized businesses by
+ * upstream RLS (the resolved read scope travels as `x-business-scope`); as
+ * defense-in-depth — mirroring `charges.ts` — any charge whose `owner` falls
+ * outside the resolved read scope is dropped before shaping.
+ *
+ * Charges nest transactions and documents, so a single charge can be large.
+ * The id cap is deliberately lower than the other detail tools, and
+ * `includeTransactions` / `includeDocuments` let a caller trade nesting for
+ * more charges per call. `shapeListResult` still applies the byte budget,
+ * dropping whole trailing charges if the payload is too big.
+ */
+
+export const GET_CHARGES_TOOL_NAME = 'accounter_get_charges';
+
+/** Lower than the flat detail tools because each charge nests its children. */
+export const MAX_CHARGE_IDS = 25;
+
+const getChargesInput = z.object({
+  chargeIds: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(MAX_CHARGE_IDS)
+    .describe(
+      `The charge ids to fetch (1–${MAX_CHARGE_IDS}). Discover ids via accounter_search_charges.`,
+    ),
+  businessIds: businessIdsInput,
+  includeTransactions: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Include each charge’s linked transactions (default true).'),
+  includeDocuments: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Include each charge’s linked documents (default true).'),
+});
+
+type GetChargesInput = z.infer<typeof getChargesInput>;
+
+const GET_CHARGES_QUERY = /* GraphQL */ `
+  query McpGetCharges(
+    $chargeIDs: [UUID!]!
+    $includeTransactions: Boolean!
+    $includeDocuments: Boolean!
+  ) {
+    chargesByIDs(chargeIDs: $chargeIDs) {
+      id
+      userDescription
+      owner {
+        id
+        name
+      }
+      counterparty {
+        id
+        name
+      }
+      totalAmount {
+        raw
+        formatted
+        currency
+      }
+      vat {
+        raw
+        formatted
+        currency
+      }
+      withholdingTax {
+        raw
+        formatted
+        currency
+      }
+      minEventDate
+      maxEventDate
+      minDebitDate
+      maxDebitDate
+      minDocumentsDate
+      maxDocumentsDate
+      tags {
+        id
+        name
+      }
+      metadata {
+        createdAt
+        updatedAt
+        invoicesCount
+        receiptsCount
+        documentsCount
+        transactionsCount
+        ledgerCount
+        miscExpensesCount
+        openDocuments
+        invalidLedger
+      }
+      transactions @include(if: $includeTransactions) {
+        __typename
+        id
+        chargeId
+        eventDate
+        effectiveDate
+        direction
+        amount {
+          raw
+          formatted
+          currency
+        }
+        sourceDescription
+        isFee
+        counterparty {
+          id
+          name
+        }
+        account {
+          id
+          name
+        }
+      }
+      additionalDocuments @include(if: $includeDocuments) {
+        __typename
+        id
+        documentType
+        ... on FinancialDocument {
+          serialNumber
+          date
+          amount {
+            raw
+            formatted
+            currency
+          }
+          vat {
+            raw
+            formatted
+            currency
+          }
+          creditor {
+            id
+            name
+          }
+          debtor {
+            id
+            name
+          }
+        }
+        ... on Unprocessed {
+          serialNumber
+          date
+          amount {
+            raw
+            formatted
+            currency
+          }
+          vat {
+            raw
+            formatted
+            currency
+          }
+          creditor {
+            id
+            name
+          }
+          debtor {
+            id
+            name
+          }
+        }
+        ... on OtherDocument {
+          serialNumber
+          date
+          amount {
+            raw
+            formatted
+            currency
+          }
+          vat {
+            raw
+            formatted
+            currency
+          }
+          creditor {
+            id
+            name
+          }
+          debtor {
+            id
+            name
+          }
+        }
+        description
+        file
+        image
+        charge {
+          id
+        }
+      }
+    }
+  }
+`;
+
+type RawCharge = McpGetChargesQuery['chargesByIDs'][number];
+
+interface NormalizedCharge {
+  id: string;
+  description: string | null;
+  ownerId: string | null;
+  ownerName: string | null;
+  counterparty: { id: string; name: string | null } | null;
+  totalAmount: ReturnType<typeof normalizeAmount>;
+  vat: ReturnType<typeof normalizeAmount>;
+  withholdingTax: ReturnType<typeof normalizeAmount>;
+  dates: {
+    minEventDate: string | null;
+    maxEventDate: string | null;
+    minDebitDate: string | null;
+    maxDebitDate: string | null;
+    minDocumentsDate: string | null;
+    maxDocumentsDate: string | null;
+  };
+  tags: Array<{ id: string; name: string }>;
+  metadata: Record<string, unknown> | null;
+  transactions: NormalizedTransaction[];
+  documents: NormalizedDocument[];
+}
+
+function normalizeCharge(charge: RawCharge): NormalizedCharge {
+  const owner = normalizeEntity(charge.owner);
+  return {
+    id: charge.id,
+    description: charge.userDescription ?? null,
+    ownerId: owner?.id ?? null,
+    ownerName: owner?.name ?? null,
+    counterparty: normalizeEntity(charge.counterparty),
+    totalAmount: normalizeAmount(charge.totalAmount),
+    vat: normalizeAmount(charge.vat),
+    withholdingTax: normalizeAmount(charge.withholdingTax),
+    dates: {
+      minEventDate: charge.minEventDate ?? null,
+      maxEventDate: charge.maxEventDate ?? null,
+      minDebitDate: charge.minDebitDate ?? null,
+      maxDebitDate: charge.maxDebitDate ?? null,
+      minDocumentsDate: charge.minDocumentsDate ?? null,
+      maxDocumentsDate: charge.maxDocumentsDate ?? null,
+    },
+    tags: (charge.tags ?? []).map(tag => ({ id: tag.id, name: tag.name })),
+    metadata: charge.metadata ? { ...charge.metadata } : null,
+    transactions: (charge.transactions ?? []).map(raw =>
+      normalizeTransaction(raw as RawTransaction),
+    ),
+    documents: (charge.additionalDocuments ?? []).map(raw => normalizeDocument(raw as RawDocument)),
+  };
+}
+
+async function handler(input: GetChargesInput, context: ToolExecutionContext): Promise<ToolResult> {
+  const variables: McpGetChargesQueryVariables = {
+    chargeIDs: input.chargeIds,
+    includeTransactions: input.includeTransactions,
+    includeDocuments: input.includeDocuments,
+  };
+  const data = await context.client.query<McpGetChargesQuery>(
+    { query: GET_CHARGES_QUERY, variables },
+    context.upstream,
+  );
+
+  const scopeIds = new Set(context.readScope.businessIds);
+  const charges = (data.chargesByIDs ?? [])
+    // Defense-in-depth owner filter (see `charges.ts`): keep a charge only when
+    // its owner is in the resolved read scope. A charge with no resolvable owner
+    // is kept — RLS already returned it and there is no owner to reject it by.
+    .filter(charge => {
+      const ownerId = charge.owner?.id;
+      return ownerId == null || scopeIds.has(ownerId);
+    })
+    .map(normalizeCharge);
+
+  return shapeListResult({
+    items: charges,
+    itemsKey: 'charges',
+    total: charges.length,
+    extra: { scope: { businessIds: context.readScope.businessIds } },
+    summarize: (shown, total) =>
+      total === 0
+        ? 'No charges were found for the given ids (they may be outside your authorized businesses).'
+        : `Found ${total} charge(s)${shown < total ? ` (showing ${shown})` : ''}.`,
+  });
+}
+
+export const getChargesTool: ToolDefinition<typeof getChargesInput> = {
+  name: GET_CHARGES_TOOL_NAME,
+  description:
+    'Fetch charges by id with their full detail: owner, counterparty, amounts (total, VAT, withholding), dates, tags, metadata counts, and — by default — their linked transactions and documents. Read-only. ' +
+    SCOPE_DESCRIPTION_SUFFIX,
+  inputSchema: getChargesInput,
+  policy: { requiresBusinessScope: true, dataClassification: 'business' },
+  handler,
+};

--- a/packages/mcp-server/src/tools/charge-details.ts
+++ b/packages/mcp-server/src/tools/charge-details.ts
@@ -5,6 +5,7 @@ import type {
   McpGetChargesQuery,
   McpGetChargesQueryVariables,
 } from '../gql/index.js';
+import { UpstreamError } from '../upstream/graphql-client.js';
 import { TIMELESS_DATE } from './dates.js';
 import {
   normalizeAmount,
@@ -397,6 +398,16 @@ function buildChargeFilters(
   return filters;
 }
 
+function isNotFoundByIdUpstreamError(error: unknown): boolean {
+  if (!(error instanceof UpstreamError) || error.code !== 'UPSTREAM_ERROR') {
+    return false;
+  }
+  return (
+    /^Charge ID=".+" not found$/i.test(error.message) ||
+    /^Couldn't find any charges$/i.test(error.message)
+  );
+}
+
 type RawCharge = McpGetChargesQuery['chargesByIDs'][number];
 
 interface NormalizedCharge {
@@ -458,18 +469,28 @@ async function handler(input: GetChargesInput, context: ToolExecutionContext): P
   const usingIds = hasChargeIds && !hasFilters;
 
   const byIdsData = usingIds
-    ? await context.client.query<McpGetChargesQuery>(
-        {
-          query: CHARGES_QUERY_DOCUMENT,
-          operationName: 'McpGetCharges',
-          variables: {
-            chargeIDs: input.chargeIds!,
-            includeTransactions: input.includeTransactions,
-            includeDocuments: input.includeDocuments,
-          } satisfies McpGetChargesQueryVariables,
-        },
-        context.upstream,
-      )
+    ? await context.client
+        .query<McpGetChargesQuery>(
+          {
+            query: CHARGES_QUERY_DOCUMENT,
+            operationName: 'McpGetCharges',
+            variables: {
+              chargeIDs: input.chargeIds!,
+              includeTransactions: input.includeTransactions,
+              includeDocuments: input.includeDocuments,
+            } satisfies McpGetChargesQueryVariables,
+          },
+          context.upstream,
+        )
+        .catch(error => {
+          // Upstream `chargesByIDs` throws for any missing id. Normalize this
+          // specific not-found condition to an empty success result so callers
+          // get consistent read semantics for out-of-scope/unknown ids.
+          if (isNotFoundByIdUpstreamError(error)) {
+            return { chargesByIDs: [] } satisfies McpGetChargesQuery;
+          }
+          throw error;
+        })
     : null;
 
   const filteredData = usingIds

--- a/packages/mcp-server/src/tools/document-details.ts
+++ b/packages/mcp-server/src/tools/document-details.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
-import type { McpGetDocumentsQuery, McpGetDocumentsQueryVariables } from '../gql/index.js';
+import type {
+  McpGetDocumentsQuery,
+  McpGetDocumentsQueryVariables,
+  McpSearchDocumentsByFiltersQuery,
+  McpSearchDocumentsByFiltersQueryVariables,
+} from '../gql/index.js';
+import { TIMELESS_DATE } from './dates.js';
 import { MAX_DETAIL_IDS, normalizeDocument, type RawDocument } from './entity-shapes.js';
 import { shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
@@ -18,118 +24,265 @@ import { businessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
 export const GET_DOCUMENTS_TOOL_NAME = 'accounter_get_documents';
 
-const getDocumentsInput = z.object({
-  documentIds: z
-    .array(z.string().min(1))
-    .min(1)
-    .max(MAX_DETAIL_IDS)
-    .describe(
-      `The document ids to fetch (1–${MAX_DETAIL_IDS}). Discover ids via accounter_get_charges ` +
-        '(each charge lists its documents).',
-    ),
-  businessIds: businessIdsInput,
-});
+const DOCUMENT_FILTER_IDS_CAP = 100;
+
+const DOCUMENT_TYPES = [
+  'INVOICE',
+  'RECEIPT',
+  'INVOICE_RECEIPT',
+  'CREDIT_INVOICE',
+  'PROFORMA',
+  'UNPROCESSED',
+  'OTHER',
+] as const;
+
+function optionalNonEmptyStringArray(max: number) {
+  return z.preprocess(
+    value => (Array.isArray(value) && value.length === 0 ? undefined : value),
+    z.array(z.string().min(1)).min(1).max(max).optional(),
+  );
+}
+
+const documentsFiltersInput = z
+  .object({
+    businessIds: optionalNonEmptyStringArray(DOCUMENT_FILTER_IDS_CAP)
+      .optional()
+      .describe('Include only documents connected to these business ids.'),
+    ownerIds: optionalNonEmptyStringArray(DOCUMENT_FILTER_IDS_CAP)
+      .optional()
+      .describe('Include only documents owned by these business ids.'),
+    chargeIds: optionalNonEmptyStringArray(DOCUMENT_FILTER_IDS_CAP)
+      .optional()
+      .describe('Include only documents linked to these charge ids.'),
+    fromDate: TIMELESS_DATE.optional().describe('Only documents dated on/after this date.'),
+    toDate: TIMELESS_DATE.optional().describe('Only documents dated on/before this date.'),
+    unmatched: z
+      .boolean()
+      .optional()
+      .describe('Include only documents without matching transactions.'),
+    type: z
+      .preprocess(
+        value => (Array.isArray(value) && value.length === 0 ? undefined : value),
+        z.array(z.enum(DOCUMENT_TYPES)).min(1).max(DOCUMENT_TYPES.length).optional(),
+      )
+      .optional()
+      .describe('Include only these document types.'),
+    missingCounterparty: z
+      .boolean()
+      .optional()
+      .describe('Include only documents with missing creditor/debtor.'),
+    missingInfo: z
+      .boolean()
+      .optional()
+      .describe('Include only documents that fail validation checks.'),
+    freeText: z
+      .string()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe(
+        'Free text search across serial number, amount, description, remarks, and party names.',
+      ),
+  })
+  .strict();
+
+const getDocumentsInput = z
+  .object({
+    documentIds: optionalNonEmptyStringArray(MAX_DETAIL_IDS)
+      .optional()
+      .describe(
+        `The document ids to fetch (1–${MAX_DETAIL_IDS}). Discover ids via accounter_get_charges ` +
+          '(each charge lists its documents).',
+      ),
+    filters: documentsFiltersInput
+      .optional()
+      .describe('Filter documents by any supported documentsByFilters predicate.'),
+    businessIds: businessIdsInput,
+  })
+  .superRefine((value, context) => {
+    const hasIds = value.documentIds !== undefined && value.documentIds.length > 0;
+    const hasFilters =
+      value.filters !== undefined &&
+      Object.values(value.filters).some(filterValue => filterValue !== undefined);
+    if (!hasIds && !hasFilters) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['documentIds'],
+        message: 'Provide documentIds, filters, or both.',
+      });
+    }
+  });
 
 type GetDocumentsInput = z.infer<typeof getDocumentsInput>;
 
-const GET_DOCUMENTS_QUERY = /* GraphQL */ `
-  query McpGetDocuments($documentIds: [UUID!]!) {
-    documentsByIds(documentIds: $documentIds) {
-      __typename
-      id
-      documentType
-      ... on FinancialDocument {
-        serialNumber
-        date
-        amount {
-          raw
-          formatted
-          currency
-        }
-        vat {
-          raw
-          formatted
-          currency
-        }
-        creditor {
-          id
-          name
-        }
-        debtor {
-          id
-          name
-        }
+type DocumentsFiltersInput = z.infer<typeof documentsFiltersInput>;
+
+const DOCUMENTS_QUERY_DOCUMENT = /* GraphQL */ `
+  fragment McpDocumentDetailsFields on Document {
+    __typename
+    id
+    documentType
+    ... on FinancialDocument {
+      serialNumber
+      date
+      amount {
+        raw
+        formatted
+        currency
       }
-      ... on Unprocessed {
-        serialNumber
-        date
-        amount {
-          raw
-          formatted
-          currency
-        }
-        vat {
-          raw
-          formatted
-          currency
-        }
-        creditor {
-          id
-          name
-        }
-        debtor {
-          id
-          name
-        }
+      vat {
+        raw
+        formatted
+        currency
       }
-      ... on OtherDocument {
-        serialNumber
-        date
-        amount {
-          raw
-          formatted
-          currency
-        }
-        vat {
-          raw
-          formatted
-          currency
-        }
-        creditor {
-          id
-          name
-        }
-        debtor {
-          id
-          name
-        }
-      }
-      description
-      file
-      image
-      charge {
+      creditor {
         id
-        owner {
-          id
-        }
+        name
+      }
+      debtor {
+        id
+        name
+      }
+    }
+    ... on Unprocessed {
+      serialNumber
+      date
+      amount {
+        raw
+        formatted
+        currency
+      }
+      vat {
+        raw
+        formatted
+        currency
+      }
+      creditor {
+        id
+        name
+      }
+      debtor {
+        id
+        name
+      }
+    }
+    ... on OtherDocument {
+      serialNumber
+      date
+      amount {
+        raw
+        formatted
+        currency
+      }
+      vat {
+        raw
+        formatted
+        currency
+      }
+      creditor {
+        id
+        name
+      }
+      debtor {
+        id
+        name
+      }
+    }
+    description
+    file
+    image
+    charge {
+      id
+      owner {
+        id
       }
     }
   }
+
+  query McpGetDocuments($documentIds: [UUID!]!) {
+    documentsByIds(documentIds: $documentIds) {
+      ...McpDocumentDetailsFields
+    }
+  }
+
+  query McpSearchDocumentsByFilters($filters: DocumentsFilters!) {
+    documentsByFilters(filters: $filters) {
+      ...McpDocumentDetailsFields
+    }
+  }
 `;
+
+function intersectOwners(
+  requested: readonly string[] | undefined,
+  scopeBusinessIds: readonly string[],
+): string[] {
+  const scopeSet = new Set(scopeBusinessIds);
+  if (!requested || requested.length === 0) {
+    return [...scopeBusinessIds];
+  }
+  return requested.filter(id => scopeSet.has(id));
+}
+
+function buildDocumentsFilters(
+  input: DocumentsFiltersInput,
+  scopeBusinessIds: readonly string[],
+): McpSearchDocumentsByFiltersQueryVariables['filters'] {
+  const ownerIds = intersectOwners(input.ownerIds, scopeBusinessIds);
+  const filters: McpSearchDocumentsByFiltersQueryVariables['filters'] = {
+    ownerIDs: ownerIds,
+  };
+  if (input.businessIds) filters.businessIDs = [...input.businessIds];
+  if (input.chargeIds) filters.chargeIDs = [...input.chargeIds];
+  if (input.fromDate) filters.fromDate = input.fromDate;
+  if (input.toDate) filters.toDate = input.toDate;
+  if (input.unmatched !== undefined) filters.unmatched = input.unmatched;
+  if (input.type) filters.type = [...input.type];
+  if (input.missingCounterparty !== undefined) {
+    filters.missingCounterparty = input.missingCounterparty;
+  }
+  if (input.missingInfo !== undefined) filters.missingInfo = input.missingInfo;
+  if (input.freeText) filters.freeText = input.freeText;
+  return filters;
+}
 
 async function handler(
   input: GetDocumentsInput,
   context: ToolExecutionContext,
 ): Promise<ToolResult> {
-  const variables: McpGetDocumentsQueryVariables = { documentIds: input.documentIds };
-  const data = await context.client.query<McpGetDocumentsQuery>(
-    { query: GET_DOCUMENTS_QUERY, variables },
-    context.upstream,
-  );
+  const hasDocumentIds = input.documentIds !== undefined && input.documentIds.length > 0;
+  const hasFilters =
+    input.filters !== undefined &&
+    Object.values(input.filters).some(filterValue => filterValue !== undefined);
+  const usingIds = hasDocumentIds && !hasFilters;
+  const data = usingIds
+    ? await context.client.query<McpGetDocumentsQuery>(
+        {
+          query: DOCUMENTS_QUERY_DOCUMENT,
+          operationName: 'McpGetDocuments',
+          variables: { documentIds: input.documentIds! } satisfies McpGetDocumentsQueryVariables,
+        },
+        context.upstream,
+      )
+    : await context.client.query<McpSearchDocumentsByFiltersQuery>(
+        {
+          query: DOCUMENTS_QUERY_DOCUMENT,
+          operationName: 'McpSearchDocumentsByFilters',
+          variables: {
+            filters: buildDocumentsFilters(input.filters ?? {}, context.readScope.businessIds),
+          } satisfies McpSearchDocumentsByFiltersQueryVariables,
+        },
+        context.upstream,
+      );
 
   const scopeIds = new Set(context.readScope.businessIds);
-  const raw = (data.documentsByIds ?? []) as RawDocument[];
+  const raw = (
+    usingIds
+      ? (data as McpGetDocumentsQuery).documentsByIds
+      : (data as McpSearchDocumentsByFiltersQuery).documentsByFilters
+  ) as RawDocument[];
+  const requestedDocumentIds = hasDocumentIds ? new Set(input.documentIds) : null;
   const documents = raw
+    .filter(document => requestedDocumentIds === null || requestedDocumentIds.has(document.id))
     // Defense-in-depth owner filter: keep a document only when its owning
     // charge's owner is in scope. A document with no resolvable charge/owner is
     // kept — RLS already returned it, and there is no owner to reject it by.
@@ -146,7 +299,9 @@ async function handler(
     extra: { scope: { businessIds: context.readScope.businessIds } },
     summarize: (shown, total) =>
       total === 0
-        ? 'No documents were found for the given ids (they may be outside your authorized businesses).'
+        ? usingIds
+          ? 'No documents were found for the given ids (they may be outside your authorized businesses).'
+          : 'No documents matched the given filters.'
         : `Found ${total} document(s)${shown < total ? ` (showing ${shown})` : ''}.`,
   });
 }
@@ -154,7 +309,7 @@ async function handler(
 export const getDocumentsTool: ToolDefinition<typeof getDocumentsInput> = {
   name: GET_DOCUMENTS_TOOL_NAME,
   description:
-    'Fetch documents (invoices, receipts, credit invoices, …) by id, with type, serial number, date, amount, VAT, creditor/debtor, and file/image links. Read-only. ' +
+    'Fetch documents (invoices, receipts, credit invoices, …) either by id or by filters (owners, charge ids, date range, type, unmatched/missing-info flags, and free-text), with type, serial number, date, amount, VAT, creditor/debtor, and file/image links. Read-only. ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: getDocumentsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/document-details.ts
+++ b/packages/mcp-server/src/tools/document-details.ts
@@ -1,0 +1,162 @@
+import { z } from 'zod';
+import type { McpGetDocumentsQuery, McpGetDocumentsQueryVariables } from '../gql/index.js';
+import { MAX_DETAIL_IDS, normalizeDocument, type RawDocument } from './entity-shapes.js';
+import { shapeListResult } from './output.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import { businessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
+
+/**
+ * Detail tool: fetch documents (invoices, receipts, …) by id (spec §8.2).
+ *
+ * Read-only. Upstream RLS narrows the fetch to the caller's authorized
+ * businesses (scope forwarded as `x-business-scope` on `context.upstream`); as
+ * defense-in-depth — mirroring `charges.ts` — any document whose owning charge
+ * resolves to an owner outside the resolved read scope is dropped before the
+ * result is shaped, so the tool stays correct even if upstream ever runs under
+ * a scope-bypassing role.
+ */
+
+export const GET_DOCUMENTS_TOOL_NAME = 'accounter_get_documents';
+
+const getDocumentsInput = z.object({
+  documentIds: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(MAX_DETAIL_IDS)
+    .describe(
+      `The document ids to fetch (1–${MAX_DETAIL_IDS}). Discover ids via accounter_get_charges ` +
+        '(each charge lists its documents).',
+    ),
+  businessIds: businessIdsInput,
+});
+
+type GetDocumentsInput = z.infer<typeof getDocumentsInput>;
+
+const GET_DOCUMENTS_QUERY = /* GraphQL */ `
+  query McpGetDocuments($documentIds: [UUID!]!) {
+    documentsByIds(documentIds: $documentIds) {
+      __typename
+      id
+      documentType
+      ... on FinancialDocument {
+        serialNumber
+        date
+        amount {
+          raw
+          formatted
+          currency
+        }
+        vat {
+          raw
+          formatted
+          currency
+        }
+        creditor {
+          id
+          name
+        }
+        debtor {
+          id
+          name
+        }
+      }
+      ... on Unprocessed {
+        serialNumber
+        date
+        amount {
+          raw
+          formatted
+          currency
+        }
+        vat {
+          raw
+          formatted
+          currency
+        }
+        creditor {
+          id
+          name
+        }
+        debtor {
+          id
+          name
+        }
+      }
+      ... on OtherDocument {
+        serialNumber
+        date
+        amount {
+          raw
+          formatted
+          currency
+        }
+        vat {
+          raw
+          formatted
+          currency
+        }
+        creditor {
+          id
+          name
+        }
+        debtor {
+          id
+          name
+        }
+      }
+      description
+      file
+      image
+      charge {
+        id
+        owner {
+          id
+        }
+      }
+    }
+  }
+`;
+
+async function handler(
+  input: GetDocumentsInput,
+  context: ToolExecutionContext,
+): Promise<ToolResult> {
+  const variables: McpGetDocumentsQueryVariables = { documentIds: input.documentIds };
+  const data = await context.client.query<McpGetDocumentsQuery>(
+    { query: GET_DOCUMENTS_QUERY, variables },
+    context.upstream,
+  );
+
+  const scopeIds = new Set(context.readScope.businessIds);
+  const raw = (data.documentsByIds ?? []) as RawDocument[];
+  const documents = raw
+    // Defense-in-depth owner filter: keep a document only when its owning
+    // charge's owner is in scope. A document with no resolvable charge/owner is
+    // kept — RLS already returned it, and there is no owner to reject it by.
+    .filter(document => {
+      const ownerId = document.charge?.owner?.id;
+      return ownerId == null || scopeIds.has(ownerId);
+    })
+    .map(normalizeDocument);
+
+  return shapeListResult({
+    items: documents,
+    itemsKey: 'documents',
+    total: documents.length,
+    extra: { scope: { businessIds: context.readScope.businessIds } },
+    summarize: (shown, total) =>
+      total === 0
+        ? 'No documents were found for the given ids (they may be outside your authorized businesses).'
+        : `Found ${total} document(s)${shown < total ? ` (showing ${shown})` : ''}.`,
+  });
+}
+
+export const getDocumentsTool: ToolDefinition<typeof getDocumentsInput> = {
+  name: GET_DOCUMENTS_TOOL_NAME,
+  description:
+    'Fetch documents (invoices, receipts, credit invoices, …) by id, with type, serial number, date, amount, VAT, creditor/debtor, and file/image links. Read-only. ' +
+    SCOPE_DESCRIPTION_SUFFIX,
+  inputSchema: getDocumentsInput,
+  policy: { requiresBusinessScope: true, dataClassification: 'business' },
+  handler,
+};

--- a/packages/mcp-server/src/tools/entity-shapes.ts
+++ b/packages/mcp-server/src/tools/entity-shapes.ts
@@ -115,7 +115,7 @@ export interface RawDocument {
   debtor?: RawEntityRef | null;
   file?: string | null;
   image?: string | null;
-  charge?: { id: string; owner?: RawEntityRef | null } | null;
+  charge?: { id: string; owner?: { id: string } | null } | null;
 }
 
 export interface NormalizedDocument {

--- a/packages/mcp-server/src/tools/entity-shapes.ts
+++ b/packages/mcp-server/src/tools/entity-shapes.ts
@@ -1,0 +1,156 @@
+/**
+ * Shared normalizers for the by-id detail tools (`get_charges`,
+ * `get_transactions`, `get_documents`).
+ *
+ * The GraphQL field selections are intentionally *not* shared as interpolated
+ * fragment strings — graphql-codegen plucks operations from plain
+ * `/* GraphQL *\/` template literals and does not resolve `${...}` interpolation,
+ * so each tool inlines its own selection set. What is shared here is the
+ * TypeScript side: normalized output shapes and the functions that build them.
+ *
+ * The `Raw*` inputs are hand-typed to the fields these tools select, so the
+ * per-operation generated node types (which are structurally identical) can be
+ * passed straight through without a codegen dependency in this module.
+ */
+
+/** Money as returned by the API's `FinancialAmount`. */
+export interface RawAmount {
+  raw: number;
+  formatted: string;
+  currency: string;
+}
+
+/** Normalized money: `value` is the numeric amount, plus display + currency. */
+export interface NormalizedAmount {
+  value: number;
+  formatted: string;
+  currency: string;
+}
+
+export function normalizeAmount(amount: RawAmount | null | undefined): NormalizedAmount | null {
+  return amount
+    ? { value: amount.raw, formatted: amount.formatted, currency: amount.currency }
+    : null;
+}
+
+/** A referenced financial entity (owner, counterparty, creditor, debtor). */
+export interface RawEntityRef {
+  id: string;
+  name: string;
+}
+
+export interface EntityRef {
+  id: string;
+  name: string | null;
+}
+
+export function normalizeEntity(entity: RawEntityRef | null | undefined): EntityRef | null {
+  return entity ? { id: entity.id, name: entity.name ?? null } : null;
+}
+
+// ---------------------------------------------------------------------------
+// Transactions
+// ---------------------------------------------------------------------------
+
+export interface RawTransaction {
+  __typename?: string;
+  id: string;
+  chargeId: string;
+  eventDate: string;
+  effectiveDate?: string | null;
+  direction: string;
+  amount?: RawAmount | null;
+  sourceDescription: string;
+  isFee?: boolean | null;
+  counterparty?: RawEntityRef | null;
+  account?: { id: string; name: string } | null;
+}
+
+export interface NormalizedTransaction {
+  id: string;
+  chargeId: string;
+  type: string | null;
+  direction: string;
+  amount: NormalizedAmount | null;
+  eventDate: string;
+  effectiveDate: string | null;
+  description: string;
+  isFee: boolean;
+  counterparty: EntityRef | null;
+  account: { id: string; name: string | null } | null;
+}
+
+export function normalizeTransaction(transaction: RawTransaction): NormalizedTransaction {
+  return {
+    id: transaction.id,
+    chargeId: transaction.chargeId,
+    type: transaction.__typename ?? null,
+    direction: transaction.direction,
+    amount: normalizeAmount(transaction.amount),
+    eventDate: transaction.eventDate,
+    effectiveDate: transaction.effectiveDate ?? null,
+    description: transaction.sourceDescription,
+    isFee: transaction.isFee ?? false,
+    counterparty: normalizeEntity(transaction.counterparty),
+    account: transaction.account
+      ? { id: transaction.account.id, name: transaction.account.name ?? null }
+      : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Documents
+// ---------------------------------------------------------------------------
+
+export interface RawDocument {
+  __typename?: string;
+  id: string;
+  documentType?: string | null;
+  serialNumber?: string | null;
+  date?: string | null;
+  amount?: RawAmount | null;
+  vat?: RawAmount | null;
+  description?: string | null;
+  creditor?: RawEntityRef | null;
+  debtor?: RawEntityRef | null;
+  file?: string | null;
+  image?: string | null;
+  charge?: { id: string; owner?: RawEntityRef | null } | null;
+}
+
+export interface NormalizedDocument {
+  id: string;
+  type: string | null;
+  documentType: string | null;
+  serialNumber: string | null;
+  date: string | null;
+  amount: NormalizedAmount | null;
+  vat: NormalizedAmount | null;
+  description: string | null;
+  creditor: EntityRef | null;
+  debtor: EntityRef | null;
+  chargeId: string | null;
+  fileUrl: string | null;
+  imageUrl: string | null;
+}
+
+export function normalizeDocument(document: RawDocument): NormalizedDocument {
+  return {
+    id: document.id,
+    type: document.__typename ?? null,
+    documentType: document.documentType ?? null,
+    serialNumber: document.serialNumber ?? null,
+    date: document.date ?? null,
+    amount: normalizeAmount(document.amount),
+    vat: normalizeAmount(document.vat),
+    description: document.description ?? null,
+    creditor: normalizeEntity(document.creditor),
+    debtor: normalizeEntity(document.debtor),
+    chargeId: document.charge?.id ?? null,
+    fileUrl: document.file ?? null,
+    imageUrl: document.image ?? null,
+  };
+}
+
+/** Shared cap on how many ids a by-id detail tool accepts in one call. */
+export const MAX_DETAIL_IDS = 50;

--- a/packages/mcp-server/src/tools/registry-instance.ts
+++ b/packages/mcp-server/src/tools/registry-instance.ts
@@ -1,8 +1,11 @@
 import { listBusinessesTool } from './businesses.js';
+import { getChargesTool } from './charge-details.js';
 import { searchChargesTool } from './charges.js';
+import { getDocumentsTool } from './document-details.js';
 import { listTagsTool, listTaxCategoriesTool } from './lookups.js';
 import { ToolRegistry } from './registry.js';
 import { balanceReportTool } from './reports.js';
+import { getTransactionsTool } from './transaction-details.js';
 
 /**
  * The process-wide registry of curated production tools. Tools register here as
@@ -19,6 +22,11 @@ export const toolRegistry = new ToolRegistry();
 // longer advertised), so this is genuinely the first tool the model sees.
 toolRegistry.register(listBusinessesTool);
 toolRegistry.register(searchChargesTool);
+// Charge detail (by id) sits next to search: the model searches, then drills
+// into specific charges — which nest their transactions and documents.
+toolRegistry.register(getChargesTool);
+toolRegistry.register(getTransactionsTool);
+toolRegistry.register(getDocumentsTool);
 toolRegistry.register(listTagsTool);
 toolRegistry.register(listTaxCategoriesTool);
 toolRegistry.register(balanceReportTool);

--- a/packages/mcp-server/src/tools/transaction-details.ts
+++ b/packages/mcp-server/src/tools/transaction-details.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+import type { McpGetTransactionsQuery, McpGetTransactionsQueryVariables } from '../gql/index.js';
+import { MAX_DETAIL_IDS, normalizeTransaction, type RawTransaction } from './entity-shapes.js';
+import { shapeListResult } from './output.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import { businessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
+
+/**
+ * Detail tool: fetch bank/card transactions by id (spec §8.2).
+ *
+ * Read-only. Results are narrowed to the caller's authorized businesses by
+ * upstream RLS (the resolved read scope travels as `x-business-scope` on
+ * `context.upstream`), so an id outside the caller's businesses simply resolves
+ * to nothing — the response never carries a transaction the caller may not read.
+ * Transactions expose no owner field of their own, so — unlike `get_charges`
+ * and `get_documents` — there is no post-fetch owner filter to apply here; RLS
+ * is the sole scope boundary.
+ */
+
+export const GET_TRANSACTIONS_TOOL_NAME = 'accounter_get_transactions';
+
+const getTransactionsInput = z.object({
+  transactionIds: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(MAX_DETAIL_IDS)
+    .describe(
+      `The transaction ids to fetch (1–${MAX_DETAIL_IDS}). Discover ids via accounter_get_charges ` +
+        '(each charge lists its transactions) or accounter_search_charges.',
+    ),
+  businessIds: businessIdsInput,
+});
+
+type GetTransactionsInput = z.infer<typeof getTransactionsInput>;
+
+const GET_TRANSACTIONS_QUERY = /* GraphQL */ `
+  query McpGetTransactions($transactionIDs: [UUID!]!) {
+    transactionsByIDs(transactionIDs: $transactionIDs) {
+      __typename
+      id
+      chargeId
+      eventDate
+      effectiveDate
+      direction
+      amount {
+        raw
+        formatted
+        currency
+      }
+      sourceDescription
+      isFee
+      counterparty {
+        id
+        name
+      }
+      account {
+        id
+        name
+      }
+    }
+  }
+`;
+
+async function handler(
+  input: GetTransactionsInput,
+  context: ToolExecutionContext,
+): Promise<ToolResult> {
+  const variables: McpGetTransactionsQueryVariables = { transactionIDs: input.transactionIds };
+  const data = await context.client.query<McpGetTransactionsQuery>(
+    { query: GET_TRANSACTIONS_QUERY, variables },
+    context.upstream,
+  );
+
+  const transactions = (data.transactionsByIDs ?? []).map(raw =>
+    normalizeTransaction(raw as RawTransaction),
+  );
+
+  return shapeListResult({
+    items: transactions,
+    itemsKey: 'transactions',
+    total: transactions.length,
+    extra: { scope: { businessIds: context.readScope.businessIds } },
+    summarize: (shown, total) =>
+      total === 0
+        ? 'No transactions were found for the given ids (they may be outside your authorized businesses).'
+        : `Found ${total} transaction(s)${shown < total ? ` (showing ${shown})` : ''}.`,
+  });
+}
+
+export const getTransactionsTool: ToolDefinition<typeof getTransactionsInput> = {
+  name: GET_TRANSACTIONS_TOOL_NAME,
+  description:
+    'Fetch bank/card transactions by id, with amount, dates, direction, counterparty, and account. Read-only. ' +
+    SCOPE_DESCRIPTION_SUFFIX,
+  inputSchema: getTransactionsInput,
+  policy: { requiresBusinessScope: true, dataClassification: 'business' },
+  handler,
+};

--- a/packages/mcp-server/src/tools/transaction-details.ts
+++ b/packages/mcp-server/src/tools/transaction-details.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
-import type { McpGetTransactionsQuery, McpGetTransactionsQueryVariables } from '../gql/index.js';
+import type {
+  McpGetTransactionsQuery,
+  McpGetTransactionsQueryVariables,
+  McpSearchTransactionsByFiltersQuery,
+  McpSearchTransactionsByFiltersQueryVariables,
+} from '../gql/index.js';
+import { TIMELESS_DATE } from './dates.js';
 import { MAX_DETAIL_IDS, normalizeTransaction, type RawTransaction } from './entity-shapes.js';
 import { shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
@@ -19,61 +25,223 @@ import { businessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
 export const GET_TRANSACTIONS_TOOL_NAME = 'accounter_get_transactions';
 
-const getTransactionsInput = z.object({
-  transactionIds: z
-    .array(z.string().min(1))
-    .min(1)
-    .max(MAX_DETAIL_IDS)
-    .describe(
-      `The transaction ids to fetch (1–${MAX_DETAIL_IDS}). Discover ids via accounter_get_charges ` +
-        '(each charge lists its transactions) or accounter_search_charges.',
+const TRANSACTION_FILTER_IDS_CAP = 100;
+
+function optionalNonEmptyStringArray(max: number) {
+  return z.preprocess(
+    value => (Array.isArray(value) && value.length === 0 ? undefined : value),
+    z.array(z.string().min(1)).min(1).max(max).optional(),
+  );
+}
+
+const transactionFiltersInput = z
+  .object({
+    byIds: optionalNonEmptyStringArray(TRANSACTION_FILTER_IDS_CAP)
+      .optional()
+      .describe('Include only these transaction ids.'),
+    byChargeIds: optionalNonEmptyStringArray(TRANSACTION_FILTER_IDS_CAP)
+      .optional()
+      .describe('Include only transactions linked to these charge ids.'),
+    byOwners: optionalNonEmptyStringArray(TRANSACTION_FILTER_IDS_CAP)
+      .optional()
+      .describe('Include only transactions owned by these business ids.'),
+    fromEventDate: TIMELESS_DATE.optional().describe(
+      'Only transactions with eventDate on/after this date.',
     ),
-  businessIds: businessIdsInput,
-});
+    toEventDate: TIMELESS_DATE.optional().describe(
+      'Only transactions with eventDate on/before this date.',
+    ),
+    fromDebitDate: TIMELESS_DATE.optional().describe(
+      'Only transactions with effectiveDate on/after this date.',
+    ),
+    toDebitDate: TIMELESS_DATE.optional().describe(
+      'Only transactions with effectiveDate on/before this date.',
+    ),
+    fromAnyDate: TIMELESS_DATE.optional().describe(
+      'Only transactions with any date (event/debit) on/after this date.',
+    ),
+    toAnyDate: TIMELESS_DATE.optional().describe(
+      'Only transactions with any date (event/debit) on/before this date.',
+    ),
+    byCounterparties: optionalNonEmptyStringArray(TRANSACTION_FILTER_IDS_CAP)
+      .optional()
+      .describe('Include only transactions whose counterparty id is in this list.'),
+    withMissingCounterparty: z
+      .boolean()
+      .optional()
+      .describe('Include only transactions with no linked counterparty.'),
+    withMissingInfo: z
+      .boolean()
+      .optional()
+      .describe('Include only transactions that fail required info validation.'),
+    freeText: z
+      .string()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Free text search across transaction fields.'),
+  })
+  .strict();
+
+const getTransactionsInput = z
+  .object({
+    transactionIds: optionalNonEmptyStringArray(MAX_DETAIL_IDS)
+      .optional()
+      .describe(
+        `The transaction ids to fetch (1–${MAX_DETAIL_IDS}). Discover ids via accounter_get_charges ` +
+          '(each charge lists its transactions) or accounter_search_charges.',
+      ),
+    filters: transactionFiltersInput
+      .optional()
+      .describe('Filter transactions by any supported transactionsByFilters predicate.'),
+    businessIds: businessIdsInput,
+  })
+  .superRefine((value, context) => {
+    const hasIds = value.transactionIds !== undefined && value.transactionIds.length > 0;
+    const hasFilters =
+      value.filters !== undefined &&
+      Object.values(value.filters).some(filterValue => filterValue !== undefined);
+    if (!hasIds && !hasFilters) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['transactionIds'],
+        message: 'Provide transactionIds, filters, or both.',
+      });
+    }
+  });
 
 type GetTransactionsInput = z.infer<typeof getTransactionsInput>;
 
-const GET_TRANSACTIONS_QUERY = /* GraphQL */ `
+type TransactionsFiltersInput = z.infer<typeof transactionFiltersInput>;
+
+const TRANSACTIONS_QUERY_DOCUMENT = /* GraphQL */ `
+  fragment McpTransactionDetailsFields on Transaction {
+    __typename
+    id
+    chargeId
+    eventDate
+    effectiveDate
+    direction
+    amount {
+      raw
+      formatted
+      currency
+    }
+    sourceDescription
+    isFee
+    counterparty {
+      id
+      name
+    }
+    account {
+      id
+      name
+    }
+  }
+
   query McpGetTransactions($transactionIDs: [UUID!]!) {
     transactionsByIDs(transactionIDs: $transactionIDs) {
-      __typename
-      id
-      chargeId
-      eventDate
-      effectiveDate
-      direction
-      amount {
-        raw
-        formatted
-        currency
-      }
-      sourceDescription
-      isFee
-      counterparty {
-        id
-        name
-      }
-      account {
-        id
-        name
-      }
+      ...McpTransactionDetailsFields
+    }
+  }
+
+  query McpSearchTransactionsByFilters($filters: TransactionsFilters) {
+    transactionsByFilters(filters: $filters) {
+      ...McpTransactionDetailsFields
     }
   }
 `;
+
+function intersectOwners(
+  requested: readonly string[] | undefined,
+  scopeBusinessIds: readonly string[],
+): string[] {
+  const scopeSet = new Set(scopeBusinessIds);
+  if (!requested || requested.length === 0) {
+    return [...scopeBusinessIds];
+  }
+  return requested.filter(id => scopeSet.has(id));
+}
+
+function buildTransactionsFilters(
+  input: TransactionsFiltersInput,
+  requestedTransactionIds: readonly string[] | undefined,
+  scopeBusinessIds: readonly string[],
+): McpSearchTransactionsByFiltersQueryVariables['filters'] {
+  const ownerIds = intersectOwners(input.byOwners, scopeBusinessIds);
+  const idsFromFilter = input.byIds;
+  const byIds =
+    requestedTransactionIds && requestedTransactionIds.length > 0
+      ? idsFromFilter && idsFromFilter.length > 0
+        ? requestedTransactionIds.filter(id => idsFromFilter.includes(id))
+        : [...requestedTransactionIds]
+      : idsFromFilter;
+  const filters: McpSearchTransactionsByFiltersQueryVariables['filters'] = {
+    byOwners: ownerIds,
+  };
+  if (byIds && byIds.length > 0) filters.byIds = [...byIds];
+  if (input.byChargeIds) filters.byChargeIds = [...input.byChargeIds];
+  if (input.fromEventDate) filters.fromEventDate = input.fromEventDate;
+  if (input.toEventDate) filters.toEventDate = input.toEventDate;
+  if (input.fromDebitDate) filters.fromDebitDate = input.fromDebitDate;
+  if (input.toDebitDate) filters.toDebitDate = input.toDebitDate;
+  if (input.fromAnyDate) filters.fromAnyDate = input.fromAnyDate;
+  if (input.toAnyDate) filters.toAnyDate = input.toAnyDate;
+  if (input.byCounterparties) filters.byCounterparties = [...input.byCounterparties];
+  if (input.withMissingCounterparty !== undefined) {
+    filters.withMissingCounterparty = input.withMissingCounterparty;
+  }
+  if (input.withMissingInfo !== undefined) {
+    filters.withMissingInfo = input.withMissingInfo;
+  }
+  if (input.freeText) filters.freeText = input.freeText;
+  return filters;
+}
 
 async function handler(
   input: GetTransactionsInput,
   context: ToolExecutionContext,
 ): Promise<ToolResult> {
-  const variables: McpGetTransactionsQueryVariables = { transactionIDs: input.transactionIds };
-  const data = await context.client.query<McpGetTransactionsQuery>(
-    { query: GET_TRANSACTIONS_QUERY, variables },
-    context.upstream,
-  );
-
-  const transactions = (data.transactionsByIDs ?? []).map(raw =>
-    normalizeTransaction(raw as RawTransaction),
-  );
+  const hasTransactionIds = input.transactionIds !== undefined && input.transactionIds.length > 0;
+  const hasFilters =
+    input.filters !== undefined &&
+    Object.values(input.filters).some(filterValue => filterValue !== undefined);
+  const usingIds = hasTransactionIds && !hasFilters;
+  const transactions = usingIds
+    ? await (async () => {
+        const variables: McpGetTransactionsQueryVariables = {
+          transactionIDs: input.transactionIds!,
+        };
+        const data = await context.client.query<McpGetTransactionsQuery>(
+          {
+            query: TRANSACTIONS_QUERY_DOCUMENT,
+            operationName: 'McpGetTransactions',
+            variables,
+          },
+          context.upstream,
+        );
+        return (data.transactionsByIDs ?? []).map(raw =>
+          normalizeTransaction(raw as RawTransaction),
+        );
+      })()
+    : await (async () => {
+        const variables: McpSearchTransactionsByFiltersQueryVariables = {
+          filters: buildTransactionsFilters(
+            input.filters ?? {},
+            input.transactionIds,
+            context.readScope.businessIds,
+          ),
+        };
+        const data = await context.client.query<McpSearchTransactionsByFiltersQuery>(
+          {
+            query: TRANSACTIONS_QUERY_DOCUMENT,
+            operationName: 'McpSearchTransactionsByFilters',
+            variables: variables as unknown as Record<string, unknown>,
+          },
+          context.upstream,
+        );
+        return (data.transactionsByFilters ?? []).map(raw => normalizeTransaction(raw));
+      })();
 
   return shapeListResult({
     items: transactions,
@@ -82,7 +250,9 @@ async function handler(
     extra: { scope: { businessIds: context.readScope.businessIds } },
     summarize: (shown, total) =>
       total === 0
-        ? 'No transactions were found for the given ids (they may be outside your authorized businesses).'
+        ? usingIds
+          ? 'No transactions were found for the given ids (they may be outside your authorized businesses).'
+          : 'No transactions matched the given filters.'
         : `Found ${total} transaction(s)${shown < total ? ` (showing ${shown})` : ''}.`,
   });
 }
@@ -90,7 +260,7 @@ async function handler(
 export const getTransactionsTool: ToolDefinition<typeof getTransactionsInput> = {
   name: GET_TRANSACTIONS_TOOL_NAME,
   description:
-    'Fetch bank/card transactions by id, with amount, dates, direction, counterparty, and account. Read-only. ' +
+    'Fetch bank/card transactions either by id or by filters (owners, charge ids, date ranges, counterparties, missing-info flags, and free-text), with amount, dates, direction, counterparty, and account. Read-only. ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: getTransactionsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/transaction-details.ts
+++ b/packages/mcp-server/src/tools/transaction-details.ts
@@ -5,6 +5,7 @@ import type {
   McpSearchTransactionsByFiltersQuery,
   McpSearchTransactionsByFiltersQueryVariables,
 } from '../gql/index.js';
+import { UpstreamError } from '../upstream/graphql-client.js';
 import { TIMELESS_DATE } from './dates.js';
 import { MAX_DETAIL_IDS, normalizeTransaction, type RawTransaction } from './entity-shapes.js';
 import { shapeListResult } from './output.js';
@@ -89,7 +90,7 @@ const getTransactionsInput = z
       .optional()
       .describe(
         `The transaction ids to fetch (1–${MAX_DETAIL_IDS}). Discover ids via accounter_get_charges ` +
-          '(each charge lists its transactions) or accounter_search_charges.',
+          '(each charge lists its transactions).',
       ),
     filters: transactionFiltersInput
       .optional()
@@ -198,6 +199,16 @@ function buildTransactionsFilters(
   return filters;
 }
 
+function isNotFoundByIdUpstreamError(error: unknown): boolean {
+  if (!(error instanceof UpstreamError) || error.code !== 'UPSTREAM_ERROR') {
+    return false;
+  }
+  return (
+    /^Transaction ID=".+" not found$/i.test(error.message) ||
+    /^Couldn't find any transactions$/i.test(error.message)
+  );
+}
+
 async function handler(
   input: GetTransactionsInput,
   context: ToolExecutionContext,
@@ -212,14 +223,24 @@ async function handler(
         const variables: McpGetTransactionsQueryVariables = {
           transactionIDs: input.transactionIds!,
         };
-        const data = await context.client.query<McpGetTransactionsQuery>(
-          {
-            query: TRANSACTIONS_QUERY_DOCUMENT,
-            operationName: 'McpGetTransactions',
-            variables,
-          },
-          context.upstream,
-        );
+        const data = await context.client
+          .query<McpGetTransactionsQuery>(
+            {
+              query: TRANSACTIONS_QUERY_DOCUMENT,
+              operationName: 'McpGetTransactions',
+              variables,
+            },
+            context.upstream,
+          )
+          .catch(error => {
+            // Upstream `transactionsByIDs` throws for any missing id. For this
+            // read-only tool we normalize that specific not-found condition to
+            // an empty result, matching the tool contract for out-of-scope ids.
+            if (isNotFoundByIdUpstreamError(error)) {
+              return { transactionsByIDs: [] } satisfies McpGetTransactionsQuery;
+            }
+            throw error;
+          });
         return (data.transactionsByIDs ?? []).map(raw =>
           normalizeTransaction(raw as RawTransaction),
         );

--- a/packages/server/src/modules/documents/resolvers/documents.resolver.ts
+++ b/packages/server/src/modules/documents/resolvers/documents.resolver.ts
@@ -54,6 +54,20 @@ export const documentsResolvers: DocumentsModule.Resolvers &
       const doc = await injector.get(DocumentsProvider).getDocumentsByIdLoader.load(documentId);
       return doc ?? null;
     },
+    documentsByIds: async (_, { documentIds }, { injector }) => {
+      // De-dupe ids so a repeated id doesn't yield duplicate rows. RLS narrows
+      // the underlying query to the caller's read scope, so ids outside it
+      // resolve to `undefined` (the loader's miss value) and are dropped here —
+      // the response only ever carries documents the caller may read.
+      const uniqueIds = [...new Set(documentIds)];
+      const loaded = await injector
+        .get(DocumentsProvider)
+        .getDocumentsByIdLoader.loadMany(uniqueIds);
+      return loaded.filter(
+        (doc): doc is Exclude<typeof doc, Error | undefined | null> =>
+          doc != null && !(doc instanceof Error),
+      );
+    },
     recentDocumentsByBusiness: async (_, { businessId, limit }, { injector }) => {
       const businessDocs = await injector
         .get(DocumentsProvider)

--- a/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
+++ b/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
@@ -5,6 +5,7 @@ export default gql`
     documents: [Document!]! @requiresAuth
     documentsByFilters(filters: DocumentsFilters!): [Document!]! @requiresAuth
     documentById(documentId: UUID!): Document @requiresAuth
+    documentsByIds(documentIds: [UUID!]!): [Document!]! @requiresAuth
     recentDocumentsByBusiness(businessId: UUID!, limit: Int): [Document!]! @requiresAuth
     recentDocumentsByClient(clientId: UUID!, limit: Int): [Document!]! @requiresAuth
     recentIssuedDocumentsByType(documentType: DocumentType!, limit: Int): [Document!]! @requiresAuth


### PR DESCRIPTION
## What & why

Enriches the MCP server's read-only surface so a model can drill into specific records after searching. Previously the only charge access was the paginated `accounter_search_charges` list; there was no way to pull a charge's transactions and documents, or to look up transactions/documents by id. This adds three by-id **detail** tools.

## New MCP tools

- **`accounter_get_charges`** — fetch charges by id (1–25 `chargeIds`) with owner, counterparty, amounts (total / VAT / withholding), the full set of dates, tags, and `metadata` counts, plus — by default — their linked **transactions and documents nested inline**. `includeTransactions` / `includeDocuments` (both default `true`) trade nesting for more charges per call via `@include`. This is the drill-down for `accounter_search_charges`.
- **`accounter_get_transactions`** — fetch bank/card transactions by id (1–50 `transactionIds`): direction, amount, event/effective dates, source description, `isFee`, `chargeId`, counterparty, account.
- **`accounter_get_documents`** — fetch documents by id (1–50 `documentIds`): `documentType`, serial number, date, amount, VAT, creditor/debtor, `chargeId`, and `file`/`image` links.

All three are read-only, business-scoped, and shape output through the existing byte-budgeting `shapeListResult` formatter.

## Server change

Adds a single query `documentsByIds(documentIds: [UUID!]!): [Document!]!` to the `documents` module (batching the existing `getDocumentsByIdLoader`, de-duping ids), so documents fetch in one round-trip — symmetric with the existing `chargesByIDs` / `transactionsByIDs`. No mutations, no other server surface touched.

## Scope & security

Scope is enforced upstream by Postgres RLS via the forwarded `x-business-scope` header (`context.upstream`), which already narrows `charges` / `transactions` / `documents` by `owner_id` — so an id outside the caller's authorized businesses simply resolves to nothing. As defense-in-depth (mirroring `accounter_search_charges`), `get_charges` and `get_documents` additionally drop any row whose resolvable owner falls outside the resolved read scope. Transactions expose no owner field, so they rely on RLS alone (documented in the handler).

## Implementation notes

- Shared TypeScript normalizers live in `tools/entity-shapes.ts`; GraphQL selection sets are inlined per query (graphql-codegen doesn't resolve interpolated fragment strings).
- Registered in `registry-instance.ts` right after `search_charges` (registration order is the advertised `tools/list` order).
- `yarn generate` (GraphQL codegen) passes — the new operations validate against the schema and generate their `Mcp*` result/variable types.

## Testing

- New `detail-tools.test.ts` (14 tests): normalization of nested transactions/documents, upstream variable forwarding, include-flag handling, owner defense-in-depth filtering, id-count caps, unknown-field rejection, empty-result summaries.
- The registry-wide `scope-forwarding` test now covers the three new tools (asserts each forwards `x-business-scope` and echoes `scope.businessIds`).
- `@accounter/mcp-server` builds clean; unit suite green (14/14 new, registry/scope/schema-contract green).
- Note: the server package's full typecheck and integration tests depend on SQL/pgtyped codegen against a live Postgres, which isn't available in this environment (no Docker daemon). The server change is a one-query resolver mirroring the existing `documentById`; CI should run `generate:sql` + server typecheck to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYzWWACrdNP2rQcDKNtxnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYzWWACrdNP2rQcDKNtxnQ)_