### PR TITLE
feat(documents): document validation info field and enriched documentsByFilters filters

### DIFF
--- a/.changeset/documents-filters-validation.md
+++ b/.changeset/documents-filters-validation.md
@@ -1,0 +1,19 @@
+---
+'@accounter/server': minor
+---
+
+Enrich the `documentsByFilters` query and expose per-document validation info.
+
+Added a `validation: DocumentValidationInfo` field to the `FinancialDocument` interface (and its
+concrete implementers). Its resolver runs all three document validations — basic required-fields,
+VAT and allocation — and combines them into a single informative response with per-check results
+(`basicValidation`, `vatValidation`, `allocationValidation`), an aggregated `issues` list and an
+overall `isValid` flag.
+
+Added new optional filters to `documentsByFilters`:
+
+- `type`: include only documents of the given document types.
+- `missingCounterparty`: include only documents missing a creditor or debtor.
+- `missingInfo`: include only documents that fail basic information validation.
+- `freeText`: free text search across serial number, total amount (raw and normalized),
+  description, remarks and creditor/debtor (counterparty) business names.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -139,6 +139,7 @@ export default [
       '@graphql-eslint/strict-id-in-types': [
         'error',
         {
+          acceptedIdNames: ['id', 'documentId'],
           acceptedIdTypes: ['ID', 'UUID'],
 
           exceptions: {
@@ -166,6 +167,7 @@ export default [
               'DocumentIncomeRecord',
               'DocumentPaymentRecord',
               'DocumentSuggestions',
+              'DocumentValidationCheck',
               'DynamicReportNodeData',
               'ExchangeRates',
               'FinancialAmount',

--- a/packages/server/src/modules/documents/helpers/validate-document.helper.ts
+++ b/packages/server/src/modules/documents/helpers/validate-document.helper.ts
@@ -1,7 +1,9 @@
 import { Injector } from 'graphql-modules';
 import { Currency, DocumentType } from '../../../shared/enums.js';
+import { dateToTimelessDateString } from '../../../shared/helpers/index.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
 import { ExchangeProvider } from '../../exchange-rates/providers/exchange.provider.js';
+import { VatProvider } from '../../vat/providers/vat.provider.js';
 import type { IGetAllDocumentsResult } from '../types.js';
 import { isInvoice } from './common.helper.js';
 
@@ -113,4 +115,85 @@ export function basicDocumentValidation(document: IGetAllDocumentsResult) {
   const isInvoiceValid = !isInvoice(document.type) || document.vat_amount != null;
 
   return hasRequiredFields && isInvoiceValid;
+}
+
+/** result of a single validation check */
+export type DocumentValidationCheck = {
+  isValid: boolean;
+  message: string | null;
+};
+
+/** aggregated validation info combining all document validations */
+export type DocumentValidationInfo = {
+  isValid: boolean;
+  issues: string[];
+  basicValidation: DocumentValidationCheck;
+  vatValidation: DocumentValidationCheck;
+  allocationValidation: DocumentValidationCheck;
+};
+
+/**
+ * Runs all document validations (basic required-fields, VAT and allocation) and
+ * combines them into a single informative response.
+ */
+export async function getDocumentValidationInfo(
+  document: IGetAllDocumentsResult,
+  injector: Injector,
+): Promise<DocumentValidationInfo> {
+  // basic required-fields validation
+  const basicValid = !!basicDocumentValidation(document);
+  const basicValidation: DocumentValidationCheck = {
+    isValid: basicValid,
+    message: basicValid ? null : `Document ID=${document.id} is missing required information`,
+  };
+
+  // VAT amount validation
+  let vatValid = true;
+  let vatMessage: string | null = null;
+  const vatRate = document.date
+    ? await injector
+        .get(VatProvider)
+        .getVatValueByDateLoader.load(dateToTimelessDateString(document.date))
+    : null;
+  if (document.vat_amount != null && vatRate == null) {
+    vatValid = false;
+    vatMessage = `Unable to determine VAT rate for document ID=${document.id}`;
+  } else {
+    vatValid = validateDocumentVat(document, vatRate ?? 0, message => {
+      vatMessage = message;
+    });
+  }
+  const vatValidation: DocumentValidationCheck = { isValid: vatValid, message: vatMessage };
+
+  // allocation number validation
+  let allocationValid = true;
+  let allocationMessage: string | null = null;
+  try {
+    allocationValid = await validateDocumentAllocation(document, injector);
+    if (!allocationValid) {
+      allocationMessage = `Allocation number is missing for document ID=${document.id}`;
+    }
+  } catch (error) {
+    allocationValid = false;
+    allocationMessage =
+      error instanceof Error
+        ? error.message
+        : `Allocation validation failed for document ID=${document.id}`;
+  }
+  const allocationValidation: DocumentValidationCheck = {
+    isValid: allocationValid,
+    message: allocationMessage,
+  };
+
+  const issues = [basicValidation, vatValidation, allocationValidation]
+    .map(check => check.message)
+    .filter((message): message is string => !!message);
+
+  return {
+    isValid: basicValid && vatValid && allocationValid,
+    issues,
+    basicValidation,
+    vatValidation,
+    allocationValidation,
+  };
 }

--- a/packages/server/src/modules/documents/helpers/validate-document.helper.ts
+++ b/packages/server/src/modules/documents/helpers/validate-document.helper.ts
@@ -125,6 +125,7 @@ export type DocumentValidationCheck = {
 
 /** aggregated validation info combining all document validations */
 export type DocumentValidationInfo = {
+  documentId: string;
   isValid: boolean;
   issues: string[];
   basicValidation: DocumentValidationCheck;
@@ -148,14 +149,17 @@ export async function getDocumentValidationInfo(
   };
 
   // VAT amount validation
-  let vatValid = true;
+  let vatValid: boolean;
   let vatMessage: string | null = null;
   const vatRate = document.date
     ? await injector
         .get(VatProvider)
         .getVatValueByDateLoader.load(dateToTimelessDateString(document.date))
     : null;
-  if (document.vat_amount != null && vatRate == null) {
+  // a falsy vat_amount (0 / null) means there is no VAT to validate, matching
+  // validateDocumentVat's own `!document.vat_amount` short-circuit — so the VAT
+  // rate is only required when an actual VAT amount is present.
+  if (document.vat_amount && vatRate == null) {
     vatValid = false;
     vatMessage = `Unable to determine VAT rate for document ID=${document.id}`;
   } else {
@@ -166,7 +170,7 @@ export async function getDocumentValidationInfo(
   const vatValidation: DocumentValidationCheck = { isValid: vatValid, message: vatMessage };
 
   // allocation number validation
-  let allocationValid = true;
+  let allocationValid: boolean;
   let allocationMessage: string | null = null;
   try {
     allocationValid = await validateDocumentAllocation(document, injector);
@@ -190,6 +194,7 @@ export async function getDocumentValidationInfo(
     .filter((message): message is string => !!message);
 
   return {
+    documentId: document.id,
     isValid: basicValid && vatValid && allocationValid,
     issues,
     basicValidation,

--- a/packages/server/src/modules/documents/providers/documents.provider.ts
+++ b/packages/server/src/modules/documents/providers/documents.provider.ts
@@ -245,6 +245,7 @@ const getDocumentsByExtendedFilters = sql<IGetDocumentsByExtendedFiltersQuery>`
     AND ($toDate ::TEXT IS NULL OR date::TEXT::DATE <= date_trunc('day', $toDate ::DATE))
     AND ($isBusinessIDs = 0 OR debtor_id IN $$businessIDs OR creditor_id IN $$businessIDs)
     AND ($isOwnerIDs = 0 OR owner_id IN $$ownerIDs)
+    AND ($isChargeIDs = 0 OR charge_id IN $$chargeIDs)
     AND ($isTypes = 0 OR type IN $$types)
     AND ($isMissingCounterparty = 0 OR debtor_id IS NULL OR creditor_id IS NULL)
     AND ($isUnmatched = 0 OR NOT EXISTS (
@@ -291,8 +292,9 @@ type IGetAdjustedDocumentsByExtendedFiltersParams = Optional<
     | 'types'
     | 'isMissingCounterparty'
     | 'freeTextNumeric'
+    | 'isChargeIDs'
   >,
-  'IDs' | 'businessIDs' | 'ownerIDs'
+  'IDs' | 'businessIDs' | 'ownerIDs' | 'chargeIDs'
 > & {
   fromDate?: TimelessDateString | null;
   toDate?: TimelessDateString | null;
@@ -383,6 +385,7 @@ export class DocumentsProvider {
     const isIDs = !!sqlParams.IDs?.filter(Boolean).length;
     const isBusinessIDs = !!sqlParams.businessIDs?.filter(Boolean).length;
     const isOwnerIDs = !!sqlParams.ownerIDs?.filter(Boolean).length;
+    const isChargeIDs = !!sqlParams.chargeIDs?.filter(Boolean).length;
     const isTypes = !!type?.filter(Boolean).length;
 
     const fullParams: IGetDocumentsByExtendedFiltersParams = {
@@ -392,12 +395,14 @@ export class DocumentsProvider {
       isIDs: isIDs ? 1 : 0,
       isBusinessIDs: isBusinessIDs ? 1 : 0,
       isOwnerIDs: isOwnerIDs ? 1 : 0,
+      isChargeIDs: isChargeIDs ? 1 : 0,
       isTypes: isTypes ? 1 : 0,
       isMissingCounterparty: missingCounterparty ? 1 : 0,
       isUnmatched: unmatched ? 1 : 0,
       IDs: isIDs ? sqlParams.IDs! : [null],
       businessIDs: isBusinessIDs ? sqlParams.businessIDs! : [null],
       ownerIDs: isOwnerIDs ? sqlParams.ownerIDs! : [null],
+      chargeIDs: isChargeIDs ? sqlParams.chargeIDs! : [null],
       types: isTypes ? type! : [null],
       // strip thousands separators so amount searches match the plain value stored in the DB
       freeTextNumeric: sqlParams.freeText ? sqlParams.freeText.replaceAll(',', '') : null,

--- a/packages/server/src/modules/documents/providers/documents.provider.ts
+++ b/packages/server/src/modules/documents/providers/documents.provider.ts
@@ -376,27 +376,31 @@ export class DocumentsProvider {
   }
 
   public getDocumentsByExtendedFilters(params: IGetAdjustedDocumentsByExtendedFiltersParams) {
-    const isIDs = !!params?.IDs?.filter(Boolean).length;
-    const isBusinessIDs = !!params?.businessIDs?.filter(Boolean).length;
-    const isOwnerIDs = !!params?.ownerIDs?.filter(Boolean).length;
-    const isTypes = !!params?.type?.filter(Boolean).length;
+    // pull out the wrapper-only fields so only pgtyped-recognized params are
+    // forwarded to the query below.
+    const { type, missingCounterparty, missingInfo, unmatched, ...sqlParams } = params;
+
+    const isIDs = !!sqlParams.IDs?.filter(Boolean).length;
+    const isBusinessIDs = !!sqlParams.businessIDs?.filter(Boolean).length;
+    const isOwnerIDs = !!sqlParams.ownerIDs?.filter(Boolean).length;
+    const isTypes = !!type?.filter(Boolean).length;
 
     const fullParams: IGetDocumentsByExtendedFiltersParams = {
+      fromVatDate: null,
+      toVatDate: null,
+      ...sqlParams,
       isIDs: isIDs ? 1 : 0,
       isBusinessIDs: isBusinessIDs ? 1 : 0,
       isOwnerIDs: isOwnerIDs ? 1 : 0,
       isTypes: isTypes ? 1 : 0,
-      isMissingCounterparty: params.missingCounterparty ? 1 : 0,
-      fromVatDate: null,
-      toVatDate: null,
-      ...params,
-      isUnmatched: params.unmatched ? 1 : 0,
-      IDs: isIDs ? params.IDs! : [null],
-      businessIDs: isBusinessIDs ? params.businessIDs! : [null],
-      ownerIDs: isOwnerIDs ? params.ownerIDs! : [null],
-      types: isTypes ? params.type! : [null],
+      isMissingCounterparty: missingCounterparty ? 1 : 0,
+      isUnmatched: unmatched ? 1 : 0,
+      IDs: isIDs ? sqlParams.IDs! : [null],
+      businessIDs: isBusinessIDs ? sqlParams.businessIDs! : [null],
+      ownerIDs: isOwnerIDs ? sqlParams.ownerIDs! : [null],
+      types: isTypes ? type! : [null],
       // strip thousands separators so amount searches match the plain value stored in the DB
-      freeTextNumeric: params.freeText ? params.freeText.replaceAll(',', '') : null,
+      freeTextNumeric: sqlParams.freeText ? sqlParams.freeText.replaceAll(',', '') : null,
     };
     return getDocumentsByExtendedFilters.run(fullParams, this.db);
   }

--- a/packages/server/src/modules/documents/providers/documents.provider.ts
+++ b/packages/server/src/modules/documents/providers/documents.provider.ts
@@ -379,8 +379,8 @@ export class DocumentsProvider {
 
   public getDocumentsByExtendedFilters(params: IGetAdjustedDocumentsByExtendedFiltersParams) {
     // pull out the wrapper-only fields so only pgtyped-recognized params are
-    // forwarded to the query below.
-    const { type, missingCounterparty, missingInfo, unmatched, ...sqlParams } = params;
+    // forwarded to the query below. `missingInfo` is applied in the resolver.
+    const { type, missingCounterparty, missingInfo: _missingInfo, unmatched, ...sqlParams } = params;
 
     const isIDs = !!sqlParams.IDs?.filter(Boolean).length;
     const isBusinessIDs = !!sqlParams.businessIDs?.filter(Boolean).length;

--- a/packages/server/src/modules/documents/providers/documents.provider.ts
+++ b/packages/server/src/modules/documents/providers/documents.provider.ts
@@ -252,6 +252,26 @@ const getDocumentsByExtendedFilters = sql<IGetDocumentsByExtendedFiltersQuery>`
       FROM accounter_schema.transactions t
       WHERE t.charge_id = charge_id
     ))
+    AND ($freeText::TEXT IS NULL OR (
+      serial_number ILIKE '%' || $freeText || '%'
+      OR description ILIKE '%' || $freeText || '%'
+      OR remarks ILIKE '%' || $freeText || '%'
+      -- match amounts. $freeTextNumeric has thousands separators stripped
+      -- so both "1,234.56" and "1234.56" match the plain value stored in the DB.
+      OR ($freeTextNumeric::TEXT IS NOT NULL AND (
+        total_amount::TEXT ILIKE '%' || $freeTextNumeric || '%'
+        OR ABS(total_amount)::TEXT ILIKE '%' || $freeTextNumeric || '%'
+      ))
+      -- match counterparty (creditor / debtor) business names
+      OR EXISTS (
+        SELECT 1 FROM accounter_schema.financial_entities fe
+        WHERE fe.id = documents.creditor_id AND fe.name ILIKE '%' || $freeText || '%'
+      )
+      OR EXISTS (
+        SELECT 1 FROM accounter_schema.financial_entities fe
+        WHERE fe.id = documents.debtor_id AND fe.name ILIKE '%' || $freeText || '%'
+      )
+    ))
   ORDER BY created_at DESC;
 `;
 
@@ -270,6 +290,7 @@ type IGetAdjustedDocumentsByExtendedFiltersParams = Optional<
     | 'isTypes'
     | 'types'
     | 'isMissingCounterparty'
+    | 'freeTextNumeric'
   >,
   'IDs' | 'businessIDs' | 'ownerIDs'
 > & {
@@ -374,6 +395,8 @@ export class DocumentsProvider {
       businessIDs: isBusinessIDs ? params.businessIDs! : [null],
       ownerIDs: isOwnerIDs ? params.ownerIDs! : [null],
       types: isTypes ? params.type! : [null],
+      // strip thousands separators so amount searches match the plain value stored in the DB
+      freeTextNumeric: params.freeText ? params.freeText.replaceAll(',', '') : null,
     };
     return getDocumentsByExtendedFilters.run(fullParams, this.db);
   }

--- a/packages/server/src/modules/documents/providers/documents.provider.ts
+++ b/packages/server/src/modules/documents/providers/documents.provider.ts
@@ -1,6 +1,7 @@
 import DataLoader from 'dataloader';
 import { Injectable, Scope } from 'graphql-modules';
 import { sql, type IDatabaseConnection } from '@pgtyped/runtime';
+import { DocumentType } from '../../../shared/enums.js';
 import { reassureOwnerIdExists } from '../../../shared/helpers/index.js';
 import type { Optional, TimelessDateString } from '../../../shared/types/index.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
@@ -244,9 +245,11 @@ const getDocumentsByExtendedFilters = sql<IGetDocumentsByExtendedFiltersQuery>`
     AND ($toDate ::TEXT IS NULL OR date::TEXT::DATE <= date_trunc('day', $toDate ::DATE))
     AND ($isBusinessIDs = 0 OR debtor_id IN $$businessIDs OR creditor_id IN $$businessIDs)
     AND ($isOwnerIDs = 0 OR owner_id IN $$ownerIDs)
+    AND ($isTypes = 0 OR type IN $$types)
+    AND ($isMissingCounterparty = 0 OR debtor_id IS NULL OR creditor_id IS NULL)
     AND ($isUnmatched = 0 OR NOT EXISTS (
-      SELECT 1 
-      FROM accounter_schema.transactions t 
+      SELECT 1
+      FROM accounter_schema.transactions t
       WHERE t.charge_id = charge_id
     ))
   ORDER BY created_at DESC;
@@ -258,12 +261,24 @@ type IGetAdjustedDocumentsByFiltersParams = Optional<
 >;
 
 type IGetAdjustedDocumentsByExtendedFiltersParams = Optional<
-  Omit<IGetDocumentsByExtendedFiltersParams, 'isIDs' | 'fromDate' | 'toDate' | 'isUnmatched'>,
+  Omit<
+    IGetDocumentsByExtendedFiltersParams,
+    | 'isIDs'
+    | 'fromDate'
+    | 'toDate'
+    | 'isUnmatched'
+    | 'isTypes'
+    | 'types'
+    | 'isMissingCounterparty'
+  >,
   'IDs' | 'businessIDs' | 'ownerIDs'
 > & {
   fromDate?: TimelessDateString | null;
   toDate?: TimelessDateString | null;
   unmatched?: boolean | null;
+  type?: readonly DocumentType[] | null;
+  missingCounterparty?: boolean | null;
+  missingInfo?: boolean | null;
 };
 
 const replaceDocumentsChargeId = sql<IReplaceDocumentsChargeIdQuery>`
@@ -343,11 +358,14 @@ export class DocumentsProvider {
     const isIDs = !!params?.IDs?.filter(Boolean).length;
     const isBusinessIDs = !!params?.businessIDs?.filter(Boolean).length;
     const isOwnerIDs = !!params?.ownerIDs?.filter(Boolean).length;
+    const isTypes = !!params?.type?.filter(Boolean).length;
 
     const fullParams: IGetDocumentsByExtendedFiltersParams = {
       isIDs: isIDs ? 1 : 0,
       isBusinessIDs: isBusinessIDs ? 1 : 0,
       isOwnerIDs: isOwnerIDs ? 1 : 0,
+      isTypes: isTypes ? 1 : 0,
+      isMissingCounterparty: params.missingCounterparty ? 1 : 0,
       fromVatDate: null,
       toVatDate: null,
       ...params,
@@ -355,6 +373,7 @@ export class DocumentsProvider {
       IDs: isIDs ? params.IDs! : [null],
       businessIDs: isBusinessIDs ? params.businessIDs! : [null],
       ownerIDs: isOwnerIDs ? params.ownerIDs! : [null],
+      types: isTypes ? params.type! : [null],
     };
     return getDocumentsByExtendedFilters.run(fullParams, this.db);
   }

--- a/packages/server/src/modules/documents/providers/documents.provider.ts
+++ b/packages/server/src/modules/documents/providers/documents.provider.ts
@@ -380,7 +380,13 @@ export class DocumentsProvider {
   public getDocumentsByExtendedFilters(params: IGetAdjustedDocumentsByExtendedFiltersParams) {
     // pull out the wrapper-only fields so only pgtyped-recognized params are
     // forwarded to the query below. `missingInfo` is applied in the resolver.
-    const { type, missingCounterparty, missingInfo: _missingInfo, unmatched, ...sqlParams } = params;
+    const {
+      type,
+      missingCounterparty,
+      missingInfo: _missingInfo,
+      unmatched,
+      ...sqlParams
+    } = params;
 
     const isIDs = !!sqlParams.IDs?.filter(Boolean).length;
     const isBusinessIDs = !!sqlParams.businessIDs?.filter(Boolean).length;

--- a/packages/server/src/modules/documents/resolvers/common.ts
+++ b/packages/server/src/modules/documents/resolvers/common.ts
@@ -3,6 +3,7 @@ import {
   formatFinancialAmount,
   optionalDateToTimelessDateString,
 } from '../../../shared/helpers/index.js';
+import { getDocumentValidationInfo } from '../helpers/validate-document.helper.js';
 import { DocumentsProvider } from '../providers/documents.provider.js';
 import type { document_type, DocumentsModule } from '../types.js';
 
@@ -75,6 +76,18 @@ export const commonFinancialDocumentsFields:
     documentRoot.exchange_rate_override == null
       ? null
       : Number(documentRoot.exchange_rate_override),
+};
+
+// `validation` lives only on the FinancialDocument interface (and its concrete
+// implementers), so it is kept separate from `commonFinancialDocumentsFields`,
+// which is also spread into the non-financial Unprocessed/OtherDocument types.
+export const commonFinancialDocumentValidationField:
+  | DocumentsModule.InvoiceResolvers
+  | DocumentsModule.ReceiptResolvers
+  | DocumentsModule.InvoiceReceiptResolvers
+  | DocumentsModule.ProformaResolvers
+  | DocumentsModule.CreditInvoiceResolvers = {
+  validation: (documentRoot, _, { injector }) => getDocumentValidationInfo(documentRoot, injector),
 };
 
 export const commonChargeFields: DocumentsModule.ChargeResolvers = {

--- a/packages/server/src/modules/documents/resolvers/documents.resolver.ts
+++ b/packages/server/src/modules/documents/resolvers/documents.resolver.ts
@@ -11,6 +11,7 @@ import { ChargesProvider } from '../../charges/providers/charges.provider.js';
 import type { IGetChargesByIdsResult } from '../../charges/types.js';
 import { TransactionsProvider } from '../../transactions/providers/transactions.provider.js';
 import { getDocumentFromFile } from '../helpers/upload.helper.js';
+import { basicDocumentValidation } from '../helpers/validate-document.helper.js';
 import { DocumentsProvider } from '../providers/documents.provider.js';
 import { IssuedDocumentsProvider } from '../providers/issued-documents.provider.js';
 import type {
@@ -23,6 +24,7 @@ import {
   commonChargeFields,
   commonDocumentsFields,
   commonFinancialDocumentsFields,
+  commonFinancialDocumentValidationField,
 } from './common.js';
 
 export const documentsResolvers: DocumentsModule.Resolvers &
@@ -41,6 +43,11 @@ export const documentsResolvers: DocumentsModule.Resolvers &
     },
     documentsByFilters: async (_, { filters }, { injector }) => {
       const dbDocs = await injector.get(DocumentsProvider).getDocumentsByExtendedFilters(filters);
+      // `missingInfo` reuses the shared basicDocumentValidation logic, so it is
+      // applied here rather than duplicating its semantics in SQL.
+      if (filters.missingInfo) {
+        return dbDocs.filter(doc => !basicDocumentValidation(doc));
+      }
       return dbDocs;
     },
     documentById: async (_, { documentId }, { injector }) => {
@@ -579,18 +586,22 @@ export const documentsResolvers: DocumentsModule.Resolvers &
   Invoice: {
     ...commonDocumentsFields,
     ...commonFinancialDocumentsFields,
+    ...commonFinancialDocumentValidationField,
   },
   InvoiceReceipt: {
     ...commonDocumentsFields,
     ...commonFinancialDocumentsFields,
+    ...commonFinancialDocumentValidationField,
   },
   CreditInvoice: {
     ...commonDocumentsFields,
     ...commonFinancialDocumentsFields,
+    ...commonFinancialDocumentValidationField,
   },
   Proforma: {
     ...commonDocumentsFields,
     ...commonFinancialDocumentsFields,
+    ...commonFinancialDocumentValidationField,
   },
   Unprocessed: {
     ...commonDocumentsFields,
@@ -603,6 +614,7 @@ export const documentsResolvers: DocumentsModule.Resolvers &
   Receipt: {
     ...commonDocumentsFields,
     ...commonFinancialDocumentsFields,
+    ...commonFinancialDocumentValidationField,
   },
   CommonCharge: commonChargeFields,
   FinancialCharge: commonChargeFields,

--- a/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
+++ b/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
@@ -148,6 +148,8 @@ export default gql`
 
   " combined validation info for a financial document, aggregating all validation checks "
   type DocumentValidationInfo {
+    " the validated document's ID "
+    documentId: UUID!
     " true only when every validation check passes "
     isValid: Boolean!
     " human readable list of all detected validation issues "

--- a/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
+++ b/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
@@ -14,6 +14,8 @@ export default gql`
   input DocumentsFilters {
     businessIDs: [UUID!]
     ownerIDs: [UUID!]
+    " Include only documents linked to the given charges "
+    chargeIDs: [UUID!]
     fromDate: TimelessDate
     toDate: TimelessDate
     " Include only documents without matching transactions "

--- a/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
+++ b/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
@@ -18,6 +18,12 @@ export default gql`
     toDate: TimelessDate
     " Include only documents without matching transactions "
     unmatched: Boolean
+    " Include only documents of the given types "
+    type: [DocumentType!]
+    " Include only documents with a missing creditor or debtor "
+    missingCounterparty: Boolean
+    " Include only documents that fail basic information validation "
+    missingInfo: Boolean
   }
 
   extend type Mutation {
@@ -130,6 +136,28 @@ export default gql`
     exchangeRateOverride: Float
   }
 
+  " result of a single document validation check "
+  type DocumentValidationCheck {
+    " whether this specific check passed "
+    isValid: Boolean!
+    " explanatory message when the check fails "
+    message: String
+  }
+
+  " combined validation info for a financial document, aggregating all validation checks "
+  type DocumentValidationInfo {
+    " true only when every validation check passes "
+    isValid: Boolean!
+    " human readable list of all detected validation issues "
+    issues: [String!]!
+    " basic required-fields validation (see basicDocumentValidation) "
+    basicValidation: DocumentValidationCheck!
+    " VAT amount validation "
+    vatValidation: DocumentValidationCheck!
+    " allocation number validation "
+    allocationValidation: DocumentValidationCheck!
+  }
+
   " represent a financial document "
   interface FinancialDocument implements Document & Linkable {
     id: UUID!
@@ -148,6 +176,8 @@ export default gql`
     noVatAmount: Float
     allocationNumber: String
     exchangeRateOverride: Float
+    " aggregated validation info combining all document validations "
+    validation: DocumentValidationInfo
   }
 
   " invoice document "
@@ -168,6 +198,7 @@ export default gql`
     noVatAmount: Float
     allocationNumber: String
     exchangeRateOverride: Float
+    validation: DocumentValidationInfo
   }
 
   " proforma document "
@@ -188,6 +219,7 @@ export default gql`
     noVatAmount: Float
     allocationNumber: String
     exchangeRateOverride: Float
+    validation: DocumentValidationInfo
   }
 
   " receipt document "
@@ -207,6 +239,7 @@ export default gql`
     exchangeRateOverride: Float
     description: String
     remarks: String
+    validation: DocumentValidationInfo
   }
 
   " Invoice receipt document - חשבונית מס קבלה "
@@ -227,6 +260,7 @@ export default gql`
     noVatAmount: Float
     allocationNumber: String
     exchangeRateOverride: Float
+    validation: DocumentValidationInfo
   }
 
   " Credit invoice document - חשבונית זיכוי "
@@ -247,6 +281,7 @@ export default gql`
     noVatAmount: Float
     allocationNumber: String
     exchangeRateOverride: Float
+    validation: DocumentValidationInfo
   }
 
   " input variables for updateDocument "

--- a/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
+++ b/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
@@ -24,6 +24,8 @@ export default gql`
     missingCounterparty: Boolean
     " Include only documents that fail basic information validation "
     missingInfo: Boolean
+    " Free text search across serial number, amount, description, remarks and counterparty (creditor / debtor) names "
+    freeText: String
   }
 
   extend type Mutation {


### PR DESCRIPTION
## Summary

Enriches the `documentsByFilters` query and adds an aggregated validation field to financial documents.

### 1. `validation` field on `FinancialDocument` (pre-step)

Adds a `validation: DocumentValidationInfo` field to the `FinancialDocument` interface and all of its concrete implementers (`Invoice`, `Proforma`, `Receipt`, `InvoiceReceipt`, `CreditInvoice`).

Its resolver runs **all three** validations from `helpers/validate-document.helper.ts` and combines them into a single informative response:

- `basicDocumentValidation` → `basicValidation`
- `validateDocumentVat` → `vatValidation`
- `validateDocumentAllocation` → `allocationValidation`

```graphql
type DocumentValidationInfo {
  isValid: Boolean!          # true only when every check passes
  issues: [String!]!         # aggregated human-readable issues
  basicValidation: DocumentValidationCheck!
  vatValidation: DocumentValidationCheck!
  allocationValidation: DocumentValidationCheck!
}

type DocumentValidationCheck {
  isValid: Boolean!
  message: String            # explanation when the check fails
}
```

A shared helper `getDocumentValidationInfo(document, injector)` was added so the combining logic has a single source of truth. The `validation` field resolver is kept in its own object (`commonFinancialDocumentValidationField`) so it is only spread into the financial types — not into the non-financial `Unprocessed`/`OtherDocument` types (graphql-modules rejects resolvers for fields absent from a type).

### 2. New `documentsByFilters` filters

Added to `DocumentsFilters`:

- **`type: [DocumentType!]`** — include only documents of the given types (SQL predicate).
- **`missingCounterparty: Boolean`** — include only documents missing a creditor or debtor (SQL predicate).
- **`missingInfo: Boolean`** — include only documents that fail `basicDocumentValidation`. Applied in the resolver so it reuses the shared validation semantics rather than duplicating them in SQL.
- **`freeText: String`** — free text search across serial number, total amount (raw and normalized with thousands separators stripped), description, remarks, and creditor/debtor (counterparty) business names. Follows the free text search pattern used in the charges provider.

All new filter fields are optional and additive — existing callers are unaffected.

## Notes

- Requires `yarn generate` (GraphQL + pgtyped) to regenerate types after the schema/SQL changes. Codegen and lint/typecheck could **not** be run in this environment because a full `yarn install` is blocked by the egress policy on `cdn.sheetjs.com` (the transitive `xlsx` tarball behind `node-xlsx`); CI should run the full generate + lint + typecheck.

## Test plan

- [ ] `yarn generate` succeeds and produces the new types.
- [ ] `yarn lint` and typecheck pass.
- [ ] Query a financial document's `validation` field and confirm the three sub-checks and aggregated `issues` are reported.
- [ ] `documentsByFilters` with `type`, `missingCounterparty`, `missingInfo`, and `freeText` returns the expected subsets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUHpu7kjb8FSx9xu7VdD2b)_