### PR TITLE
feat(transactions): add transactionsByFilters query

### DIFF
--- a/.changeset/transactions-by-filters-query.md
+++ b/.changeset/transactions-by-filters-query.md
@@ -1,0 +1,9 @@
+---
+"@accounter/server": minor
+---
+
+Add a `transactionsByFilters` query to the transactions module. It fetches transactions filtered by
+transaction ids, charge ids, owners (scoped to the authorized read scope), counterparty ids, date
+ranges (event date, debit date, or any date), missing counterparty, missing info (fails transaction
+validation), and free text (source description / reference, amount, counter account, origin key, and
+counterparty name).

--- a/packages/server/src/modules/transactions/providers/transactions.provider.ts
+++ b/packages/server/src/modules/transactions/providers/transactions.provider.ts
@@ -7,6 +7,8 @@ import type {
   IGetSimilarTransactionsParams,
   IGetSimilarTransactionsQuery,
   IGetTransactionsByChargeIdsQuery,
+  IGetTransactionsByExtendedFiltersParams,
+  IGetTransactionsByExtendedFiltersQuery,
   IGetTransactionsByFiltersParams,
   IGetTransactionsByFiltersQuery,
   IGetTransactionsByIdsQuery,
@@ -44,6 +46,38 @@ const getTransactionsByFilters = sql<IGetTransactionsByFiltersQuery>`
     AND ($isBusinessIDs = 0 OR business_id IN $$businessIDs)
     AND ($isOwnerIDs = 0 OR owner_id IN $$ownerIDs)
   ORDER BY event_date DESC;
+`;
+
+const getTransactionsByExtendedFilters = sql<IGetTransactionsByExtendedFiltersQuery>`
+  SELECT t.*
+  FROM accounter_schema.transactions t
+  LEFT JOIN accounter_schema.financial_entities fe ON fe.id = t.business_id
+  WHERE
+    ($isIDs = 0 OR t.id IN $$IDs)
+    AND ($isOwnerIDs = 0 OR t.owner_id IN $$ownerIDs)
+    AND ($isCounterpartyIDs = 0 OR t.business_id IN $$counterpartyIDs)
+    AND ($fromEventDate ::TEXT IS NULL OR t.event_date::TEXT::DATE >= date_trunc('day', $fromEventDate ::DATE))
+    AND ($toEventDate ::TEXT IS NULL OR t.event_date::TEXT::DATE <= date_trunc('day', $toEventDate ::DATE))
+    AND ($fromDebitDate ::TEXT IS NULL OR COALESCE(t.debit_date_override, t.debit_date)::TEXT::DATE >= date_trunc('day', $fromDebitDate ::DATE))
+    AND ($toDebitDate ::TEXT IS NULL OR COALESCE(t.debit_date_override, t.debit_date)::TEXT::DATE <= date_trunc('day', $toDebitDate ::DATE))
+    AND ($fromAnyDate ::TEXT IS NULL OR GREATEST(t.event_date, COALESCE(t.debit_date_override, t.debit_date))::TEXT::DATE >= date_trunc('day', $fromAnyDate ::DATE))
+    AND ($toAnyDate ::TEXT IS NULL OR LEAST(t.event_date, COALESCE(t.debit_date_override, t.debit_date))::TEXT::DATE <= date_trunc('day', $toAnyDate ::DATE))
+    AND ($withMissingCounterparty = FALSE OR t.business_id IS NULL)
+    AND ($withMissingInfo = FALSE OR t.business_id IS NULL OR (t.debit_date IS NULL AND t.debit_date_override IS NULL))
+    AND (
+      $freeText ::TEXT IS NULL
+      OR t.source_description ILIKE '%' || $freeText || '%'
+      OR t.source_reference ILIKE '%' || $freeText || '%'
+      OR t.counter_account ILIKE '%' || $freeText || '%'
+      OR t.origin_key ILIKE '%' || $freeText || '%'
+      OR fe.name ILIKE '%' || $freeText || '%'
+      -- match transaction amount. $freeTextNumeric has thousands separators stripped
+      -- so both "1,234.56" and "1234.56" match the plain value stored in the DB.
+      OR ($freeTextNumeric ::TEXT IS NOT NULL
+          AND (t.amount::TEXT ILIKE '%' || $freeTextNumeric || '%'
+               OR ABS(t.amount)::TEXT ILIKE '%' || $freeTextNumeric || '%'))
+    )
+  ORDER BY t.event_date DESC;
 `;
 
 const getSimilarTransactions = sql<IGetSimilarTransactionsQuery>`
@@ -110,6 +144,34 @@ type IGetAdjustedTransactionsByFiltersParams = Optional<
   toEventDate?: TimelessDateString | null;
   fromDebitDate?: TimelessDateString | null;
   toDebitDate?: TimelessDateString | null;
+};
+
+type IGetAdjustedTransactionsByExtendedFiltersParams = Optional<
+  Omit<
+    IGetTransactionsByExtendedFiltersParams,
+    | 'isIDs'
+    | 'isOwnerIDs'
+    | 'isCounterpartyIDs'
+    | 'fromEventDate'
+    | 'toEventDate'
+    | 'fromDebitDate'
+    | 'toDebitDate'
+    | 'fromAnyDate'
+    | 'toAnyDate'
+    | 'freeTextNumeric'
+    | 'withMissingCounterparty'
+    | 'withMissingInfo'
+  >,
+  'IDs' | 'ownerIDs' | 'counterpartyIDs' | 'freeText'
+> & {
+  fromEventDate?: TimelessDateString | null;
+  toEventDate?: TimelessDateString | null;
+  fromDebitDate?: TimelessDateString | null;
+  toDebitDate?: TimelessDateString | null;
+  fromAnyDate?: TimelessDateString | null;
+  toAnyDate?: TimelessDateString | null;
+  withMissingCounterparty?: boolean | null;
+  withMissingInfo?: boolean | null;
 };
 
 @Injectable({
@@ -185,6 +247,39 @@ export class TransactionsProvider {
       ownerIDs: isOwnerIDs ? params.ownerIDs! : [null],
     };
     return getTransactionsByFilters.run(fullParams, this.db);
+  }
+
+  public getTransactionsByExtendedFilters(params: IGetAdjustedTransactionsByExtendedFiltersParams) {
+    const isIDs = !!params?.IDs?.length;
+    const isOwnerIDs = !!params?.ownerIDs?.length;
+    const isCounterpartyIDs = !!params?.counterpartyIDs?.length;
+
+    const fullParams: IGetTransactionsByExtendedFiltersParams = {
+      fromEventDate: null,
+      toEventDate: null,
+      fromDebitDate: null,
+      toDebitDate: null,
+      fromAnyDate: null,
+      toAnyDate: null,
+      ...params,
+      isIDs: isIDs ? 1 : 0,
+      isOwnerIDs: isOwnerIDs ? 1 : 0,
+      isCounterpartyIDs: isCounterpartyIDs ? 1 : 0,
+      IDs: isIDs ? params.IDs! : [null],
+      ownerIDs: isOwnerIDs ? params.ownerIDs! : [null],
+      counterpartyIDs: isCounterpartyIDs ? params.counterpartyIDs! : [null],
+      withMissingCounterparty: params.withMissingCounterparty ?? false,
+      withMissingInfo: params.withMissingInfo ?? false,
+      freeText: params.freeText ?? null,
+      // strip thousands separators so amount searches match the plain value stored in the DB
+      freeTextNumeric: params.freeText ? params.freeText.replaceAll(',', '') : null,
+    };
+    return getTransactionsByExtendedFilters.run(fullParams, this.db).then(res =>
+      res.map(t => {
+        this.transactionByIdLoader.prime(t.id, t);
+        return t;
+      }),
+    );
   }
 
   public async getSimilarTransactions(params: IGetSimilarTransactionsParams) {

--- a/packages/server/src/modules/transactions/providers/transactions.provider.ts
+++ b/packages/server/src/modules/transactions/providers/transactions.provider.ts
@@ -54,14 +54,28 @@ const getTransactionsByExtendedFilters = sql<IGetTransactionsByExtendedFiltersQu
   LEFT JOIN accounter_schema.financial_entities fe ON fe.id = t.business_id
   WHERE
     ($isIDs = 0 OR t.id IN $$IDs)
+    AND ($isChargeIDs = 0 OR t.charge_id IN $$chargeIDs)
     AND ($isOwnerIDs = 0 OR t.owner_id IN $$ownerIDs)
     AND ($isCounterpartyIDs = 0 OR t.business_id IN $$counterpartyIDs)
     AND ($fromEventDate ::TEXT IS NULL OR t.event_date::TEXT::DATE >= date_trunc('day', $fromEventDate ::DATE))
     AND ($toEventDate ::TEXT IS NULL OR t.event_date::TEXT::DATE <= date_trunc('day', $toEventDate ::DATE))
     AND ($fromDebitDate ::TEXT IS NULL OR COALESCE(t.debit_date_override, t.debit_date)::TEXT::DATE >= date_trunc('day', $fromDebitDate ::DATE))
     AND ($toDebitDate ::TEXT IS NULL OR COALESCE(t.debit_date_override, t.debit_date)::TEXT::DATE <= date_trunc('day', $toDebitDate ::DATE))
-    AND ($fromAnyDate ::TEXT IS NULL OR GREATEST(t.event_date, COALESCE(t.debit_date_override, t.debit_date))::TEXT::DATE >= date_trunc('day', $fromAnyDate ::DATE))
-    AND ($toAnyDate ::TEXT IS NULL OR LEAST(t.event_date, COALESCE(t.debit_date_override, t.debit_date))::TEXT::DATE <= date_trunc('day', $toAnyDate ::DATE))
+    -- "any date" matches when a single date (event OR debit) falls within the requested range,
+    -- so a transaction whose event date precedes the range and debit date follows it is excluded.
+    AND (
+      ($fromAnyDate ::TEXT IS NULL AND $toAnyDate ::TEXT IS NULL)
+      OR (
+        t.event_date IS NOT NULL
+        AND ($fromAnyDate ::TEXT IS NULL OR t.event_date::TEXT::DATE >= date_trunc('day', $fromAnyDate ::DATE))
+        AND ($toAnyDate ::TEXT IS NULL OR t.event_date::TEXT::DATE <= date_trunc('day', $toAnyDate ::DATE))
+      )
+      OR (
+        COALESCE(t.debit_date_override, t.debit_date) IS NOT NULL
+        AND ($fromAnyDate ::TEXT IS NULL OR COALESCE(t.debit_date_override, t.debit_date)::TEXT::DATE >= date_trunc('day', $fromAnyDate ::DATE))
+        AND ($toAnyDate ::TEXT IS NULL OR COALESCE(t.debit_date_override, t.debit_date)::TEXT::DATE <= date_trunc('day', $toAnyDate ::DATE))
+      )
+    )
     AND ($withMissingCounterparty = FALSE OR t.business_id IS NULL)
     AND ($withMissingInfo = FALSE OR t.business_id IS NULL OR (t.debit_date IS NULL AND t.debit_date_override IS NULL))
     AND (
@@ -150,6 +164,7 @@ type IGetAdjustedTransactionsByExtendedFiltersParams = Optional<
   Omit<
     IGetTransactionsByExtendedFiltersParams,
     | 'isIDs'
+    | 'isChargeIDs'
     | 'isOwnerIDs'
     | 'isCounterpartyIDs'
     | 'fromEventDate'
@@ -162,7 +177,7 @@ type IGetAdjustedTransactionsByExtendedFiltersParams = Optional<
     | 'withMissingCounterparty'
     | 'withMissingInfo'
   >,
-  'IDs' | 'ownerIDs' | 'counterpartyIDs' | 'freeText'
+  'IDs' | 'chargeIDs' | 'ownerIDs' | 'counterpartyIDs' | 'freeText'
 > & {
   fromEventDate?: TimelessDateString | null;
   toEventDate?: TimelessDateString | null;
@@ -251,6 +266,7 @@ export class TransactionsProvider {
 
   public getTransactionsByExtendedFilters(params: IGetAdjustedTransactionsByExtendedFiltersParams) {
     const isIDs = !!params?.IDs?.length;
+    const isChargeIDs = !!params?.chargeIDs?.length;
     const isOwnerIDs = !!params?.ownerIDs?.length;
     const isCounterpartyIDs = !!params?.counterpartyIDs?.length;
 
@@ -263,9 +279,11 @@ export class TransactionsProvider {
       toAnyDate: null,
       ...params,
       isIDs: isIDs ? 1 : 0,
+      isChargeIDs: isChargeIDs ? 1 : 0,
       isOwnerIDs: isOwnerIDs ? 1 : 0,
       isCounterpartyIDs: isCounterpartyIDs ? 1 : 0,
       IDs: isIDs ? params.IDs! : [null],
+      chargeIDs: isChargeIDs ? params.chargeIDs! : [null],
       ownerIDs: isOwnerIDs ? params.ownerIDs! : [null],
       counterpartyIDs: isCounterpartyIDs ? params.counterpartyIDs! : [null],
       withMissingCounterparty: params.withMissingCounterparty ?? false,

--- a/packages/server/src/modules/transactions/resolvers/transactions.resolver.ts
+++ b/packages/server/src/modules/transactions/resolvers/transactions.resolver.ts
@@ -63,7 +63,7 @@ export const transactionsResolvers: TransactionsModule.Resolvers &
       // if any are outside it), so byOwners can never broaden access.
       const ownerIDs = await injector
         .get(ScopeProvider)
-        .getReadScope(filters?.byOwners ?? undefined);
+        .getReadScope(filters?.byOwners ? [...filters.byOwners] : undefined);
       // Guard against an empty read scope: passing no owner ids to the provider is
       // treated as "no owner filter" and would return transactions across all owners.
       if (ownerIDs.length === 0) {

--- a/packages/server/src/modules/transactions/resolvers/transactions.resolver.ts
+++ b/packages/server/src/modules/transactions/resolvers/transactions.resolver.ts
@@ -58,6 +58,26 @@ export const transactionsResolvers: TransactionsModule.Resolvers &
         .then(res => res.map(t => t.id));
       return transactions;
     },
+    transactionsByFilters: async (_, { filters }, { injector }) => {
+      const ownerIDs = await injector.get(ScopeProvider).getReadScope();
+      const transactions = await injector
+        .get(TransactionsProvider)
+        .getTransactionsByExtendedFilters({
+          ownerIDs,
+          fromEventDate: filters?.fromEventDate,
+          toEventDate: filters?.toEventDate,
+          fromDebitDate: filters?.fromDebitDate,
+          toDebitDate: filters?.toDebitDate,
+          fromAnyDate: filters?.fromAnyDate,
+          toAnyDate: filters?.toAnyDate,
+          counterpartyIDs: filters?.byCounterparties ?? undefined,
+          withMissingCounterparty: filters?.withMissingCounterparty,
+          withMissingInfo: filters?.withMissingInfo,
+          freeText: filters?.freeText?.trim() || null,
+        })
+        .then(res => res.map(t => t.id));
+      return transactions;
+    },
   },
   Mutation: {
     updateTransaction: async (_, { transactionId, fields }, { injector }) => {

--- a/packages/server/src/modules/transactions/resolvers/transactions.resolver.ts
+++ b/packages/server/src/modules/transactions/resolvers/transactions.resolver.ts
@@ -59,11 +59,22 @@ export const transactionsResolvers: TransactionsModule.Resolvers &
       return transactions;
     },
     transactionsByFilters: async (_, { filters }, { injector }) => {
-      const ownerIDs = await injector.get(ScopeProvider).getReadScope();
+      // getReadScope narrows the authorized scope by the requested owners (throwing
+      // if any are outside it), so byOwners can never broaden access.
+      const ownerIDs = await injector
+        .get(ScopeProvider)
+        .getReadScope(filters?.byOwners ?? undefined);
+      // Guard against an empty read scope: passing no owner ids to the provider is
+      // treated as "no owner filter" and would return transactions across all owners.
+      if (ownerIDs.length === 0) {
+        return [];
+      }
       const transactions = await injector
         .get(TransactionsProvider)
         .getTransactionsByExtendedFilters({
           ownerIDs,
+          IDs: filters?.byIds ?? undefined,
+          chargeIDs: filters?.byChargeIds ?? undefined,
           fromEventDate: filters?.fromEventDate,
           toEventDate: filters?.toEventDate,
           fromDebitDate: filters?.fromDebitDate,

--- a/packages/server/src/modules/transactions/typeDefs/transactions.graphql.ts
+++ b/packages/server/src/modules/transactions/typeDefs/transactions.graphql.ts
@@ -10,6 +10,12 @@ export default gql`
 
   " filter options for the transactionsByFilters query "
   input TransactionsFilters {
+    " Include only transactions with one of these transaction ids "
+    byIds: [UUID!]
+    " Include only transactions linked to one of these charges "
+    byChargeIds: [UUID!]
+    " Include only transactions owned by one of these financial entities (must be within the authorized read scope) "
+    byOwners: [UUID!]
     " Include only transactions with event date on or after this date "
     fromEventDate: TimelessDate
     " Include only transactions with event date on or before this date "

--- a/packages/server/src/modules/transactions/typeDefs/transactions.graphql.ts
+++ b/packages/server/src/modules/transactions/typeDefs/transactions.graphql.ts
@@ -4,6 +4,32 @@ export default gql`
   extend type Query {
     transactionsByIDs(transactionIDs: [UUID!]!): [Transaction!]! @requiresAuth
     transactionsByFinancialEntity(financialEntityID: UUID!): [Transaction!]! @requiresAuth
+    " fetch transactions filtered by the given criteria "
+    transactionsByFilters(filters: TransactionsFilters): [Transaction!]! @requiresAuth
+  }
+
+  " filter options for the transactionsByFilters query "
+  input TransactionsFilters {
+    " Include only transactions with event date on or after this date "
+    fromEventDate: TimelessDate
+    " Include only transactions with event date on or before this date "
+    toEventDate: TimelessDate
+    " Include only transactions with debit date on or after this date "
+    fromDebitDate: TimelessDate
+    " Include only transactions with debit date on or before this date "
+    toDebitDate: TimelessDate
+    " Include only transactions with any date (event or debit) on or after this date "
+    fromAnyDate: TimelessDate
+    " Include only transactions with any date (event or debit) on or before this date "
+    toAnyDate: TimelessDate
+    " Include only transactions whose counterparty is one of these financial entities "
+    byCounterparties: [UUID!]
+    " Include only transactions with a missing counterparty (no linked business) "
+    withMissingCounterparty: Boolean
+    " Include only transactions with missing required info (fail transaction validation) "
+    withMissingInfo: Boolean
+    " Include only transactions matching this free text (source description / reference, amount, counter account, origin key, counterparty name) "
+    freeText: String
   }
 
   extend type Mutation {


### PR DESCRIPTION
## Summary

Adds a new `transactionsByFilters` query to the transactions GraphQL module, letting clients fetch transactions filtered by a rich set of criteria. Results are scoped to the caller's read scope.

## Filters (`TransactionsFilters` input)

- **Date ranges** — `fromEventDate`/`toEventDate` (event date), `fromDebitDate`/`toDebitDate` (debit date, honoring `debit_date_override`), and `fromAnyDate`/`toAnyDate` (matches if any of the transaction's dates fall in range).
- **Counterparty ids** — `byCounterparties`: only transactions linked to one of the given financial entities.
- **Missing counterparty** — `withMissingCounterparty`: transactions with no linked business.
- **Missing info** — `withMissingInfo`: transactions that fail transaction validation (mirrors `isTransactionsValid` — missing business, or missing both debit date and override).
- **Free text** — `freeText`: matches across `source_description`, `source_reference`, `counter_account`, `origin_key`, the counterparty (business) name, and the transaction amount. The amount search strips thousands separators so both `1,234.56` and `1234.56` match the plain value stored in the DB — mirroring the existing charges free-text search.

## Implementation

- **typeDefs** (`transactions.graphql.ts`) — new `transactionsByFilters` query (`@requiresAuth`) and `TransactionsFilters` input type.
- **provider** (`transactions.provider.ts`) — new `getTransactionsByExtendedFilters` SQL query joining `financial_entities` for counterparty-name search, plus a wrapper method that normalizes params and primes the by-id DataLoader.
- **resolver** (`transactions.resolver.ts`) — `transactionsByFilters` resolver that applies the read scope and returns transaction ids.

## Notes

Codegen (`yarn generate`), lint, and typecheck could not be run in this environment: dependency install fails because the `xlsx`/SheetJS transitive dependency is served from a CDN blocked by the network policy. The generated `__generated__` types (git-ignored) will be produced by `yarn generate` on a normal checkout — the new SQL query params (`IGetTransactionsByExtendedFiltersParams`/`Query`) and GraphQL resolver types follow the existing naming conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01442QbMVx1cDbJgKdF2CX67

---
_Generated by [Claude Code](https://claude.ai/code/session_01442QbMVx1cDbJgKdF2CX67)_