### PR TITLE
Support batch ledger-record regeneration

### DIFF
--- a/.changeset/@accounter_client-4121-dependencies.md
+++ b/.changeset/@accounter_client-4121-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`csv-parse@7.0.2` ↗︎](https://www.npmjs.com/package/csv-parse/v/7.0.2) (from `7.0.1`, in `dependencies`)

--- a/.changeset/@accounter_green-invoice-graphql-4121-dependencies.md
+++ b/.changeset/@accounter_green-invoice-graphql-4121-dependencies.md
@@ -1,0 +1,12 @@
+---
+"@accounter/green-invoice-graphql": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-mesh/config@0.109.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/config/v/0.109.1) (from `0.109.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/cross-helpers@0.4.16` ↗︎](https://www.npmjs.com/package/@graphql-mesh/cross-helpers/v/0.4.16) (from `0.4.15`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/http@0.107.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/http/v/0.107.1) (from `0.107.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/json-schema@0.110.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/json-schema/v/0.110.1) (from `0.110.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/runtime@0.107.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/runtime/v/0.107.1) (from `0.107.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/store@0.105.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/store/v/0.105.1) (from `0.105.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/types@0.105.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/types/v/0.105.1) (from `0.105.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/utils@0.105.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.105.1) (from `0.105.0`, in `dependencies`)

--- a/.changeset/@accounter_hashavshevet-mesh-4121-dependencies.md
+++ b/.changeset/@accounter_hashavshevet-mesh-4121-dependencies.md
@@ -1,0 +1,13 @@
+---
+"@accounter/hashavshevet-mesh": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-mesh/config@0.109.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/config/v/0.109.1) (from `0.109.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/cross-helpers@0.4.16` ↗︎](https://www.npmjs.com/package/@graphql-mesh/cross-helpers/v/0.4.16) (from `0.4.15`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/http@0.107.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/http/v/0.107.1) (from `0.107.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/json-schema@0.110.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/json-schema/v/0.110.1) (from `0.110.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/runtime@0.107.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/runtime/v/0.107.1) (from `0.107.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/store@0.105.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/store/v/0.105.1) (from `0.105.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/transform-resolvers-composition@0.105.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/transform-resolvers-composition/v/0.105.1) (from `0.105.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/types@0.105.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/types/v/0.105.1) (from `0.105.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/utils@0.105.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.105.1) (from `0.105.0`, in `dependencies`)

--- a/.changeset/@accounter_payper-mesh-4121-dependencies.md
+++ b/.changeset/@accounter_payper-mesh-4121-dependencies.md
@@ -1,0 +1,13 @@
+---
+"@accounter/payper-mesh": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-mesh/config@0.109.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/config/v/0.109.1) (from `0.109.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/cross-helpers@0.4.16` ↗︎](https://www.npmjs.com/package/@graphql-mesh/cross-helpers/v/0.4.16) (from `0.4.15`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/http@0.107.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/http/v/0.107.1) (from `0.107.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/json-schema@0.110.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/json-schema/v/0.110.1) (from `0.110.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/runtime@0.107.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/runtime/v/0.107.1) (from `0.107.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/store@0.105.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/store/v/0.105.1) (from `0.105.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/transform-rename@0.106.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/transform-rename/v/0.106.1) (from `0.106.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/types@0.105.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/types/v/0.105.1) (from `0.105.0`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/utils@0.105.1` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.105.1) (from `0.105.0`, in `dependencies`)

--- a/.changeset/@accounter_scraper-app-4121-dependencies.md
+++ b/.changeset/@accounter_scraper-app-4121-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/scraper-app": patch
+---
+dependencies updates:
+  - Updated dependency [`fastify@5.11.2` ↗︎](https://www.npmjs.com/package/fastify/v/5.11.2) (from `5.11.0`, in `dependencies`)

--- a/.changeset/@accounter_server-4121-dependencies.md
+++ b/.changeset/@accounter_server-4121-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/server": patch
+---
+dependencies updates:
+  - Updated dependency [`jose@6.2.8` ↗︎](https://www.npmjs.com/package/jose/v/6.2.8) (from `6.2.7`, in `dependencies`)

--- a/.changeset/batch-regenerate-ledger-records.md
+++ b/.changeset/batch-regenerate-ledger-records.md
@@ -1,0 +1,16 @@
+---
+'@accounter/server': minor
+'@accounter/client': minor
+---
+
+Support batch ledger-record regeneration from the charges table.
+
+The `regenerateLedgerRecords` mutation now accepts a list of charge ids
+(`chargeIds: [UUID!]!`) and returns a `GeneratedLedgerRecords` result per charge, in order. Each
+charge is regenerated independently, so a single failure surfaces as a per-charge `CommonError`
+instead of aborting the whole batch.
+
+On the client, the charges table's selection-column header now exposes a bulk-actions menu with a
+"Regenerate ledger" option that regenerates the ledger for all selected charges (with the same
+confirmation modal as the per-charge button). The existing per-charge regenerate button calls the
+same mutation with a single-element array.

--- a/packages/client/src/components/charges/charges-batch-actions-menu.tsx
+++ b/packages/client/src/components/charges/charges-batch-actions-menu.tsx
@@ -56,10 +56,7 @@ export function ChargesBatchActionsMenu({ table }: Props): ReactElement {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
-          <DropdownMenuItem
-            disabled={selectedCount === 0}
-            onSelect={() => setConfirmOpen(true)}
-          >
+          <DropdownMenuItem disabled={selectedCount === 0} onSelect={() => setConfirmOpen(true)}>
             <RefreshCcwDot className="size-4" />
             Regenerate ledger
           </DropdownMenuItem>

--- a/packages/client/src/components/charges/charges-batch-actions-menu.tsx
+++ b/packages/client/src/components/charges/charges-batch-actions-menu.tsx
@@ -1,0 +1,76 @@
+import { useState, type ReactElement } from 'react';
+import { MoreVertical, RefreshCcwDot } from 'lucide-react';
+import type { Table } from '@tanstack/react-table';
+import { useRegenerateLedgerRecords } from '../../hooks/use-regenerate-ledger-records.js';
+import { ConfirmationModal } from '../common/index.js';
+import { Button } from '../ui/button.js';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu.js';
+import type { ChargeRow } from './charges-table.js';
+
+interface Props {
+  table: Table<ChargeRow>;
+}
+
+/**
+ * Bulk-action menu rendered next to the selection column header. Operates on the table's currently
+ * selected rows. Currently exposes a single action — batch "Regenerate ledger" — which mirrors the
+ * per-charge {@link RegenerateLedgerRecordsButton} (confirmation modal included) for every selected
+ * charge in one request.
+ */
+export function ChargesBatchActionsMenu({ table }: Props): ReactElement {
+  const { regenerateLedgerRecords } = useRegenerateLedgerRecords();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const selectedCount = table.getSelectedRowModel().rows.length;
+
+  function onRegenerate(): void {
+    const rows = table.getSelectedRowModel().rows;
+    if (rows.length === 0) {
+      return;
+    }
+    regenerateLedgerRecords(rows.map(row => row.original.id)).then(() => {
+      // Refresh each affected row so the table reflects the regenerated ledger.
+      rows.forEach(row => row.original.onChange());
+    });
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6"
+            aria-label="Batch charge actions"
+            onClick={event => event.stopPropagation()}
+          >
+            <MoreVertical className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem
+            disabled={selectedCount === 0}
+            onSelect={() => setConfirmOpen(true)}
+          >
+            <RefreshCcwDot className="size-4" />
+            Regenerate ledger
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <ConfirmationModal
+        open={confirmOpen}
+        setOpen={setConfirmOpen}
+        onConfirm={onRegenerate}
+        title={`Are you sure you want to regenerate ledger records for ${selectedCount} selected charge${
+          selectedCount === 1 ? '' : 's'
+        }?`}
+      />
+    </>
+  );
+}

--- a/packages/client/src/components/charges/charges-batch-actions-menu.tsx
+++ b/packages/client/src/components/charges/charges-batch-actions-menu.tsx
@@ -29,13 +29,15 @@ export function ChargesBatchActionsMenu({ table }: Props): ReactElement {
   const selectedCount = table.getSelectedRowModel().rows.length;
 
   function onRegenerate(): void {
-    const rows = table.getSelectedRowModel().rows;
+    const { rows } = table.getSelectedRowModel();
     if (rows.length === 0) {
       return;
     }
     regenerateLedgerRecords(rows.map(row => row.original.id)).then(() => {
       // Refresh each affected row so the table reflects the regenerated ledger.
-      rows.forEach(row => row.original.onChange());
+      for (const row of rows) {
+        row.original.onChange();
+      }
     });
   }
 

--- a/packages/client/src/components/charges/columns.tsx
+++ b/packages/client/src/components/charges/columns.tsx
@@ -19,13 +19,14 @@ import {
   Vat,
 } from './cells/index.js';
 import { ChargeActionsMenu } from './charge-actions-menu.js';
+import { ChargesBatchActionsMenu } from './charges-batch-actions-menu.js';
 import type { ChargeRow } from './charges-table.js';
 
 export const columns: ColumnDef<ChargeRow>[] = [
   {
     id: 'select',
     header: ({ table }) => (
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-row gap-1 items-center">
         <Checkbox
           checked={
             table.getIsAllPageRowsSelected() ||
@@ -34,6 +35,7 @@ export const columns: ColumnDef<ChargeRow>[] = [
           onCheckedChange={value => table.toggleAllPageRowsSelected(!!value)}
           aria-label="Select all"
         />
+        <ChargesBatchActionsMenu table={table} />
       </div>
     ),
     cell: ({ row }) => (

--- a/packages/client/src/components/common/buttons/regenerate-ledger-records-button.tsx
+++ b/packages/client/src/components/common/buttons/regenerate-ledger-records-button.tsx
@@ -18,9 +18,7 @@ export function RegenerateLedgerRecordsButton({
   const { regenerateLedgerRecords } = useRegenerateLedgerRecords();
 
   function onRegenerate(): void {
-    regenerateLedgerRecords({
-      chargeId,
-    }).then(onChange);
+    regenerateLedgerRecords([chargeId]).then(onChange);
   }
 
   return (

--- a/packages/client/src/hooks/use-regenerate-ledger-records.ts
+++ b/packages/client/src/hooks/use-regenerate-ledger-records.ts
@@ -1,17 +1,13 @@
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 import { useMutation } from 'urql';
-import {
-  RegenerateLedgerDocument,
-  type RegenerateLedgerMutation,
-  type RegenerateLedgerMutationVariables,
-} from '../gql/graphql.js';
+import { RegenerateLedgerDocument, type RegenerateLedgerMutation } from '../gql/graphql.js';
 import { handleCommonErrors } from '../helpers/error-handling.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
-  mutation RegenerateLedger($chargeId: UUID!) {
-    regenerateLedgerRecords(chargeId: $chargeId) {
+  mutation RegenerateLedger($chargeIds: [UUID!]!) {
+    regenerateLedgerRecords(chargeIds: $chargeIds) {
       __typename
       ... on Ledger {
         records {
@@ -25,14 +21,16 @@ import { handleCommonErrors } from '../helpers/error-handling.js';
   }
 `;
 
-type Ledger = Extract<
-  RegenerateLedgerMutation['regenerateLedgerRecords'],
-  { __typename: 'Ledger' }
->;
+type RegenerateResult = RegenerateLedgerMutation['regenerateLedgerRecords'][number];
 
 type UseRegenerateLedgerRecords = {
   fetching: boolean;
-  regenerateLedgerRecords: (variables: RegenerateLedgerMutationVariables) => Promise<Ledger | void>;
+  /**
+   * Regenerate ledger records for the given charges. The single regenerate button passes a
+   * one-element array; the batch action passes every selected charge. Each charge is regenerated
+   * independently server-side, so partial failures are reported without failing the rest.
+   */
+  regenerateLedgerRecords: (chargeIds: string[]) => Promise<RegenerateResult[] | void>;
 };
 
 const NOTIFICATION_ID = 'regenerateLedgerRecords';
@@ -43,27 +41,50 @@ export const useRegenerateLedgerRecords = (): UseRegenerateLedgerRecords => {
 
   const [{ fetching }, mutate] = useMutation(RegenerateLedgerDocument);
   const regenerateLedgerRecords = useCallback(
-    async (variables: RegenerateLedgerMutationVariables) => {
+    async (chargeIds: string[]) => {
       const message = 'Error regenerating ledger';
-      const notificationId = `${NOTIFICATION_ID}-${variables.chargeId}`;
-      toast.loading('Regenerating Ledger', {
-        id: notificationId,
-      });
+      const isBatch = chargeIds.length > 1;
+      const notificationId = `${NOTIFICATION_ID}-${chargeIds.join('-')}`;
+      toast.loading(
+        isBatch ? `Regenerating Ledger for ${chargeIds.length} charges` : 'Regenerating Ledger',
+        {
+          id: notificationId,
+        },
+      );
       try {
-        const res = await mutate(variables);
-        const data = handleCommonErrors(res, message, notificationId, 'regenerateLedgerRecords');
+        const res = await mutate({ chargeIds });
+        const data = handleCommonErrors(res, message, notificationId);
         if (data) {
-          toast.success('Success', {
-            id: notificationId,
-            description: 'Ledger records were regenerated',
-          });
-          return data.regenerateLedgerRecords;
+          const results = data.regenerateLedgerRecords;
+          const failures = results.filter(result => result.__typename === 'CommonError');
+
+          // Every charge failed — surface the combined message via the error branch below.
+          if (failures.length > 0 && failures.length === results.length) {
+            throw new Error(failures.map(failure => failure.message).join('\n'));
+          }
+
+          if (failures.length > 0) {
+            toast.warning('Partial success', {
+              id: notificationId,
+              description: `${results.length - failures.length}/${results.length} charges regenerated. ${failures.length} failed.`,
+              duration: 100_000,
+              closeButton: true,
+            });
+          } else {
+            toast.success('Success', {
+              id: notificationId,
+              description: isBatch
+                ? `Ledger records were regenerated for ${results.length} charges`
+                : 'Ledger records were regenerated',
+            });
+          }
+          return results;
         }
       } catch (e) {
         console.error(`${message}: ${e}`);
         toast.error('Error', {
           id: notificationId,
-          description: message,
+          description: e instanceof Error ? e.message : message,
           duration: 100_000,
           closeButton: true,
         });

--- a/packages/client/src/hooks/use-regenerate-ledger-records.ts
+++ b/packages/client/src/hooks/use-regenerate-ledger-records.ts
@@ -44,7 +44,11 @@ export const useRegenerateLedgerRecords = (): UseRegenerateLedgerRecords => {
     async (chargeIds: string[]) => {
       const message = 'Error regenerating ledger';
       const isBatch = chargeIds.length > 1;
-      const notificationId = `${NOTIFICATION_ID}-${chargeIds.join('-')}`;
+      // Keep the toast id short and stable: per-charge for a single regenerate (so it dedupes with
+      // that charge's own toast), a fixed id for a batch (joining every UUID could grow unbounded).
+      const notificationId = isBatch
+        ? `${NOTIFICATION_ID}-batch`
+        : `${NOTIFICATION_ID}-${chargeIds[0]}`;
       toast.loading(
         isBatch ? `Regenerating Ledger for ${chargeIds.length} charges` : 'Regenerating Ledger',
         {

--- a/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
@@ -97,6 +97,10 @@ async function getInvoicePaymentCurrencyDiffErrors(
   }
 }
 
+// Max charges regenerated in parallel by `regenerateLedgerRecords`. Keeps large
+// batch selections from saturating the DB connection pool.
+const REGENERATE_LEDGER_CONCURRENCY = 5;
+
 // Regenerate the ledger records for a single charge. Any failure (charge not
 // found, locked, or a generation/storage error) is returned as a `CommonError`
 // rather than thrown, so a batched call never aborts the remaining charges.
@@ -396,9 +400,19 @@ export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'Generate
       // Regenerate each charge independently so a single failure surfaces as a
       // per-charge `CommonError` instead of aborting the whole batch. The single
       // regenerate button calls this with a one-element array.
-      return Promise.all(
-        chargeIds.map(chargeId => regenerateSingleChargeLedgerRecords(chargeId, context, info)),
-      );
+      //
+      // Process in bounded-concurrency chunks (rather than one big `Promise.all`)
+      // so a large selection doesn't fan out every charge's loader/insert/delete
+      // work at once and exhaust DB connections. Order of results is preserved.
+      const results: ResolversTypes['GeneratedLedgerRecords'][] = [];
+      for (let i = 0; i < chargeIds.length; i += REGENERATE_LEDGER_CONCURRENCY) {
+        const chunk = chargeIds.slice(i, i + REGENERATE_LEDGER_CONCURRENCY);
+        const chunkResults = await Promise.all(
+          chunk.map(chargeId => regenerateSingleChargeLedgerRecords(chargeId, context, info)),
+        );
+        results.push(...chunkResults);
+      }
+      return results;
     },
     lockLedgerRecords: async (_, { date }, { injector }) => {
       try {

--- a/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql';
+import { GraphQLError, type GraphQLResolveInfo } from 'graphql';
 import { type Injector } from 'graphql-modules';
 import { Repeater } from 'graphql-yoga';
 import {
@@ -94,6 +94,154 @@ async function getInvoicePaymentCurrencyDiffErrors(
       err,
     );
     return [];
+  }
+}
+
+// Regenerate the ledger records for a single charge. Any failure (charge not
+// found, locked, or a generation/storage error) is returned as a `CommonError`
+// rather than thrown, so a batched call never aborts the remaining charges.
+async function regenerateSingleChargeLedgerRecords(
+  chargeId: string,
+  context: GraphQLModules.ModuleContext,
+  info: GraphQLResolveInfo,
+): Promise<ResolversTypes['GeneratedLedgerRecords']> {
+  const { injector } = context;
+  try {
+    const { ledgerLock, ownerId } = await injector
+      .get(AdminContextProvider)
+      .getVerifiedAdminContext();
+    const charge = await injector.get(ChargesProvider).getChargeByIdLoader.load(chargeId);
+    if (!charge) {
+      return {
+        __typename: 'CommonError',
+        message: `Charge with id ${chargeId} not found`,
+      };
+    }
+    if (await isChargeLocked(charge, injector, ledgerLock)) {
+      return {
+        __typename: 'CommonError',
+        message: `Charge with id ${chargeId} is locked`,
+      };
+    }
+
+    const generated = await ledgerGenerationByCharge(
+      charge,
+      { insertLedgerRecordsIfNotExists: true },
+      context,
+      info,
+    );
+    if (!generated || 'message' in generated) {
+      const message = generated?.message ?? 'generation error';
+      throw new Error(message);
+    }
+
+    const records = generated.records as IGetLedgerRecordsByChargesIdsResult[];
+
+    const storageLedgerRecords = await injector
+      .get(LedgerProvider)
+      .getLedgerRecordsByChargesIdLoader.load(chargeId);
+
+    const fullMatching = ledgerRecordsGenerationFullMatchComparison(storageLedgerRecords, records);
+
+    if (fullMatching.isFullyMatched) {
+      return {
+        records: storageLedgerRecords,
+        charge,
+        errors: generated.errors,
+      };
+    }
+
+    const { toUpdate, toRemove } = ledgerRecordsGenerationPartialMatchComparison(
+      fullMatching.unmatchedStorageRecords,
+      fullMatching.unmatchedNewRecords,
+    );
+
+    const [newRecords, recordsToUpdate] = toUpdate.reduce(
+      (acc, record) => {
+        if (record.id === EMPTY_UUID) {
+          acc[0].push(record);
+        } else {
+          acc[1].push(record);
+        }
+        return acc;
+      },
+      [[], []] as [IGetLedgerRecordsByChargesIdsResult[], IGetLedgerRecordsByChargesIdsResult[]],
+    );
+
+    const updatePromise = injector
+      .get(LedgerProvider)
+      .deleteLedgerRecordsByIdLoader.loadMany(recordsToUpdate.map(r => r.id))
+      .catch(e => {
+        const message = `Failed to delete ledger records for charge ID="${chargeId}"`;
+        console.error(`${message}: ${e}`);
+        if (e instanceof GraphQLError) {
+          throw e;
+        }
+        throw new Error(message);
+      })
+      .then(() =>
+        injector.get(LedgerProvider).insertLedgerRecords({
+          ledgerRecords: recordsToUpdate
+            .map(record => convertLedgerRecordToInput(record, ownerId))
+            .map(record => {
+              record.chargeId = chargeId;
+              return record as IInsertLedgerRecordsParams['ledgerRecords'][number];
+            }),
+        }),
+      )
+      .catch(e => {
+        if (e instanceof GraphQLError) {
+          throw e;
+        }
+        const message = `Failed to update ledger records for charge ID="${chargeId}"`;
+        console.error(`${message}: ${e}`);
+        throw new Error(message);
+      });
+    const insertPromise =
+      newRecords.length > 0
+        ? injector
+            .get(LedgerProvider)
+            .insertLedgerRecords({
+              ledgerRecords: newRecords.map(record =>
+                convertLedgerRecordToInput(record, ownerId),
+              ) as IInsertLedgerRecordsParams['ledgerRecords'],
+            })
+            .catch(e => {
+              const message = `Failed to insert new ledger records for charge ID="${chargeId}"`;
+              console.error(`${message}: ${e}`);
+              if (e instanceof GraphQLError) {
+                throw e;
+              }
+              throw new Error(message);
+            })
+        : Promise.resolve();
+    const removePromises = toRemove.map(record =>
+      injector
+        .get(LedgerProvider)
+        .deleteLedgerRecordsByIdLoader.load(record.id)
+        .catch(e => {
+          const message = `Failed to delete ledger records for charge ID="${chargeId}"`;
+          console.error(`${message}: ${e}`);
+          if (e instanceof GraphQLError) {
+            throw e;
+          }
+          throw new Error(message);
+        }),
+    );
+    await Promise.all([updatePromise, insertPromise, ...removePromises]);
+
+    const degradedCharges = await degradeChargesAccountantApproval(injector, [chargeId]);
+
+    return {
+      records: toUpdate,
+      charge: degradedCharges.get(chargeId) ?? charge,
+      errors: generated.errors,
+    };
+  } catch (e) {
+    return {
+      __typename: 'CommonError',
+      message: `Failed to generate ledger records for charge ID="${chargeId}"\n${e}`,
+    };
   }
 }
 
@@ -244,150 +392,13 @@ export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'Generate
     },
   },
   Mutation: {
-    regenerateLedgerRecords: async (_, { chargeId }, context, info) => {
-      const { injector } = context;
-      const { ledgerLock, ownerId } = await injector
-        .get(AdminContextProvider)
-        .getVerifiedAdminContext();
-      const charge = await injector.get(ChargesProvider).getChargeByIdLoader.load(chargeId);
-      if (!charge) {
-        throw new GraphQLError(`Charge with id ${chargeId} not found`);
-      }
-      if (await isChargeLocked(charge, injector, ledgerLock)) {
-        return {
-          __typename: 'CommonError',
-          message: `Charge with id ${chargeId} is locked`,
-        };
-      }
-      try {
-        const generated = await ledgerGenerationByCharge(
-          charge,
-          { insertLedgerRecordsIfNotExists: true },
-          context,
-          info,
-        );
-        if (!generated || 'message' in generated) {
-          const message = generated?.message ?? 'generation error';
-          throw new Error(message);
-        }
-
-        const records = generated.records as IGetLedgerRecordsByChargesIdsResult[];
-
-        const storageLedgerRecords = await injector
-          .get(LedgerProvider)
-          .getLedgerRecordsByChargesIdLoader.load(chargeId);
-
-        const fullMatching = ledgerRecordsGenerationFullMatchComparison(
-          storageLedgerRecords,
-          records,
-        );
-
-        if (fullMatching.isFullyMatched) {
-          return {
-            records: storageLedgerRecords,
-            charge,
-            errors: generated.errors,
-          };
-        }
-
-        const { toUpdate, toRemove } = ledgerRecordsGenerationPartialMatchComparison(
-          fullMatching.unmatchedStorageRecords,
-          fullMatching.unmatchedNewRecords,
-        );
-
-        const [newRecords, recordsToUpdate] = toUpdate.reduce(
-          (acc, record) => {
-            if (record.id === EMPTY_UUID) {
-              acc[0].push(record);
-            } else {
-              acc[1].push(record);
-            }
-            return acc;
-          },
-          [[], []] as [
-            IGetLedgerRecordsByChargesIdsResult[],
-            IGetLedgerRecordsByChargesIdsResult[],
-          ],
-        );
-
-        const updatePromise = injector
-          .get(LedgerProvider)
-          .deleteLedgerRecordsByIdLoader.loadMany(recordsToUpdate.map(r => r.id))
-          .catch(e => {
-            const message = `Failed to delete ledger records for charge ID="${chargeId}"`;
-            console.error(`${message}: ${e}`);
-            if (e instanceof GraphQLError) {
-              throw e;
-            }
-            throw new Error(message);
-          })
-          .then(() =>
-            injector.get(LedgerProvider).insertLedgerRecords({
-              ledgerRecords: recordsToUpdate
-                .map(record => convertLedgerRecordToInput(record, ownerId))
-                .map(record => {
-                  record.chargeId = chargeId;
-                  return record as IInsertLedgerRecordsParams['ledgerRecords'][number];
-                }),
-            }),
-          )
-          .catch(e => {
-            if (e instanceof GraphQLError) {
-              throw e;
-            }
-            const message = `Failed to update ledger records for charge ID="${chargeId}"`;
-            console.error(`${message}: ${e}`);
-            throw new Error(message);
-          });
-        const insertPromise =
-          newRecords.length > 0
-            ? injector
-                .get(LedgerProvider)
-                .insertLedgerRecords({
-                  ledgerRecords: newRecords.map(record =>
-                    convertLedgerRecordToInput(record, ownerId),
-                  ) as IInsertLedgerRecordsParams['ledgerRecords'],
-                })
-                .catch(e => {
-                  const message = `Failed to insert new ledger records for charge ID="${chargeId}"`;
-                  console.error(`${message}: ${e}`);
-                  if (e instanceof GraphQLError) {
-                    throw e;
-                  }
-                  throw new Error(message);
-                })
-            : Promise.resolve();
-        const removePromises = toRemove.map(record =>
-          injector
-            .get(LedgerProvider)
-            .deleteLedgerRecordsByIdLoader.load(record.id)
-            .catch(e => {
-              const message = `Failed to delete ledger records for charge ID="${chargeId}"`;
-              console.error(`${message}: ${e}`);
-              if (e instanceof GraphQLError) {
-                throw e;
-              }
-              throw new Error(message);
-            }),
-        );
-        await Promise.all([updatePromise, insertPromise, ...removePromises]);
-
-        const degradedCharges = await degradeChargesAccountantApproval(injector, [chargeId]);
-
-        return {
-          records: toUpdate,
-          charge: degradedCharges.get(chargeId) ?? charge,
-          errors: generated.errors,
-        };
-      } catch (e) {
-        if (e instanceof GraphQLError) {
-          throw e;
-        }
-        return {
-          __typename: 'CommonError',
-          message: `Failed to generate ledger records for charge ID="${chargeId}"\n${e}`,
-        };
-      }
+    regenerateLedgerRecords: async (_, { chargeIds }, context, info) => {
+      // Regenerate each charge independently so a single failure surfaces as a
+      // per-charge `CommonError` instead of aborting the whole batch. The single
+      // regenerate button calls this with a one-element array.
+      return Promise.all(
+        chargeIds.map(chargeId => regenerateSingleChargeLedgerRecords(chargeId, context, info)),
+      );
     },
     lockLedgerRecords: async (_, { date }, { injector }) => {
       try {

--- a/packages/server/src/modules/ledger/typeDefs/ledger.graphql.ts
+++ b/packages/server/src/modules/ledger/typeDefs/ledger.graphql.ts
@@ -10,7 +10,8 @@ export default gql`
   }
 
   extend type Mutation {
-    regenerateLedgerRecords(chargeId: UUID!): GeneratedLedgerRecords!
+    " regenerate ledger records for one or more charges; returns a result per charge, in order "
+    regenerateLedgerRecords(chargeIds: [UUID!]!): [GeneratedLedgerRecords!]!
       @requiresAuth
       @requiresAnyRole(roles: ["business_owner", "accountant"])
     lockLedgerRecords(date: TimelessDate!): Boolean!


### PR DESCRIPTION
Enable regenerating ledger records for multiple charges in a single request, with per-charge error handling.

## Summary

The `regenerateLedgerRecords` mutation now accepts a list of charge IDs and returns a result per charge. Each charge is regenerated independently server-side, so a single failure surfaces as a per-charge `CommonError` instead of aborting the entire batch. The client gains a bulk-actions menu in the charges table to regenerate ledger for all selected charges at once.

## Changes

**Server:**
- Extracted charge-level regeneration logic into `regenerateSingleChargeLedgerRecords()` helper function that returns `CommonError` on failure instead of throwing
- Updated `regenerateLedgerRecords` mutation to accept `chargeIds: [UUID!]!` and return `GeneratedLedgerRecords[]` (one result per charge, in order)
- Added `GraphQLResolveInfo` import for type safety

**Client:**
- Added `ChargesBatchActionsMenu` component that renders a dropdown menu in the selection column header with a "Regenerate ledger" action for all selected rows
- Updated `useRegenerateLedgerRecords` hook to accept an array of charge IDs and handle partial failures with appropriate toast notifications (success, partial success, or error)
- Updated `RegenerateLedgerRecordsButton` to call the hook with a single-element array
- Updated GraphQL mutation to use `chargeIds` parameter and handle array results

**Schema:**
- Updated `regenerateLedgerRecords` mutation signature in typeDefs

The per-charge regenerate button continues to work as before (passing a one-element array), while the new batch action enables bulk operations with granular error reporting.

https://claude.ai/code/session_01C2oqFiJjQmhHDzvTWHx9i6