### PR TITLE
Refactor admin context to data-driven business roles (#3612)

### DIFF
--- a/packages/migrations/src/actions/2026-07-30T10-00-00.add-admin-business-roles-table.ts
+++ b/packages/migrations/src/actions/2026-07-30T10-00-00.add-admin-business-roles-table.ts
@@ -1,0 +1,50 @@
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+export default {
+  name: '2026-07-30T10-00-00.add-admin-business-roles-table.sql',
+  run: ({ sql }) => sql`
+    -- Abstract, per-tenant classification of businesses by the "role" they play
+    -- in an admin/user context (data sources + dividend-payment + VAT-excluded).
+    -- Replaces the hardcoded, institution-specific columns/UUIDs previously
+    -- enumerated inside admin-context.provider.ts (#3612), and lets each tenant
+    -- own an arbitrary set of data sources without a schema/code change.
+    CREATE TYPE accounter_schema.admin_business_role AS ENUM (
+      'BANK_ACCOUNT',
+      'CREDIT_CARD',
+      'CRYPTO_WALLET',
+      'DIVIDEND_PAYMENT',
+      'VAT_EXCLUDED'
+    );
+
+    CREATE TABLE accounter_schema.admin_business_roles (
+      owner_id    UUID                                 NOT NULL REFERENCES accounter_schema.businesses(id) ON DELETE CASCADE,
+      business_id UUID                                 NOT NULL REFERENCES accounter_schema.businesses(id) ON DELETE CASCADE,
+      role        accounter_schema.admin_business_role NOT NULL,
+      created_at  TIMESTAMPTZ                          NOT NULL DEFAULT now(),
+      updated_at  TIMESTAMPTZ                          NOT NULL DEFAULT now(),
+      PRIMARY KEY (owner_id, business_id, role)
+    );
+
+    -- Primary read pattern: "all business ids of role X for owner Y".
+    CREATE INDEX admin_business_roles_owner_role_idx
+      ON accounter_schema.admin_business_roles (owner_id, role);
+
+    -- Row Level Security: multi-business read scope (any business in the request's
+    -- authorized scope) for reads; single explicit write-target for writes. Mirrors
+    -- the pattern established by 2026-05-25T10-00-00.rls-multi-business-scope.
+    ALTER TABLE accounter_schema.admin_business_roles ENABLE ROW LEVEL SECURITY;
+
+    CREATE POLICY tenant_isolation ON accounter_schema.admin_business_roles
+      FOR ALL
+      USING (owner_id = ANY (accounter_schema.get_current_business_scope()))
+      WITH CHECK (owner_id = accounter_schema.get_current_business_id());
+
+    -- Force RLS even for the table owner (superusers still bypass).
+    ALTER TABLE accounter_schema.admin_business_roles FORCE ROW LEVEL SECURITY;
+
+    CREATE TRIGGER set_updated_at
+      BEFORE UPDATE ON accounter_schema.admin_business_roles
+      FOR EACH ROW
+      EXECUTE FUNCTION accounter_schema.update_general_updated_at();
+  `,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2026-07-30T10-00-00.add-admin-business-roles-table.ts
+++ b/packages/migrations/src/actions/2026-07-30T10-00-00.add-admin-business-roles-table.ts
@@ -39,6 +39,17 @@ export default {
       USING (owner_id = ANY (accounter_schema.get_current_business_scope()))
       WITH CHECK (owner_id = accounter_schema.get_current_business_id());
 
+    -- Pin DELETEs to the single write-target business. Postgres evaluates only
+    -- USING for DELETE (WITH CHECK is ignored), so without this a multi-business
+    -- read scope could delete another in-scope tenant's rows. A RESTRICTIVE policy
+    -- ANDs with the permissive one above, matching the guarantee that
+    -- 2026-05-26T10-00-00.rls-delete-write-target retrofitted onto every existing
+    -- tenant table (new tables must add it themselves).
+    CREATE POLICY tenant_isolation_delete ON accounter_schema.admin_business_roles
+      AS RESTRICTIVE
+      FOR DELETE
+      USING (owner_id = accounter_schema.get_current_business_id());
+
     -- Force RLS even for the table owner (superusers still bypass).
     ALTER TABLE accounter_schema.admin_business_roles FORCE ROW LEVEL SECURITY;
 

--- a/packages/migrations/src/actions/2026-07-30T11-00-00.backfill-admin-business-roles.ts
+++ b/packages/migrations/src/actions/2026-07-30T11-00-00.backfill-admin-business-roles.ts
@@ -1,0 +1,57 @@
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+export default {
+  name: '2026-07-30T11-00-00.backfill-admin-business-roles.sql',
+  run: ({ sql }) => sql`
+    -- Backfill admin_business_roles from the existing per-institution columns on
+    -- user_context, preserving current admin-context behavior once the provider
+    -- stops enumerating those columns/UUIDs in code (#3612).
+    --
+    -- Runs under the migration's privileged (RLS-bypassing) connection, so it sees
+    -- and writes every tenant's rows regardless of FORCE ROW LEVEL SECURITY.
+    INSERT INTO accounter_schema.admin_business_roles (owner_id, business_id, role)
+    SELECT owner_id, business_id, role
+    FROM (
+      SELECT owner_id, poalim_business_id AS business_id, 'BANK_ACCOUNT'::accounter_schema.admin_business_role AS role FROM accounter_schema.user_context
+      UNION ALL
+      SELECT owner_id, discount_business_id, 'BANK_ACCOUNT'::accounter_schema.admin_business_role FROM accounter_schema.user_context
+      UNION ALL
+      SELECT owner_id, otsar_hahayal_business_id, 'BANK_ACCOUNT'::accounter_schema.admin_business_role FROM accounter_schema.user_context
+      UNION ALL
+      SELECT owner_id, isracard_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context
+      UNION ALL
+      SELECT owner_id, amex_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context
+      UNION ALL
+      SELECT owner_id, cal_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context
+      UNION ALL
+      SELECT owner_id, otsar_hahayal_credit_card_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context
+      UNION ALL
+      SELECT owner_id, etana_business_id, 'CRYPTO_WALLET'::accounter_schema.admin_business_role FROM accounter_schema.user_context
+      UNION ALL
+      SELECT owner_id, kraken_business_id, 'CRYPTO_WALLET'::accounter_schema.admin_business_role FROM accounter_schema.user_context
+      UNION ALL
+      SELECT owner_id, etherscan_business_id, 'CRYPTO_WALLET'::accounter_schema.admin_business_role FROM accounter_schema.user_context
+      UNION ALL
+      SELECT owner_id, vat_business_id, 'VAT_EXCLUDED'::accounter_schema.admin_business_role FROM accounter_schema.user_context
+      UNION ALL
+      SELECT owner_id, tax_business_id, 'VAT_EXCLUDED'::accounter_schema.admin_business_role FROM accounter_schema.user_context
+      UNION ALL
+      SELECT owner_id, social_security_business_id, 'VAT_EXCLUDED'::accounter_schema.admin_business_role FROM accounter_schema.user_context
+    ) roles
+    WHERE business_id IS NOT NULL
+    ON CONFLICT DO NOTHING;
+
+    -- Dividend-payment businesses were previously a hardcoded, GLOBAL array of two
+    -- UUIDs applied to every tenant (a cross-tenant leak). Re-home each UUID to the
+    -- single tenant that actually owns it, so it only surfaces for that tenant.
+    INSERT INTO accounter_schema.admin_business_roles (owner_id, business_id, role)
+    SELECT fe.owner_id, fe.id, 'DIVIDEND_PAYMENT'::accounter_schema.admin_business_role
+    FROM accounter_schema.financial_entities fe
+    WHERE fe.id IN (
+      '4bcca705-5b47-41c5-ba26-1e42c69cbf0d', -- Uri Dividend
+      '909fbe3c-0419-44ed-817d-ab774e93748a'  -- Dotan Dividend
+    )
+      AND fe.owner_id IS NOT NULL
+    ON CONFLICT DO NOTHING;
+  `,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -194,6 +194,8 @@ import migration_2026_07_06T17_00_00_enhance_conversion_recognition from './acti
 import migration_2026_07_07T13_00_00_extend_deel_table from './actions/2026-07-07T13-00-00.extend-deel-table.js';
 import migration_2026_07_08T17_00_00_poalim_ils_trigger_fix from './actions/2026-07-08T17-00-00.poalim-ils-trigger-fix.js';
 import migration_2026_08_01T10_00_00_extended_tags_owner_id from './actions/2026-08-01T10-00-00.extended-tags-owner-id.js';
+import migration_2026_07_30T10_00_00_add_admin_business_roles_table from './actions/2026-07-30T10-00-00.add-admin-business-roles-table.js';
+import migration_2026_07_30T11_00_00_backfill_admin_business_roles from './actions/2026-07-30T11-00-00.backfill-admin-business-roles.js';
 import { runMigrations } from './pg-migrator.js';
 
 export const MIGRATIONS = [
@@ -392,6 +394,8 @@ export const MIGRATIONS = [
   migration_2026_07_07T13_00_00_extend_deel_table,
   migration_2026_07_08T17_00_00_poalim_ils_trigger_fix,
   migration_2026_08_01T10_00_00_extended_tags_owner_id,
+  migration_2026_07_30T10_00_00_add_admin_business_roles_table,
+  migration_2026_07_30T11_00_00_backfill_admin_business_roles,
 ] as const;
 
 export const LATEST_MIGRATION_NAME = MIGRATIONS[MIGRATIONS.length - 1]?.name;

--- a/packages/server/scripts/seed-admin-context.ts
+++ b/packages/server/scripts/seed-admin-context.ts
@@ -204,6 +204,25 @@ export async function seedAdminCore(
     console.log('ℹ️  user_context already exists, skipping insert');
   }
 
+  // 7. Classify authority businesses as VAT-report-excluded through the abstract
+  // admin_business_roles table (replaces the hardcoded vat/tax/social-security
+  // list in admin-context.provider — see #3612). Idempotent.
+  await client.query(
+    `INSERT INTO accounter_schema.admin_business_roles (owner_id, business_id, role)
+     VALUES
+       ($1, $2, 'VAT_EXCLUDED'::accounter_schema.admin_business_role),
+       ($1, $3, 'VAT_EXCLUDED'::accounter_schema.admin_business_role),
+       ($1, $4, 'VAT_EXCLUDED'::accounter_schema.admin_business_role)
+     ON CONFLICT DO NOTHING`,
+    [
+      adminEntityId,
+      authorityBusinessIds['VAT'],
+      authorityBusinessIds['Tax'],
+      authorityBusinessIds['Social Security'],
+    ],
+  );
+  console.log('✅ Authority VAT-excluded roles created');
+
   console.log('🎉 Admin context seed complete!');
   return { adminEntityId };
 }

--- a/packages/server/src/__tests__/seed-admin-context.integration.test.ts
+++ b/packages/server/src/__tests__/seed-admin-context.integration.test.ts
@@ -198,6 +198,34 @@ describe('seedAdminCore integration', () => {
     });
   });
 
+  it('should classify authority businesses as VAT_EXCLUDED admin_business_roles', async () => {
+    await db.withTransaction(async client => {
+      const { adminEntityId } = await seedAdminCore(client);
+
+      const context = (
+        await client.query(`SELECT * FROM accounter_schema.user_context WHERE owner_id = $1`, [
+          adminEntityId,
+        ])
+      ).rows[0];
+
+      const roles = await client.query(
+        `SELECT business_id FROM accounter_schema.admin_business_roles
+         WHERE owner_id = $1 AND role = 'VAT_EXCLUDED'`,
+        [adminEntityId],
+      );
+
+      // vat + tax + social-security authority businesses, data-driven (see #3612)
+      expect(roles.rows).toHaveLength(3);
+      expect(roles.rows.map(r => r.business_id).sort()).toEqual(
+        [
+          context.vat_business_id,
+          context.tax_business_id,
+          context.social_security_business_id,
+        ].sort(),
+      );
+    });
+  });
+
   it('should validate foreign key relationships', async () => {
     await db.withTransaction(async client => {
       const { adminEntityId } = await seedAdminCore(client);

--- a/packages/server/src/modules/admin-context/__tests__/admin-context.provider.test.ts
+++ b/packages/server/src/modules/admin-context/__tests__/admin-context.provider.test.ts
@@ -197,4 +197,77 @@ describe('AdminContextProvider', () => {
     expect(result?.defaultLocalCurrency).toBe('EUR');
     expect(dbProvider.query).toHaveBeenCalledTimes(2); // No additional call, using cache
   });
+
+  describe('normalizeContext (data-driven admin_business_roles)', () => {
+    const buildRow = (overrides: Record<string, unknown>) =>
+      ({
+        owner_id: 'owner-1',
+        default_local_currency: 'ILS',
+        default_fiat_currency_for_crypto_conversions: 'USD',
+        ...overrides,
+      }) as unknown as Parameters<AdminContextProvider['normalizeContext']>[0];
+
+    it('derives data-source arrays from the role aggregate columns', () => {
+      const ctx = provider.normalizeContext(
+        buildRow({
+          bank_account_business_ids: ['bank-1', 'bank-2'],
+          credit_card_business_ids: ['card-1'],
+          crypto_wallet_business_ids: ['wallet-1'],
+          foreign_securities_business_id: 'fs-1',
+        }),
+      );
+
+      expect(ctx.financialAccounts.bankAccountIds).toEqual(['bank-1', 'bank-2']);
+      expect(ctx.financialAccounts.creditCardIds).toEqual(['card-1']);
+      expect(ctx.financialAccounts.internalWalletsIds).toEqual(
+        expect.arrayContaining(['bank-1', 'bank-2', 'card-1', 'wallet-1', 'fs-1']),
+      );
+      expect(ctx.financialAccounts.internalWalletsIds).toHaveLength(5);
+    });
+
+    it('derives dividend and VAT-excluded arrays from roles without any hardcoded UUIDs', () => {
+      const ctx = provider.normalizeContext(
+        buildRow({
+          dividend_payment_business_ids: ['div-1'],
+          dividend_withholding_tax_business_id: 'wh-1',
+          vat_excluded_business_ids: ['vat-1', 'tax-1', 'ss-1'],
+        }),
+      );
+
+      expect(ctx.dividends.dividendPaymentBusinessIds).toEqual(['div-1']);
+      expect(ctx.dividends.dividendBusinessIds).toEqual(['wh-1', 'div-1']);
+      expect(ctx.authorities.vatReportExcludedBusinessNames).toEqual(['vat-1', 'tax-1', 'ss-1']);
+      // The previously hardcoded, cross-tenant dividend UUIDs must no longer leak in.
+      expect(ctx.dividends.dividendPaymentBusinessIds).not.toContain(
+        '4bcca705-5b47-41c5-ba26-1e42c69cbf0d',
+      );
+      expect(ctx.dividends.dividendPaymentBusinessIds).not.toContain(
+        '909fbe3c-0419-44ed-817d-ab774e93748a',
+      );
+    });
+
+    it('defaults every role-derived array to empty when the aggregates are absent', () => {
+      const ctx = provider.normalizeContext(buildRow({}));
+
+      expect(ctx.financialAccounts.bankAccountIds).toEqual([]);
+      expect(ctx.financialAccounts.creditCardIds).toEqual([]);
+      expect(ctx.financialAccounts.internalWalletsIds).toEqual([]);
+      expect(ctx.dividends.dividendPaymentBusinessIds).toEqual([]);
+      expect(ctx.dividends.dividendBusinessIds).toEqual([]);
+      expect(ctx.authorities.vatReportExcludedBusinessNames).toEqual([]);
+    });
+
+    it('de-duplicates internal wallets when one business holds multiple roles', () => {
+      const ctx = provider.normalizeContext(
+        buildRow({
+          bank_account_business_ids: ['dup', 'bank-2'],
+          credit_card_business_ids: ['dup'],
+          crypto_wallet_business_ids: ['dup'],
+          foreign_securities_business_id: 'dup',
+        }),
+      );
+
+      expect(ctx.financialAccounts.internalWalletsIds).toEqual(['dup', 'bank-2']);
+    });
+  });
 });

--- a/packages/server/src/modules/admin-context/providers/admin-context.provider.ts
+++ b/packages/server/src/modules/admin-context/providers/admin-context.provider.ts
@@ -18,10 +18,20 @@ import type {
   IUpdateAdminContextQuery,
 } from '../types.js';
 
+// The per-role correlated subqueries below expose each admin_business_role group
+// (see #3612) as an aggregated uuid[] column on the context row, so the runtime
+// arrays (bank accounts, credit cards, internal wallets, dividend payments,
+// VAT-excluded) are data-driven instead of enumerated from named columns/UUIDs.
 const getAdminContexts = sql<IGetAdminContextsQuery>`
-  SELECT *
-  FROM accounter_schema.user_context
-  WHERE owner_id IN $$ownerIds;
+  SELECT
+    uc.*,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'BANK_ACCOUNT'), '{}'::uuid[]) AS bank_account_business_ids,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'CREDIT_CARD'), '{}'::uuid[]) AS credit_card_business_ids,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'CRYPTO_WALLET'), '{}'::uuid[]) AS crypto_wallet_business_ids,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'DIVIDEND_PAYMENT'), '{}'::uuid[]) AS dividend_payment_business_ids,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'VAT_EXCLUDED'), '{}'::uuid[]) AS vat_excluded_business_ids
+  FROM accounter_schema.user_context uc
+  WHERE uc.owner_id IN $$ownerIds;
 `;
 
 const updateAdminContext = sql<IUpdateAdminContextQuery>`
@@ -292,8 +302,37 @@ const updateAdminContext = sql<IUpdateAdminContextQuery>`
       locality
     )
   WHERE owner_id = $ownerId
-  RETURNING *;
+  RETURNING
+    user_context.*,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'BANK_ACCOUNT'), '{}'::uuid[]) AS bank_account_business_ids,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'CREDIT_CARD'), '{}'::uuid[]) AS credit_card_business_ids,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'CRYPTO_WALLET'), '{}'::uuid[]) AS crypto_wallet_business_ids,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'DIVIDEND_PAYMENT'), '{}'::uuid[]) AS dividend_payment_business_ids,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'VAT_EXCLUDED'), '{}'::uuid[]) AS vat_excluded_business_ids;
 `;
+
+/**
+ * Legacy per-institution `updateAdminContext` inputs mapped to their abstract
+ * {@link https://github.com/Urigo/accounter-fullstack/issues/3612 admin_business_role}.
+ * This lets the deprecated typed mutation inputs (poalimBusinessId, …) keep
+ * admin_business_roles in sync so the role-derived arrays reflect them. Phase 2
+ * replaces these inputs with an abstract data-source API and removes this adapter.
+ */
+const PROVIDER_INPUT_ROLES: ReadonlyArray<[keyof IUpdateAdminContextParams, string]> = [
+  ['poalimBusinessId', 'BANK_ACCOUNT'],
+  ['discountBusinessId', 'BANK_ACCOUNT'],
+  ['otsarHahayalBusinessId', 'BANK_ACCOUNT'],
+  ['isracardBusinessId', 'CREDIT_CARD'],
+  ['amexBusinessId', 'CREDIT_CARD'],
+  ['calBusinessId', 'CREDIT_CARD'],
+  ['otsarHahayalCreditCardBusinessId', 'CREDIT_CARD'],
+  ['etanaBusinessId', 'CRYPTO_WALLET'],
+  ['krakenBusinessId', 'CRYPTO_WALLET'],
+  ['etherscanBusinessId', 'CRYPTO_WALLET'],
+  ['vatBusinessId', 'VAT_EXCLUDED'],
+  ['taxBusinessId', 'VAT_EXCLUDED'],
+  ['socialSecurityBusinessId', 'VAT_EXCLUDED'],
+];
 
 @Injectable({
   scope: Scope.Operation,
@@ -311,31 +350,35 @@ export class AdminContextProvider {
   ) {}
 
   public normalizeContext(rawContext: IGetAdminContextsResult): AdminContext {
-    const dividendPaymentBusinessIds = [
-      '4bcca705-5b47-41c5-ba26-1e42c69cbf0d', // Uri Dividend
-      '909fbe3c-0419-44ed-817d-ab774e93748a', // Dotan Dividend
-      // TODO: fetch those IDs from DB somehow
-    ];
-    const bankAccountIds = [
-      rawContext.poalim_business_id,
-      rawContext.discount_business_id,
-      rawContext.otsar_hahayal_business_id,
-    ].filter(Boolean) as string[];
-    const creditCardIds = [
-      rawContext.isracard_business_id,
-      rawContext.amex_business_id,
-      rawContext.cal_business_id,
-      rawContext.otsar_hahayal_credit_card_business_id,
-    ].filter(Boolean) as string[];
+    // Data-driven data-source / classification arrays, sourced from
+    // admin_business_roles (see #3612) instead of hardcoded per-institution
+    // columns or literal UUIDs. `toIdArray` is defensive against pgTyped's array
+    // nullability and against callers (e.g. unit tests) that supply a row without
+    // the aggregated columns.
+    const toIdArray = (value: readonly (string | null)[] | null | undefined): string[] =>
+      (value ?? []).filter((id): id is string => id != null);
+
+    const bankAccountIds = toIdArray(rawContext.bank_account_business_ids);
+    const creditCardIds = toIdArray(rawContext.credit_card_business_ids);
+    const cryptoWalletIds = toIdArray(rawContext.crypto_wallet_business_ids);
+    const dividendPaymentBusinessIds = toIdArray(rawContext.dividend_payment_business_ids);
+    const vatReportExcludedBusinessNames = toIdArray(rawContext.vat_excluded_business_ids);
     const salaryBatchedBusinessIds = [
       rawContext.batched_employees_business_id,
       rawContext.batched_funds_business_id,
     ].filter(Boolean) as string[];
-    const vatReportExcludedBusinessNames = [
-      rawContext.vat_business_id,
-      rawContext.tax_business_id,
-      rawContext.social_security_business_id,
-    ];
+    // Internal wallets = every self-owned data source (banks + cards + crypto)
+    // plus the foreign-securities business, de-duplicated.
+    const internalWalletsIds = Array.from(
+      new Set(
+        [
+          ...bankAccountIds,
+          ...creditCardIds,
+          ...cryptoWalletIds,
+          rawContext.foreign_securities_business_id,
+        ].filter(Boolean) as string[],
+      ),
+    );
     return {
       defaultLocalCurrency: formatCurrency(rawContext.default_local_currency),
       defaultCryptoConversionFiatCurrency: formatCurrency(
@@ -404,14 +447,7 @@ export class AdminContextProvider {
         foreignSecuritiesBusinessId: rawContext.foreign_securities_business_id,
         bankAccountIds,
         creditCardIds,
-        internalWalletsIds: [
-          ...bankAccountIds,
-          ...creditCardIds,
-          rawContext.etana_business_id,
-          rawContext.kraken_business_id,
-          rawContext.etherscan_business_id,
-          rawContext.foreign_securities_business_id,
-        ].filter(Boolean) as string[],
+        internalWalletsIds,
       },
       salaries: {
         zkufotExpensesTaxCategoryId: rawContext.zkufot_expenses_tax_category_id,
@@ -490,6 +526,10 @@ export class AdminContextProvider {
 
     this.cachedContext = null;
 
+    // Persist role rows for any legacy per-institution inputs BEFORE the update,
+    // so the RETURNING aggregates below already include the change.
+    await this.syncProviderBusinessRoles(ownerId, params);
+
     const updatedContexts = await updateAdminContext.run({ ...params, ownerId }, this.db);
     if (updatedContexts.length >= 1) {
       const normalizedContext = this.normalizeContext(updatedContexts[0]);
@@ -497,6 +537,39 @@ export class AdminContextProvider {
       return normalizedContext;
     }
     return null;
+  }
+
+  /**
+   * Write-through adapter for the legacy typed provider/authority business inputs:
+   * upsert the matching admin_business_roles rows so the role-derived arrays stay
+   * consistent when those inputs are used. Additive only (ON CONFLICT DO NOTHING) —
+   * removals are owned by the Phase 2 data-source API. No-op (and no query) when
+   * the update carries none of these inputs.
+   */
+  private async syncProviderBusinessRoles(
+    ownerId: string,
+    params: IUpdateAdminContextParams,
+  ): Promise<void> {
+    const values: unknown[] = [ownerId];
+    const rows: string[] = [];
+    for (const [key, role] of PROVIDER_INPUT_ROLES) {
+      const businessId = params[key];
+      if (typeof businessId === 'string' && businessId.length > 0) {
+        rows.push(
+          `($1, $${values.length + 1}, $${values.length + 2}::accounter_schema.admin_business_role)`,
+        );
+        values.push(businessId, role);
+      }
+    }
+    if (rows.length === 0) {
+      return;
+    }
+    await this.db.query(
+      `INSERT INTO accounter_schema.admin_business_roles (owner_id, business_id, role)
+       VALUES ${rows.join(', ')}
+       ON CONFLICT DO NOTHING`,
+      values,
+    );
   }
 
   private async batchAdminContextsByOwnerIds(ownerIds: readonly string[]) {

--- a/packages/server/src/modules/admin-context/providers/admin-context.provider.ts
+++ b/packages/server/src/modules/admin-context/providers/admin-context.provider.ts
@@ -25,11 +25,11 @@ import type {
 const getAdminContexts = sql<IGetAdminContextsQuery>`
   SELECT
     uc.*,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'BANK_ACCOUNT'), '{}'::uuid[]) AS bank_account_business_ids,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'CREDIT_CARD'), '{}'::uuid[]) AS credit_card_business_ids,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'CRYPTO_WALLET'), '{}'::uuid[]) AS crypto_wallet_business_ids,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'DIVIDEND_PAYMENT'), '{}'::uuid[]) AS dividend_payment_business_ids,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'VAT_EXCLUDED'), '{}'::uuid[]) AS vat_excluded_business_ids
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'BANK_ACCOUNT'), '{}'::uuid[]) AS bank_account_business_ids,
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'CREDIT_CARD'), '{}'::uuid[]) AS credit_card_business_ids,
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'CRYPTO_WALLET'), '{}'::uuid[]) AS crypto_wallet_business_ids,
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'DIVIDEND_PAYMENT'), '{}'::uuid[]) AS dividend_payment_business_ids,
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'VAT_EXCLUDED'), '{}'::uuid[]) AS vat_excluded_business_ids
   FROM accounter_schema.user_context uc
   WHERE uc.owner_id IN $$ownerIds;
 `;
@@ -304,11 +304,11 @@ const updateAdminContext = sql<IUpdateAdminContextQuery>`
   WHERE owner_id = $ownerId
   RETURNING
     user_context.*,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'BANK_ACCOUNT'), '{}'::uuid[]) AS bank_account_business_ids,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'CREDIT_CARD'), '{}'::uuid[]) AS credit_card_business_ids,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'CRYPTO_WALLET'), '{}'::uuid[]) AS crypto_wallet_business_ids,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'DIVIDEND_PAYMENT'), '{}'::uuid[]) AS dividend_payment_business_ids,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'VAT_EXCLUDED'), '{}'::uuid[]) AS vat_excluded_business_ids;
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'BANK_ACCOUNT'), '{}'::uuid[]) AS bank_account_business_ids,
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'CREDIT_CARD'), '{}'::uuid[]) AS credit_card_business_ids,
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'CRYPTO_WALLET'), '{}'::uuid[]) AS crypto_wallet_business_ids,
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'DIVIDEND_PAYMENT'), '{}'::uuid[]) AS dividend_payment_business_ids,
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = user_context.owner_id AND r.role = 'VAT_EXCLUDED'), '{}'::uuid[]) AS vat_excluded_business_ids;
 `;
 
 /**

--- a/packages/server/src/modules/onboarding/providers/admin-onboarding.provider.ts
+++ b/packages/server/src/modules/onboarding/providers/admin-onboarding.provider.ts
@@ -59,8 +59,15 @@ const getBootstrapBusiness = sql<IGetBootstrapBusinessQuery>`
 `;
 
 const getBootstrapContext = sql<IGetBootstrapContextQuery>`
-  SELECT * FROM accounter_schema.user_context
-  WHERE owner_id = $ownerId;
+  SELECT
+    uc.*,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'BANK_ACCOUNT'), '{}'::uuid[]) AS bank_account_business_ids,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'CREDIT_CARD'), '{}'::uuid[]) AS credit_card_business_ids,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'CRYPTO_WALLET'), '{}'::uuid[]) AS crypto_wallet_business_ids,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'DIVIDEND_PAYMENT'), '{}'::uuid[]) AS dividend_payment_business_ids,
+    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'VAT_EXCLUDED'), '{}'::uuid[]) AS vat_excluded_business_ids
+  FROM accounter_schema.user_context uc
+  WHERE uc.owner_id = $ownerId;
 `;
 
 const expireActiveInvitations = sql<IExpireActiveInvitationsQuery>`
@@ -259,6 +266,24 @@ export class AdminOnboardingProvider {
       await client.query(
         `INSERT INTO accounter_schema.user_context (${columns}) VALUES (${placeholders}) ON CONFLICT (owner_id) DO NOTHING`,
         Object.values(contextCols),
+      );
+
+      // 6b. Classify the authority businesses as VAT-report-excluded via the
+      // abstract admin_business_roles table (replaces the previously hardcoded
+      // vat/tax/social-security list in admin-context.provider — see #3612).
+      await client.query(
+        `INSERT INTO accounter_schema.admin_business_roles (owner_id, business_id, role)
+         VALUES
+           ($1, $2, 'VAT_EXCLUDED'::accounter_schema.admin_business_role),
+           ($1, $3, 'VAT_EXCLUDED'::accounter_schema.admin_business_role),
+           ($1, $4, 'VAT_EXCLUDED'::accounter_schema.admin_business_role)
+         ON CONFLICT DO NOTHING`,
+        [
+          adminEntityId,
+          authorityBusinessIds['VAT'],
+          authorityBusinessIds['Tax'],
+          authorityBusinessIds['Social Security'],
+        ],
       );
 
       // 7. Create Auth0 user (blocked) + invitation

--- a/packages/server/src/modules/onboarding/providers/admin-onboarding.provider.ts
+++ b/packages/server/src/modules/onboarding/providers/admin-onboarding.provider.ts
@@ -61,11 +61,11 @@ const getBootstrapBusiness = sql<IGetBootstrapBusinessQuery>`
 const getBootstrapContext = sql<IGetBootstrapContextQuery>`
   SELECT
     uc.*,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'BANK_ACCOUNT'), '{}'::uuid[]) AS bank_account_business_ids,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'CREDIT_CARD'), '{}'::uuid[]) AS credit_card_business_ids,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'CRYPTO_WALLET'), '{}'::uuid[]) AS crypto_wallet_business_ids,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'DIVIDEND_PAYMENT'), '{}'::uuid[]) AS dividend_payment_business_ids,
-    COALESCE((SELECT array_agg(r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'VAT_EXCLUDED'), '{}'::uuid[]) AS vat_excluded_business_ids
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'BANK_ACCOUNT'), '{}'::uuid[]) AS bank_account_business_ids,
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'CREDIT_CARD'), '{}'::uuid[]) AS credit_card_business_ids,
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'CRYPTO_WALLET'), '{}'::uuid[]) AS crypto_wallet_business_ids,
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'DIVIDEND_PAYMENT'), '{}'::uuid[]) AS dividend_payment_business_ids,
+    COALESCE((SELECT array_agg(r.business_id ORDER BY r.business_id) FROM accounter_schema.admin_business_roles r WHERE r.owner_id = uc.owner_id AND r.role = 'VAT_EXCLUDED'), '{}'::uuid[]) AS vat_excluded_business_ids
   FROM accounter_schema.user_context uc
   WHERE uc.owner_id = $ownerId;
 `;

--- a/scripts/seed-demo-data.ts
+++ b/scripts/seed-demo-data.ts
@@ -215,6 +215,7 @@ async function seedDemoData() {
                      accounter_schema.business_users,
                      accounter_schema.tags,
                      accounter_schema.tax_categories,
+                     accounter_schema.admin_business_roles,
                      accounter_schema.businesses,
                      accounter_schema.user_context,
                      accounter_schema.financial_entities

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -526,6 +526,49 @@ async function createAdminBusinessContext(
     console.error('Failed to create context:', e);
     throw new Error('Failed to create context', { cause: e });
   }
+
+  // derive admin business roles from the freshly-created context, so data sources
+  // (banks/cards/crypto) and VAT-excluded authorities are classified through the
+  // abstract admin_business_roles table (see #3612) rather than hardcoded columns.
+  try {
+    await client.query(`
+      INSERT INTO accounter_schema.admin_business_roles (owner_id, business_id, role)
+      SELECT owner_id, business_id, role
+      FROM (
+        SELECT owner_id, poalim_business_id AS business_id, 'BANK_ACCOUNT'::accounter_schema.admin_business_role AS role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        UNION ALL
+        SELECT owner_id, discount_business_id, 'BANK_ACCOUNT'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        UNION ALL
+        SELECT owner_id, otsar_hahayal_business_id, 'BANK_ACCOUNT'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        UNION ALL
+        SELECT owner_id, isracard_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        UNION ALL
+        SELECT owner_id, amex_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        UNION ALL
+        SELECT owner_id, cal_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        UNION ALL
+        SELECT owner_id, otsar_hahayal_credit_card_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        UNION ALL
+        SELECT owner_id, etana_business_id, 'CRYPTO_WALLET'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        UNION ALL
+        SELECT owner_id, kraken_business_id, 'CRYPTO_WALLET'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        UNION ALL
+        SELECT owner_id, etherscan_business_id, 'CRYPTO_WALLET'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        UNION ALL
+        SELECT owner_id, vat_business_id, 'VAT_EXCLUDED'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        UNION ALL
+        SELECT owner_id, tax_business_id, 'VAT_EXCLUDED'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        UNION ALL
+        SELECT owner_id, social_security_business_id, 'VAT_EXCLUDED'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+      ) roles
+      WHERE business_id IS NOT NULL
+      ON CONFLICT DO NOTHING;
+    `);
+  } catch (e) {
+    console.error('Failed to create admin business roles:', e);
+    throw new Error('Failed to create admin business roles', { cause: e });
+  }
+
   console.log('✅ Admin business context created successfully');
 }
 

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -535,35 +535,37 @@ async function createAdminBusinessContext(
       INSERT INTO accounter_schema.admin_business_roles (owner_id, business_id, role)
       SELECT owner_id, business_id, role
       FROM (
-        SELECT owner_id, poalim_business_id AS business_id, 'BANK_ACCOUNT'::accounter_schema.admin_business_role AS role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, poalim_business_id AS business_id, 'BANK_ACCOUNT'::accounter_schema.admin_business_role AS role FROM accounter_schema.user_context WHERE owner_id = $1
         UNION ALL
-        SELECT owner_id, discount_business_id, 'BANK_ACCOUNT'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, discount_business_id, 'BANK_ACCOUNT'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = $1
         UNION ALL
-        SELECT owner_id, otsar_hahayal_business_id, 'BANK_ACCOUNT'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, otsar_hahayal_business_id, 'BANK_ACCOUNT'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = $1
         UNION ALL
-        SELECT owner_id, isracard_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, isracard_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = $1
         UNION ALL
-        SELECT owner_id, amex_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, amex_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = $1
         UNION ALL
-        SELECT owner_id, cal_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, cal_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = $1
         UNION ALL
-        SELECT owner_id, otsar_hahayal_credit_card_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, otsar_hahayal_credit_card_business_id, 'CREDIT_CARD'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = $1
         UNION ALL
-        SELECT owner_id, etana_business_id, 'CRYPTO_WALLET'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, etana_business_id, 'CRYPTO_WALLET'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = $1
         UNION ALL
-        SELECT owner_id, kraken_business_id, 'CRYPTO_WALLET'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, kraken_business_id, 'CRYPTO_WALLET'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = $1
         UNION ALL
-        SELECT owner_id, etherscan_business_id, 'CRYPTO_WALLET'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, etherscan_business_id, 'CRYPTO_WALLET'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = $1
         UNION ALL
-        SELECT owner_id, vat_business_id, 'VAT_EXCLUDED'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, vat_business_id, 'VAT_EXCLUDED'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = $1
         UNION ALL
-        SELECT owner_id, tax_business_id, 'VAT_EXCLUDED'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, tax_business_id, 'VAT_EXCLUDED'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = $1
         UNION ALL
-        SELECT owner_id, social_security_business_id, 'VAT_EXCLUDED'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = '${adminEntityId}'
+        SELECT owner_id, social_security_business_id, 'VAT_EXCLUDED'::accounter_schema.admin_business_role FROM accounter_schema.user_context WHERE owner_id = $1
       ) roles
       WHERE business_id IS NOT NULL
       ON CONFLICT DO NOTHING;
-    `);
+    `,
+      [adminEntityId],
+    );
   } catch (e) {
     console.error('Failed to create admin business roles:', e);
     throw new Error('Failed to create admin business roles', { cause: e });


### PR DESCRIPTION
## Summary

Replaces hardcoded, institution-specific business ID columns and literal UUIDs in the admin context provider with an abstract, data-driven `admin_business_roles` table. This enables tenants to own arbitrary sets of data sources (banks, credit cards, crypto wallets) and authorities without schema or code changes.

## Key Changes

- **New database table**: `admin_business_roles` with enum type for role classification (BANK_ACCOUNT, CREDIT_CARD, CRYPTO_WALLET, DIVIDEND_PAYMENT, VAT_EXCLUDED)
  - Includes RLS policies mirroring existing multi-business scope patterns
  - Primary index on (owner_id, role) for efficient aggregation queries

- **SQL query refactoring**: Updated `getAdminContexts` and `updateAdminContext` queries to aggregate business IDs by role using correlated subqueries, exposing them as array columns (e.g., `bank_account_business_ids`, `credit_card_business_ids`)

- **Provider normalization logic**: Rewrote `normalizeContext()` to derive all data-source and authority arrays from the role aggregates instead of hardcoded columns/UUIDs
  - Removed hardcoded dividend payment UUIDs that were leaking across tenants
  - Consolidated internal wallets derivation with deduplication

- **Legacy input adapter**: Added `syncProviderBusinessRoles()` method to write-through sync deprecated typed mutation inputs (e.g., `poalimBusinessId`, `isracardBusinessId`) to `admin_business_roles` rows, maintaining consistency during the transition period

- **Migrations & seeding**: 
  - Two new migrations: table creation + backfill from existing columns
  - Updated seed scripts (`seed.ts`, `seed-admin-context.ts`, `admin-onboarding.provider.ts`) to populate roles
  - Updated `getBootstrapContext` query in onboarding provider

- **Test coverage**: Added comprehensive test suite for `normalizeContext()` covering role aggregation, empty defaults, deduplication, and removal of cross-tenant UUID leaks

## Implementation Details

- The adapter is additive-only (ON CONFLICT DO NOTHING) for legacy inputs; removals are owned by Phase 2's data-source API
- Defensive null-handling in `toIdArray()` helper accounts for pgTyped array nullability and test fixtures
- Dividend payment businesses are re-homed from global hardcoded UUIDs to per-tenant roles via financial_entities lookup
- All queries use COALESCE with empty array defaults to handle rows without aggregates (e.g., from unit tests)

https://claude.ai/code/session_01C9AcvxDWxpnbZ9oXRp3y6F