### PR TITLE
test(mcp-server): fix tests broken by increased MCP limits (#4116)

### DIFF
--- a/.changeset/mcp-server-limits-tests.md
+++ b/.changeset/mcp-server-limits-tests.md
@@ -1,0 +1,12 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Fix unit tests that broke when the MCP tool limits were raised. Several tests
+hardcoded the old caps, so inputs meant to exceed a bound (a wide date range, an
+over-cap page size, a full lookup payload) became valid once the limits grew.
+The assertions now derive their boundary values from the exported constants
+(`MAX_PAGE_SIZE`, `MAX_DATE_RANGE_DAYS`, `MAX_REPORT_DATE_RANGE_DAYS`,
+`MAX_FILTERED_CHARGES`), and the byte-budget no-truncation case is pinned to a
+row count that genuinely fits the payload budget, so the suite tracks future
+limit changes.

--- a/packages/mcp-server/src/tools/__tests__/byte-budget.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/byte-budget.test.ts
@@ -89,15 +89,19 @@ describe('payload byte budget with owner-tagged rows', () => {
     expect(serialized.length).toBeLessThanOrEqual(MAX_TOOL_RESULT_BYTES);
   });
 
-  it('does not truncate when the same row count fits the budget', async () => {
+  it('does not truncate when the row count fits the budget', async () => {
+    // A full MAX_LOOKUP_RESULTS lookup no longer fits the byte budget even with
+    // short names, so this pins the no-truncation contract at a count that does
+    // fit. Kept below the result cap so nothing is dropped for either reason.
+    const fittingRowCount = 500;
     const result = await executeRegisteredTool({
       tool: listTagsTool,
       rawArgs: {},
       auth: authContext(),
       correlationId: 'c',
-      // Short names: 500 rows well inside the budget.
+      // Short names: rows well inside the budget.
       client: clientReturning({
-        allTags: Array.from({ length: MAX_LOOKUP_RESULTS }, (_, i) => ({
+        allTags: Array.from({ length: fittingRowCount }, (_, i) => ({
           id: `t${i}`,
           name: `n${i}`,
           namePath: [`n${i}`],
@@ -112,7 +116,7 @@ describe('payload byte budget with owner-tagged rows', () => {
       continuation?: unknown;
     };
     expect(structured.truncated).toBe(false);
-    expect(structured.returnedCount).toBe(MAX_LOOKUP_RESULTS);
+    expect(structured.returnedCount).toBe(fittingRowCount);
     expect(structured.continuation).toBeUndefined();
   });
 });

--- a/packages/mcp-server/src/tools/__tests__/charges.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/charges.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
 import type { AuthPrincipal } from '../../auth/token.js';
 import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
-import { searchChargesTool } from '../charges.js';
+import { MAX_DATE_RANGE_DAYS, MAX_PAGE_SIZE, searchChargesTool } from '../charges.js';
 import { executeRegisteredTool } from '../execute.js';
 
 function authContext(businessIds: string[]): McpAuthContext {
@@ -287,17 +287,18 @@ describe('searchChargesTool — invalid filters', () => {
 
   it('rejects a date range wider than the cap', async () => {
     const client = clientReturning(oneCharge);
-    const result = await run(client, authContext(['b1']), {
-      fromDate: '2024-01-01',
-      toDate: '2026-01-01',
-    });
+    const fromDate = '2024-01-01';
+    // One day beyond the cap, derived from the constant so the test tracks it.
+    const toMs = Date.UTC(2024, 0, 1) + (MAX_DATE_RANGE_DAYS + 1) * 24 * 60 * 60 * 1000;
+    const toDate = new Date(toMs).toISOString().slice(0, 10);
+    const result = await run(client, authContext(['b1']), { fromDate, toDate });
     expect(result.isError).toBe(true);
     expect((result.structuredContent as { message: string }).message).toMatch(/must not exceed/);
   });
 
   it('rejects a page size above the cap', async () => {
     const client = clientReturning(oneCharge);
-    const result = await run(client, authContext(['b1']), { pageSize: 500 });
+    const result = await run(client, authContext(['b1']), { pageSize: MAX_PAGE_SIZE + 1 });
     expect(result.isError).toBe(true);
     expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
   });

--- a/packages/mcp-server/src/tools/__tests__/detail-tools.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/detail-tools.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
 import type { AuthPrincipal } from '../../auth/token.js';
 import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
-import { getChargesTool, MAX_CHARGE_IDS } from '../charge-details.js';
+import { getChargesTool, MAX_CHARGE_IDS, MAX_FILTERED_CHARGES } from '../charge-details.js';
 import { getDocumentsTool } from '../document-details.js';
 import { MAX_DETAIL_IDS } from '../entity-shapes.js';
 import { executeRegisteredTool } from '../execute.js';
@@ -284,7 +284,7 @@ describe('getChargesTool', () => {
     expect(variables.includeTransactions).toBe(false);
     expect(variables.includeDocuments).toBe(true);
     expect(variables.page).toBe(0);
-    expect(variables.limit).toBe(100);
+    expect(variables.limit).toBe(MAX_FILTERED_CHARGES);
   });
 
   it('combines chargeIds with filters and keeps only requested ids', async () => {

--- a/packages/mcp-server/src/tools/__tests__/reports.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/reports.test.ts
@@ -3,7 +3,7 @@ import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
 import type { AuthPrincipal } from '../../auth/token.js';
 import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
 import { executeRegisteredTool } from '../execute.js';
-import { balanceReportTool, MAX_REPORT_ROWS } from '../reports.js';
+import { balanceReportTool, MAX_REPORT_DATE_RANGE_DAYS, MAX_REPORT_ROWS } from '../reports.js';
 
 /**
  * The caller's business role is the membership `roleId` resolved upstream — the
@@ -138,10 +138,13 @@ describe('balanceReportTool — invalid range', () => {
 
   it('rejects a range wider than the cap', async () => {
     const client = clientReturning([]);
+    // One day beyond the cap, derived from the constant so the test tracks it.
+    const toMs = Date.UTC(2024, 0, 1) + (MAX_REPORT_DATE_RANGE_DAYS + 1) * 24 * 60 * 60 * 1000;
+    const toDate = new Date(toMs).toISOString().slice(0, 10);
     const result = await run(client, authContext(['b1']), {
       businessId: 'b1',
       fromDate: '2024-01-01',
-      toDate: '2026-01-01',
+      toDate,
     });
     expect(result.isError).toBe(true);
     expect((result.structuredContent as { message: string }).message).toMatch(/must not exceed/);

--- a/packages/mcp-server/src/tools/charge-details.ts
+++ b/packages/mcp-server/src/tools/charge-details.ts
@@ -45,7 +45,7 @@ export const MAX_CHARGE_IDS = 300;
 const CHARGE_FILTER_IDS_CAP = 300;
 const CHARGE_FILTER_TAGS_CAP = 50;
 const CHARGE_FILTER_TEXT_MAX = 200;
-const MAX_FILTERED_CHARGES = 300;
+export const MAX_FILTERED_CHARGES = 300;
 
 function optionalNonEmptyStringArray(max: number) {
   return z.preprocess(


### PR DESCRIPTION
## Problem

PR #4116 ("Increase MCP limits") raised several MCP tool caps:

| Constant | Old | New |
| --- | --- | --- |
| `MAX_PAGE_SIZE` | 50 | 500 |
| `MAX_DATE_RANGE_DAYS` | 366 | 1096 |
| `MAX_REPORT_DATE_RANGE_DAYS` | 366 | 1096 |
| `MAX_FILTERED_CHARGES` | 100 | 300 |
| `MAX_LOOKUP_RESULTS` | 500 | 1000 |

Several tests hardcoded the **old** boundary values. Once the caps grew, those inputs became *valid*, so the tests that expected a rejection (or expected no truncation) started failing:

- `charges.test.ts` — "rejects a date range wider than the cap" (731-day range now within the 1096 cap) and "rejects a page size above the cap" (`pageSize: 500` now equals the cap).
- `reports.test.ts` — "rejects a range wider than the cap" (same 731-day range).
- `detail-tools.test.ts` — asserted the forwarded `limit` was the literal `100` (now `300`).
- `byte-budget.test.ts` — "does not truncate when the same row count fits the budget" fed `MAX_LOOKUP_RESULTS` (now 1000) short rows, which serialize to ~62.7 KB and no longer fit the 60 KB payload budget, so the response now *does* truncate.

## Fix

Make the assertions track the exported constants instead of stale literals:

- **charges / reports**: derive the over-cap `toDate` as `MAX_*_DATE_RANGE_DAYS + 1` days past a fixed `fromDate`, and use `MAX_PAGE_SIZE + 1` for the page-size test.
- **detail-tools**: assert the forwarded limit equals `MAX_FILTERED_CHARGES` (now `export`ed from `charge-details.ts`).
- **byte-budget**: pin the no-truncation case at a row count that genuinely fits the byte budget (500) rather than the result cap, since a full `MAX_LOOKUP_RESULTS` lookup no longer fits regardless of name length. The truncation case is unchanged.

Deriving the boundaries from the constants keeps these tests correct through future limit changes.

## Verification

`vitest run` for `@accounter/mcp-server` — all previously failing limit tests pass. The only remaining failures are in `schema-contract.test.ts`, which requires the git-ignored generated `schema.graphql` (`yarn generate:graphql`); they are unrelated to this change and pre-exist in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMW3D9XBUJWd42Z9FA5zJL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMW3D9XBUJWd42Z9FA5zJL)_