### PR TITLE
Fix self-issued detection collapsing forwarded supplier invoices

### DIFF
--- a/.changeset/email-gateway-self-issued-forwarder.md
+++ b/.changeset/email-gateway-self-issued-forwarder.md
@@ -1,0 +1,27 @@
+---
+'@accounter/email-ingestion-gateway': patch
+'@accounter/server': patch
+---
+
+Fix email-ingestion falsely marking forwarded supplier invoices as self-issued (SELF_ISSUED
+DUPLICATE) and silently dropping them.
+
+When a supplier (e.g. Aiven) emails a tenant's Accounts-Payable Google Group, the mailing list
+rewrites the quoted `From:` to the group's own forwarding address (`'Aiven Billing' via Account
+Payables <ap@…>`). The real issuer's address survived only as a body contact/footer `mailto:` link,
+which the issuer-candidate extractor did not harvest — so the only recognized address was the
+forwarder, hard-coded as a self-issuing provider. The email was bound to the tenant's own business
+and skipped at ingest as a `DUPLICATE` (`SELF_ISSUED`), inserting nothing.
+
+- **Gateway `mime-extractor.ts`**: harvest any body `mailto:` link (not only header-anchored
+  `From:`/`Reply-To:`/`Sender:` addresses) as lower-priority issuer candidates, so a real issuer
+  reachable only through a contact/footer link is still recovered for server-side recognition.
+- **Server `email-ingestion-control.resolver.ts`**: a positive *external* business recognition now
+  wins over the single-address self-issued heuristic. When recognition identifies a real
+  counterparty (any business other than the tenant), the documents are attributed to it and the
+  self-issued check is skipped, so a supplier invoice routed through the tenant's own forwarding
+  group is no longer misclassified.
+- **Server `email-ingestion-ingest.provider.ts`**: the self-issued / tenant-matched path now
+  **QUARANTINEs** (recorded, visible, reprocessable) instead of silently returning `DUPLICATE` with
+  nothing written, so a misclassification is never silent data loss. The `SELF_ISSUED` reason code
+  now pairs with the `QUARANTINED` outcome.

--- a/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
@@ -686,26 +686,26 @@ describe('extractFromMime — body capture & issuer candidates', () => {
   });
 
   it('recovers the real issuer from a body contact mailto when the quoted From is a forwarder', async () => {
-    // The Aiven-via-Google-Group case: the mailing list rewrote the quoted `From:`
-    // to the forwarding group address, so the real issuer survives only as a
-    // footer/contact `mailto:` link. It must still be harvested — appended after
-    // the header-anchored forwarder address, not instead of it.
+    // Mailing-list forward: the list rewrote the quoted `From:` to the forwarding
+    // group address, so the real issuer survives only as a footer/contact `mailto:`
+    // link. It must still be harvested — appended after the header-anchored
+    // forwarder address, not instead of it.
     const html = [
       '<div>---------- Forwarded message ---------</div>',
-      '<div>From: \'Aiven Billing\' via Account Payables &lt;<a href="mailto:ap@the-guild.dev">ap@the-guild.dev</a>&gt;</div>',
-      '<div>To: <a href="mailto:ap@the-guild.dev">ap@the-guild.dev</a></div>',
-      '<p>If you have any questions, contact <a href="mailto:billing@aiven.io">billing@aiven.io</a>.</p>',
+      '<div>From: \'Vendor Billing\' via Group Alias &lt;<a href="mailto:group@tenant.example">group@tenant.example</a>&gt;</div>',
+      '<div>To: <a href="mailto:group@tenant.example">group@tenant.example</a></div>',
+      '<p>If you have any questions, contact <a href="mailto:billing@vendor.example">billing@vendor.example</a>.</p>',
     ].join('');
     const result = await extractFromMime(makeHtmlMime(html));
     expect(result.success).toBe(true);
     if (result.success) {
       const candidates = result.senderEvidence.issuerCandidates;
       // the real issuer, recovered from the contact mailto link
-      expect(candidates).toContain('billing@aiven.io');
+      expect(candidates).toContain('billing@vendor.example');
       // the forwarder group (header-anchored) is still present and ordered first
-      expect(candidates).toContain('ap@the-guild.dev');
-      expect(candidates.indexOf('ap@the-guild.dev')).toBeLessThan(
-        candidates.indexOf('billing@aiven.io'),
+      expect(candidates).toContain('group@tenant.example');
+      expect(candidates.indexOf('group@tenant.example')).toBeLessThan(
+        candidates.indexOf('billing@vendor.example'),
       );
     }
   });

--- a/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/mime-extractor.test.ts
@@ -685,6 +685,31 @@ describe('extractFromMime — body capture & issuer candidates', () => {
     }
   });
 
+  it('recovers the real issuer from a body contact mailto when the quoted From is a forwarder', async () => {
+    // The Aiven-via-Google-Group case: the mailing list rewrote the quoted `From:`
+    // to the forwarding group address, so the real issuer survives only as a
+    // footer/contact `mailto:` link. It must still be harvested — appended after
+    // the header-anchored forwarder address, not instead of it.
+    const html = [
+      '<div>---------- Forwarded message ---------</div>',
+      '<div>From: \'Aiven Billing\' via Account Payables &lt;<a href="mailto:ap@the-guild.dev">ap@the-guild.dev</a>&gt;</div>',
+      '<div>To: <a href="mailto:ap@the-guild.dev">ap@the-guild.dev</a></div>',
+      '<p>If you have any questions, contact <a href="mailto:billing@aiven.io">billing@aiven.io</a>.</p>',
+    ].join('');
+    const result = await extractFromMime(makeHtmlMime(html));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const candidates = result.senderEvidence.issuerCandidates;
+      // the real issuer, recovered from the contact mailto link
+      expect(candidates).toContain('billing@aiven.io');
+      // the forwarder group (header-anchored) is still present and ordered first
+      expect(candidates).toContain('ap@the-guild.dev');
+      expect(candidates.indexOf('ap@the-guild.dev')).toBeLessThan(
+        candidates.indexOf('billing@aiven.io'),
+      );
+    }
+  });
+
   it('extracts the issuer and the PDF from the forwarded-cloudflare.eml fixture', async () => {
     const raw = readFileSync(new URL('./fixtures/forwarded-cloudflare.eml', import.meta.url));
     const result = await extractFromMime(raw);

--- a/packages/email-ingestion-gateway/src/contracts.ts
+++ b/packages/email-ingestion-gateway/src/contracts.ts
@@ -25,9 +25,12 @@ export const IngestReasonCode = {
   OVERSIZE_MESSAGE: 'OVERSIZE_MESSAGE',
   TIMEOUT: 'TIMEOUT',
   TRANSIENT_UPSTREAM: 'TRANSIENT_UPSTREAM',
-  // Self-issued document: a confirmation email for an invoice the tenant issued
-  // itself (e.g. via Morning/greeninvoice). The underlying document already
-  // exists on the server from creation, so the email is skipped as a DUPLICATE.
+  // Self-issued document: the recognized issuer is the tenant's own business —
+  // typically a confirmation email for an invoice the tenant issued itself (e.g.
+  // via Morning/greeninvoice), whose document already exists from creation. The
+  // email is not inserted; it is QUARANTINED (recorded, visible, reprocessable)
+  // rather than dropped, because the same signal can also fire on a real supplier
+  // invoice that collapsed onto the tenant's own forwarding address.
   SELF_ISSUED: 'SELF_ISSUED',
   // Document preparation failed on the server (e.g. Cloudinary upload error)
   // after the email was accepted. The email is QUARANTINED (recorded, retryable

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -202,14 +202,26 @@ const ISSUER_CANDIDATE_RE = new RegExp(
   `(?:From|Reply-To|Sender):[\\s\\S]{0,250}?(?:href="mailto:([^"?]+)"|(${ISSUER_EMAIL}))`,
   'gi',
 );
+// Any `mailto:` link anywhere in the body, used as a lower-priority fallback.
+// A mailing-list forward ("… via <Group> <group@…>", e.g. a Google Group)
+// rewrites the quoted `From:` to the group's own address, so the header-anchored
+// regex above only recovers the forwarder — the real issuer survives only as a
+// contact/footer link ("If you have questions, contact billing@vendor.com" →
+// `<a href="mailto:billing@vendor.com">`). Harvesting those lets the server's
+// issuer lookup still match the issuing business. Extra addresses are harmless:
+// the server only matches candidates that are registered to a business, and its
+// candidate ordering already prefers non-forwarder addresses.
+const MAILTO_LINK_RE = /mailto:([^"'?>\s]+)/gi;
 const MAX_ISSUER_CANDIDATES = 25;
 
 function extractIssuerCandidates(body: string): string[] {
   const candidates: string[] = [];
   const seen = new Set<string>();
-  for (const match of body.matchAll(ISSUER_CANDIDATE_RE)) {
-    let email = match[1] ?? match[2] ?? '';
-    if (match[1]) {
+
+  // Returns true once the candidate cap is reached, so callers stop scanning.
+  const add = (raw: string, percentDecode: boolean): boolean => {
+    let email = raw;
+    if (percentDecode) {
       try {
         email = decodeURIComponent(email);
       } catch {
@@ -221,10 +233,26 @@ function extractIssuerCandidates(body: string): string[] {
     if (email && !seen.has(key)) {
       seen.add(key);
       candidates.push(email);
-      if (candidates.length >= MAX_ISSUER_CANDIDATES) {
-        break;
-      }
+    }
+    return candidates.length >= MAX_ISSUER_CANDIDATES;
+  };
+
+  // 1. Header-anchored addresses from the quoted From/Reply-To/Sender block —
+  //    highest signal, kept first so they win in the server's selection policy.
+  for (const match of body.matchAll(ISSUER_CANDIDATE_RE)) {
+    if (add(match[1] ?? match[2] ?? '', Boolean(match[1]))) {
+      return candidates;
     }
   }
+
+  // 2. Any other `mailto:` link in the body (contact/footer addresses) —
+  //    lower signal, appended after the header-anchored candidates. Deduped
+  //    against them via `seen`, so a link already captured above is not repeated.
+  for (const match of body.matchAll(MAILTO_LINK_RE)) {
+    if (add(match[1] ?? '', true)) {
+      return candidates;
+    }
+  }
+
   return candidates;
 }

--- a/packages/email-ingestion-gateway/src/mime-extractor.ts
+++ b/packages/email-ingestion-gateway/src/mime-extractor.ts
@@ -240,7 +240,7 @@ function extractIssuerCandidates(body: string): string[] {
   // 1. Header-anchored addresses from the quoted From/Reply-To/Sender block —
   //    highest signal, kept first so they win in the server's selection policy.
   for (const match of body.matchAll(ISSUER_CANDIDATE_RE)) {
-    if (add(match[1] ?? match[2] ?? '', Boolean(match[1]))) {
+    if (add(match[1] ?? match[2] ?? '', !!match[1])) {
       return candidates;
     }
   }

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-control.resolver.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-control.resolver.test.ts
@@ -238,4 +238,38 @@ describe('Mutation.requestIngestControl', () => {
     // and no treatment config is returned (the email is skipped at ingest).
     expect((result as { businessEmailConfig: unknown }).businessEmailConfig).toBeNull();
   });
+
+  it('binds a recognized external business even when the evidence would self-issue', async () => {
+    const issueGrant = vi.fn().mockResolvedValue(mockGrant);
+    // A real supplier (Aiven) is recognized from a body-harvested candidate, but
+    // the live From collapses onto the tenant's own forwarding group — which the
+    // single-address self-issued heuristic would otherwise flag as self-issued.
+    // Recognition must win: the invoice is attributed to the supplier, not dropped.
+    const recognizeBusinessFromEvidence = vi
+      .fn()
+      .mockResolvedValue({ businessId: 'biz-aiven', config: { attachments: ['PDF'] } });
+    const injector = makeInjector({ issueGrant, recognizeBusinessFromEvidence });
+
+    const result = await resolver(
+      {} as never,
+      {
+        input: {
+          ...baseInput,
+          senderEvidence: {
+            from: 'ap@the-guild.dev',
+            issuerCandidates: ['ap@the-guild.dev', 'billing@aiven.io'],
+          },
+        },
+      },
+      { injector } as never,
+      {} as never,
+    );
+
+    // The recognized external business is bound — not the tenant.
+    expect(issueGrant.mock.calls[0][0].businessId).toBe('biz-aiven');
+    // and its treatment config is returned so the gateway does the document work.
+    expect(result).toMatchObject({
+      businessEmailConfig: { businessId: 'biz-aiven', attachments: ['PDF'] },
+    });
+  });
 });

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-control.resolver.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-control.resolver.test.ts
@@ -241,13 +241,13 @@ describe('Mutation.requestIngestControl', () => {
 
   it('binds a recognized external business even when the evidence would self-issue', async () => {
     const issueGrant = vi.fn().mockResolvedValue(mockGrant);
-    // A real supplier (Aiven) is recognized from a body-harvested candidate, but
-    // the live From collapses onto the tenant's own forwarding group — which the
+    // A real supplier is recognized from a body-harvested candidate, but the live
+    // From collapses onto the tenant's own forwarding group — which the
     // single-address self-issued heuristic would otherwise flag as self-issued.
     // Recognition must win: the invoice is attributed to the supplier, not dropped.
     const recognizeBusinessFromEvidence = vi
       .fn()
-      .mockResolvedValue({ businessId: 'biz-aiven', config: { attachments: ['PDF'] } });
+      .mockResolvedValue({ businessId: 'biz-vendor', config: { attachments: ['PDF'] } });
     const injector = makeInjector({ issueGrant, recognizeBusinessFromEvidence });
 
     const result = await resolver(
@@ -256,8 +256,8 @@ describe('Mutation.requestIngestControl', () => {
         input: {
           ...baseInput,
           senderEvidence: {
-            from: 'ap@the-guild.dev',
-            issuerCandidates: ['ap@the-guild.dev', 'billing@aiven.io'],
+            from: 'group@tenant.example',
+            issuerCandidates: ['group@tenant.example', 'billing@vendor.example'],
           },
         },
       },
@@ -266,10 +266,10 @@ describe('Mutation.requestIngestControl', () => {
     );
 
     // The recognized external business is bound — not the tenant.
-    expect(issueGrant.mock.calls[0][0].businessId).toBe('biz-aiven');
+    expect(issueGrant.mock.calls[0][0].businessId).toBe('biz-vendor');
     // and its treatment config is returned so the gateway does the document work.
     expect(result).toMatchObject({
-      businessEmailConfig: { businessId: 'biz-aiven', attachments: ['PDF'] },
+      businessEmailConfig: { businessId: 'biz-vendor', attachments: ['PDF'] },
     });
   });
 });

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
@@ -304,11 +304,12 @@ describe('EmailIngestionIngestProvider.performIngest — self-issued', () => {
     vi.useRealTimers();
   });
 
+  const quarantineRow = { id: 'q-self' };
   const idemRow = {
     id: 'idem-row',
     idempotency_key: IDEM_KEY,
     owner_id: TENANT_ID,
-    outcome: IngestOutcome.DUPLICATE,
+    outcome: IngestOutcome.QUARANTINED,
     ingest_id: null,
     audit_id: 'audit-self',
     created_at: NOW,
@@ -317,7 +318,7 @@ describe('EmailIngestionIngestProvider.performIngest — self-issued', () => {
     id: 'dedup-row',
     owner_id: TENANT_ID,
     fingerprint: 'fp',
-    outcome: IngestOutcome.DUPLICATE,
+    outcome: IngestOutcome.QUARANTINED,
     ingest_id: null,
     correlation_id: CORR_ID,
     created_at: NOW,
@@ -335,9 +336,10 @@ describe('EmailIngestionIngestProvider.performIngest — self-issued', () => {
     ],
   };
 
-  it('returns DUPLICATE with SELF_ISSUED when the issuer is the tenant own business', async () => {
+  it('returns QUARANTINED with SELF_ISSUED when the issuer is the tenant own business', async () => {
     const { provider, uploadInvoiceToCloudinary, dataCalls } = makeProvider(VALID_GRANT_SELF_ISSUED, [
       { rows: [], rowCount: 0 }, // early idempotency miss
+      { rows: [quarantineRow], rowCount: 1 }, // quarantine insert
       { rows: [idemRow], rowCount: 1 }, // idempotency insert
       { rows: [dedupRow], rowCount: 1 }, // dedup insert
     ]);
@@ -345,22 +347,26 @@ describe('EmailIngestionIngestProvider.performIngest — self-issued', () => {
     const result = await provider.performIngest(inputWithContent, ocrInjector);
 
     expect(result).toMatchObject({
-      outcome: IngestOutcome.DUPLICATE,
-      existingIngestId: null,
+      outcome: IngestOutcome.QUARANTINED,
       reasonCode: IngestReasonCode.SELF_ISSUED,
     });
     // No document work (upload/OCR run together in prepareDocuments) and no
-    // charge/document rows are written for a self-issued duplicate.
+    // charge/document rows are written — the email is quarantined, not inserted.
     expect(uploadInvoiceToCloudinary).not.toHaveBeenCalled();
     expect(dataCalls.some(c => c.text.includes('INTO accounter_schema.charges'))).toBe(false);
     expect(dataCalls.some(c => c.text.includes('INTO accounter_schema.documents'))).toBe(false);
+    // A quarantine row is recorded so the misclassification is never silent.
+    expect(
+      dataCalls.some(c => c.text.includes('INTO accounter_schema.email_ingestion_quarantine')),
+    ).toBe(true);
   });
 
-  it('persists idempotency + dedup so a retry short-circuits, without dedup lookup or insert queries', async () => {
+  it('persists quarantine + idempotency + dedup so a retry short-circuits, without dedup lookup query', async () => {
     const { provider, validateAndConsumeGrant, dataCalls, dataQueries } = makeProvider(
       VALID_GRANT_SELF_ISSUED,
       [
         { rows: [], rowCount: 0 }, // early idempotency miss
+        { rows: [quarantineRow], rowCount: 1 }, // quarantine insert
         { rows: [idemRow], rowCount: 1 }, // idempotency insert
         { rows: [dedupRow], rowCount: 1 }, // dedup insert
       ],
@@ -369,10 +375,12 @@ describe('EmailIngestionIngestProvider.performIngest — self-issued', () => {
     await provider.performIngest(BASE_INPUT, ocrInjector);
 
     // The grant IS validated/consumed; the self-issued check then short-circuits
-    // before any dedup lookup, charge or document insert — but still records the
-    // idempotency key + dedup fingerprint so retries return DUPLICATE cleanly.
+    // before any dedup lookup, charge or document insert — but records the
+    // quarantine row plus the idempotency key + dedup fingerprint so retries
+    // short-circuit at the early idempotency check.
     expect(validateAndConsumeGrant).toHaveBeenCalled();
-    expect(dataQueries).toHaveLength(3); // early idem lookup + idem insert + dedup insert
+    expect(dataQueries).toHaveLength(4); // early idem lookup + quarantine insert + idem insert + dedup insert
+    expect(dataCalls.some(c => c.text.includes('INTO accounter_schema.email_ingestion_quarantine'))).toBe(true);
     expect(dataCalls.some(c => c.text.includes('INTO accounter_schema.email_ingestion_idempotency_keys'))).toBe(true);
     expect(dataCalls.some(c => c.text.includes('INTO accounter_schema.email_ingestion_dedup_fingerprints'))).toBe(true);
   });

--- a/packages/server/src/modules/email-ingestion/contracts.ts
+++ b/packages/server/src/modules/email-ingestion/contracts.ts
@@ -25,9 +25,12 @@ export const IngestReasonCode = {
   OVERSIZE_MESSAGE: 'OVERSIZE_MESSAGE',
   TIMEOUT: 'TIMEOUT',
   TRANSIENT_UPSTREAM: 'TRANSIENT_UPSTREAM',
-  // Self-issued document: a confirmation email for an invoice the tenant issued
-  // itself (e.g. via Morning/greeninvoice). The underlying document already
-  // exists on the server from creation, so the email is skipped as a DUPLICATE.
+  // Self-issued document: the recognized issuer is the tenant's own business —
+  // typically a confirmation email for an invoice the tenant issued itself (e.g.
+  // via Morning/greeninvoice), whose document already exists from creation. The
+  // email is not inserted; it is QUARANTINED (recorded, visible, reprocessable)
+  // rather than dropped, because the same signal can also fire on a real supplier
+  // invoice that collapsed onto the tenant's own forwarding address.
   SELF_ISSUED: 'SELF_ISSUED',
   // Document preparation failed on the server (e.g. Cloudinary upload error)
   // after the email was accepted. The email is QUARANTINED (recorded, retryable

--- a/packages/server/src/modules/email-ingestion/providers/email-ingestion-ingest.provider.ts
+++ b/packages/server/src/modules/email-ingestion/providers/email-ingestion-ingest.provider.ts
@@ -187,8 +187,6 @@ export type IngestResult =
       outcome: typeof IngestOutcome.DUPLICATE;
       existingIngestId: string | null;
       auditId: string;
-      /** Present only for self-issued skips (SELF_ISSUED); absent for content re-deliveries. */
-      reasonCode?: string;
     }
   | { outcome: typeof IngestOutcome.QUARANTINED; auditId: string; reasonCode: string }
   | { outcome: typeof IngestOutcome.REJECTED; reasonCode: string };
@@ -276,13 +274,18 @@ export class EmailIngestionIngestProvider {
     const corrId = correlationId ?? randomUUID();
     const fingerprint = computeDedupFingerprint(tenantId, rawMessageHash);
 
-    // Self-issued short-circuit: when the recognized issuing business is the
-    // tenant's own business, the email is a confirmation of an invoice the
-    // tenant issued itself (e.g. via Morning/greeninvoice). That document was
-    // already inserted at creation time, so ingesting it would duplicate it —
-    // skip before any upload/OCR/insert. Reported as DUPLICATE (the document
-    // already exists) with a SELF_ISSUED reason. Consume the grant and persist
-    // the idempotency key + dedup fingerprint in one transaction so a gateway
+    // Self-issued short-circuit: the recognized issuing business is the tenant's
+    // own business. The canonical case is a confirmation of an invoice the tenant
+    // issued itself (e.g. via Morning/greeninvoice), whose document already exists
+    // from creation — so we must not re-insert it. But the same signal also fires
+    // when a real supplier invoice reaches the tenant through its own forwarding
+    // group and no external issuer could be recognized (the issuer heuristic
+    // collapses onto the forwarder/tenant). Silently dropping those (the previous
+    // DUPLICATE behavior) lost the document with no trace. Instead QUARANTINE
+    // before any upload/OCR/insert: recorded, visible, and reprocessable, so a
+    // misclassification is never silent data loss, while a genuine self-issued
+    // duplicate is still not inserted. Consume the grant and persist the quarantine
+    // row + idempotency key + dedup fingerprint in one transaction so a gateway
     // retry short-circuits at the early idempotency check.
     if (businessId === tenantId) {
       return withTenantContext(this.dbProvider.pool, tenantId, async client => {
@@ -294,24 +297,15 @@ export class EmailIngestionIngestProvider {
           return { outcome: IngestOutcome.REJECTED, reasonCode: consumed.reason };
         }
 
-        const auditId = randomUUID();
-        await this.persistIdempotencyAndDedup({
-          idempotencyKey,
-          tenantId,
-          fingerprint,
-          outcome: IngestOutcome.DUPLICATE,
-          ingestId: null,
-          auditId,
-          correlationId: corrId,
-          client,
-        });
-
-        return {
-          outcome: IngestOutcome.DUPLICATE,
-          existingIngestId: null,
-          auditId,
+        return this.recordQuarantine(client, {
           reasonCode: IngestReasonCode.SELF_ISSUED,
-        };
+          tenantId,
+          messageId,
+          rawMessageHash,
+          idempotencyKey,
+          fingerprint,
+          correlationId: corrId,
+        });
       });
     }
 

--- a/packages/server/src/modules/email-ingestion/resolvers/email-ingestion-control.resolver.ts
+++ b/packages/server/src/modules/email-ingestion/resolvers/email-ingestion-control.resolver.ts
@@ -80,10 +80,13 @@ const requestIngestControl: MutationResolvers['requestIngestControl'] = async (
         expiresAt: grant.expiresAt.toISOString(),
       },
       // null signals "no business recognized" → gateway applies default
-      // treatment. We return config only for a recognized external business;
-      // self-issued (and tenant-matched) emails are dropped/quarantined at ingest,
-      // so we return no treatment config either, sparing the gateway needless
-      // document work (link-fetch / body→PDF) for a document that will be skipped.
+      // treatment. We return config only for a recognized external business.
+      // When none is recognized the email is not inserted at ingest — a
+      // self-issued/tenant-matched email is QUARANTINED (recorded and
+      // reprocessable, never silently dropped; see
+      // EmailIngestionIngestProvider.performIngest) — so we return no treatment
+      // config either, sparing the gateway needless document work (link-fetch /
+      // body→PDF) for a document that will not be inserted.
       businessEmailConfig: externalBusinessId
         ? {
             businessId: externalBusinessId,

--- a/packages/server/src/modules/email-ingestion/resolvers/email-ingestion-control.resolver.ts
+++ b/packages/server/src/modules/email-ingestion/resolvers/email-ingestion-control.resolver.ts
@@ -31,19 +31,30 @@ const requestIngestControl: MutationResolvers['requestIngestControl'] = async (
       input.senderEvidence ?? undefined,
     );
 
-    // Self-issued detection: confirmation emails for invoices the tenant issued
-    // through its own invoicing platform (e.g. Morning/greeninvoice). The
-    // document already exists on the server from creation, so binding the
-    // tenant's own business as the issuer lets the ingest step recognize the
-    // duplicate and skip it (see EmailIngestionIngestProvider.performIngest).
-    // Mirrors the legacy gmail-listener self-issued skip. The recipient alias is
-    // passed as the tenant's own inbound address so a mailing-list forward that
-    // rewrites `From` into that alias is still recognized as self — keeping the
-    // check tenant-agnostic.
-    const selfIssued = isSelfIssuedSenderEvidence(input.senderEvidence ?? undefined, [
-      input.recipientAlias,
-    ]);
-    const issuingBusinessId = selfIssued ? aliasResult.tenantId : businessId;
+    // A positive *external* recognition wins over the self-issued heuristic: if a
+    // real counterparty business (anything other than the tenant itself) matched a
+    // sender-evidence address, attribute the documents to it and skip the
+    // self-issued check entirely. Without this, a supplier invoice that reaches the
+    // tenant through its own forwarding group — which rewrites the quoted `From` to
+    // a forwarder address and so collapses the single-address self-issued heuristic
+    // onto that forwarder — would be wrongly bound to the tenant and dropped at
+    // ingest, even though recognition had already identified the real supplier.
+    const externalBusinessId =
+      businessId && businessId !== aliasResult.tenantId ? businessId : null;
+
+    // Self-issued detection (fallback, only when no external issuer was found):
+    // confirmation emails for invoices the tenant issued through its own invoicing
+    // platform (e.g. Morning/greeninvoice). Binding the tenant's own business as the
+    // issuer lets the ingest step recognize it and skip it (see
+    // EmailIngestionIngestProvider.performIngest). Mirrors the legacy gmail-listener
+    // self-issued skip. The recipient alias is passed as the tenant's own inbound
+    // address so a mailing-list forward that rewrites `From` into that alias is
+    // still recognized as self — keeping the check tenant-agnostic.
+    const selfIssued =
+      externalBusinessId === null &&
+      isSelfIssuedSenderEvidence(input.senderEvidence ?? undefined, [input.recipientAlias]);
+    const issuingBusinessId =
+      externalBusinessId ?? (selfIssued ? aliasResult.tenantId : businessId);
 
     const expiresAt = new Date(Date.now() + GRANT_TTL_MS);
     const grant = await control.issueGrant({
@@ -69,18 +80,18 @@ const requestIngestControl: MutationResolvers['requestIngestControl'] = async (
         expiresAt: grant.expiresAt.toISOString(),
       },
       // null signals "no business recognized" → gateway applies default
-      // treatment. Self-issued emails are dropped at ingest, so we return no
-      // treatment config either, sparing the gateway needless document work
-      // (link-fetch / body→PDF) for a document that will be skipped.
-      businessEmailConfig:
-        !selfIssued && businessId
-          ? {
-              businessId,
-              internalEmailLinks: config.internalEmailLinks ?? null,
-              emailBody: config.emailBody ?? null,
-              attachments: config.attachments ?? null,
-            }
-          : null,
+      // treatment. We return config only for a recognized external business;
+      // self-issued (and tenant-matched) emails are dropped/quarantined at ingest,
+      // so we return no treatment config either, sparing the gateway needless
+      // document work (link-fetch / body→PDF) for a document that will be skipped.
+      businessEmailConfig: externalBusinessId
+        ? {
+            businessId: externalBusinessId,
+            internalEmailLinks: config.internalEmailLinks ?? null,
+            emailBody: config.emailBody ?? null,
+            attachments: config.attachments ?? null,
+          }
+        : null,
     };
   } catch (err) {
     throw new GraphQLError('Failed to process ingest control request', {


### PR DESCRIPTION
## Summary

Fix email-ingestion falsely marking forwarded supplier invoices as self-issued and silently dropping them when they arrive through the tenant's own forwarding group (e.g., Google Group).

When a supplier emails a tenant's AP group, the mailing list rewrites the quoted `From:` to the group's forwarding address. The real issuer's address survived only as a body contact/footer `mailto:` link, which was not harvested. This caused the email to be bound to the tenant's own business and skipped at ingest as a silent `DUPLICATE`, losing the document entirely.

## Key Changes

- **Gateway `mime-extractor.ts`**: Harvest any body `mailto:` link (not only header-anchored `From:`/`Reply-To:`/`Sender:` addresses) as lower-priority issuer candidates. This recovers real issuers reachable only through contact/footer links while preserving the priority ordering of header-anchored addresses.

- **Server `email-ingestion-control.resolver.ts`**: External business recognition now wins over the single-address self-issued heuristic. When recognition identifies a real counterparty (any business other than the tenant), documents are attributed to it and the self-issued check is skipped entirely. This prevents supplier invoices routed through the tenant's own forwarding group from being misclassified.

- **Server `email-ingestion-ingest.provider.ts`**: The self-issued / tenant-matched path now **QUARANTINEs** (recorded, visible, reprocessable) instead of silently returning `DUPLICATE` with nothing written. This ensures misclassifications are never silent data loss. The `SELF_ISSUED` reason code now pairs with the `QUARANTINED` outcome.

- **Contracts**: Updated `SELF_ISSUED` reason code documentation to reflect the new behavior and explain why the same signal can fire on real supplier invoices that collapsed onto the tenant's forwarding address.

- **Tests**: Added test coverage for the external business recognition winning over self-issued heuristic, and updated self-issued tests to verify quarantine behavior instead of silent duplicate drops.

https://claude.ai/code/session_01WSX6LQxJJ1Vz2gdfFVDJk9