### PR TITLE
fix(email-ingestion): ingest foreign supplier invoices without hitting the auth-coupled providers

### DIFF
--- a/.changeset/email-ingestion-foreign-vat-authcontext.md
+++ b/.changeset/email-ingestion-foreign-vat-authcontext.md
@@ -1,0 +1,21 @@
+---
+'@accounter/server': patch
+---
+
+Fix `UPLOAD_FAILED` quarantine (`Missing businessId in AuthContext`) when ingesting a recognized
+foreign supplier invoice through the email-ingestion gateway.
+
+The gateway ingest runs under a `gateway_control_plane` context with no auth session, so it
+deliberately uses `withTenantContext` (raw pool + pinned RLS) instead of `TenantAwareDBClient`. But
+the shared `getDocumentFromUrlsAndOcrData` helper's foreign-counterparty VAT-0 fallback reached into
+the auth-coupled `BusinessesProvider` / `AdminContextProvider` loaders, whose `TenantAwareDBClient`
+throws `Missing businessId in AuthContext` in that context. The throw became a
+`DocumentPreparationError` → `UPLOAD_FAILED` quarantine, so any recognized **foreign** supplier
+invoice (VAT null) forwarded through the gateway was quarantined instead of inserted.
+
+- `getDocumentFromUrlsAndOcrData` now accepts an optional `vatFallbackContext`
+  (`{ counterpartyCountry, adminLocality }`); when provided it drives the VAT-0 fallback instead of
+  the auth-coupled loaders. The legacy path (no argument) is unchanged.
+- `EmailIngestionIngestProvider.prepareDocuments` resolves the counterparty country and the tenant's
+  admin locality via the raw pool under the tenant's RLS context (alongside the existing hash-dedup
+  read) and passes them in — so the control-plane ingest never touches the auth-coupled providers.

--- a/packages/server/src/modules/documents/helpers/upload.helper.ts
+++ b/packages/server/src/modules/documents/helpers/upload.helper.ts
@@ -169,6 +169,14 @@ export async function getDocumentFromUrlsAndOcrData(
   adminBusinessId: string,
   chargeId?: string | null,
   fileHash?: number,
+  // When provided, the counterparty country + admin locality used for the
+  // foreign-counterparty VAT-0 fallback are taken from here instead of the
+  // auth-coupled `BusinessesProvider` / `AdminContextProvider` loaders. The
+  // gateway email-ingestion path passes this because it runs under a control-plane
+  // context with no auth session, where those loaders' `TenantAwareDBClient` throws
+  // "Missing businessId in AuthContext". Absent (the default), the auth-coupled
+  // loaders are used, as before.
+  vatFallbackContext?: { counterpartyCountry: string | null; adminLocality: string | null },
 ): Promise<IInsertDocumentsParams['documents'][number]> {
   const sides = figureOutSides(
     ocrData.documentType,
@@ -179,12 +187,19 @@ export async function getDocumentFromUrlsAndOcrData(
 
   // in case of missing VAT, use 0 for foreign counterparties
   if (ocrData.counterpartyId && ocrData.vat == null) {
-    const [business, adminContext] = await Promise.all([
-      injector.get(BusinessesProvider).getBusinessByIdLoader.load(ocrData.counterpartyId),
-      injector.get(AdminContextProvider).adminContextByOwnerIdLoader.load(adminBusinessId),
-    ]);
-    if (business && adminContext && business.country !== adminContext.locality) {
-      ocrData.vat = 0;
+    if (vatFallbackContext) {
+      const { counterpartyCountry, adminLocality } = vatFallbackContext;
+      if (adminLocality != null && counterpartyCountry !== adminLocality) {
+        ocrData.vat = 0;
+      }
+    } else {
+      const [business, adminContext] = await Promise.all([
+        injector.get(BusinessesProvider).getBusinessByIdLoader.load(ocrData.counterpartyId),
+        injector.get(AdminContextProvider).adminContextByOwnerIdLoader.load(adminBusinessId),
+      ]);
+      if (business && adminContext && business.country !== adminContext.locality) {
+        ocrData.vat = 0;
+      }
     }
   }
 

--- a/packages/server/src/modules/documents/helpers/upload.helper.ts
+++ b/packages/server/src/modules/documents/helpers/upload.helper.ts
@@ -189,7 +189,11 @@ export async function getDocumentFromUrlsAndOcrData(
   if (ocrData.counterpartyId && ocrData.vat == null) {
     if (vatFallbackContext) {
       const { counterpartyCountry, adminLocality } = vatFallbackContext;
-      if (adminLocality != null && counterpartyCountry != null && counterpartyCountry !== adminLocality) {
+      if (
+        adminLocality != null &&
+        counterpartyCountry != null &&
+        counterpartyCountry !== adminLocality
+      ) {
         ocrData.vat = 0;
       }
     } else {

--- a/packages/server/src/modules/documents/helpers/upload.helper.ts
+++ b/packages/server/src/modules/documents/helpers/upload.helper.ts
@@ -189,7 +189,7 @@ export async function getDocumentFromUrlsAndOcrData(
   if (ocrData.counterpartyId && ocrData.vat == null) {
     if (vatFallbackContext) {
       const { counterpartyCountry, adminLocality } = vatFallbackContext;
-      if (adminLocality != null && counterpartyCountry !== adminLocality) {
+      if (adminLocality != null && counterpartyCountry != null && counterpartyCountry !== adminLocality) {
         ocrData.vat = 0;
       }
     } else {

--- a/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
+++ b/packages/server/src/modules/email-ingestion/__tests__/email-ingestion-ingest.provider.test.ts
@@ -243,6 +243,8 @@ describe('EmailIngestionIngestProvider.performIngest — grant validation', () =
       [
         { rows: [], rowCount: 0 }, // early idempotency miss
         { rows: [], rowCount: 0 }, // prepareDocuments: checkDocumentByHash → new candidate
+        { rows: [{ country: 'IL' }], rowCount: 1 }, // prepareDocuments: counterparty country (VAT-0 fallback input)
+        { rows: [{ locality: 'IL' }], rowCount: 1 }, // prepareDocuments: admin locality (VAT-0 fallback input)
         { rows: [{ id: 'q-id' }], rowCount: 1 }, // quarantine insert
         { rows: [idemRow], rowCount: 1 }, // idempotency insert
         { rows: [dedupRow], rowCount: 1 }, // dedup insert
@@ -628,6 +630,8 @@ describe('EmailIngestionIngestProvider.performIngest — document persistence', 
       [
         { rows: [], rowCount: 0 }, // early idempotency miss
         { rows: [], rowCount: 0 }, // document-by-hash miss (prepare tx, pre-upload)
+        { rows: [{ country: 'IL' }], rowCount: 1 }, // prepareDocuments: counterparty country (VAT-0 fallback input)
+        { rows: [{ locality: 'IL' }], rowCount: 1 }, // prepareDocuments: admin locality (VAT-0 fallback input)
         { rows: [], rowCount: 0 }, // idempotency miss
         { rows: [], rowCount: 0 }, // dedup fingerprint miss
         { rows: [{ id: 'charge-1' }], rowCount: 1 }, // charge insert
@@ -656,10 +660,53 @@ describe('EmailIngestionIngestProvider.performIngest — document persistence', 
     expect(docInsert?.values).toContain(BUSINESS_ID);
   });
 
+  it('resolves foreign-counterparty VAT via the raw pool, not the auth-coupled providers', async () => {
+    // Regression: the gateway ingest runs under a control-plane context with no auth
+    // session. The foreign-counterparty VAT-0 fallback must read the counterparty
+    // country + admin locality via the raw pool — never via BusinessesProvider /
+    // AdminContextProvider, whose TenantAwareDBClient throws "Missing businessId in
+    // AuthContext" here (which had surfaced as an UPLOAD_FAILED quarantine).
+    businessesProvider.getBusinessByIdLoader.load.mockClear();
+    adminContextProvider.adminContextByOwnerIdLoader.load.mockClear();
+
+    const { provider, dataCalls } = makeProvider(VALID_GRANT_WITH_BUSINESS, [
+      { rows: [], rowCount: 0 }, // early idempotency miss
+      { rows: [], rowCount: 0 }, // document-by-hash miss (prepare tx, pre-upload)
+      { rows: [{ country: 'US' }], rowCount: 1 }, // counterparty country (foreign)
+      { rows: [{ locality: 'IL' }], rowCount: 1 }, // admin locality
+      { rows: [], rowCount: 0 }, // idempotency miss
+      { rows: [], rowCount: 0 }, // dedup fingerprint miss
+      { rows: [{ id: 'charge-1' }], rowCount: 1 }, // charge insert
+      { rows: [{ id: 'doc-1' }], rowCount: 1 }, // document insert
+      { rows: [idemRow], rowCount: 1 }, // idempotency insert
+      { rows: [dedupRow], rowCount: 1 }, // dedup insert
+    ]);
+
+    const result = await provider.performIngest(inputWithContent, ocrInjector);
+
+    expect(result).toMatchObject({ outcome: IngestOutcome.INSERTED, ingestId: 'charge-1' });
+    // The VAT-0 fallback inputs are read via the raw pool…
+    expect(
+      dataCalls.some(
+        c => c.text.includes('FROM accounter_schema.businesses') && c.text.includes('country'),
+      ),
+    ).toBe(true);
+    expect(
+      dataCalls.some(
+        c => c.text.includes('FROM accounter_schema.user_context') && c.text.includes('locality'),
+      ),
+    ).toBe(true);
+    // …and never via the auth-coupled providers (which would throw in this context).
+    expect(businessesProvider.getBusinessByIdLoader.load).not.toHaveBeenCalled();
+    expect(adminContextProvider.adminContextByOwnerIdLoader.load).not.toHaveBeenCalled();
+  });
+
   it('sets a descriptive charge description from subject, sender, and received date', async () => {
     const { provider, dataCalls } = makeProvider(VALID_GRANT_WITH_BUSINESS, [
       { rows: [], rowCount: 0 }, // early idempotency miss
       { rows: [], rowCount: 0 }, // document-by-hash miss (prepare tx, pre-upload)
+      { rows: [{ country: 'IL' }], rowCount: 1 }, // prepareDocuments: counterparty country (VAT-0 fallback input)
+      { rows: [{ locality: 'IL' }], rowCount: 1 }, // prepareDocuments: admin locality (VAT-0 fallback input)
       { rows: [], rowCount: 0 }, // idempotency miss
       { rows: [], rowCount: 0 }, // dedup fingerprint miss
       { rows: [{ id: 'charge-1' }], rowCount: 1 }, // charge insert
@@ -689,6 +736,8 @@ describe('EmailIngestionIngestProvider.performIngest — document persistence', 
     const { provider, dataCalls } = makeProvider(VALID_GRANT_WITH_BUSINESS, [
       { rows: [], rowCount: 0 }, // early idempotency miss
       { rows: [], rowCount: 0 }, // document-by-hash miss (prepare tx, pre-upload)
+      { rows: [{ country: 'IL' }], rowCount: 1 }, // prepareDocuments: counterparty country (VAT-0 fallback input)
+      { rows: [{ locality: 'IL' }], rowCount: 1 }, // prepareDocuments: admin locality (VAT-0 fallback input)
       { rows: [], rowCount: 0 }, // idempotency miss
       { rows: [], rowCount: 0 }, // dedup fingerprint miss
       { rows: [{ id: 'charge-1' }], rowCount: 1 }, // charge insert

--- a/packages/server/src/modules/email-ingestion/providers/email-ingestion-ingest.provider.ts
+++ b/packages/server/src/modules/email-ingestion/providers/email-ingestion-ingest.provider.ts
@@ -492,20 +492,51 @@ export class EmailIngestionIngestProvider {
     }));
 
     // Find the documents new to this tenant under its RLS context (a short read,
-    // no network I/O held in a long-lived transaction).
-    const newCandidates = await withTenantContext(this.dbProvider.pool, tenantId, async client => {
-      const fresh: typeof candidates = [];
-      for (const candidate of candidates) {
-        const existing = await checkDocumentByHashForIngest.run(
-          { ownerId: tenantId, fileHash: candidate.fileHash.toString() },
-          client,
-        );
-        if (existing.length === 0) {
-          fresh.push(candidate);
+    // no network I/O held in a long-lived transaction). In the same tenant-pinned
+    // read, resolve the inputs for the foreign-counterparty VAT-0 fallback — the
+    // counterparty's country and the tenant's admin locality — so
+    // getDocumentFromUrlsAndOcrData never has to reach into the auth-coupled
+    // Businesses/AdminContext providers, whose TenantAwareDBClient throws
+    // "Missing businessId in AuthContext" in this control-plane context. These use
+    // the raw client directly (no pgtyped) so the control-plane read stays
+    // self-contained; RLS is pinned to the tenant, and the explicit owner_id filter
+    // is defense-in-depth.
+    const { newCandidates, vatFallbackContext } = await withTenantContext(
+      this.dbProvider.pool,
+      tenantId,
+      async client => {
+        const fresh: typeof candidates = [];
+        for (const candidate of candidates) {
+          const existing = await checkDocumentByHashForIngest.run(
+            { ownerId: tenantId, fileHash: candidate.fileHash.toString() },
+            client,
+          );
+          if (existing.length === 0) {
+            fresh.push(candidate);
+          }
         }
-      }
-      return fresh;
-    });
+
+        let ctx: { counterpartyCountry: string | null; adminLocality: string | null } | undefined;
+        if (fresh.length > 0 && businessId) {
+          const [countryRes, localityRes] = await Promise.all([
+            client.query<{ country: string | null }>(
+              'SELECT country FROM accounter_schema.businesses WHERE id = $1 AND owner_id = $2 LIMIT 1',
+              [businessId, tenantId],
+            ),
+            client.query<{ locality: string | null }>(
+              'SELECT locality FROM accounter_schema.user_context WHERE owner_id = $1 LIMIT 1',
+              [tenantId],
+            ),
+          ]);
+          ctx = {
+            counterpartyCountry: countryRes.rows[0]?.country ?? null,
+            adminLocality: localityRes.rows[0]?.locality ?? null,
+          };
+        }
+
+        return { newCandidates: fresh, vatFallbackContext: ctx };
+      },
+    );
 
     // Upload + OCR the new documents in parallel, outside any transaction. A
     // failure here — the Cloudinary upload or the params build; OCR itself is
@@ -539,6 +570,9 @@ export class EmailIngestionIngestProvider {
             tenantId,
             null,
             fileHash,
+            // Pre-resolved above (raw pool, tenant RLS) so the fallback never calls
+            // the auth-coupled providers in this control-plane context.
+            vatFallbackContext,
           );
           // Mirror the legacy `insertEmailDocuments` resolver, which overrides the
           // OCR-derived remarks with an email identifier. (There it is the email


### PR DESCRIPTION
## Problem

Forwarding a **recognized foreign supplier invoice** (e.g. a Cloudflare invoice) through the email-ingestion gateway quarantined with `UPLOAD_FAILED`. The real server-side cause was:

```
Error: Missing businessId in AuthContext
    at TenantAwareDBClient.setRLSVariables (tenant-db-client.js:289)
    at TenantAwareDBClient.ensureSession (tenant-db-client.js:212)
```

The gateway ingest runs under a `gateway_control_plane` context with **no auth session**, which is why `EmailIngestionIngestProvider` deliberately uses `withTenantContext` (raw pool + pinned RLS) everywhere instead of `TenantAwareDBClient`. But the shared `getDocumentFromUrlsAndOcrData` helper's **foreign-counterparty VAT-0 fallback** reached back into the auth-coupled `BusinessesProvider` / `AdminContextProvider` loaders, whose `TenantAwareDBClient` throws `Missing businessId in AuthContext` in that context. The throw became a `DocumentPreparationError` → `UPLOAD_FAILED` quarantine.

The fallback fires exactly when `ocrData.counterpartyId` is set (a business was recognized) and `ocrData.vat == null` (a **foreign** invoice with no Israeli VAT) — so every recognized foreign supplier invoice forwarded through the gateway was quarantined instead of inserted. This is a pre-existing bug in the v2 ingest path that #4127 exposed by making recognition succeed.

## Fix

- `getDocumentFromUrlsAndOcrData` now accepts an optional `vatFallbackContext` (`{ counterpartyCountry, adminLocality }`). When provided, it drives the VAT-0 fallback from those values instead of the auth-coupled loaders. The legacy path (no argument) is unchanged.
- `EmailIngestionIngestProvider.prepareDocuments` resolves the counterparty's country and the tenant's admin locality via the **raw pool under the tenant's RLS context** — in the same tenant-pinned read already used for hash-dedup — and passes them in. The control-plane ingest therefore never touches the auth-coupled providers.

The two reads use the raw `PoolClient` directly (no pgtyped) so the control-plane read stays self-contained; RLS is pinned to the tenant and an explicit `owner_id` filter is defense-in-depth.

## Tests

- New regression test: a recognized foreign counterparty ingests as `INSERTED`, the VAT-0 inputs are read via the raw pool (`accounter_schema.businesses` / `accounter_schema.user_context`), and the auth-coupled `getBusinessByIdLoader` / `adminContextByOwnerIdLoader` are **not** called.
- Updated the ingest fixtures (`UPLOAD_FAILED` + document-persistence cases) for the two new reads.

> Note: the local `yarn install` is blocked here by the org egress policy (the `xlsx` tarball host `cdn.sheetjs.com` returns 403), so I validated the logic by inspection + replication and am relying on CI to run the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSX6LQxJJ1Vz2gdfFVDJk9)_