### PR TITLE
Add xlsx dependency resolution for @e965/xlsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
   },
   "resolutions": {
     "@slonik/pg-driver@npm:^49.10.9": "patch:@slonik/pg-driver@npm%3A49.10.9#~/.yarn/patches/@slonik-pg-driver-npm-49.10.9-8d2c0c21df.patch",
-    "graphql": "16.14.2"
+    "graphql": "16.14.2",
+    "xlsx": "npm:@e965/xlsx@0.20.3"
   },
   "lint-staged": {
     "*.--write": "prettier --write"

--- a/yarn.lock
+++ b/yarn.lock
@@ -26655,12 +26655,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xlsx@https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz":
-  version: 0.20.2
-  resolution: "xlsx@https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
+"xlsx@npm:@e965/xlsx@0.20.3":
+  version: 0.20.3
+  resolution: "@e965/xlsx@npm:0.20.3"
   bin:
-    xlsx: ./bin/xlsx.njs
-  checksum: 10c0/664dff22e5ecd83d595f34e00ac90ee852d16e45b72385ada54291551b808c6848b166fb395f5e35249ca976a5b5d514e793ccbcc0a611b87a600ae4024d605a
+    xlsx: bin/xlsx.njs
+  checksum: 10c0/29416c391f55010af50eab38f8d3d3622e656463edb1670e58071a7ed250888a49e63d61fc6a12ed6e431ea045424868cc488374f3ded841e7ae472fbd0a2720
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Add a Yarn resolution to pin `xlsx` to the `@e965/xlsx@0.20.3` fork, ensuring consistent dependency resolution across the monorepo.

## Changes
- Added `"xlsx": "npm:@e965/xlsx@0.20.3"` to the `resolutions` field in `package.json`

## Details
This resolution ensures that any transitive dependencies requiring `xlsx` will resolve to the `@e965/xlsx` fork at version 0.20.3, providing consistent behavior across the monorepo and avoiding version conflicts.

https://claude.ai/code/session_01BVdS46ketfnPRB9aqwPo5o