### PR TITLE
Add batch tag operations for charges

### DIFF
--- a/.changeset/batch-charge-tags.md
+++ b/.changeset/batch-charge-tags.md
@@ -1,0 +1,16 @@
+---
+'@accounter/server': minor
+'@accounter/client': minor
+---
+
+Batch add/remove tags across selected charges from the charges table.
+
+Server: new `batchUpdateChargesTags(chargeIds: [UUID!]!, addTagIds: [UUID!], removeTagIds: [UUID!])`
+mutation. It adds and/or removes the given tags on every listed charge while leaving each charge's
+other tags untouched (additive/subtractive — unlike `batchUpdateCharges(fields.tags)`, which
+replaces a charge's whole tag set). Inserts are idempotent and processing is bounded-concurrency.
+Consistent with the existing convention, a tag-only change does **not** degrade accountant approval.
+
+Client: the charges table's selection-column bulk-actions menu gains a "Change tags" action opening
+a dialog with Add/Remove modes and a tag multi-select, applied to all selected charges in one
+request.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -149,6 +149,7 @@ export default [
               'AnnualId',
               'AutoMatchChargesResult',
               'BatchUpdateChargesSuccessfulResult',
+              'BatchUpdateChargesTagsSuccessfulResult',
               'BusinessEmailConfig',
               'BusinessTripSummary',
               'BusinessTripSummaryRow',

--- a/packages/client/src/components/charges/charges-batch-actions-menu.tsx
+++ b/packages/client/src/components/charges/charges-batch-actions-menu.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement } from 'react';
-import { MoreVertical, RefreshCcwDot } from 'lucide-react';
+import { MoreVertical, RefreshCcwDot, Tags } from 'lucide-react';
 import type { Table } from '@tanstack/react-table';
 import { useRegenerateLedgerRecords } from '../../hooks/use-regenerate-ledger-records.js';
 import { ConfirmationModal } from '../common/index.js';
@@ -10,6 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu.js';
+import { ChargesBatchTagsDialog } from './charges-batch-tags-dialog.js';
 import type { ChargeRow } from './charges-table.js';
 
 interface Props {
@@ -18,27 +19,31 @@ interface Props {
 
 /**
  * Bulk-action menu rendered next to the selection column header. Operates on the table's currently
- * selected rows. Currently exposes a single action — batch "Regenerate ledger" — which mirrors the
- * per-charge {@link RegenerateLedgerRecordsButton} (confirmation modal included) for every selected
- * charge in one request.
+ * selected rows. Exposes batch "Regenerate ledger" (mirrors the per-charge
+ * {@link RegenerateLedgerRecordsButton}, confirmation modal included) and "Change tags" (add/remove
+ * tags across all selected charges), each in a single request.
  */
 export function ChargesBatchActionsMenu({ table }: Props): ReactElement {
   const { regenerateLedgerRecords } = useRegenerateLedgerRecords();
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [tagsOpen, setTagsOpen] = useState(false);
 
-  const selectedCount = table.getSelectedRowModel().rows.length;
+  const { rows } = table.getSelectedRowModel();
+  const selectedCount = rows.length;
+  const selectedIds = rows.map(row => row.original.id);
+
+  // Refresh each selected row so the table reflects the applied change.
+  function refreshSelected(): void {
+    for (const row of rows) {
+      row.original.onChange();
+    }
+  }
 
   function onRegenerate(): void {
-    const { rows } = table.getSelectedRowModel();
-    if (rows.length === 0) {
+    if (selectedIds.length === 0) {
       return;
     }
-    regenerateLedgerRecords(rows.map(row => row.original.id)).then(() => {
-      // Refresh each affected row so the table reflects the regenerated ledger.
-      for (const row of rows) {
-        row.original.onChange();
-      }
-    });
+    regenerateLedgerRecords(selectedIds).then(refreshSelected);
   }
 
   return (
@@ -60,6 +65,10 @@ export function ChargesBatchActionsMenu({ table }: Props): ReactElement {
             <RefreshCcwDot className="size-4" />
             Regenerate ledger
           </DropdownMenuItem>
+          <DropdownMenuItem disabled={selectedCount === 0} onSelect={() => setTagsOpen(true)}>
+            <Tags className="size-4" />
+            Change tags
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
       <ConfirmationModal
@@ -69,6 +78,12 @@ export function ChargesBatchActionsMenu({ table }: Props): ReactElement {
         title={`Are you sure you want to regenerate ledger records for ${selectedCount} selected charge${
           selectedCount === 1 ? '' : 's'
         }?`}
+      />
+      <ChargesBatchTagsDialog
+        chargeIds={selectedIds}
+        open={tagsOpen}
+        onOpenChange={setTagsOpen}
+        onDone={refreshSelected}
       />
     </>
   );

--- a/packages/client/src/components/charges/charges-batch-tags-dialog.tsx
+++ b/packages/client/src/components/charges/charges-batch-tags-dialog.tsx
@@ -87,8 +87,8 @@ export function ChargesBatchTagsDialog({
             Change tags for {count} charge{count === 1 ? '' : 's'}
           </DialogTitle>
           <DialogDescription>
-            Add the selected tags to, or remove them from, every selected charge. Other tags are left
-            unchanged.
+            Add the selected tags to, or remove them from, every selected charge. Other tags are
+            left unchanged.
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-3">

--- a/packages/client/src/components/charges/charges-batch-tags-dialog.tsx
+++ b/packages/client/src/components/charges/charges-batch-tags-dialog.tsx
@@ -55,6 +55,15 @@ export function ChargesBatchTagsDialog({
     reset();
   };
 
+  // Single close path so both the Dialog's own dismissals (overlay/esc/X) and the Cancel button
+  // clear the selection before closing.
+  const handleOpenChange = (nextOpen: boolean): void => {
+    if (!nextOpen) {
+      reset();
+    }
+    onOpenChange(nextOpen);
+  };
+
   const onApply = async (): Promise<void> => {
     if (selectedTags.length === 0 || count === 0) {
       return;
@@ -71,15 +80,7 @@ export function ChargesBatchTagsDialog({
   };
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={nextOpen => {
-        if (!nextOpen) {
-          reset();
-        }
-        onOpenChange(nextOpen);
-      }}
-    >
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-md" onClick={event => event.stopPropagation()}>
         <DialogHeader>
           <DialogTitle>
@@ -111,7 +112,7 @@ export function ChargesBatchTagsDialog({
           </div>
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
             Cancel
           </Button>
           <Button

--- a/packages/client/src/components/charges/charges-batch-tags-dialog.tsx
+++ b/packages/client/src/components/charges/charges-batch-tags-dialog.tsx
@@ -1,0 +1,127 @@
+import { useState, type ReactElement } from 'react';
+import { useBatchUpdateChargesTags } from '../../hooks/use-batch-update-charges-tags.js';
+import { useGetTags } from '../../hooks/use-get-tags.js';
+import { MultiSelect } from '../common/index.js';
+import { Button } from '../ui/button.js';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog.js';
+import { Label } from '../ui/label.js';
+import { Tabs, TabsList, TabsTrigger } from '../ui/tabs.js';
+
+type Mode = 'add' | 'remove';
+
+interface Props {
+  /** Charge ids the tag change is applied to (the table's selected rows). */
+  chargeIds: string[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called after a successful apply, so the caller can refresh the affected rows. */
+  onDone: () => void;
+}
+
+/**
+ * Batch add or remove tags across the selected charges. "Add" mode adds the chosen tags to every
+ * selected charge (keeping their other tags); "Remove" mode removes the chosen tags. Backed by the
+ * `batchUpdateChargesTags` mutation via {@link useBatchUpdateChargesTags}.
+ */
+export function ChargesBatchTagsDialog({
+  chargeIds,
+  open,
+  onOpenChange,
+  onDone,
+}: Props): ReactElement {
+  const { selectableTags, fetching: fetchingTags } = useGetTags();
+  const { fetching, batchUpdateChargesTags } = useBatchUpdateChargesTags();
+  const [mode, setMode] = useState<Mode>('add');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  // Bumped to force-remount the (internally stateful) MultiSelect, clearing its selection.
+  const [resetNonce, setResetNonce] = useState(0);
+
+  const count = chargeIds.length;
+
+  const reset = (): void => {
+    setSelectedTags([]);
+    setResetNonce(nonce => nonce + 1);
+  };
+
+  const onModeChange = (value: string): void => {
+    setMode(value as Mode);
+    reset();
+  };
+
+  const onApply = async (): Promise<void> => {
+    if (selectedTags.length === 0 || count === 0) {
+      return;
+    }
+    const res = await batchUpdateChargesTags({
+      chargeIds,
+      ...(mode === 'add' ? { addTagIds: selectedTags } : { removeTagIds: selectedTags }),
+    });
+    if (res) {
+      reset();
+      onOpenChange(false);
+      onDone();
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={nextOpen => {
+        if (!nextOpen) {
+          reset();
+        }
+        onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent className="sm:max-w-md" onClick={event => event.stopPropagation()}>
+        <DialogHeader>
+          <DialogTitle>
+            Change tags for {count} charge{count === 1 ? '' : 's'}
+          </DialogTitle>
+          <DialogDescription>
+            Add the selected tags to, or remove them from, every selected charge. Other tags are left
+            unchanged.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-3">
+          <Tabs value={mode} onValueChange={onModeChange}>
+            <TabsList className="w-full">
+              <TabsTrigger value="add">Add tags</TabsTrigger>
+              <TabsTrigger value="remove">Remove tags</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <div className="grid gap-1">
+            <Label>Tags</Label>
+            <MultiSelect
+              key={`${mode}-${resetNonce}`}
+              options={selectableTags}
+              onValueChange={setSelectedTags}
+              defaultValue={selectedTags}
+              placeholder={mode === 'add' ? 'Select tags to add' : 'Select tags to remove'}
+              variant="default"
+              disabled={fetchingTags}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void onApply()}
+            disabled={fetching || selectedTags.length === 0 || count === 0}
+          >
+            {mode === 'add' ? 'Add to' : 'Remove from'} {count} charge{count === 1 ? '' : 's'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/hooks/use-batch-update-charges-tags.ts
+++ b/packages/client/src/hooks/use-batch-update-charges-tags.ts
@@ -1,0 +1,89 @@
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { useMutation } from 'urql';
+import {
+  BatchUpdateChargesTagsDocument,
+  type BatchUpdateChargesTagsMutation,
+  type BatchUpdateChargesTagsMutationVariables,
+} from '../gql/graphql.js';
+import { handleCommonErrors } from '../helpers/error-handling.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  mutation BatchUpdateChargesTags(
+    $chargeIds: [UUID!]!
+    $addTagIds: [UUID!]
+    $removeTagIds: [UUID!]
+  ) {
+    batchUpdateChargesTags(
+      chargeIds: $chargeIds
+      addTagIds: $addTagIds
+      removeTagIds: $removeTagIds
+    ) {
+      __typename
+      ... on BatchUpdateChargesTagsSuccessfulResult {
+        charges {
+          id
+        }
+      }
+      ... on CommonError {
+        message
+      }
+    }
+  }
+`;
+
+type Charges = Extract<
+  BatchUpdateChargesTagsMutation['batchUpdateChargesTags'],
+  { __typename: 'BatchUpdateChargesTagsSuccessfulResult' }
+>['charges'];
+
+type UseBatchUpdateChargesTags = {
+  fetching: boolean;
+  batchUpdateChargesTags: (
+    variables: BatchUpdateChargesTagsMutationVariables,
+  ) => Promise<Charges | undefined>;
+};
+
+const NOTIFICATION_ID = 'batchUpdateChargesTags';
+
+export const useBatchUpdateChargesTags = (): UseBatchUpdateChargesTags => {
+  const [{ fetching }, mutate] = useMutation(BatchUpdateChargesTagsDocument);
+  const batchUpdateChargesTags = useCallback(
+    async (variables: BatchUpdateChargesTagsMutationVariables) => {
+      const count = variables.chargeIds.length;
+      const message = 'Error updating charges tags';
+      // Short, stable toast id — a batch action, so don't build it from every selected UUID.
+      const notificationId = `${NOTIFICATION_ID}-batch`;
+      toast.loading('Updating tags', {
+        id: notificationId,
+      });
+      try {
+        const res = await mutate(variables);
+        const data = handleCommonErrors(res, message, notificationId, 'batchUpdateChargesTags');
+        if (data) {
+          toast.success('Success', {
+            id: notificationId,
+            description: `Tags updated for ${count} charge${count > 1 ? 's' : ''}`,
+          });
+          return data.batchUpdateChargesTags.charges;
+        }
+      } catch (e) {
+        console.error(`${message}: ${e}`);
+        toast.error('Error', {
+          id: notificationId,
+          description: message,
+          duration: 100_000,
+          closeButton: true,
+        });
+      }
+      return void 0;
+    },
+    [mutate],
+  );
+
+  return {
+    fetching,
+    batchUpdateChargesTags,
+  };
+};

--- a/packages/server/src/modules/tags/helpers/batch-charge-tags.helper.ts
+++ b/packages/server/src/modules/tags/helpers/batch-charge-tags.helper.ts
@@ -1,0 +1,51 @@
+import { GraphQLError } from 'graphql';
+import { Injector } from 'graphql-modules';
+import { ChargeTagsProvider } from '../providers/charge-tags.provider.js';
+
+// Max charges processed in parallel. Keeps a large selection × many tags from
+// fanning out unbounded DB work (one delete + N inserts per charge) and
+// exhausting the connection pool.
+const CHARGE_TAGS_CONCURRENCY = 5;
+
+/**
+ * Additive/subtractive tag update across many charges: adds `addTagIds` to and removes
+ * `removeTagIds` from every charge in `chargeIds`, keeping each charge's other tags untouched.
+ *
+ * Unlike the charges module's `batchUpdateChargesTags` (which replaces a charge's whole tag set),
+ * this only touches the given ids. Inserts are idempotent (`ON CONFLICT DO NOTHING`); removing a
+ * tag a charge doesn't have is a harmless no-op. Ids present in both lists are treated as adds
+ * (the caller is expected to have de-duplicated, but order here is remove-then-add per charge).
+ */
+export async function applyChargeTagChanges(
+  injector: Injector,
+  chargeIds: readonly string[],
+  addTagIds: readonly string[],
+  removeTagIds: readonly string[],
+): Promise<void> {
+  const chargeTagsProvider = injector.get(ChargeTagsProvider);
+
+  for (let i = 0; i < chargeIds.length; i += CHARGE_TAGS_CONCURRENCY) {
+    const chunk = chargeIds.slice(i, i + CHARGE_TAGS_CONCURRENCY);
+    await Promise.all(
+      chunk.map(async chargeId => {
+        // Remove first so an id appearing in both lists ends up added.
+        if (removeTagIds.length > 0) {
+          await chargeTagsProvider
+            .clearChargeTags({ chargeId, tagIDs: [...removeTagIds] })
+            .catch(e => {
+              console.error(e);
+              throw new GraphQLError(
+                `Error removing tags IDs="${removeTagIds}" from charge ID="${chargeId}"`,
+              );
+            });
+        }
+        for (const tagId of addTagIds) {
+          await chargeTagsProvider.insertChargeTag({ chargeId, tagId }).catch(e => {
+            console.error(e);
+            throw new GraphQLError(`Error adding tag ID="${tagId}" to charge ID="${chargeId}"`);
+          });
+        }
+      }),
+    );
+  }
+}

--- a/packages/server/src/modules/tags/helpers/batch-charge-tags.helper.ts
+++ b/packages/server/src/modules/tags/helpers/batch-charge-tags.helper.ts
@@ -13,8 +13,8 @@ const CHARGE_TAGS_CONCURRENCY = 5;
  *
  * Unlike the charges module's `batchUpdateChargesTags` (which replaces a charge's whole tag set),
  * this only touches the given ids. Inserts are idempotent (`ON CONFLICT DO NOTHING`); removing a
- * tag a charge doesn't have is a harmless no-op. Ids present in both lists are treated as adds
- * (the caller is expected to have de-duplicated, but order here is remove-then-add per charge).
+ * tag a charge doesn't have is a harmless no-op. Removal happens before addition per charge, so an
+ * id present in both lists ends up added ("add wins").
  */
 export async function applyChargeTagChanges(
   injector: Injector,

--- a/packages/server/src/modules/tags/resolvers/tags.resolvers.ts
+++ b/packages/server/src/modules/tags/resolvers/tags.resolvers.ts
@@ -98,13 +98,14 @@ export const tagsResolvers: TagsModule.Resolvers &
       if (!chargeIds || chargeIds.length === 0) {
         return { __typename: 'CommonError', message: 'No charges provided' };
       }
+      const addIds = addTagIds ?? [];
       const removeIds = removeTagIds ?? [];
-      // Drop from adds any id that's also being removed, so a tag in both lists isn't churned.
-      const addIds = (addTagIds ?? []).filter(id => !removeIds.includes(id));
       if (addIds.length === 0 && removeIds.length === 0) {
         return { __typename: 'CommonError', message: 'No tag changes provided' };
       }
       try {
+        // `applyChargeTagChanges` removes then adds per charge, so an id in both lists ends up
+        // added ("add wins") — no need to pre-filter the add list here.
         await applyChargeTagChanges(injector, chargeIds, addIds, removeIds);
 
         const loadedCharges = await injector
@@ -114,9 +115,12 @@ export const tagsResolvers: TagsModule.Resolvers &
             console.error(e);
             throw new GraphQLError('Error loading updated charges');
           });
-        const charges = loadedCharges.filter(
-          (charge): charge is IGetChargesByIdsResult => !!charge && !(charge instanceof Error),
-        );
+        // Fail the whole op if any charge can't be reloaded, rather than silently returning a
+        // partial set (mirrors batchUpdateCharges' post-load validation).
+        if (loadedCharges.some(charge => !charge || charge instanceof Error)) {
+          throw new GraphQLError(`Some updated charges not found (IDs "${chargeIds.join('", "')}")`);
+        }
+        const charges = loadedCharges as IGetChargesByIdsResult[];
         // Tag-only change: intentionally does NOT degrade accountant approval (matches the
         // `tags`-excluded-from-degrade convention used by updateCharge / batchUpdateCharges).
         return { charges };

--- a/packages/server/src/modules/tags/resolvers/tags.resolvers.ts
+++ b/packages/server/src/modules/tags/resolvers/tags.resolvers.ts
@@ -1,11 +1,16 @@
 import { GraphQLError } from 'graphql';
+import type { Resolvers } from '../../../__generated__/types.js';
 import { EMPTY_UUID } from '../../../shared/constants.js';
+import { ChargesProvider } from '../../charges/providers/charges.provider.js';
+import type { IGetChargesByIdsResult } from '../../charges/types.js';
+import { applyChargeTagChanges } from '../helpers/batch-charge-tags.helper.js';
 import { ChargeTagsProvider } from '../providers/charge-tags.provider.js';
 import { TagsProvider } from '../providers/tags.provider.js';
 import type { TagsModule } from '../types.js';
 import { commonTagsChargeFields } from './common.js';
 
-export const tagsResolvers: TagsModule.Resolvers = {
+export const tagsResolvers: TagsModule.Resolvers &
+  Pick<Resolvers, 'BatchUpdateChargesTagsResult'> = {
   Query: {
     allTags: (_, __, { injector }) => injector.get(TagsProvider).getAllTags(),
   },
@@ -88,6 +93,49 @@ export const tagsResolvers: TagsModule.Resolvers = {
           console.error(JSON.stringify(e, null, 2));
           throw new GraphQLError(`Error updating tag id "${id}"`);
         });
+    },
+    batchUpdateChargesTags: async (_, { chargeIds, addTagIds, removeTagIds }, { injector }) => {
+      if (!chargeIds || chargeIds.length === 0) {
+        return { __typename: 'CommonError', message: 'No charges provided' };
+      }
+      const removeIds = removeTagIds ?? [];
+      // Drop from adds any id that's also being removed, so a tag in both lists isn't churned.
+      const addIds = (addTagIds ?? []).filter(id => !removeIds.includes(id));
+      if (addIds.length === 0 && removeIds.length === 0) {
+        return { __typename: 'CommonError', message: 'No tag changes provided' };
+      }
+      try {
+        await applyChargeTagChanges(injector, chargeIds, addIds, removeIds);
+
+        const loadedCharges = await injector
+          .get(ChargesProvider)
+          .getChargeByIdLoader.loadMany(chargeIds)
+          .catch(e => {
+            console.error(e);
+            throw new GraphQLError('Error loading updated charges');
+          });
+        const charges = loadedCharges.filter(
+          (charge): charge is IGetChargesByIdsResult => !!charge && !(charge instanceof Error),
+        );
+        // Tag-only change: intentionally does NOT degrade accountant approval (matches the
+        // `tags`-excluded-from-degrade convention used by updateCharge / batchUpdateCharges).
+        return { charges };
+      } catch (e) {
+        let message = 'Error updating charges tags';
+        if (e instanceof GraphQLError) {
+          message = e.message;
+        } else {
+          console.error(e);
+        }
+        return { __typename: 'CommonError', message };
+      }
+    },
+  },
+  BatchUpdateChargesTagsResult: {
+    __resolveType: (obj, _context, _info) => {
+      if (('__typename' in obj && obj.__typename === 'CommonError') || 'message' in obj)
+        return 'CommonError';
+      return 'BatchUpdateChargesTagsSuccessfulResult';
     },
   },
   Tag: {

--- a/packages/server/src/modules/tags/resolvers/tags.resolvers.ts
+++ b/packages/server/src/modules/tags/resolvers/tags.resolvers.ts
@@ -9,175 +9,177 @@ import { TagsProvider } from '../providers/tags.provider.js';
 import type { TagsModule } from '../types.js';
 import { commonTagsChargeFields } from './common.js';
 
-export const tagsResolvers: TagsModule.Resolvers &
-  Pick<Resolvers, 'BatchUpdateChargesTagsResult'> = {
-  Query: {
-    allTags: (_, __, { injector }) => injector.get(TagsProvider).getAllTags(),
-  },
-  Mutation: {
-    addTag: (_, { name }, { injector }) => {
-      return injector
-        .get(TagsProvider)
-        .addNewTag({ name })
-        .catch(e => {
-          console.error(JSON.stringify(e, null, 2));
-          throw new GraphQLError(`Error adding tag "${name}"`);
-        })
-        .then(() => true);
+export const tagsResolvers: TagsModule.Resolvers & Pick<Resolvers, 'BatchUpdateChargesTagsResult'> =
+  {
+    Query: {
+      allTags: (_, __, { injector }) => injector.get(TagsProvider).getAllTags(),
     },
-    deleteTag: (_, { id }, { injector }) => {
-      return injector
-        .get(TagsProvider)
-        .deleteTag({ id })
-        .catch(e => {
-          console.error(JSON.stringify(e, null, 2));
-          throw new GraphQLError(`Error deleting tag id "${id}"`);
-        })
-        .then(() => true);
-    },
-    updateTagParent: (_, { id, parentId }, { injector }) => {
-      return injector
-        .get(TagsProvider)
-        .updateTagParent({ id, parentId: parentId === EMPTY_UUID ? null : parentId })
-        .catch(e => {
-          console.error(JSON.stringify(e, null, 2));
-          throw new GraphQLError(`Error updating parent of tag id "${id}"`);
-        })
-        .then(() => true);
-    },
-    updateTagPart: (_, { tagId, chargeId, part }, { injector }) => {
-      return injector
-        .get(ChargeTagsProvider)
-        .updateChargeTagPart({ tagId, chargeId, part })
-        .catch(e => {
-          console.error(JSON.stringify(e, null, 2));
-          throw new GraphQLError(
-            `Error updating tag's part (id "${tagId}", charge id "${chargeId}")`,
-          );
-        })
-        .then(() => true);
-    },
-    updateTag: async (_, { id, fields }, { injector }) => {
-      const promises: Array<Promise<unknown>> = [];
-      if (fields.name) {
-        promises.push(
-          injector
-            .get(TagsProvider)
-            .renameTag({ id, newName: fields.name })
-            .catch(e => {
-              console.error(JSON.stringify(e, null, 2));
-              throw new GraphQLError(`Error renaming tag id "${id}"`);
-            }),
-        );
-      }
-      if (fields.parentId) {
-        promises.push(
-          injector
-            .get(TagsProvider)
-            .updateTagParent({
-              id,
-              parentId: fields.parentId === EMPTY_UUID ? null : fields.parentId,
-            })
-            .catch(e => {
-              console.error(JSON.stringify(e, null, 2));
-              throw new GraphQLError(`Error updating parent of tag id "${id}"`);
-            }),
-        );
-      }
-      if (promises.length === 0) {
-        return true;
-      }
-      return Promise.all(promises)
-        .then(() => true)
-        .catch(e => {
-          console.error(JSON.stringify(e, null, 2));
-          throw new GraphQLError(`Error updating tag id "${id}"`);
-        });
-    },
-    batchUpdateChargesTags: async (_, { chargeIds, addTagIds, removeTagIds }, { injector }) => {
-      if (!chargeIds || chargeIds.length === 0) {
-        return { __typename: 'CommonError', message: 'No charges provided' };
-      }
-      const addIds = addTagIds ?? [];
-      const removeIds = removeTagIds ?? [];
-      if (addIds.length === 0 && removeIds.length === 0) {
-        return { __typename: 'CommonError', message: 'No tag changes provided' };
-      }
-      try {
-        // `applyChargeTagChanges` removes then adds per charge, so an id in both lists ends up
-        // added ("add wins") — no need to pre-filter the add list here.
-        await applyChargeTagChanges(injector, chargeIds, addIds, removeIds);
-
-        const loadedCharges = await injector
-          .get(ChargesProvider)
-          .getChargeByIdLoader.loadMany(chargeIds)
+    Mutation: {
+      addTag: (_, { name }, { injector }) => {
+        return injector
+          .get(TagsProvider)
+          .addNewTag({ name })
           .catch(e => {
-            console.error(e);
-            throw new GraphQLError('Error loading updated charges');
-          });
-        // Fail the whole op if any charge can't be reloaded, rather than silently returning a
-        // partial set (mirrors batchUpdateCharges' post-load validation).
-        if (loadedCharges.some(charge => !charge || charge instanceof Error)) {
-          throw new GraphQLError(`Some updated charges not found (IDs "${chargeIds.join('", "')}")`);
-        }
-        const charges = loadedCharges as IGetChargesByIdsResult[];
-        // Tag-only change: intentionally does NOT degrade accountant approval (matches the
-        // `tags`-excluded-from-degrade convention used by updateCharge / batchUpdateCharges).
-        return { charges };
-      } catch (e) {
-        let message = 'Error updating charges tags';
-        if (e instanceof GraphQLError) {
-          message = e.message;
-        } else {
-          console.error(e);
-        }
-        return { __typename: 'CommonError', message };
-      }
-    },
-  },
-  BatchUpdateChargesTagsResult: {
-    __resolveType: (obj, _context, _info) => {
-      if (('__typename' in obj && obj.__typename === 'CommonError') || 'message' in obj)
-        return 'CommonError';
-      return 'BatchUpdateChargesTagsSuccessfulResult';
-    },
-  },
-  Tag: {
-    id: tag => tag.id!,
-    name: tag => tag.name!,
-    ownerId: tag => tag.owner_id!,
-    parent: (dbTag, _, { injector }) =>
-      dbTag.parent
-        ? injector
-            .get(TagsProvider)
-            .getTagByIDLoader.load(dbTag.parent)
-            .then(res => res ?? null)
-        : null,
-    namePath: dbTag => dbTag.names_path,
-    fullPath: (dbTag, _, { injector }) =>
-      dbTag.ids_path
-        ? dbTag.ids_path.map(id =>
+            console.error(JSON.stringify(e, null, 2));
+            throw new GraphQLError(`Error adding tag "${name}"`);
+          })
+          .then(() => true);
+      },
+      deleteTag: (_, { id }, { injector }) => {
+        return injector
+          .get(TagsProvider)
+          .deleteTag({ id })
+          .catch(e => {
+            console.error(JSON.stringify(e, null, 2));
+            throw new GraphQLError(`Error deleting tag id "${id}"`);
+          })
+          .then(() => true);
+      },
+      updateTagParent: (_, { id, parentId }, { injector }) => {
+        return injector
+          .get(TagsProvider)
+          .updateTagParent({ id, parentId: parentId === EMPTY_UUID ? null : parentId })
+          .catch(e => {
+            console.error(JSON.stringify(e, null, 2));
+            throw new GraphQLError(`Error updating parent of tag id "${id}"`);
+          })
+          .then(() => true);
+      },
+      updateTagPart: (_, { tagId, chargeId, part }, { injector }) => {
+        return injector
+          .get(ChargeTagsProvider)
+          .updateChargeTagPart({ tagId, chargeId, part })
+          .catch(e => {
+            console.error(JSON.stringify(e, null, 2));
+            throw new GraphQLError(
+              `Error updating tag's part (id "${tagId}", charge id "${chargeId}")`,
+            );
+          })
+          .then(() => true);
+      },
+      updateTag: async (_, { id, fields }, { injector }) => {
+        const promises: Array<Promise<unknown>> = [];
+        if (fields.name) {
+          promises.push(
             injector
               .get(TagsProvider)
-              .getTagByIDLoader.load(id)
-              .then(res => {
-                if (!res) {
-                  throw new Error(`Tag with id ${id}, ancestor of tag id ${dbTag.id} not found`);
-                }
-                return res;
+              .renameTag({ id, newName: fields.name })
+              .catch(e => {
+                console.error(JSON.stringify(e, null, 2));
+                throw new GraphQLError(`Error renaming tag id "${id}"`);
               }),
-          )
-        : [],
-  },
-  BankDepositCharge: commonTagsChargeFields,
-  BusinessTripCharge: commonTagsChargeFields,
-  CommonCharge: commonTagsChargeFields,
-  ConversionCharge: commonTagsChargeFields,
-  CreditcardBankCharge: commonTagsChargeFields,
-  DividendCharge: commonTagsChargeFields,
-  FinancialCharge: commonTagsChargeFields,
-  ForeignSecuritiesCharge: commonTagsChargeFields,
-  InternalTransferCharge: commonTagsChargeFields,
-  MonthlyVatCharge: commonTagsChargeFields,
-  SalaryCharge: commonTagsChargeFields,
-};
+          );
+        }
+        if (fields.parentId) {
+          promises.push(
+            injector
+              .get(TagsProvider)
+              .updateTagParent({
+                id,
+                parentId: fields.parentId === EMPTY_UUID ? null : fields.parentId,
+              })
+              .catch(e => {
+                console.error(JSON.stringify(e, null, 2));
+                throw new GraphQLError(`Error updating parent of tag id "${id}"`);
+              }),
+          );
+        }
+        if (promises.length === 0) {
+          return true;
+        }
+        return Promise.all(promises)
+          .then(() => true)
+          .catch(e => {
+            console.error(JSON.stringify(e, null, 2));
+            throw new GraphQLError(`Error updating tag id "${id}"`);
+          });
+      },
+      batchUpdateChargesTags: async (_, { chargeIds, addTagIds, removeTagIds }, { injector }) => {
+        if (!chargeIds || chargeIds.length === 0) {
+          return { __typename: 'CommonError', message: 'No charges provided' };
+        }
+        const addIds = addTagIds ?? [];
+        const removeIds = removeTagIds ?? [];
+        if (addIds.length === 0 && removeIds.length === 0) {
+          return { __typename: 'CommonError', message: 'No tag changes provided' };
+        }
+        try {
+          // `applyChargeTagChanges` removes then adds per charge, so an id in both lists ends up
+          // added ("add wins") — no need to pre-filter the add list here.
+          await applyChargeTagChanges(injector, chargeIds, addIds, removeIds);
+
+          const loadedCharges = await injector
+            .get(ChargesProvider)
+            .getChargeByIdLoader.loadMany(chargeIds)
+            .catch(e => {
+              console.error(e);
+              throw new GraphQLError('Error loading updated charges');
+            });
+          // Fail the whole op if any charge can't be reloaded, rather than silently returning a
+          // partial set (mirrors batchUpdateCharges' post-load validation).
+          if (loadedCharges.some(charge => !charge || charge instanceof Error)) {
+            throw new GraphQLError(
+              `Some updated charges not found (IDs "${chargeIds.join('", "')}")`,
+            );
+          }
+          const charges = loadedCharges as IGetChargesByIdsResult[];
+          // Tag-only change: intentionally does NOT degrade accountant approval (matches the
+          // `tags`-excluded-from-degrade convention used by updateCharge / batchUpdateCharges).
+          return { charges };
+        } catch (e) {
+          let message = 'Error updating charges tags';
+          if (e instanceof GraphQLError) {
+            message = e.message;
+          } else {
+            console.error(e);
+          }
+          return { __typename: 'CommonError', message };
+        }
+      },
+    },
+    BatchUpdateChargesTagsResult: {
+      __resolveType: (obj, _context, _info) => {
+        if (('__typename' in obj && obj.__typename === 'CommonError') || 'message' in obj)
+          return 'CommonError';
+        return 'BatchUpdateChargesTagsSuccessfulResult';
+      },
+    },
+    Tag: {
+      id: tag => tag.id!,
+      name: tag => tag.name!,
+      ownerId: tag => tag.owner_id!,
+      parent: (dbTag, _, { injector }) =>
+        dbTag.parent
+          ? injector
+              .get(TagsProvider)
+              .getTagByIDLoader.load(dbTag.parent)
+              .then(res => res ?? null)
+          : null,
+      namePath: dbTag => dbTag.names_path,
+      fullPath: (dbTag, _, { injector }) =>
+        dbTag.ids_path
+          ? dbTag.ids_path.map(id =>
+              injector
+                .get(TagsProvider)
+                .getTagByIDLoader.load(id)
+                .then(res => {
+                  if (!res) {
+                    throw new Error(`Tag with id ${id}, ancestor of tag id ${dbTag.id} not found`);
+                  }
+                  return res;
+                }),
+            )
+          : [],
+    },
+    BankDepositCharge: commonTagsChargeFields,
+    BusinessTripCharge: commonTagsChargeFields,
+    CommonCharge: commonTagsChargeFields,
+    ConversionCharge: commonTagsChargeFields,
+    CreditcardBankCharge: commonTagsChargeFields,
+    DividendCharge: commonTagsChargeFields,
+    FinancialCharge: commonTagsChargeFields,
+    ForeignSecuritiesCharge: commonTagsChargeFields,
+    InternalTransferCharge: commonTagsChargeFields,
+    MonthlyVatCharge: commonTagsChargeFields,
+    SalaryCharge: commonTagsChargeFields,
+  };

--- a/packages/server/src/modules/tags/typeDefs/tags.graphql.ts
+++ b/packages/server/src/modules/tags/typeDefs/tags.graphql.ts
@@ -21,12 +21,28 @@ export default gql`
     updateTag(id: UUID!, fields: UpdateTagFieldsInput!): Boolean!
       @requiresAuth
       @requiresAnyRole(roles: ["business_owner", "accountant"])
+    " add and/or remove tags across many charges at once; returns the updated charges "
+    batchUpdateChargesTags(
+      chargeIds: [UUID!]!
+      addTagIds: [UUID!]
+      removeTagIds: [UUID!]
+    ): BatchUpdateChargesTagsResult!
+      @requiresAuth
+      @requiresAnyRole(roles: ["business_owner", "accountant"])
   }
 
   " input variables for updateTag "
   input UpdateTagFieldsInput {
     name: String
     parentId: UUID
+  }
+
+  " result type for batchUpdateChargesTags "
+  union BatchUpdateChargesTagsResult = BatchUpdateChargesTagsSuccessfulResult | CommonError
+
+  " successful result of batchUpdateChargesTags "
+  type BatchUpdateChargesTagsSuccessfulResult {
+    charges: [Charge!]!
   }
 
   extend interface Charge {


### PR DESCRIPTION
Adds the ability to batch add or remove tags across multiple selected charges from the charges table, with a new dialog UI and GraphQL mutation.

## Changes

**Server:**
- New `batchUpdateChargesTags` GraphQL mutation that additively/subtractively updates tags across many charges in a single request
- New `applyChargeTagChanges` helper that processes tag changes with bounded concurrency (5 parallel) to prevent connection pool exhaustion
- Tag-only changes do not degrade accountant approval (consistent with existing convention)
- Returns the updated charges on success or a `CommonError` on failure

**Client:**
- New `ChargesBatchTagsDialog` component with Add/Remove modes and tag multi-select
- New `useBatchUpdateChargesTags` hook wrapping the GraphQL mutation with toast notifications
- Integrated "Change tags" action into the charges table's bulk-actions menu
- Selected rows are refreshed after successful tag updates

## Implementation Details

- Inserts are idempotent (`ON CONFLICT DO NOTHING`); removing a tag a charge doesn't have is a no-op
- If a tag ID appears in both add and remove lists, it is treated as an add (remove-then-add order per charge)
- The dialog uses a `resetNonce` key to force-remount the internal MultiSelect component and clear its selection when switching modes or closing
- Concurrency is limited to 5 charges in parallel to prevent unbounded DB work and connection pool exhaustion

https://claude.ai/code/session_01C2oqFiJjQmhHDzvTWHx9i6