### PR TITLE
Align MAX credit card schema with actual API response

### DIFF
--- a/.changeset/extend-max-creditcard-schemas.md
+++ b/.changeset/extend-max-creditcard-schemas.md
@@ -1,0 +1,25 @@
+---
+'@accounter/scraper-app': patch
+'@accounter/server': patch
+---
+
+Align the MAX credit card ingestion path with what MAX actually returns.
+
+The Zod payload schema for MAX was `.loose()` and covered only a handful of fields, so the nested
+`dealData`, `merchantData` and `runtimeReference` blocks were never validated and were passed
+through to the GraphQL mutation unflattened. `max.schema.ts` now models the full transaction
+(strictly), and `maxVars` flattens the nested blocks into the `MaxTransactionInput` columns the
+server expects.
+
+MAX omits large parts of `dealData` for some transaction types, so the `MaxTransactionInput` fields
+backing those columns are now nullable, and the numeric ones (`dealDataAmount`, `dealDataAmountIls`,
+`dealDataExchangeRate`, `originalAmount`, …) are typed as `Float` rather than `String`. Boolean
+fields backing `bit` columns are converted to `1`/`0` via a new `convertBooleanToBit` helper —
+previously a JS boolean was sent to a `bit` column, which Postgres rejects.
+
+A migration drops the matching `NOT NULL` constraints on
+`accounter_schema.max_creditcard_transactions` and updates the insert trigger so the two NOT NULL
+transaction columns fed from those fields keep working: `source_reference` falls back from `arn` to
+`uid`, and `currency_rate` coalesces to its default of `0`. The MAX deduplication index is rebuilt
+with `NULLS NOT DISTINCT` so that rows with a null `arn` or `payment_date` still dedup on
+`ON CONFLICT`.

--- a/packages/migrations/src/actions/2026-08-07T10-00-00.relax-max-creditcard-not-null.ts
+++ b/packages/migrations/src/actions/2026-08-07T10-00-00.relax-max-creditcard-not-null.ts
@@ -1,0 +1,143 @@
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+export default {
+  name: '2026-08-07T10-00-00.relax-max-creditcard-not-null.sql',
+  run: ({ sql }) => sql`
+    -- MAX does not populate these fields for every transaction type (e.g. refunds,
+    -- fee rows and installment rows arrive without a dealData block at all), so the
+    -- GraphQL input accepts them as nullable. Align the table with that reality.
+    ALTER TABLE accounter_schema.max_creditcard_transactions
+      ALTER COLUMN actual_payment_amount DROP NOT NULL,
+      ALTER COLUMN arn DROP NOT NULL,
+      ALTER COLUMN deal_data_acq DROP NOT NULL,
+      ALTER COLUMN deal_data_adjustment_type DROP NOT NULL,
+      ALTER COLUMN deal_data_amount DROP NOT NULL,
+      ALTER COLUMN deal_data_amount_ils DROP NOT NULL,
+      ALTER COLUMN deal_data_amount_left DROP NOT NULL,
+      ALTER COLUMN deal_data_arn DROP NOT NULL,
+      ALTER COLUMN deal_data_authorization_number DROP NOT NULL,
+      ALTER COLUMN deal_data_commission_vat DROP NOT NULL,
+      ALTER COLUMN deal_data_exchange_direct DROP NOT NULL,
+      ALTER COLUMN deal_data_exchange_rate DROP NOT NULL,
+      ALTER COLUMN deal_data_interest_amount DROP NOT NULL,
+      ALTER COLUMN deal_data_issuer_currency DROP NOT NULL,
+      ALTER COLUMN deal_data_plan DROP NOT NULL,
+      ALTER COLUMN deal_data_pos_entry_emv DROP NOT NULL,
+      ALTER COLUMN deal_data_processing_date DROP NOT NULL,
+      ALTER COLUMN deal_data_ref_nbr DROP NOT NULL,
+      ALTER COLUMN deal_data_tdm_card_token DROP NOT NULL,
+      ALTER COLUMN deal_data_tdm_transaction_type DROP NOT NULL,
+      ALTER COLUMN deal_data_transaction_type DROP NOT NULL,
+      ALTER COLUMN deal_data_txn_code DROP NOT NULL,
+      ALTER COLUMN deal_data_user_name DROP NOT NULL,
+      ALTER COLUMN payment_date DROP NOT NULL,
+      ALTER COLUMN promotion_club DROP NOT NULL;
+
+    -- arn and payment_date are part of the deduplication key. Once they are
+    -- nullable, the default NULLS DISTINCT behaviour would let identical rows
+    -- through, so rebuild the index with NULLS NOT DISTINCT.
+    DROP INDEX IF EXISTS accounter_schema.max_creditcard_transactions_uid_uindex;
+    CREATE UNIQUE INDEX IF NOT EXISTS max_creditcard_transactions_uid_uindex
+      ON accounter_schema.max_creditcard_transactions (
+        uid,
+        arn,
+        purchase_date,
+        payment_date,
+        original_amount
+      ) NULLS NOT DISTINCT;
+
+    -- The insert trigger fed two NOT NULL transaction columns straight from
+    -- columns that are now nullable:
+    --   * source_reference <- arn: fall back to uid, MAX's own per-transaction
+    --     identifier, so the reference stays stable and unique.
+    --   * currency_rate <- deal_data_exchange_rate: passing NULL explicitly would
+    --     bypass the column default, so coalesce to that same default (0).
+    -- Without this, relaxing the columns above just moves the failure downstream.
+    create or replace function accounter_schema.insert_max_creditcard_transaction_handler() returns trigger
+        language plpgsql
+    as
+    $$
+    DECLARE
+        merged_id      UUID;
+        account_id_var UUID;
+        owner_id_var   UUID;
+        charge_id_var  UUID = NULL;
+    BEGIN
+        -- filter summarize records
+        -- Create merged raw transactions record:
+        INSERT INTO accounter_schema.transactions_raw_list (max_creditcard_id)
+        VALUES (NEW.id)
+        RETURNING id INTO merged_id;
+
+        -- get account and owner IDs
+        SELECT id, owner
+        INTO account_id_var, owner_id_var
+        FROM accounter_schema.financial_accounts
+        WHERE account_number = NEW.short_card_number;
+
+        IF account_id_var IS NULL THEN
+            RAISE EXCEPTION 'No matching account found for card number: %', NEW.short_card_number;
+        END IF;
+
+        -- check if matching charge exists:
+        -- TBD
+
+        -- create new charge
+        IF (charge_id_var IS NULL) THEN
+            INSERT INTO accounter_schema.charges (owner_id)
+            VALUES (owner_id_var)
+            RETURNING id INTO charge_id_var;
+        END IF;
+
+        -- check if new record is fee
+        -- TBD
+
+        -- check if new record contains fees
+        -- TBD
+
+        IF NOT (NEW.original_currency = 'ILS') THEN
+            RAISE EXCEPTION 'Unknown currency: %', NEW.original_currency;
+        END IF;
+
+        IF (NEW.actual_payment_amount IS NULL) THEN
+            RAISE EXCEPTION 'Transaction amount cannot be null';
+        END IF;
+
+        -- create new transaction
+        INSERT INTO accounter_schema.transactions (owner_id, account_id, charge_id, source_id, source_description, currency,
+                                                   event_date, debit_date, amount, current_balance, source_reference,
+                                                   currency_rate, debit_timestamp, source_origin, counter_account,
+                                                   origin_key)
+        VALUES (owner_id_var,
+                account_id_var,
+                charge_id_var,
+                merged_id,
+                CONCAT_WS(' | ', NEW.merchant_name, NEW.comments),
+                CAST(
+                        (
+                            CASE
+                                WHEN NEW.original_currency = 'ILS' THEN 'ILS'
+                                -- use ILS as default:
+                                ELSE 'ILS' END
+                            ) as accounter_schema.currency
+                ),
+                NEW.purchase_date,
+                NEW.payment_date,
+                NEW.actual_payment_amount * -1,
+                0,
+                COALESCE(NEW.arn, NEW.uid),
+                COALESCE(NEW.deal_data_exchange_rate, 0),
+                NEW.payment_date +
+                NEW.deal_data_purchase_time,
+                'MAX',
+                CASE
+                    WHEN NEW.merchant_tax_id::text <> ''::text
+                        THEN NEW.merchant_tax_id::text
+                    ELSE NEW.merchant_name
+                    END, NEW.id);
+
+        RETURN NEW;
+    END ;
+    $$;
+  `,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -194,6 +194,7 @@ import migration_2026_07_06T17_00_00_enhance_conversion_recognition from './acti
 import migration_2026_07_07T13_00_00_extend_deel_table from './actions/2026-07-07T13-00-00.extend-deel-table.js';
 import migration_2026_07_08T17_00_00_poalim_ils_trigger_fix from './actions/2026-07-08T17-00-00.poalim-ils-trigger-fix.js';
 import migration_2026_08_01T10_00_00_extended_tags_owner_id from './actions/2026-08-01T10-00-00.extended-tags-owner-id.js';
+import migration_2026_08_07T10_00_00_relax_max_creditcard_not_null from './actions/2026-08-07T10-00-00.relax-max-creditcard-not-null.js';
 import { runMigrations } from './pg-migrator.js';
 
 export const MIGRATIONS = [
@@ -392,6 +393,7 @@ export const MIGRATIONS = [
   migration_2026_07_07T13_00_00_extend_deel_table,
   migration_2026_07_08T17_00_00_poalim_ils_trigger_fix,
   migration_2026_08_01T10_00_00_extended_tags_owner_id,
+  migration_2026_08_07T10_00_00_relax_max_creditcard_not_null,
 ] as const;
 
 export const LATEST_MIGRATION_NAME = MIGRATIONS[MIGRATIONS.length - 1]?.name;

--- a/packages/server/src/modules/scraper-ingestion/helpers/validators.helper.ts
+++ b/packages/server/src/modules/scraper-ingestion/helpers/validators.helper.ts
@@ -346,7 +346,7 @@ export function validateMaxTransactions(
     issuerId: t.issuerId,
     merchantAddress: t.merchantAddress,
     merchantCoordinates: t.merchantCoordinates,
-    merchantMaxPhone: convertBooleanToBit(t.merchantMaxPhone, true) as unknown as boolean,
+    merchantMaxPhone: convertBooleanToBit(t.merchantMaxPhone, false) as unknown as boolean,
     merchant: t.merchant,
     merchantCommercialName: t.merchantCommercialName,
     merchantNumber: t.merchantNumber,


### PR DESCRIPTION
## Summary

Fixes the MAX credit card transaction ingestion path to properly handle the actual structure and nullability of MAX's API responses. The Zod payload schema was previously `.loose()` and incomplete, causing nested `dealData`, `merchantData`, and `runtimeReference` blocks to bypass validation and be passed unflattened to the GraphQL mutation. This change models the full transaction structure strictly and flattens nested fields into the expected GraphQL input columns.

## Key Changes

- **Schema validation** (`max.schema.ts`):
  - Replaced `.loose()` with strict validation of the complete MAX transaction structure
  - Added schemas for nested `dealData`, `merchantData`, and `runtimeReference` blocks
  - Changed numeric fields from `String` to `Float` (e.g., `originalAmount`, `dealDataAmount`, `dealDataExchangeRate`)
  - Made nullable fields optional to match MAX's actual behavior (omits `dealData` for refunds, fees, installments)

- **GraphQL mutation** (`mutations.ts`):
  - Updated `maxVars()` to flatten nested blocks into individual `MaxTransactionInput` fields
  - Converts boolean fields to `1`/`0` via new `convertBooleanToBit()` helper (Postgres `bit` columns reject JS booleans)
  - Handles nullable fields with appropriate defaults (e.g., `arn` → `uid` for `source_reference`, `dealDataExchangeRate` → `0` for `currency_rate`)

- **GraphQL schema** (`scraper-ingestion.graphql.ts`):
  - Made `MaxTransactionInput` fields nullable where MAX omits them
  - Changed numeric field types from `String!` to `Float` (with appropriate nullability)
  - Removed `!` from fields that MAX doesn't populate for all transaction types

- **Database migration** (`2026-08-07T10-00-00.relax-max-creditcard-not-null.ts`):
  - Drops `NOT NULL` constraints on 25 columns in `max_creditcard_transactions` table
  - Rebuilds deduplication index with `NULLS NOT DISTINCT` (since `arn` and `payment_date` are now nullable)
  - Updates insert trigger to safely handle nullable `arn` and `deal_data_exchange_rate` columns

- **Test fixtures**:
  - Added `makeMaxTransaction()` and `makeMaxAccount()` helpers for consistent test data
  - Added `makePoalimAccount()` and `makePoalimIlsPayload()` helpers for Poalim tests
  - Added `makeIsracardPayload()` helper for Isracard/Amex tests
  - Updated existing tests to use new fixtures

- **Type exports**:
  - Added `ConfigurableSourceType` and `CONFIGURABLE_SOURCE_TYPES` to distinguish user-configurable sources from discovered ones
  - Updated API type references (`BankAccount` → `AccountRecord`)

## Implementation Details

- The `convertBooleanToBit()` helper converts JS booleans to `1`/`0` for Postgres `bit` columns, with optional fallback to `0` for non-nullable columns
- Nullable numeric fields are coalesced to sensible defaults in the trigger (e.g., `COALESCE(NEW.deal_data_exchange_rate, 0)`)
- The deduplication index now uses `NULLS NOT DISTINCT` to prevent duplicate rows when `arn` or `payment_date` are NULL

https://claude.ai/code/session_017HP2cLyiwCrLcJRfzWhKom