### PR TITLE
feat(mcp-server): harden connection-dropout observability

### DIFF
--- a/.changeset/mcp-server-connection-dropout-observability.md
+++ b/.changeset/mcp-server-connection-dropout-observability.md
@@ -1,0 +1,21 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Harden connection-dropout observability so idle spin-downs, cold starts, and
+client disconnects are diagnosable from the server side, and split token expiry
+from other auth failures.
+
+- Log the previously-silent `missing_token` 401 (with a `category` field) so
+  tokenless reconnect probes are visible instead of a blind spot.
+- Meter `expired_token` separately from `invalid_token`: `TokenVerificationError`
+  now carries an `expired` flag derived from jose's `ERR_JWT_EXPIRED`. The
+  transport response is unchanged (RFC 6750 `invalid_token` + `WWW-Authenticate`);
+  only the metric bucket and log `category` differ, distinguishing "clients
+  should refresh" from "tokens are misconfigured/abused".
+- Add `aborted`/`responseCompleted` (from `res.writableFinished`, so a
+  disconnect after `end()` but before the flush completes is not miscounted as
+  completed) and `uptimeSeconds` to completion logs, `msSinceLastRequest` to
+  request-start logs, and `pid` to the startup log.
+
+Observability-only: no change to tools, transport behavior, or auth decisions.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -180,7 +180,10 @@ Every request is assigned a `requestId` and a `correlationId` (the latter inheri
 `X-Correlation-Id` header when present, otherwise generated). The correlation id is echoed back on
 the response and propagated upstream via the `X-Correlation-Id` header on every GraphQL call.
 Structured JSON logs are emitted at request start and completion, carrying `requestId`,
-`correlationId`, `method`, `route`, and — on completion — `status` and `latencyMs`. Secrets and
+`correlationId`, `method`, `route`, and — on completion — `status` and `latencyMs`. Completion logs
+also carry `responseCompleted`/`aborted` (a client that hung up mid-response) and `uptimeSeconds`,
+and `request started` carries `msSinceLastRequest` (idle gap; absent on a process's first request) —
+so idle spin-downs, cold starts, and client-side disconnects are visible from the logs. Secrets and
 authorization headers are never logged.
 
 ### Metrics
@@ -193,7 +196,10 @@ process (labels never carry PII — only tool names, outcome classes, and error 
   `authorization_error`, `rate_limited`, `upstream_error`, `timeout_error`, `internal_error`).
 - **`latencyMs`** — a latency histogram with per-bucket (non-cumulative) counts in ms plus an `+Inf`
   overflow bucket, alongside running `count`/`sum` totals.
-- **`authFailuresTotal`** — auth failure counter keyed by reason (`missing_token`, `invalid_token`).
+- **`authFailuresTotal`** — auth failure counter keyed by reason (`missing_token`, `expired_token`,
+  `invalid_token`). `expired_token` (a live token that aged out) is metered separately from
+  `invalid_token` (bad signature/issuer/audience) so "clients should refresh" is distinguishable
+  from "tokens are misconfigured/abused".
 - **`upstreamErrorsTotal`** — upstream failure counter keyed by category.
 - **`rateLimitedTotal`** — total rate-limited requests.
 

--- a/packages/mcp-server/docs/operations-runbook.md
+++ b/packages/mcp-server/docs/operations-runbook.md
@@ -21,13 +21,13 @@ is limited to behavior actually implemented in `packages/mcp-server`.
 
 Labels never carry PII — only tool names, outcome classes, and error categories.
 
-| Metric                | Shape                                                | Watch for                                                           |
-| --------------------- | ---------------------------------------------------- | ------------------------------------------------------------------- |
-| `requestsTotal`       | counter keyed `"<tool>\|<outcome>"`                  | Rising `*_error` outcomes; ratio of `success` to errors per tool.   |
-| `latencyMs`           | histogram (per-bucket counts + count/sum)            | p95/p99 drift; `sum/count` mean latency creeping up.                |
-| `authFailuresTotal`   | counter by reason (`missing_token`, `invalid_token`) | Spikes in `invalid_token` → token/audience misconfig or abuse.      |
-| `upstreamErrorsTotal` | counter by category                                  | Sustained `TIMEOUT_ERROR`/`UPSTREAM_ERROR` → upstream health issue. |
-| `rateLimitedTotal`    | counter                                              | Sustained growth → limits too tight or a hot client.                |
+| Metric                | Shape                                                                 | Watch for                                                                                                                                                                                                     |
+| --------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `requestsTotal`       | counter keyed `"<tool>\|<outcome>"`                                   | Rising `*_error` outcomes; ratio of `success` to errors per tool.                                                                                                                                             |
+| `latencyMs`           | histogram (per-bucket counts + count/sum)                             | p95/p99 drift; `sum/count` mean latency creeping up.                                                                                                                                                          |
+| `authFailuresTotal`   | counter by reason (`missing_token`, `expired_token`, `invalid_token`) | `expired_token` = live tokens aging out (clients should refresh); `invalid_token` = bad signature/issuer/audience → misconfig or abuse; a burst of `missing_token` = clients reconnecting (tokenless probes). |
+| `upstreamErrorsTotal` | counter by category                                                   | Sustained `TIMEOUT_ERROR`/`UPSTREAM_ERROR` → upstream health issue.                                                                                                                                           |
+| `rateLimitedTotal`    | counter                                                               | Sustained growth → limits too tight or a hot client.                                                                                                                                                          |
 
 Baseline latency targets and the load profile are captured by
 `packages/mcp-server/src/__tests__/perf.test.ts` (`yarn workspace @accounter/mcp-server benchmark`).
@@ -38,11 +38,30 @@ Structured JSON, one object per line. Every request carries `requestId` and `cor
 latter inherited from an inbound `X-Correlation-Id` header when present, and echoed on the
 response + propagated upstream). Secrets and `Authorization` headers are never logged.
 
+Request logs carry extra fields that make idle/cold-start/disconnect symptoms diagnosable:
+
+- **`msSinceLastRequest`** (on `request started`) — gap since this process last saw a request.
+  Absent on the first request of a process, which — paired with a fresh `mcp server started` line
+  (now tagged with `pid`) — is the cold-start signal.
+- **`aborted` / `responseCompleted`** (on `request completed`) — `aborted: true` means the client
+  hung up before the response finished, the server-side fingerprint of a client-side timeout (e.g. a
+  request abandoned while the instance was cold starting).
+- **`uptimeSeconds`** (on `request completed`) — process uptime; values that keep resetting to
+  near-zero across requests reveal an instance that is restarting/spinning down rather than staying
+  warm.
+- **`category`** (on `access token verification failed`) — `missing_token` / `expired_token` /
+  `invalid_token`, matching the metric buckets.
+
 Useful queries (adapt to your log backend):
 
 - **Trace one request across hops**: filter by `correlationId == "<id>"` (spans MCP → GraphQL).
-- **Auth failures**: `message == "access token verification failed"` (carries `reason`, never the
-  token).
+- **Auth failures**: `message == "access token verification failed"` (carries `reason` + `category`,
+  never the token). Tokenless probes (`category == "missing_token"`) are now logged too — previously
+  they were silent.
+- **Cold starts / spin-downs**: `message == "mcp server started"` (one per process start), or
+  `request completed` where `uptimeSeconds` is small, or `request started` with a large
+  `msSinceLastRequest`.
+- **Client-side disconnects**: `request completed` where `aborted == true`.
 - **Upstream failures**: `message` starting `span end` with `name == "upstream:graphql"` and a
   non-zero error, or tool results logged with `code` in (`UPSTREAM_ERROR`, `TIMEOUT_ERROR`).
 - **Slow requests**: completion logs where `latencyMs` exceeds your target.
@@ -53,10 +72,15 @@ Useful queries (adapt to your log backend):
 
 ### A. Elevated `401`s / all calls failing auth
 
-1. Check `authFailuresTotal` split: `missing_token` vs `invalid_token`.
+1. Check `authFailuresTotal` split: `missing_token` vs `expired_token` vs `invalid_token`.
 2. `invalid_token` spike → verify `AUTH0_ISSUER_URL` and `AUTH0_AUDIENCE` match the tokens clients
    present, and the tenant JWKS is reachable. A JWKS outage surfaces as a `5xx` (not `401`).
-3. Confirm the clock/expiry: expired tokens are `invalid_token` by design.
+3. `expired_token` spike → tokens are aging out faster than clients refresh; the transport still
+   answers `401 invalid_token` (RFC 6750), but the metric is bucketed as `expired_token`. Check the
+   Auth0 access-token lifetime and that clients hold a working refresh token.
+4. A `missing_token` spike with prompt recovery (a `401` immediately followed by a
+   `/.well-known/oauth-protected-resource` fetch and a `200`) is the normal reconnect handshake, not
+   an incident.
 
 ### B. Elevated `UPSTREAM_ERROR` / `TIMEOUT_ERROR`
 
@@ -77,6 +101,41 @@ Useful queries (adapt to your log backend):
 2. Memberships are resolved server-side from `business_users` via `myMemberships`; scope narrowing
    outside memberships is denied (`AUTHORIZATION_ERROR`). Verify the server-side rows and the
    caller's token.
+
+### E. Client connection "dies" / requires manual re-auth after idle
+
+Symptom: a connected Claude client (Desktop/claude.ai) that was working goes dead after a period of
+inactivity (e.g. overnight) and only recovers when the user manually reconnects.
+
+**First conclusion to reach for: hosting, not auth.** The connector is stateless and does not hold a
+session — an idle timeout or redeploy cannot evict server-side session state, because there is none.
+The observed cause of this symptom (investigated Aug 2026) was an **idle-spin-down host**: the
+instance slept after 15 minutes with no requests and cold-started (~15s) on the next one. Because
+MCP Streamable HTTP is request/response, the client sends nothing between prompts, so **the client
+cannot keep the instance warm** — any gap in user activity guarantees a spin-down, and the first
+request after the gap hits a cold boot. If that request exceeds the client's timeout it fails
+client-side (a `499`/abort at the edge, not a `5xx` the app logs), and the client marks the
+connector disconnected.
+
+Diagnosis checklist:
+
+1. **App logs** — is there a `SIGTERM` / `shutdown` roughly 15 min after the _last_ request, then a
+   later `mcp server started` (new `pid`)? That cadence is idle spin-down. `POST /mcp` requests that
+   land after a gap show a large `msSinceLastRequest`; a restarting instance shows small
+   `uptimeSeconds`.
+2. **Platform edge logs** (e.g. Render → Logs, `type: request`) — `502`/`503` during boot windows,
+   or `499`/timeouts on `POST /mcp` when the user returned, confirm requests failing at the edge
+   while the instance was unavailable. The app cannot log a request it never received.
+3. **Auth is a red herring here unless** `authFailuresTotal.expired_token` / `invalid_token` is
+   actually rising, or Auth0 logs show failed refresh (`type: fer`/`fert`). A lone `missing_token`
+   401 that immediately recovers via `/.well-known/oauth-protected-resource` → `200` is the _normal_
+   reconnect handshake, not a failure.
+
+**Fix: keep the instance always-on.** Run the connector on a hosting tier that does not spin down on
+idle (preferred), or keep it warm with an external pinger hitting `GET /health` more often than the
+idle window (`/health` needs no auth). Ensure health-check-gated / zero-downtime deploys so
+redeploys don't drop in-flight requests. Token refresh, `401` handling, and statelessness are all
+functioning; the hosting tier is the lever.
 
 ## 5. Rollback
 

--- a/packages/mcp-server/src/__tests__/logger.test.ts
+++ b/packages/mcp-server/src/__tests__/logger.test.ts
@@ -85,4 +85,18 @@ describe('field helpers', () => {
     expect(fields.status).toBe(200);
     expect(fields.latencyMs).toBeGreaterThanOrEqual(0);
   });
+
+  it('completionFields merges disconnect/uptime extras when provided', () => {
+    const fields = completionFields(ctx, 499, {
+      responseCompleted: false,
+      aborted: true,
+      uptimeSeconds: 12,
+    });
+    expect(fields).toMatchObject({
+      status: 499,
+      responseCompleted: false,
+      aborted: true,
+      uptimeSeconds: 12,
+    });
+  });
 });

--- a/packages/mcp-server/src/__tests__/logger.test.ts
+++ b/packages/mcp-server/src/__tests__/logger.test.ts
@@ -99,4 +99,15 @@ describe('field helpers', () => {
       uptimeSeconds: 12,
     });
   });
+
+  it('completionFields keeps canonical status/latency even if extra tries to override them', () => {
+    // `extra` is spread first, so a stray `status`/`latencyMs` cannot corrupt
+    // the completion log. (Cast past the typed shape to simulate a bad caller.)
+    const fields = completionFields(ctx, 200, {
+      status: 500,
+      latencyMs: -1,
+    } as unknown as Parameters<typeof completionFields>[2]);
+    expect(fields.status).toBe(200);
+    expect(fields.latencyMs).toBeGreaterThanOrEqual(0);
+  });
 });

--- a/packages/mcp-server/src/auth/__tests__/token.test.ts
+++ b/packages/mcp-server/src/auth/__tests__/token.test.ts
@@ -104,11 +104,26 @@ describe('verifyAccessTokenWithKey', () => {
     ).rejects.toBeInstanceOf(TokenVerificationError);
   });
 
-  it('rejects an expired token', async () => {
+  it('rejects an expired token and flags it as expired', async () => {
     const token = await sign({ expiresIn: Math.floor(Date.now() / 1000) - 60 });
-    await expect(
-      verifyAccessTokenWithKey(token, publicKey, { issuer: ISSUER, audience: AUDIENCE }),
-    ).rejects.toBeInstanceOf(TokenVerificationError);
+    const error = await verifyAccessTokenWithKey(token, publicKey, {
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(TokenVerificationError);
+    // Expiry is distinguishable from other invalid-token failures so the auth
+    // layer can meter it separately.
+    expect((error as TokenVerificationError).expired).toBe(true);
+  });
+
+  it('does not flag a non-expiry failure (wrong issuer) as expired', async () => {
+    const token = await sign({ issuer: 'https://evil.example/' });
+    const error = await verifyAccessTokenWithKey(token, publicKey, {
+      issuer: ISSUER,
+      audience: AUDIENCE,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(TokenVerificationError);
+    expect((error as TokenVerificationError).expired).toBe(false);
   });
 
   it('rejects a token signed by a different key', async () => {

--- a/packages/mcp-server/src/auth/token.ts
+++ b/packages/mcp-server/src/auth/token.ts
@@ -47,9 +47,20 @@ export class TokenVerificationError extends Error {
   /** RFC 6750 error code surfaced in the WWW-Authenticate challenge. */
   public readonly code = 'invalid_token';
 
-  constructor(message: string) {
+  /**
+   * True when verification failed *specifically because the token expired* (as
+   * opposed to a bad signature, wrong issuer/audience, etc.). The transport
+   * response is identical — RFC 6750 uses `invalid_token` for both — but this
+   * lets the auth layer record an `expired_token` metric distinct from other
+   * `invalid_token` failures, which is the difference between "clients need to
+   * refresh sooner" and "tokens are misconfigured/abused".
+   */
+  public readonly expired: boolean;
+
+  constructor(message: string, options?: { expired?: boolean }) {
     super(message);
     this.name = 'TokenVerificationError';
+    this.expired = options?.expired ?? false;
   }
 }
 
@@ -148,8 +159,12 @@ export async function verifyAccessTokenWithKey(
       throw error;
     }
     if (isTokenValidationError(error)) {
-      // Normalize to a safe, token-free message.
-      throw new TokenVerificationError(error instanceof Error ? error.message : 'invalid token');
+      // Normalize to a safe, token-free message. Preserve whether the failure
+      // was expiry specifically, so the auth layer can meter it separately.
+      const expired = (error as { code?: unknown })?.code === 'ERR_JWT_EXPIRED';
+      throw new TokenVerificationError(error instanceof Error ? error.message : 'invalid token', {
+        expired,
+      });
     }
     // Infrastructure/unexpected error — let it propagate (becomes a 5xx).
     throw error;

--- a/packages/mcp-server/src/logger.ts
+++ b/packages/mcp-server/src/logger.ts
@@ -80,7 +80,29 @@ export function createRequestLogger(context: RequestContext): RequestLogger {
   };
 }
 
+/**
+ * Extra completion fields the transport supplies from the response/process so a
+ * disconnect is diagnosable after the fact.
+ *
+ * - `responseCompleted` — the response was fully written (`res.writableEnded`).
+ * - `aborted` — the connection closed before the response finished, i.e. the
+ *   client hung up mid-flight (the server-side fingerprint of a client-side
+ *   timeout, such as a request abandoned during a cold start).
+ * - `uptimeSeconds` — process uptime at completion; a value that keeps resetting
+ *   to near-zero across requests reveals an instance that is restarting/cold
+ *   starting rather than staying warm.
+ */
+export interface CompletionExtra {
+  responseCompleted?: boolean;
+  aborted?: boolean;
+  uptimeSeconds?: number;
+}
+
 /** Log fields describing request completion, including latency. */
-export function completionFields(context: RequestContext, status: number): Record<string, unknown> {
-  return { status, latencyMs: elapsedMs(context) };
+export function completionFields(
+  context: RequestContext,
+  status: number,
+  extra?: CompletionExtra,
+): Record<string, unknown> {
+  return { status, latencyMs: elapsedMs(context), ...extra };
 }

--- a/packages/mcp-server/src/logger.ts
+++ b/packages/mcp-server/src/logger.ts
@@ -84,10 +84,11 @@ export function createRequestLogger(context: RequestContext): RequestLogger {
  * Extra completion fields the transport supplies from the response/process so a
  * disconnect is diagnosable after the fact.
  *
- * - `responseCompleted` — the response was fully written (`res.writableEnded`).
- * - `aborted` — the connection closed before the response finished, i.e. the
- *   client hung up mid-flight (the server-side fingerprint of a client-side
- *   timeout, such as a request abandoned during a cold start).
+ * - `responseCompleted` — the response fully finished flushing to the socket
+ *   (`res.writableFinished`, not merely `end()` having been called).
+ * - `aborted` — the connection closed before the response finished flushing,
+ *   i.e. the client hung up mid-flight (the server-side fingerprint of a
+ *   client-side timeout, such as a request abandoned during a cold start).
  * - `uptimeSeconds` — process uptime at completion; a value that keeps resetting
  *   to near-zero across requests reveals an instance that is restarting/cold
  *   starting rather than staying warm.
@@ -98,11 +99,15 @@ export interface CompletionExtra {
   uptimeSeconds?: number;
 }
 
-/** Log fields describing request completion, including latency. */
+/**
+ * Log fields describing request completion, including latency. `extra` is
+ * spread first so the canonical `status`/`latencyMs` always win — a caller
+ * cannot accidentally emit a completion log with an overridden status.
+ */
 export function completionFields(
   context: RequestContext,
   status: number,
   extra?: CompletionExtra,
 ): Record<string, unknown> {
-  return { status, latencyMs: elapsedMs(context), ...extra };
+  return { ...extra, status, latencyMs: elapsedMs(context) };
 }

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildAuthContext } from '../../auth/identity.js';
 import { TokenVerificationError } from '../../auth/token.js';
 import { verifyAccessToken } from '../../auth/verifier.js';
+import { getMetrics, resetMetrics } from '../../observability/metrics.js';
 import { dispatchMcpRequest, handleMcpBody, MCP_PROTOCOL_VERSION, mcpHttpHandler } from '../handler.js';
 import type { JsonRpcErrorResponse, JsonRpcSuccess } from '../jsonrpc.js';
 import { JsonRpcErrorCode } from '../jsonrpc.js';
@@ -223,6 +224,44 @@ describe('mcpHttpHandler', () => {
     expect(wwwAuth?.[1]).toContain('error="invalid_token"');
     vi.unstubAllEnvs();
     resetEnvCache();
+  });
+
+  it('records a `missing_token` auth failure when no bearer token is present', async () => {
+    resetMetrics();
+    const res = mockRes();
+    await mcpHttpHandler(mockReq(rpc('tools/list'), {}), res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+    expect(getMetrics().snapshot().authFailuresTotal).toMatchObject({ missing_token: 1 });
+  });
+
+  it('meters an expired token as `expired_token`, distinct from `invalid_token`', async () => {
+    resetMetrics();
+    mockVerify.mockRejectedValue(new TokenVerificationError('token expired', { expired: true }));
+
+    const res = mockRes();
+    await mcpHttpHandler(mockReq(rpc('tools/list'), { authorization: 'Bearer expired' }), res);
+
+    // Transport response is still a 401 with the standard invalid_token code…
+    expect(res.writeHead).toHaveBeenCalledWith(401, { 'Content-Type': 'application/json' });
+    const wwwAuth = res.setHeader.mock.calls.find(([name]) => name === 'WWW-Authenticate');
+    expect(wwwAuth?.[1]).toContain('error="invalid_token"');
+    // …but the metric is bucketed as expired, not invalid.
+    const failures = getMetrics().snapshot().authFailuresTotal;
+    expect(failures).toMatchObject({ expired_token: 1 });
+    expect(failures.invalid_token ?? 0).toBe(0);
+  });
+
+  it('meters a non-expiry verification failure as `invalid_token`', async () => {
+    resetMetrics();
+    mockVerify.mockRejectedValue(new TokenVerificationError('bad signature'));
+
+    const res = mockRes();
+    await mcpHttpHandler(mockReq(rpc('tools/list'), { authorization: 'Bearer bad' }), res);
+
+    const failures = getMetrics().snapshot().authFailuresTotal;
+    expect(failures).toMatchObject({ invalid_token: 1 });
+    expect(failures.expired_token ?? 0).toBe(0);
   });
 
   it('challenges with 401 + error="invalid_token" when identity mapping fails', async () => {

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -284,6 +284,23 @@ async function authenticate(
   const token = extractBearerToken(req);
   if (!token) {
     getMetrics().recordAuthFailure('missing_token');
+    // Log the tokenless 401 too (previously silent). A client re-establishing a
+    // connection probes without a token, gets this 401, then follows the
+    // WWW-Authenticate pointer to re-auth — so a burst of `missing_token` here
+    // is the fingerprint of clients reconnecting, distinct from `expired_token`
+    // (a live token that aged out) or `invalid_token` (a broken token).
+    const context = getRequestContext(req);
+    if (context) {
+      createRequestLogger(context).warn('access token verification failed', {
+        reason: 'missing bearer token',
+        category: 'missing_token',
+      });
+    } else {
+      log('warn', 'access token verification failed', {
+        reason: 'missing bearer token',
+        category: 'missing_token',
+      });
+    }
     sendUnauthorized(res, {
       resourceMetadataUrl: protectedResourceMetadataUrl(env.server.publicBaseUrl),
     });
@@ -313,15 +330,22 @@ async function authenticate(
     if (!(error instanceof TokenVerificationError) && !(error instanceof IdentityMappingError)) {
       throw error;
     }
-    getMetrics().recordAuthFailure('invalid_token');
+    // Meter expiry separately from other invalid-token failures: an expired
+    // token means the client should have refreshed, whereas a bad
+    // signature/issuer/audience (or an unmappable identity) points at
+    // misconfiguration or abuse. The transport response is identical.
+    const category =
+      error instanceof TokenVerificationError && error.expired ? 'expired_token' : 'invalid_token';
+    getMetrics().recordAuthFailure(category);
     // Log the reason only — never the token.
     const context = getRequestContext(req);
     if (context) {
       createRequestLogger(context).warn('access token verification failed', {
         reason: error.message,
+        category,
       });
     } else {
-      log('warn', 'access token verification failed', { reason: error.message });
+      log('warn', 'access token verification failed', { reason: error.message, category });
     }
     sendUnauthorized(res, {
       resourceMetadataUrl: protectedResourceMetadataUrl(env.server.publicBaseUrl),

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -89,10 +89,27 @@ export const routes: Record<string, Record<string, RouteHandler>> = {
   },
 };
 
+/**
+ * Wall-clock of the last request seen by this process, for the idle-gap marker
+ * below. Process-local and best-effort (not synchronized across concurrent
+ * requests) — it exists to make idle periods and cold starts visible in the
+ * logs, not to be exact.
+ */
+let lastRequestAtMs: number | undefined;
+
 export async function requestHandler(req: IncomingMessage, res: ServerResponse): Promise<void> {
   const context = createRequestContext(req);
   setRequestContext(req, context);
   const logger = createRequestLogger(context);
+
+  // Idle-gap marker: how long since this process last saw a request. `undefined`
+  // on the very first request of a process — which, paired with the startup log,
+  // is itself the cold-start signal. A large gap here after a quiet period is
+  // what an idle spin-down + cold start looks like from inside the app.
+  const nowMs = performance.now();
+  const msSinceLastRequest =
+    lastRequestAtMs === undefined ? undefined : Math.round(nowMs - lastRequestAtMs);
+  lastRequestAtMs = nowMs;
 
   // Tag the auto-instrumented incoming HTTP span with the business-level
   // correlation id (and request id) so this MCP trace — and, via `traceparent`
@@ -107,11 +124,23 @@ export async function requestHandler(req: IncomingMessage, res: ServerResponse):
   // Echo the correlation id so callers can tie their logs to ours.
   res.setHeader('X-Correlation-Id', context.correlationId);
 
-  logger.info('request started');
+  logger.info(
+    'request started',
+    msSinceLastRequest === undefined ? undefined : { msSinceLastRequest },
+  );
   // Log completion on `close` (not `finish`) so an aborted/prematurely-closed
   // connection still emits a completion log instead of a silent blind spot.
+  // `aborted`/`responseCompleted` make that distinction explicit, and
+  // `uptimeSeconds` surfaces restart/cold-start churn.
   res.once('close', () => {
-    logger.info('request completed', completionFields(context, res.statusCode));
+    logger.info(
+      'request completed',
+      completionFields(context, res.statusCode, {
+        responseCompleted: res.writableEnded,
+        aborted: !res.writableEnded,
+        uptimeSeconds: Math.round(process.uptime()),
+      }),
+    );
   });
 
   try {
@@ -216,11 +245,15 @@ export function start(): Server {
   process.once('SIGTERM', () => shutdown('SIGTERM'));
 
   server.listen(env.server.port, () => {
+    // `pid` tags this process instance so restarts are distinguishable in
+    // aggregated logs; each `mcp server started` line marks a fresh (cold)
+    // start of the transport.
     log('info', 'mcp server started', {
       service: SERVICE_NAME,
       version: getServiceVersion(),
       port: env.server.port,
       enabled: env.server.enabled,
+      pid: process.pid,
     });
   });
 

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -90,10 +90,11 @@ export const routes: Record<string, Record<string, RouteHandler>> = {
 };
 
 /**
- * Wall-clock of the last request seen by this process, for the idle-gap marker
- * below. Process-local and best-effort (not synchronized across concurrent
- * requests) — it exists to make idle periods and cold starts visible in the
- * logs, not to be exact.
+ * Monotonic (process-relative, from `performance.now()`) timestamp of the last
+ * request seen by this process, for the idle-gap marker below. Not wall-clock —
+ * only differences within this process are meaningful. Process-local and
+ * best-effort (not synchronized across concurrent requests); it exists to make
+ * idle periods and cold starts visible in the logs, not to be exact.
  */
 let lastRequestAtMs: number | undefined;
 
@@ -136,8 +137,11 @@ export async function requestHandler(req: IncomingMessage, res: ServerResponse):
     logger.info(
       'request completed',
       completionFields(context, res.statusCode, {
-        responseCompleted: res.writableEnded,
-        aborted: !res.writableEnded,
+        // `writableFinished` (fully flushed), not `writableEnded` (end() called):
+        // a client that hangs up after end() but before the flush completes is a
+        // mid-flight disconnect, and must not be logged as completed.
+        responseCompleted: res.writableFinished,
+        aborted: !res.writableFinished,
         uptimeSeconds: Math.round(process.uptime()),
       }),
     );


### PR DESCRIPTION
## Background

A Claude Desktop connector "died" after an idle period and required manual re-auth. Investigation (using the server's own logs + Render edge logs) traced the root cause to an **idle-spin-down host** — the instance slept after 15 min of inactivity and cold-started (~15s) on the next request. Because MCP Streamable HTTP is request/response, the client sends nothing between prompts and so **cannot keep the instance warm**; the first request after a gap hit a cold boot and failed client-side.

**Auth was not the cause** — token refresh, `401` handling, and statelessness were all working. The real gap was that the app logs *couldn't distinguish* a hosting spin-down from a token/auth failure. The hosting fix (always-on tier) has already been applied by the maintainer; this PR delivers the code/doc hardening so the next incident is diagnosable from the server side, plus a small auth-metric improvement.

## Changes

**Logging / metrics (`src`)**
- Log the previously-**silent `missing_token` 401** (with a `category` field) — tokenless reconnect probes are now visible instead of a blind spot.
- Meter **`expired_token` separately from `invalid_token`**: `TokenVerificationError` carries an `expired` flag derived from jose's `ERR_JWT_EXPIRED`. The transport response is unchanged (RFC 6750 `invalid_token` + `WWW-Authenticate`); only the metric bucket and log `category` differ. This distinguishes "clients should refresh" from "tokens are misconfigured/abused".
- Add **`aborted` / `responseCompleted`** and **`uptimeSeconds`** to completion logs, **`msSinceLastRequest`** to request-start logs, and **`pid`** to the startup log — so idle gaps, cold starts, restart churn, and client-side disconnects are greppable.

**Docs**
- `docs/operations-runbook.md`: new incident playbook **"Client connection dies / requires manual re-auth after idle"** (hosting, not auth) recording the investigation and fix; new log-field + metric-bucket references; updated auth playbook.
- `README.md`: observability section updated for the new fields and the `expired_token` bucket.

**Tests**
- Expiry `expired` flag (and non-expiry stays `false`).
- Auth-failure metric split: `missing_token`, `expired_token`, `invalid_token`.
- `completionFields` merges the new disconnect/uptime extras.

## Verification
- `yarn workspace @accounter/mcp-server test` → 415 passed
- `yarn workspace @accounter/mcp-server typecheck` → clean
- `yarn workspace @accounter/mcp-server lint` → clean
- Prettier clean on all touched files

## Notes / follow-ups (not in this PR)
- **P0 hosting** (always-on tier) — done on the maintainer's side (Render plan upgrade).
- **P2 Auth0 hardening** (gap #7: purpose-built Regular Web App, `offline_access`, refresh rotation/lifetimes) — config-only, awaiting confirmation of the current Auth0 settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ppw8cQibtaBoVYupdiCuEQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ppw8cQibtaBoVYupdiCuEQ)_