### PR TITLE
Upgrade react-hook-form to 7.85.0 and remove onClick handlers

### DIFF
--- a/.changeset/@accounter_client-4100-dependencies.md
+++ b/.changeset/@accounter_client-4100-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`react-hook-form@7.85.0` ↗︎](https://www.npmjs.com/package/react-hook-form/v/7.85.0) (from `7.83.0`, in `dependencies`)

--- a/.changeset/@accounter_client-4158-dependencies.md
+++ b/.changeset/@accounter_client-4158-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`react-hook-form@7.85.0` ↗︎](https://www.npmjs.com/package/react-hook-form/v/7.85.0) (from `7.83.0`, in `dependencies`)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -66,7 +66,7 @@
     "react-dnd": "16.0.1",
     "react-dom": "19.2.8",
     "react-error-boundary": "6.1.2",
-    "react-hook-form": "7.83.0",
+    "react-hook-form": "7.85.0",
     "react-number-format": "5.4.5",
     "react-router-dom": "7.18.2",
     "react-to-pdf": "3.2.2",

--- a/packages/client/src/components/common/forms/edit-charge.tsx
+++ b/packages/client/src/components/common/forms/edit-charge.tsx
@@ -367,7 +367,6 @@ export const EditCharge = ({ charge, close, onChange }: Props): ReactElement => 
           <div className="mt-10 mb-5 flex justify-center gap-5">
             <button
               type="submit"
-              onClick={(): (() => Promise<void>) => handleSubmit(onChargeSubmit)}
               className="mt-8 text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
               disabled={isChargeLoading || Object.keys(dirtyChargeFields).length === 0}
             >

--- a/packages/client/src/components/common/forms/edit-tag.tsx
+++ b/packages/client/src/components/common/forms/edit-tag.tsx
@@ -83,7 +83,6 @@ export const EditTag = ({ onDone, data, close }: Props): ReactElement => {
         <div className="mt-10 mb-5 flex justify-center gap-5">
           <button
             type="submit"
-            onClick={(): (() => Promise<void>) => handleSubmit(onTagSubmit)}
             className="mt-8 text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
             disabled={isTagLoading || Object.keys(dirtyFields).length === 0}
           >

--- a/packages/client/src/components/common/forms/modify-salary-record.tsx
+++ b/packages/client/src/components/common/forms/modify-salary-record.tsx
@@ -832,7 +832,6 @@ export const ModifySalaryRecord = ({
         <div className="mt-10 mb-5 flex justify-center gap-5">
           <button
             type="submit"
-            onClick={(): (() => Promise<void>) => handleSalaryRecordSubmit(onSalaryRecordSubmit)}
             className="mt-8 text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
             disabled={isModifying || Object.keys(dirtySalaryRecordFields).length === 0}
           >

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,7 +117,7 @@ __metadata:
     react-dnd: "npm:16.0.1"
     react-dom: "npm:19.2.8"
     react-error-boundary: "npm:6.1.2"
-    react-hook-form: "npm:7.83.0"
+    react-hook-form: "npm:7.85.0"
     react-number-format: "npm:5.4.5"
     react-router-dom: "npm:7.18.2"
     react-to-pdf: "npm:3.2.2"
@@ -22875,12 +22875,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-hook-form@npm:7.83.0":
-  version: 7.83.0
-  resolution: "react-hook-form@npm:7.83.0"
+"react-hook-form@npm:7.85.0":
+  version: 7.85.0
+  resolution: "react-hook-form@npm:7.85.0"
   peerDependencies:
     react: ^16.8.0 || ^17 || ^18 || ^19
-  checksum: 10c0/3a1cfbb6bd614833675e1db1c079e05dc51c4f26c5259424023846a380de22d51748a755032a9983af492d25cbe98c524eecadce3c75e6997ff136e7538be06e
+  checksum: 10c0/53e81f4116129efa8e08c620cd334f74541174a82f3e4ce7a8839193c69a561b9bed070b4a46f24654c4860c474ddbb504d2ad402297708c8c2b80f1f6116d59
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Upgrade `react-hook-form` from 7.83.0 to 7.85.0 and remove redundant `onClick` handlers from form submit buttons across multiple form components.

## Changes

- **Dependency**: Updated `react-hook-form` to 7.85.0 in `@accounter/client`
- **Form components**: Removed unnecessary `onClick={(): (() => Promise<void>) => handleSubmit(...)}` handlers from submit buttons in:
  - `EditCharge` component
  - `EditTag` component
  - `ModifySalaryRecord` component

## Implementation Details

The `onClick` handlers were redundant because `react-hook-form` automatically handles form submission through the `type="submit"` attribute on buttons within a form element. The form's `onSubmit` handler (via `useForm`) already manages the submission flow, making the explicit `onClick` wrapper unnecessary. This cleanup aligns with react-hook-form best practices and simplifies the code.

https://claude.ai/code/session_01Sy99NAQpakgaqMnYKoYZdz