### PR TITLE
Expose charge filters to MCP and align tenant terminology

### DIFF
--- a/.changeset/mcp-charge-filters-and-member-terminology.md
+++ b/.changeset/mcp-charge-filters-and-member-terminology.md
@@ -1,0 +1,19 @@
+---
+'@accounter/mcp-server': patch
+'@accounter/server': patch
+---
+
+Expose the full set of query filters to the MCP tools and align tenant terminology.
+
+- `accounter_get_charges` / `accounter_search_charges` accept the full `ChargeFilter` surface via a
+  shared charge-filter schema, and the transaction/document detail tools accept their respective
+  `*ByFilters` predicates alongside ids.
+- Share entity shape definitions across tools so charge, transaction and document payloads stay
+  consistent, and extend the schema-contract tests to guard the exposed filter surface.
+- Lookup tools (businesses, tags, tax categories) expose their upstream filter arguments.
+- Rename the tenant-scoping input from `businessId` to `memberBusinessId` across tool inputs, auth
+  identity handling and docs, so it is no longer confused with the business entities the tools
+  return.
+- Server: `allCharges` now forwards `fromDate` / `toDate` to `getChargesByFilters` in addition to
+  `fromAnyDate` / `toAnyDate`; previously those two filters were silently dropped and returned an
+  unfiltered result.


### PR DESCRIPTION
## Summary

Expands the MCP server's query capabilities by exposing the full `ChargeFilter` surface to tools, standardizes entity shape definitions across tools, and renames tenant-scoping terminology from `businessId` to `memberBusinessId` for clarity.

## Key Changes

- **MCP charge tools**: `accounter_get_charges` and `accounter_search_charges` now accept the complete `ChargeFilter` surface via a shared charge-filter schema. Transaction and document detail tools now accept their respective `*ByFilters` predicates alongside ID-based lookups.

- **Shared entity schemas**: Charge, transaction, and document payload definitions are now shared across tools to ensure consistency, with extended schema-contract tests to guard the exposed filter surface.

- **Lookup tool filters**: Businesses, tags, and tax categories tools now expose their upstream filter arguments.

- **Tenant terminology**: Renamed `businessId` to `memberBusinessId` across:
  - MCP tool inputs
  - Auth identity handling
  - Documentation
  
  This eliminates confusion between the tenant-scoping parameter and the business entities returned by tools.

- **Server date filtering**: `allCharges` now correctly forwards `fromDate` / `toDate` to `getChargesByFilters` in addition to `fromAnyDate` / `toAnyDate`. Previously, these filters were silently dropped, resulting in unfiltered results.

## Affected Packages

- `@accounter/mcp-server`
- `@accounter/server`

https://claude.ai/code/session_01RpJQh1nbdrrKEKvABupXWC