### PR TITLE
feat(ledger,contracts): filterable queries + dedicated MCP tools

### DIFF
--- a/.changeset/ledger-contract-filter-tools.md
+++ b/.changeset/ledger-contract-filter-tools.md
@@ -11,9 +11,9 @@ Server:
   value date or either, by the financial entity in any of the four debit/credit account slots, by
   owner and by charge.
 - `LedgerRecord` now exposes `ownerId` and `chargeId`.
-- `contractsByFilters(filters: ContractsFilters)` filters contracts by admin (owner) business,
+- `contractsByFilters(filters: ContractsFilters)` filters contracts by owning (admin) business,
   client, contract id and active state.
-- `Contract` now exposes `adminId`.
+- `Contract` now exposes `ownerId` (matching the platform-wide row-owner field name).
 
 MCP server: new read-only `accounter_get_ledger_records` and `accounter_get_contracts` tools built
 on those queries, following the existing business-scoping and output-shaping conventions.

--- a/.changeset/ledger-contract-filter-tools.md
+++ b/.changeset/ledger-contract-filter-tools.md
@@ -1,0 +1,19 @@
+---
+'@accounter/server': minor
+'@accounter/mcp-server': minor
+---
+
+Add filterable ledger-record and contract queries, and expose them as dedicated MCP tools.
+
+Server:
+
+- `ledgerRecordsByFilters(filters: LedgerRecordsFilters)` filters ledger records by invoice date,
+  value date or either, by the financial entity in any of the four debit/credit account slots, by
+  owner and by charge.
+- `LedgerRecord` now exposes `ownerId` and `chargeId`.
+- `contractsByFilters(filters: ContractsFilters)` filters contracts by admin (owner) business,
+  client, contract id and active state.
+- `Contract` now exposes `adminId`.
+
+MCP server: new read-only `accounter_get_ledger_records` and `accounter_get_contracts` tools built
+on those queries, following the existing business-scoping and output-shaping conventions.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -140,10 +140,10 @@ scope, because it _is_ the scope.
   a second call. Date ranges are bounded (≤ 1096 days) and rows capped (≤ 500, default 200) with a
   `truncated` flag.
 - **`accounter_get_contracts`** — read-only **client billing contracts**. Filters by `clientIds`, by
-  `contractIds`, and by `isActive`. The admin (owner) axis is the membership axis — a contract is
-  always owned by a business you are a member of — so `memberBusinessIds` doubles as the admin
-  filter and is forwarded as the upstream `filters.adminIds`; there is no separate `adminIds` input
-  to drift from it. Each row reports its `adminId` plus the client, period, amount, billing cycle,
+  `contractIds`, and by `isActive`. The owning ("admin") business axis is the membership axis — a
+  contract is always owned by a business you are a member of — so `memberBusinessIds` doubles as the
+  owner filter and is forwarded as the upstream `filters.ownerIds`; there is no separate owner input
+  to drift from it. Each row reports its `ownerId` plus the client, period, amount, billing cycle,
   document type, product/plan, and purchase orders.
 - **`accounter_list_tags`** — list tags for categorizing charges, optionally filtered by name and by
   `memberBusinessIds`. Rows carry `ownerId`. Deterministically sorted (name, then id) and

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -18,12 +18,13 @@ Phase 1 (read-only) is feature-complete. The server provides: strict startup env
 transport with `/health`, `/metrics`, the OAuth protected-resource metadata endpoint, and the MCP
 route (`POST /mcp`, JSON-RPC 2.0) with graceful shutdown; Auth0 bearer-token verification; identity
 mapping to an internal user + business-membership context with memberships resolved from the
-Accounter GraphQL server; a curated registry of nine read-only tools
+Accounter GraphQL server; a curated registry of eleven read-only tools
 (`accounter_list_business_memberships`, `accounter_search_charges`, `accounter_get_charges`,
-`accounter_get_transactions`, `accounter_get_documents`, `accounter_list_tags`,
-`accounter_list_tax_categories`, `accounter_list_businesses`, `accounter_balance_report`) each gated
-by strict input validation, a per-tool authorization policy, and business-scope narrowing forwarded
-upstream as `x-business-scope`; a hardened upstream GraphQL client (timeout, bounded retries, header
+`accounter_get_transactions`, `accounter_get_documents`, `accounter_get_ledger_records`,
+`accounter_get_contracts`, `accounter_list_tags`, `accounter_list_tax_categories`,
+`accounter_list_businesses`, `accounter_balance_report`) each gated by strict input validation, a
+per-tool authorization policy, and business-scope narrowing forwarded upstream as
+`x-business-scope`; a hardened upstream GraphQL client (timeout, bounded retries, header
 propagation, sanitized errors); a unified error taxonomy; per-`tools/call` rate limiting; in-process
 operational metrics (request/outcome counters, a latency histogram, auth-failure counters) exposed
 at `GET /metrics`; and OpenTelemetry tracing exported to Grafana Tempo (opt-in), correlated with the
@@ -129,6 +130,19 @@ scope, because it _is_ the scope.
   amount, VAT, creditor/debtor, `chargeId`, `file`/`image` links, and `ownerId` (inherited from the
   document's charge). A document whose owning charge falls outside the resolved scope is dropped as
   defense-in-depth on top of RLS.
+- **`accounter_get_ledger_records`** — read-only **double-entry ledger records** search. Filters on
+  the three date axes a record has (`fromInvoiceDate`/`toInvoiceDate`,
+  `fromValueDate`/`toValueDate`, or `fromDate`/`toDate` matching either), on the financial entity in
+  any of the four account slots (`financialEntityIds` plus an optional `financialEntityAccounts`
+  subset of `DEBIT_ACCOUNT_1`, `DEBIT_ACCOUNT_2`, `CREDIT_ACCOUNT_1`, `CREDIT_ACCOUNT_2`), and on
+  `chargeIds`. Each row reports its `ownerId` and `chargeId` alongside the four debit/credit entries
+  (account, amount, local currency amount), so results spanning businesses or charges group without
+  a second call. Date ranges are bounded (≤ 1096 days) and rows capped (≤ 500, default 200) with a
+  `truncated` flag.
+- **`accounter_get_contracts`** — read-only **client billing contracts**. Filters by admin (owner)
+  business (`adminIds`, intersected with the resolved scope), by `clientIds`, by `contractIds`, and
+  by `isActive`. Each row reports its `adminId` plus the client, period, amount, billing cycle,
+  document type, product/plan, and purchase orders.
 - **`accounter_list_tags`** — list tags for categorizing charges, optionally filtered by name and by
   `memberBusinessIds`. Rows carry `ownerId`. Deterministically sorted (name, then id) and
   size-capped (≤ 500).

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -139,9 +139,11 @@ scope, because it _is_ the scope.
   (account, amount, local currency amount), so results spanning businesses or charges group without
   a second call. Date ranges are bounded (≤ 1096 days) and rows capped (≤ 500, default 200) with a
   `truncated` flag.
-- **`accounter_get_contracts`** — read-only **client billing contracts**. Filters by admin (owner)
-  business (`adminIds`, intersected with the resolved scope), by `clientIds`, by `contractIds`, and
-  by `isActive`. Each row reports its `adminId` plus the client, period, amount, billing cycle,
+- **`accounter_get_contracts`** — read-only **client billing contracts**. Filters by `clientIds`, by
+  `contractIds`, and by `isActive`. The admin (owner) axis is the membership axis — a contract is
+  always owned by a business you are a member of — so `memberBusinessIds` doubles as the admin
+  filter and is forwarded as the upstream `filters.adminIds`; there is no separate `adminIds` input
+  to drift from it. Each row reports its `adminId` plus the client, period, amount, billing cycle,
   document type, product/plan, and purchase orders.
 - **`accounter_list_tags`** — list tags for categorizing charges, optionally filtered by name and by
   `memberBusinessIds`. Rows carry `ownerId`. Deterministically sorted (name, then id) and

--- a/packages/mcp-server/src/tools/__tests__/contracts.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/contracts.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { getContractsTool, MAX_CONTRACTS } from '../contracts.js';
+import { executeRegisteredTool } from '../execute.js';
+
+function authContext(memberBusinessIds: string[]): McpAuthContext {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: [],
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+  return buildAuthContext(
+    principal,
+    memberBusinessIds.map(memberBusinessId => ({ memberBusinessId, roleId: 'accountant' })),
+  );
+}
+
+function clientReturning(data: unknown, capture?: (body: unknown) => void) {
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    capture?.(JSON.parse(init.body as string));
+    return { ok: true, status: 200, json: async () => ({ data }) } as unknown as Response;
+  });
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+function run(client: UpstreamGraphQLClient, auth: McpAuthContext, rawArgs: unknown) {
+  return executeRegisteredTool({
+    tool: getContractsTool,
+    rawArgs,
+    auth,
+    correlationId: 'corr-1',
+    client,
+    authorization: 'Bearer tok',
+  });
+}
+
+const contract = {
+  id: 'contract-1',
+  adminId: 'b1',
+  isActive: true,
+  startDate: '2026-01-01',
+  endDate: '2026-12-31',
+  billingCycle: 'MONTHLY',
+  documentType: 'INVOICE',
+  product: 'HIVE',
+  plan: null,
+  purchaseOrders: ['PO-1'],
+  remarks: null,
+  amount: { raw: 1000, formatted: '$1,000.00', currency: 'USD' },
+  client: { id: 'client-1', originalBusiness: { id: 'biz-9', name: 'Acme' } },
+};
+
+describe('getContractsTool — successful read', () => {
+  it('normalizes contracts and reports the owning admin business', async () => {
+    const client = clientReturning({ contractsByFilters: [contract] });
+    const result = await run(client, authContext(['b1']), {});
+
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as {
+      contracts: Array<Record<string, unknown>>;
+      totalCount: number;
+      scope: { memberBusinessIds: string[] };
+    };
+    expect(structured.contracts).toEqual([
+      {
+        id: 'contract-1',
+        adminId: 'b1',
+        client: { id: 'client-1', businessId: 'biz-9', name: 'Acme' },
+        isActive: true,
+        startDate: '2026-01-01',
+        endDate: '2026-12-31',
+        billingCycle: 'MONTHLY',
+        documentType: 'INVOICE',
+        product: 'HIVE',
+        plan: null,
+        purchaseOrders: ['PO-1'],
+        remarks: null,
+        amount: { value: 1000, formatted: '$1,000.00', currency: 'USD' },
+      },
+    ]);
+    expect(structured.totalCount).toBe(1);
+    expect(structured.scope).toEqual({ memberBusinessIds: ['b1'] });
+  });
+
+  it('defaults adminIds to the resolved read scope', async () => {
+    let body: unknown;
+    const client = clientReturning({ contractsByFilters: [] }, captured => {
+      body = captured;
+    });
+    await run(client, authContext(['b1', 'b2']), {});
+
+    const filters = (body as { variables: { filters: Record<string, unknown> } }).variables.filters;
+    expect(filters).toEqual({ adminIds: ['b1', 'b2'] });
+  });
+
+  it('forwards client, contract and active filters', async () => {
+    let body: unknown;
+    const client = clientReturning({ contractsByFilters: [] }, captured => {
+      body = captured;
+    });
+    await run(client, authContext(['b1']), {
+      clientIds: ['client-1'],
+      contractIds: ['contract-1'],
+      isActive: false,
+    });
+
+    const filters = (body as { variables: { filters: Record<string, unknown> } }).variables.filters;
+    expect(filters).toEqual({
+      adminIds: ['b1'],
+      clientIds: ['client-1'],
+      contractIds: ['contract-1'],
+      isActive: false,
+    });
+  });
+
+  // An explicit `adminIds` must never widen the request past the caller's own
+  // businesses, even though the scope is also enforced upstream.
+  it('intersects an explicit adminIds with the read scope', async () => {
+    let body: unknown;
+    const client = clientReturning({ contractsByFilters: [] }, captured => {
+      body = captured;
+    });
+    await run(client, authContext(['b1', 'b2']), { adminIds: ['b2', 'b3'] });
+
+    const filters = (body as { variables: { filters: { adminIds: string[] } } }).variables.filters;
+    expect(filters.adminIds).toEqual(['b2']);
+  });
+});
+
+describe('getContractsTool — input validation', () => {
+  it(`rejects a limit above ${MAX_CONTRACTS}`, async () => {
+    const result = await run(clientReturning({}), authContext(['b1']), {
+      limit: MAX_CONTRACTS + 1,
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects unknown fields', async () => {
+    const result = await run(clientReturning({}), authContext(['b1']), { unknownField: true });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects an out-of-scope memberBusinessId', async () => {
+    const result = await run(clientReturning({}), authContext(['b1']), {
+      memberBusinessIds: ['not-mine'],
+    });
+    expect(result.isError).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/contracts.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/contracts.test.ts
@@ -46,7 +46,7 @@ function run(client: UpstreamGraphQLClient, auth: McpAuthContext, rawArgs: unkno
 
 const contract = {
   id: 'contract-1',
-  adminId: 'b1',
+  ownerId: 'b1',
   isActive: true,
   startDate: '2026-01-01',
   endDate: '2026-12-31',
@@ -61,7 +61,7 @@ const contract = {
 };
 
 describe('getContractsTool — successful read', () => {
-  it('normalizes contracts and reports the owning admin business', async () => {
+  it('normalizes contracts and reports the owning business', async () => {
     const client = clientReturning({ contractsByFilters: [contract] });
     const result = await run(client, authContext(['b1']), {});
 
@@ -74,7 +74,7 @@ describe('getContractsTool — successful read', () => {
     expect(structured.contracts).toEqual([
       {
         id: 'contract-1',
-        adminId: 'b1',
+        ownerId: 'b1',
         client: { id: 'client-1', businessId: 'biz-9', name: 'Acme' },
         isActive: true,
         startDate: '2026-01-01',
@@ -92,7 +92,7 @@ describe('getContractsTool — successful read', () => {
     expect(structured.scope).toEqual({ memberBusinessIds: ['b1'] });
   });
 
-  it('sends the resolved read scope as adminIds', async () => {
+  it('sends the resolved read scope as ownerIds', async () => {
     let body: unknown;
     const client = clientReturning({ contractsByFilters: [] }, captured => {
       body = captured;
@@ -100,7 +100,7 @@ describe('getContractsTool — successful read', () => {
     await run(client, authContext(['b1', 'b2']), {});
 
     const filters = (body as { variables: { filters: Record<string, unknown> } }).variables.filters;
-    expect(filters).toEqual({ adminIds: ['b1', 'b2'] });
+    expect(filters).toEqual({ ownerIds: ['b1', 'b2'] });
   });
 
   it('forwards client, contract and active filters', async () => {
@@ -116,25 +116,25 @@ describe('getContractsTool — successful read', () => {
 
     const filters = (body as { variables: { filters: Record<string, unknown> } }).variables.filters;
     expect(filters).toEqual({
-      adminIds: ['b1'],
+      ownerIds: ['b1'],
       clientIds: ['client-1'],
       contractIds: ['contract-1'],
       isActive: false,
     });
   });
 
-  // The admin axis is narrowed through the scope field, which the policy layer
-  // validates against memberships — so a narrowed scope narrows `adminIds`, and
+  // The owner axis is narrowed through the scope field, which the policy layer
+  // validates against memberships — so a narrowed scope narrows `ownerIds`, and
   // an out-of-scope id is rejected rather than intersected away (see below).
-  it('narrows adminIds when memberBusinessIds narrows the scope', async () => {
+  it('narrows ownerIds when memberBusinessIds narrows the scope', async () => {
     let body: unknown;
     const client = clientReturning({ contractsByFilters: [] }, captured => {
       body = captured;
     });
     await run(client, authContext(['b1', 'b2']), { memberBusinessIds: ['b2'] });
 
-    const filters = (body as { variables: { filters: { adminIds: string[] } } }).variables.filters;
-    expect(filters.adminIds).toEqual(['b2']);
+    const filters = (body as { variables: { filters: { ownerIds: string[] } } }).variables.filters;
+    expect(filters.ownerIds).toEqual(['b2']);
   });
 });
 

--- a/packages/mcp-server/src/tools/__tests__/contracts.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/contracts.test.ts
@@ -92,7 +92,7 @@ describe('getContractsTool — successful read', () => {
     expect(structured.scope).toEqual({ memberBusinessIds: ['b1'] });
   });
 
-  it('defaults adminIds to the resolved read scope', async () => {
+  it('sends the resolved read scope as adminIds', async () => {
     let body: unknown;
     const client = clientReturning({ contractsByFilters: [] }, captured => {
       body = captured;
@@ -123,14 +123,15 @@ describe('getContractsTool — successful read', () => {
     });
   });
 
-  // An explicit `adminIds` must never widen the request past the caller's own
-  // businesses, even though the scope is also enforced upstream.
-  it('intersects an explicit adminIds with the read scope', async () => {
+  // The admin axis is narrowed through the scope field, which the policy layer
+  // validates against memberships — so a narrowed scope narrows `adminIds`, and
+  // an out-of-scope id is rejected rather than intersected away (see below).
+  it('narrows adminIds when memberBusinessIds narrows the scope', async () => {
     let body: unknown;
     const client = clientReturning({ contractsByFilters: [] }, captured => {
       body = captured;
     });
-    await run(client, authContext(['b1', 'b2']), { adminIds: ['b2', 'b3'] });
+    await run(client, authContext(['b1', 'b2']), { memberBusinessIds: ['b2'] });
 
     const filters = (body as { variables: { filters: { adminIds: string[] } } }).variables.filters;
     expect(filters.adminIds).toEqual(['b2']);

--- a/packages/mcp-server/src/tools/__tests__/ledger.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/ledger.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { executeRegisteredTool } from '../execute.js';
+import {
+  DEFAULT_LEDGER_RECORDS,
+  getLedgerRecordsTool,
+  MAX_LEDGER_DATE_RANGE_DAYS,
+  MAX_LEDGER_RECORDS,
+} from '../ledger.js';
+
+function authContext(memberBusinessIds: string[]): McpAuthContext {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: [],
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+  return buildAuthContext(
+    principal,
+    memberBusinessIds.map(memberBusinessId => ({ memberBusinessId, roleId: 'accountant' })),
+  );
+}
+
+function clientReturning(data: unknown, capture?: (body: unknown) => void) {
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    capture?.(JSON.parse(init.body as string));
+    return { ok: true, status: 200, json: async () => ({ data }) } as unknown as Response;
+  });
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+function run(client: UpstreamGraphQLClient, auth: McpAuthContext, rawArgs: unknown) {
+  return executeRegisteredTool({
+    tool: getLedgerRecordsTool,
+    rawArgs,
+    auth,
+    correlationId: 'corr-1',
+    client,
+    authorization: 'Bearer tok',
+  });
+}
+
+const amount = (raw: number) => ({ raw, formatted: `₪${raw}`, currency: 'ILS' });
+
+function record(id: string) {
+  return {
+    id,
+    ownerId: 'b1',
+    chargeId: 'charge-1',
+    invoiceDate: '2026-01-05',
+    valueDate: '2026-01-07',
+    description: 'Coffee',
+    reference: 'ref-1',
+    debitAmount1: amount(12.5),
+    debitAmount2: null,
+    creditAmount1: amount(12.5),
+    creditAmount2: null,
+    localCurrencyDebitAmount1: amount(12.5),
+    localCurrencyDebitAmount2: null,
+    localCurrencyCreditAmount1: amount(12.5),
+    localCurrencyCreditAmount2: null,
+    debitAccount1: { id: 'fe1', name: 'Expenses' },
+    debitAccount2: null,
+    creditAccount1: { id: 'fe2', name: 'Bank' },
+    creditAccount2: null,
+  };
+}
+
+describe('getLedgerRecordsTool — successful read', () => {
+  it('normalizes records into debit/credit entries carrying owner and charge ids', async () => {
+    const client = clientReturning({ ledgerRecordsByFilters: [record('l1')] });
+    const result = await run(client, authContext(['b1']), {});
+
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as {
+      ledgerRecords: Array<Record<string, unknown>>;
+      totalCount: number;
+      truncated: boolean;
+    };
+    expect(structured.ledgerRecords).toEqual([
+      {
+        id: 'l1',
+        ownerId: 'b1',
+        chargeId: 'charge-1',
+        invoiceDate: '2026-01-05',
+        valueDate: '2026-01-07',
+        description: 'Coffee',
+        reference: 'ref-1',
+        debit1: {
+          account: { id: 'fe1', name: 'Expenses' },
+          amount: { value: 12.5, formatted: '₪12.5', currency: 'ILS' },
+          localCurrencyAmount: { value: 12.5, formatted: '₪12.5', currency: 'ILS' },
+        },
+        debit2: { account: null, amount: null, localCurrencyAmount: null },
+        credit1: {
+          account: { id: 'fe2', name: 'Bank' },
+          amount: { value: 12.5, formatted: '₪12.5', currency: 'ILS' },
+          localCurrencyAmount: { value: 12.5, formatted: '₪12.5', currency: 'ILS' },
+        },
+        credit2: { account: null, amount: null, localCurrencyAmount: null },
+      },
+    ]);
+    expect(structured.totalCount).toBe(1);
+    expect(structured.truncated).toBe(false);
+  });
+
+  it('forwards every filter axis and scopes to the authorized businesses', async () => {
+    let body: unknown;
+    const client = clientReturning({ ledgerRecordsByFilters: [] }, captured => {
+      body = captured;
+    });
+    await run(client, authContext(['b1', 'b2']), {
+      fromInvoiceDate: '2026-01-01',
+      toInvoiceDate: '2026-01-31',
+      fromValueDate: '2026-02-01',
+      toValueDate: '2026-02-28',
+      fromDate: '2026-01-01',
+      toDate: '2026-03-01',
+      financialEntityIds: ['fe1'],
+      financialEntityAccounts: ['DEBIT_ACCOUNT_1', 'CREDIT_ACCOUNT_2'],
+      chargeIds: ['charge-1'],
+      limit: 10,
+    });
+
+    const filters = (body as { variables: { filters: Record<string, unknown> } }).variables.filters;
+    expect(filters).toEqual({
+      // The tool's "any date" pair maps onto the upstream from/toAnyDate fields.
+      fromAnyDate: '2026-01-01',
+      toAnyDate: '2026-03-01',
+      fromInvoiceDate: '2026-01-01',
+      toInvoiceDate: '2026-01-31',
+      fromValueDate: '2026-02-01',
+      toValueDate: '2026-02-28',
+      financialEntityIds: ['fe1'],
+      financialEntityAccounts: ['DEBIT_ACCOUNT_1', 'CREDIT_ACCOUNT_2'],
+      chargeIds: ['charge-1'],
+      ownerIds: ['b1', 'b2'],
+      // One extra row is requested so a full page can be reported as truncated.
+      limit: 11,
+    });
+  });
+
+  it('narrows ownerIds to the requested memberBusinessIds subset', async () => {
+    let body: unknown;
+    const client = clientReturning({ ledgerRecordsByFilters: [] }, captured => {
+      body = captured;
+    });
+    await run(client, authContext(['b1', 'b2']), { memberBusinessIds: ['b2'] });
+
+    const filters = (body as { variables: { filters: { ownerIds: string[] } } }).variables.filters;
+    expect(filters.ownerIds).toEqual(['b2']);
+  });
+
+  it('reports truncation without leaking the probe row', async () => {
+    const records = Array.from({ length: 4 }, (_, index) => record(`l${index}`));
+    const client = clientReturning({ ledgerRecordsByFilters: records });
+    const result = await run(client, authContext(['b1']), { limit: 3 });
+
+    const structured = result.structuredContent as {
+      ledgerRecords: unknown[];
+      truncated: boolean;
+      continuation?: { reason: string };
+    };
+    expect(structured.ledgerRecords).toHaveLength(3);
+    expect(structured.truncated).toBe(true);
+    expect(structured.continuation?.reason).toBe('result_cap');
+  });
+
+  it('defaults limit to the bounded page size', async () => {
+    let body: unknown;
+    const client = clientReturning({ ledgerRecordsByFilters: [] }, captured => {
+      body = captured;
+    });
+    await run(client, authContext(['b1']), {});
+
+    const filters = (body as { variables: { filters: { limit: number } } }).variables.filters;
+    expect(filters.limit).toBe(DEFAULT_LEDGER_RECORDS + 1);
+  });
+});
+
+describe('getLedgerRecordsTool — input validation', () => {
+  it.each([
+    ['invoice', { fromInvoiceDate: '2026-03-01', toInvoiceDate: '2026-01-01' }],
+    ['value', { fromValueDate: '2026-03-01', toValueDate: '2026-01-01' }],
+    ['any', { fromDate: '2026-03-01', toDate: '2026-01-01' }],
+  ])('rejects an inverted %s date range', async (_axis, rawArgs) => {
+    const result = await run(clientReturning({}), authContext(['b1']), rawArgs);
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects an impossible calendar date that matches the format', async () => {
+    const result = await run(clientReturning({}), authContext(['b1']), {
+      fromInvoiceDate: '2026-02-31',
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it(`rejects a range wider than ${MAX_LEDGER_DATE_RANGE_DAYS} days`, async () => {
+    const result = await run(clientReturning({}), authContext(['b1']), {
+      fromDate: '2020-01-01',
+      toDate: '2026-01-01',
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it(`rejects a limit above ${MAX_LEDGER_RECORDS}`, async () => {
+    const result = await run(clientReturning({}), authContext(['b1']), {
+      limit: MAX_LEDGER_RECORDS + 1,
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects an unknown account slot', async () => {
+    const result = await run(clientReturning({}), authContext(['b1']), {
+      financialEntityAccounts: ['DEBIT_ACCOUNT_3'],
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects an out-of-scope memberBusinessId', async () => {
+    const result = await run(clientReturning({}), authContext(['b1']), {
+      memberBusinessIds: ['not-mine'],
+    });
+    expect(result.isError).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/scope-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/scope-contract.test.ts
@@ -5,8 +5,10 @@ import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
 import { listBusinessMembershipsTool } from '../businesses.js';
 import { getChargesTool } from '../charge-details.js';
 import { searchChargesTool } from '../charges.js';
+import { getContractsTool } from '../contracts.js';
 import { getDocumentsTool } from '../document-details.js';
 import { executeRegisteredTool } from '../execute.js';
+import { getLedgerRecordsTool } from '../ledger.js';
 import { listBusinessesTool, listTagsTool, listTaxCategoriesTool } from '../lookups.js';
 import type { ToolExecutionContext, ToolResult } from '../registry.js';
 import { balanceReportTool } from '../reports.js';
@@ -52,6 +54,8 @@ function clientReturning(data: unknown) {
 
 const BUSINESS_SCOPED_TOOLS = [
   searchChargesTool,
+  getLedgerRecordsTool,
+  getContractsTool,
   listTagsTool,
   listTaxCategoriesTool,
   listBusinessesTool,
@@ -62,7 +66,13 @@ const BUSINESS_SCOPED_TOOLS = [
 // suffix (see lookups.ts), so it is deliberately excluded from the shared-suffix
 // assertion below — but still checked for the discovery pointer, the
 // `memberBusinessIds` input, and the echoed scope like the other list tools.
-const MULTI_BUSINESS_TOOLS = [searchChargesTool, listTagsTool, listTaxCategoriesTool];
+const MULTI_BUSINESS_TOOLS = [
+  searchChargesTool,
+  getLedgerRecordsTool,
+  getContractsTool,
+  listTagsTool,
+  listTaxCategoriesTool,
+];
 
 describe('uniform business-scope input', () => {
   it.each(MULTI_BUSINESS_TOOLS.map(tool => [tool.name, tool] as const))(

--- a/packages/mcp-server/src/tools/contracts.ts
+++ b/packages/mcp-server/src/tools/contracts.ts
@@ -8,17 +8,17 @@ import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.
 /**
  * Read-only client-contracts search.
  *
- * A contract is the billing agreement between an admin business (the owner) and
- * a client. The admin side *is* the membership axis — a contract you can see is
+ * A contract is the billing agreement between an owning ("admin") business and a
+ * client. The owner side *is* the membership axis — a contract you can see is
  * owned by a business you are a member of — so the shared `memberBusinessIds`
- * doubles as the admin filter and maps onto the upstream `filters.adminIds`.
- * There is deliberately no second `adminIds` input: a tool-level field narrowing
- * the same axis as the scope field would need its own intersection rule, and
- * getting that rule wrong silently answers a different question than the one
- * asked. The remaining axes are the client (`clientIds`) and specific contracts
- * (`contractIds`, to re-fetch one a previous answer referenced). Every row
- * reports its `adminId` so a result spanning admin businesses can be grouped
- * without a second call.
+ * doubles as the owner filter and maps onto the upstream `filters.ownerIds`.
+ * There is deliberately no separate owner input on the tool: a second field
+ * narrowing the same axis as the scope field would need its own intersection
+ * rule, and getting that rule wrong silently answers a different question than
+ * the one asked. The remaining axes are the client (`clientIds`) and specific
+ * contracts (`contractIds`, to re-fetch one a previous answer referenced). Every
+ * row reports its `ownerId` so a result spanning owning businesses can be
+ * grouped without a second call.
  */
 
 export const GET_CONTRACTS_TOOL_NAME = 'accounter_get_contracts';
@@ -58,7 +58,7 @@ const GET_CONTRACTS_QUERY = /* GraphQL */ `
   query McpGetContracts($filters: ContractsFilters) {
     contractsByFilters(filters: $filters) {
       id
-      adminId
+      ownerId
       isActive
       startDate
       endDate
@@ -90,8 +90,8 @@ type RawContract = McpGetContractsQuery['contractsByFilters'][number];
 /** Normalized contract shape returned to the caller. */
 export interface NormalizedContract {
   id: string;
-  /** Owning admin business, so multi-business results can be grouped. */
-  adminId: string;
+  /** Owning business, so multi-business results can be grouped. */
+  ownerId: string;
   client: { id: string; businessId: string; name: string };
   isActive: boolean;
   startDate: string;
@@ -108,7 +108,7 @@ export interface NormalizedContract {
 function normalizeContract(contract: RawContract): NormalizedContract {
   return {
     id: contract.id,
-    adminId: contract.adminId,
+    ownerId: contract.ownerId,
     client: {
       id: contract.client.id,
       businessId: contract.client.originalBusiness.id,
@@ -132,13 +132,13 @@ function buildFilters(
   memberBusinessIds: readonly string[],
 ): NonNullable<McpGetContractsQueryVariables['filters']> {
   const filters: NonNullable<McpGetContractsQueryVariables['filters']> = {};
-  // The resolved scope is the admin filter: `memberBusinessIds` has already been
+  // The resolved scope is the owner filter: `memberBusinessIds` has already been
   // validated against the caller's memberships by the policy layer (out-of-scope
   // ids are rejected, never dropped), so it can go straight through as
-  // `adminIds`. Kept as an explicit predicate even though `x-business-scope`
+  // `ownerIds`. Kept as an explicit predicate even though `x-business-scope`
   // narrows via RLS upstream: defense in depth.
   if (memberBusinessIds.length > 0) {
-    filters.adminIds = [...memberBusinessIds];
+    filters.ownerIds = [...memberBusinessIds];
   }
   if (input.clientIds?.length) filters.clientIds = [...input.clientIds];
   if (input.contractIds?.length) filters.contractIds = [...input.contractIds];
@@ -182,7 +182,7 @@ async function handler(
 export const getContractsTool: ToolDefinition<typeof getContractsInput> = {
   name: GET_CONTRACTS_TOOL_NAME,
   description:
-    'List client billing contracts within your authorized businesses. Filter by client, by contract id, and by active state; `memberBusinessIds` narrows to specific admin (owner) businesses, since a contract is always owned by one of yours. Each row reports its `adminId`. Read-only. ' +
+    'List client billing contracts within your authorized businesses. Filter by client, by contract id, and by active state; `memberBusinessIds` narrows to specific owning (admin) businesses, since a contract is always owned by one of yours. Each row reports its `ownerId`. Read-only. ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: getContractsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/contracts.ts
+++ b/packages/mcp-server/src/tools/contracts.ts
@@ -8,12 +8,17 @@ import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.
 /**
  * Read-only client-contracts search.
  *
- * A contract is the billing agreement between an admin business (the owner —
- * one of *your* businesses) and a client. The two useful axes are therefore the
- * admin side and the client side, and the tool filters on either; `contractIds`
- * is there to re-fetch a specific contract a previous answer referenced. Every
- * row reports its `adminId` so a result spanning admin businesses can be
- * grouped without a second call.
+ * A contract is the billing agreement between an admin business (the owner) and
+ * a client. The admin side *is* the membership axis — a contract you can see is
+ * owned by a business you are a member of — so the shared `memberBusinessIds`
+ * doubles as the admin filter and maps onto the upstream `filters.adminIds`.
+ * There is deliberately no second `adminIds` input: a tool-level field narrowing
+ * the same axis as the scope field would need its own intersection rule, and
+ * getting that rule wrong silently answers a different question than the one
+ * asked. The remaining axes are the client (`clientIds`) and specific contracts
+ * (`contractIds`, to re-fetch one a previous answer referenced). Every row
+ * reports its `adminId` so a result spanning admin businesses can be grouped
+ * without a second call.
  */
 
 export const GET_CONTRACTS_TOOL_NAME = 'accounter_get_contracts';
@@ -31,9 +36,6 @@ const idList = (what: string) =>
 
 const getContractsInput = z.object({
   memberBusinessIds: memberBusinessIdsInput,
-  adminIds: idList(
-    'owned by any of these admin (owner) businesses — must be a subset of the businesses you belong to',
-  ),
   clientIds: idList('belonging to any of these clients'),
   contractIds: idList('with these ids'),
   isActive: z
@@ -130,19 +132,13 @@ function buildFilters(
   memberBusinessIds: readonly string[],
 ): NonNullable<McpGetContractsQueryVariables['filters']> {
   const filters: NonNullable<McpGetContractsQueryVariables['filters']> = {};
-  // Narrow to the admin businesses the caller asked for, intersected with the
-  // resolved read scope. Without the intersection an explicit `adminIds` would
-  // widen the request past the caller's own businesses; the scope is already
-  // enforced upstream, but a business-scoped tool must not send an
-  // unauthorized owner id in the first place.
-  const requested = input.adminIds?.length ? input.adminIds : undefined;
-  const admins = requested
-    ? memberBusinessIds.length > 0
-      ? requested.filter(id => memberBusinessIds.includes(id))
-      : requested
-    : memberBusinessIds;
-  if (admins.length > 0) {
-    filters.adminIds = [...admins];
+  // The resolved scope is the admin filter: `memberBusinessIds` has already been
+  // validated against the caller's memberships by the policy layer (out-of-scope
+  // ids are rejected, never dropped), so it can go straight through as
+  // `adminIds`. Kept as an explicit predicate even though `x-business-scope`
+  // narrows via RLS upstream: defense in depth.
+  if (memberBusinessIds.length > 0) {
+    filters.adminIds = [...memberBusinessIds];
   }
   if (input.clientIds?.length) filters.clientIds = [...input.clientIds];
   if (input.contractIds?.length) filters.contractIds = [...input.contractIds];
@@ -186,7 +182,7 @@ async function handler(
 export const getContractsTool: ToolDefinition<typeof getContractsInput> = {
   name: GET_CONTRACTS_TOOL_NAME,
   description:
-    'List client billing contracts within your authorized businesses. Filter by admin (owner) business, by client, by contract id, and by active state. Each row reports its `adminId`. Read-only. ' +
+    'List client billing contracts within your authorized businesses. Filter by client, by contract id, and by active state; `memberBusinessIds` narrows to specific admin (owner) businesses, since a contract is always owned by one of yours. Each row reports its `adminId`. Read-only. ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: getContractsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/contracts.ts
+++ b/packages/mcp-server/src/tools/contracts.ts
@@ -1,0 +1,192 @@
+import { z } from 'zod';
+import type { McpGetContractsQuery, McpGetContractsQueryVariables } from '../gql/index.js';
+import { normalizeAmount, type NormalizedAmount } from './entity-shapes.js';
+import { shapeListResult } from './output.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
+
+/**
+ * Read-only client-contracts search.
+ *
+ * A contract is the billing agreement between an admin business (the owner —
+ * one of *your* businesses) and a client. The two useful axes are therefore the
+ * admin side and the client side, and the tool filters on either; `contractIds`
+ * is there to re-fetch a specific contract a previous answer referenced. Every
+ * row reports its `adminId` so a result spanning admin businesses can be
+ * grouped without a second call.
+ */
+
+export const GET_CONTRACTS_TOOL_NAME = 'accounter_get_contracts';
+
+/** Hard caps keeping responses bounded (spec §9.1, §9.3). */
+export const MAX_CONTRACTS = 500;
+export const MAX_CONTRACT_FILTER_IDS = 50;
+
+const idList = (what: string) =>
+  z
+    .array(z.string().min(1))
+    .max(MAX_CONTRACT_FILTER_IDS)
+    .optional()
+    .describe(`Only contracts ${what}.`);
+
+const getContractsInput = z.object({
+  memberBusinessIds: memberBusinessIdsInput,
+  adminIds: idList(
+    'owned by any of these admin (owner) businesses — must be a subset of the businesses you belong to',
+  ),
+  clientIds: idList('belonging to any of these clients'),
+  contractIds: idList('with these ids'),
+  isActive: z
+    .boolean()
+    .optional()
+    .describe('Restrict to active (true) or inactive (false) contracts. Omit for both.'),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_CONTRACTS)
+    .optional()
+    .default(MAX_CONTRACTS)
+    .describe(`Maximum contracts to return (capped at ${MAX_CONTRACTS}).`),
+});
+
+type GetContractsInput = z.infer<typeof getContractsInput>;
+
+const GET_CONTRACTS_QUERY = /* GraphQL */ `
+  query McpGetContracts($filters: ContractsFilters) {
+    contractsByFilters(filters: $filters) {
+      id
+      adminId
+      isActive
+      startDate
+      endDate
+      billingCycle
+      documentType
+      product
+      plan
+      purchaseOrders
+      remarks
+      amount {
+        raw
+        formatted
+        currency
+      }
+      client {
+        id
+        originalBusiness {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+/** A single contract as returned by the generated `McpGetContracts` query. */
+type RawContract = McpGetContractsQuery['contractsByFilters'][number];
+
+/** Normalized contract shape returned to the caller. */
+export interface NormalizedContract {
+  id: string;
+  /** Owning admin business, so multi-business results can be grouped. */
+  adminId: string;
+  client: { id: string; businessId: string; name: string };
+  isActive: boolean;
+  startDate: string;
+  endDate: string;
+  billingCycle: string;
+  documentType: string;
+  product: string | null;
+  plan: string | null;
+  purchaseOrders: string[];
+  remarks: string | null;
+  amount: NormalizedAmount | null;
+}
+
+function normalizeContract(contract: RawContract): NormalizedContract {
+  return {
+    id: contract.id,
+    adminId: contract.adminId,
+    client: {
+      id: contract.client.id,
+      businessId: contract.client.originalBusiness.id,
+      name: contract.client.originalBusiness.name,
+    },
+    isActive: contract.isActive,
+    startDate: contract.startDate,
+    endDate: contract.endDate,
+    billingCycle: contract.billingCycle,
+    documentType: contract.documentType,
+    product: contract.product ?? null,
+    plan: contract.plan ?? null,
+    purchaseOrders: [...contract.purchaseOrders],
+    remarks: contract.remarks ?? null,
+    amount: normalizeAmount(contract.amount),
+  };
+}
+
+function buildFilters(
+  input: GetContractsInput,
+  memberBusinessIds: readonly string[],
+): NonNullable<McpGetContractsQueryVariables['filters']> {
+  const filters: NonNullable<McpGetContractsQueryVariables['filters']> = {};
+  // Narrow to the admin businesses the caller asked for, intersected with the
+  // resolved read scope. Without the intersection an explicit `adminIds` would
+  // widen the request past the caller's own businesses; the scope is already
+  // enforced upstream, but a business-scoped tool must not send an
+  // unauthorized owner id in the first place.
+  const requested = input.adminIds?.length ? input.adminIds : undefined;
+  const admins = requested
+    ? memberBusinessIds.length > 0
+      ? requested.filter(id => memberBusinessIds.includes(id))
+      : requested
+    : memberBusinessIds;
+  if (admins.length > 0) {
+    filters.adminIds = [...admins];
+  }
+  if (input.clientIds?.length) filters.clientIds = [...input.clientIds];
+  if (input.contractIds?.length) filters.contractIds = [...input.contractIds];
+  if (input.isActive !== undefined) filters.isActive = input.isActive;
+  return filters;
+}
+
+async function handler(
+  input: GetContractsInput,
+  context: ToolExecutionContext,
+): Promise<ToolResult> {
+  const variables: McpGetContractsQueryVariables = {
+    filters: buildFilters(input, context.readScope.memberBusinessIds),
+  };
+  const data = await context.client.query<McpGetContractsQuery>(
+    { query: GET_CONTRACTS_QUERY, variables },
+    context.upstream,
+  );
+
+  const all = data.contractsByFilters ?? [];
+  const contracts = all.slice(0, input.limit).map(normalizeContract);
+
+  const scope = { memberBusinessIds: context.readScope.memberBusinessIds };
+  const scopeNote =
+    scope.memberBusinessIds.length > 1 ? ` across ${scope.memberBusinessIds.length} businesses` : '';
+
+  return shapeListResult({
+    items: contracts,
+    itemsKey: 'contracts',
+    total: all.length,
+    extra: { scope, limit: input.limit },
+    summarize: (shown, total, truncated) =>
+      total === 0
+        ? `No contracts matched the given filters${scopeNote}.`
+        : `Found ${total} contract(s)${scopeNote}${truncated ? `; showing ${shown}` : ''}.`,
+  });
+}
+
+export const getContractsTool: ToolDefinition<typeof getContractsInput> = {
+  name: GET_CONTRACTS_TOOL_NAME,
+  description:
+    'List client billing contracts within your authorized businesses. Filter by admin (owner) business, by client, by contract id, and by active state. Each row reports its `adminId`. Read-only. ' +
+    SCOPE_DESCRIPTION_SUFFIX,
+  inputSchema: getContractsInput,
+  policy: { requiresBusinessScope: true, dataClassification: 'business' },
+  handler,
+};

--- a/packages/mcp-server/src/tools/contracts.ts
+++ b/packages/mcp-server/src/tools/contracts.ts
@@ -167,7 +167,9 @@ async function handler(
 
   const scope = { memberBusinessIds: context.readScope.memberBusinessIds };
   const scopeNote =
-    scope.memberBusinessIds.length > 1 ? ` across ${scope.memberBusinessIds.length} businesses` : '';
+    scope.memberBusinessIds.length > 1
+      ? ` across ${scope.memberBusinessIds.length} businesses`
+      : '';
 
   return shapeListResult({
     items: contracts,

--- a/packages/mcp-server/src/tools/ledger.ts
+++ b/packages/mcp-server/src/tools/ledger.ts
@@ -1,0 +1,343 @@
+import { z } from 'zod';
+import type { McpGetLedgerRecordsQuery, McpGetLedgerRecordsQueryVariables } from '../gql/index.js';
+import { DAY_MS, parseCalendarDate, TIMELESS_DATE } from './dates.js';
+import { normalizeAmount, normalizeEntity, type NormalizedAmount } from './entity-shapes.js';
+import { ToolInputError } from './execute.js';
+import { shapeListResult } from './output.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
+
+/**
+ * Read-only ledger-records search.
+ *
+ * The double-entry ledger is the accounting source of truth, so this is the
+ * tool to answer "what was posted against account X" or "show me the entries
+ * behind charge Y" — questions the charge-level tools can only approximate.
+ *
+ * Filters mirror the upstream `ledgerRecordsByFilters` query: the three date
+ * axes a record has (invoice date, value date, or either), the financial entity
+ * sitting in any of the four debit/credit account slots, the owning business,
+ * and the charge. Every returned row carries its `ownerId` and `chargeId`, so a
+ * result spanning businesses or charges can be grouped without a second call.
+ */
+
+export const GET_LEDGER_RECORDS_TOOL_NAME = 'accounter_get_ledger_records';
+
+/** Hard caps keeping responses bounded (spec §9.1, §9.3). */
+export const MAX_LEDGER_RECORDS = 500;
+export const DEFAULT_LEDGER_RECORDS = 200;
+export const MAX_LEDGER_DATE_RANGE_DAYS = 1096; // ~3 years
+export const MAX_LEDGER_FILTER_IDS = 50;
+
+/**
+ * The account slots a financial entity can occupy on a record. Named after the
+ * `debitAccount1`/`creditAccount2`/… fields the response returns, so a filter
+ * value and the field it matches read the same.
+ */
+const LEDGER_ACCOUNTS = [
+  'DEBIT_ACCOUNT_1',
+  'DEBIT_ACCOUNT_2',
+  'CREDIT_ACCOUNT_1',
+  'CREDIT_ACCOUNT_2',
+] as const;
+
+const idList = (what: string) =>
+  z
+    .array(z.string().min(1))
+    .max(MAX_LEDGER_FILTER_IDS)
+    .optional()
+    .describe(`Only records ${what}.`);
+
+const getLedgerRecordsInput = z.object({
+  memberBusinessIds: memberBusinessIdsInput,
+  fromInvoiceDate: TIMELESS_DATE.optional().describe(
+    'Only records with an invoice date on/after this date (YYYY-MM-DD).',
+  ),
+  toInvoiceDate: TIMELESS_DATE.optional().describe(
+    'Only records with an invoice date on/before this date (YYYY-MM-DD).',
+  ),
+  fromValueDate: TIMELESS_DATE.optional().describe(
+    'Only records with a value date on/after this date (YYYY-MM-DD).',
+  ),
+  toValueDate: TIMELESS_DATE.optional().describe(
+    'Only records with a value date on/before this date (YYYY-MM-DD).',
+  ),
+  fromDate: TIMELESS_DATE.optional().describe(
+    'Only records whose invoice date OR value date is on/after this date (YYYY-MM-DD). Use this when you do not care which of the two dates matches.',
+  ),
+  toDate: TIMELESS_DATE.optional().describe(
+    'Only records whose invoice date OR value date is on/before this date (YYYY-MM-DD).',
+  ),
+  financialEntityIds: idList(
+    'referencing any of these financial entities (businesses or tax categories)',
+  ),
+  financialEntityAccounts: z
+    .array(z.enum(LEDGER_ACCOUNTS))
+    .max(LEDGER_ACCOUNTS.length)
+    .optional()
+    .describe(
+      'Which account slots `financialEntityIds` is matched against. Omit to match any of the four.',
+    ),
+  chargeIds: idList('belonging to any of these charges'),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_LEDGER_RECORDS)
+    .optional()
+    .default(DEFAULT_LEDGER_RECORDS)
+    .describe(`Maximum records to return (capped at ${MAX_LEDGER_RECORDS}).`),
+});
+
+type GetLedgerRecordsInput = z.infer<typeof getLedgerRecordsInput>;
+
+const GET_LEDGER_RECORDS_QUERY = /* GraphQL */ `
+  query McpGetLedgerRecords($filters: LedgerRecordsFilters) {
+    ledgerRecordsByFilters(filters: $filters) {
+      id
+      ownerId
+      chargeId
+      invoiceDate
+      valueDate
+      description
+      reference
+      debitAmount1 {
+        raw
+        formatted
+        currency
+      }
+      debitAmount2 {
+        raw
+        formatted
+        currency
+      }
+      creditAmount1 {
+        raw
+        formatted
+        currency
+      }
+      creditAmount2 {
+        raw
+        formatted
+        currency
+      }
+      localCurrencyDebitAmount1 {
+        raw
+        formatted
+        currency
+      }
+      localCurrencyDebitAmount2 {
+        raw
+        formatted
+        currency
+      }
+      localCurrencyCreditAmount1 {
+        raw
+        formatted
+        currency
+      }
+      localCurrencyCreditAmount2 {
+        raw
+        formatted
+        currency
+      }
+      debitAccount1 {
+        id
+        name
+      }
+      debitAccount2 {
+        id
+        name
+      }
+      creditAccount1 {
+        id
+        name
+      }
+      creditAccount2 {
+        id
+        name
+      }
+    }
+  }
+`;
+
+/** A single record as returned by the generated `McpGetLedgerRecords` query. */
+type RawLedgerRecord = McpGetLedgerRecordsQuery['ledgerRecordsByFilters'][number];
+
+/** One side of a double-entry posting: the account and what was posted to it. */
+interface NormalizedLedgerEntry {
+  account: { id: string; name: string | null } | null;
+  amount: NormalizedAmount | null;
+  localCurrencyAmount: NormalizedAmount | null;
+}
+
+/** Normalized ledger record returned to the caller. */
+export interface NormalizedLedgerRecord {
+  id: string;
+  /** Owning business, so multi-business results can be grouped by the model. */
+  ownerId: string | null;
+  /** Charge the record belongs to — feed it to `accounter_get_charges`. */
+  chargeId: string;
+  invoiceDate: string;
+  valueDate: string;
+  description: string | null;
+  reference: string | null;
+  debit1: NormalizedLedgerEntry;
+  debit2: NormalizedLedgerEntry;
+  credit1: NormalizedLedgerEntry;
+  credit2: NormalizedLedgerEntry;
+}
+
+/** Reject an inverted or too-wide range on each of the three date axes. */
+function assertDateRanges(input: GetLedgerRecordsInput): void {
+  const axes = [
+    { label: 'invoice', from: input.fromInvoiceDate, to: input.toInvoiceDate },
+    { label: 'value', from: input.fromValueDate, to: input.toValueDate },
+    { label: '', from: input.fromDate, to: input.toDate },
+  ] as const;
+
+  for (const { label, from, to } of axes) {
+    const prefix = label ? `${label} ` : '';
+    let fromMs: number | undefined;
+    let toMs: number | undefined;
+    // Validate each supplied date on its own — a value can match the format
+    // regex yet be an impossible calendar date (e.g. 2026-02-31).
+    if (from !== undefined) {
+      const parsed = parseCalendarDate(from);
+      if (parsed === null) {
+        throw new ToolInputError(`Invalid ${prefix}from date`);
+      }
+      fromMs = parsed;
+    }
+    if (to !== undefined) {
+      const parsed = parseCalendarDate(to);
+      if (parsed === null) {
+        throw new ToolInputError(`Invalid ${prefix}to date`);
+      }
+      toMs = parsed;
+    }
+    if (fromMs !== undefined && toMs !== undefined) {
+      if (fromMs > toMs) {
+        throw new ToolInputError(
+          `The ${prefix}from date must be on or before the ${prefix}to date`,
+        );
+      }
+      if (Math.round((toMs - fromMs) / DAY_MS) > MAX_LEDGER_DATE_RANGE_DAYS) {
+        throw new ToolInputError(`Date range must not exceed ${MAX_LEDGER_DATE_RANGE_DAYS} days`);
+      }
+    }
+  }
+}
+
+function buildFilters(
+  input: GetLedgerRecordsInput,
+  memberBusinessIds: readonly string[],
+): NonNullable<McpGetLedgerRecordsQueryVariables['filters']> {
+  const filters: NonNullable<McpGetLedgerRecordsQueryVariables['filters']> = {
+    // Ask upstream for one extra row so a full page can be reported as
+    // truncated instead of silently looking like the complete answer.
+    limit: input.limit + 1,
+  };
+  // Always scope to the authorized businesses. Kept as an explicit predicate
+  // even though `x-business-scope` narrows via RLS upstream: defense in depth,
+  // and the tool stays correct if upstream ever runs under a scope-bypassing
+  // role.
+  if (memberBusinessIds.length > 0) {
+    filters.ownerIds = [...memberBusinessIds];
+  }
+  if (input.fromInvoiceDate) filters.fromInvoiceDate = input.fromInvoiceDate;
+  if (input.toInvoiceDate) filters.toInvoiceDate = input.toInvoiceDate;
+  if (input.fromValueDate) filters.fromValueDate = input.fromValueDate;
+  if (input.toValueDate) filters.toValueDate = input.toValueDate;
+  if (input.fromDate) filters.fromAnyDate = input.fromDate;
+  if (input.toDate) filters.toAnyDate = input.toDate;
+  if (input.financialEntityIds?.length) {
+    filters.financialEntityIds = [...input.financialEntityIds];
+  }
+  if (input.financialEntityAccounts?.length) {
+    filters.financialEntityAccounts = [...input.financialEntityAccounts];
+  }
+  if (input.chargeIds?.length) filters.chargeIds = [...input.chargeIds];
+  return filters;
+}
+
+function normalizeRecord(record: RawLedgerRecord): NormalizedLedgerRecord {
+  return {
+    id: record.id,
+    ownerId: record.ownerId ?? null,
+    chargeId: record.chargeId,
+    invoiceDate: record.invoiceDate,
+    valueDate: record.valueDate,
+    description: record.description ?? null,
+    reference: record.reference ?? null,
+    debit1: {
+      account: normalizeEntity(record.debitAccount1),
+      amount: normalizeAmount(record.debitAmount1),
+      localCurrencyAmount: normalizeAmount(record.localCurrencyDebitAmount1),
+    },
+    debit2: {
+      account: normalizeEntity(record.debitAccount2),
+      amount: normalizeAmount(record.debitAmount2),
+      localCurrencyAmount: normalizeAmount(record.localCurrencyDebitAmount2),
+    },
+    credit1: {
+      account: normalizeEntity(record.creditAccount1),
+      amount: normalizeAmount(record.creditAmount1),
+      localCurrencyAmount: normalizeAmount(record.localCurrencyCreditAmount1),
+    },
+    credit2: {
+      account: normalizeEntity(record.creditAccount2),
+      amount: normalizeAmount(record.creditAmount2),
+      localCurrencyAmount: normalizeAmount(record.localCurrencyCreditAmount2),
+    },
+  };
+}
+
+async function handler(
+  input: GetLedgerRecordsInput,
+  context: ToolExecutionContext,
+): Promise<ToolResult> {
+  assertDateRanges(input);
+
+  const variables: McpGetLedgerRecordsQueryVariables = {
+    filters: buildFilters(input, context.readScope.memberBusinessIds),
+  };
+  const data = await context.client.query<McpGetLedgerRecordsQuery>(
+    { query: GET_LEDGER_RECORDS_QUERY, variables },
+    context.upstream,
+  );
+
+  const all = data.ledgerRecordsByFilters ?? [];
+  // The probe row (limit + 1) only tells us more exist; it is not returned.
+  const hasMore = all.length > input.limit;
+  const records = all.slice(0, input.limit).map(normalizeRecord);
+
+  const scope = { memberBusinessIds: context.readScope.memberBusinessIds };
+  const scopeNote =
+    scope.memberBusinessIds.length > 1 ? ` across ${scope.memberBusinessIds.length} businesses` : '';
+
+  return shapeListResult({
+    items: records,
+    itemsKey: 'ledgerRecords',
+    // `total` is unknown when capped — report at least one beyond what is shown
+    // so the result is correctly marked truncated with a continuation hint.
+    total: hasMore ? records.length + 1 : records.length,
+    extra: { scope, limit: input.limit },
+    summarize: (shown, _total, truncated) =>
+      shown === 0
+        ? `No ledger records matched the given filters${scopeNote}.`
+        : `Found ${shown} ledger record(s)${scopeNote}${
+            truncated ? ' (more available — narrow the filters or raise `limit`)' : ''
+          }.`,
+  });
+}
+
+export const getLedgerRecordsTool: ToolDefinition<typeof getLedgerRecordsInput> = {
+  name: GET_LEDGER_RECORDS_TOOL_NAME,
+  description:
+    'Search double-entry ledger records within your authorized businesses. Filter by invoice date, value date, or either; by the financial entity in any of the debit/credit account slots; and by charge id. Each row reports its `ownerId` and `chargeId`. Read-only. ' +
+    SCOPE_DESCRIPTION_SUFFIX,
+  inputSchema: getLedgerRecordsInput,
+  policy: { requiresBusinessScope: true, dataClassification: 'business' },
+  handler,
+};

--- a/packages/mcp-server/src/tools/ledger.ts
+++ b/packages/mcp-server/src/tools/ledger.ts
@@ -314,7 +314,9 @@ async function handler(
 
   const scope = { memberBusinessIds: context.readScope.memberBusinessIds };
   const scopeNote =
-    scope.memberBusinessIds.length > 1 ? ` across ${scope.memberBusinessIds.length} businesses` : '';
+    scope.memberBusinessIds.length > 1
+      ? ` across ${scope.memberBusinessIds.length} businesses`
+      : '';
 
   return shapeListResult({
     items: records,

--- a/packages/mcp-server/src/tools/registry-instance.ts
+++ b/packages/mcp-server/src/tools/registry-instance.ts
@@ -1,7 +1,9 @@
 import { listBusinessMembershipsTool } from './businesses.js';
 import { getChargesTool } from './charge-details.js';
 import { searchChargesTool } from './charges.js';
+import { getContractsTool } from './contracts.js';
 import { getDocumentsTool } from './document-details.js';
+import { getLedgerRecordsTool } from './ledger.js';
 import { listBusinessesTool, listTagsTool, listTaxCategoriesTool } from './lookups.js';
 import { ToolRegistry } from './registry.js';
 import { balanceReportTool } from './reports.js';
@@ -27,6 +29,10 @@ toolRegistry.register(searchChargesTool);
 toolRegistry.register(getChargesTool);
 toolRegistry.register(getTransactionsTool);
 toolRegistry.register(getDocumentsTool);
+// Ledger records are the accounting layer under a charge, so they follow the
+// charge/transaction/document drill-down rather than sitting with the lookups.
+toolRegistry.register(getLedgerRecordsTool);
+toolRegistry.register(getContractsTool);
 toolRegistry.register(listTagsTool);
 toolRegistry.register(listTaxCategoriesTool);
 // The full business directory sits with the other reference-data lookups.

--- a/packages/server/src/modules/contracts/providers/contracts.provider.ts
+++ b/packages/server/src/modules/contracts/providers/contracts.provider.ts
@@ -43,7 +43,7 @@ const getContractsByClientIds = sql<IGetContractsByClientIdsQuery>`
 const getContractsByFilters = sql<IGetContractsByFiltersQuery>`
     SELECT *
     FROM accounter_schema.clients_contracts
-    WHERE ($isAdminIds = 0 OR owner_id IN $$adminIds)
+    WHERE ($isOwnerIds = 0 OR owner_id IN $$ownerIds)
       AND ($isClientIds = 0 OR client_id IN $$clientIds)
       AND ($isContractIds = 0 OR id IN $$contractIds)
       -- a NULL is_active reads as inactive everywhere else (the resolver
@@ -157,7 +157,7 @@ const insertContract = sql<IInsertContractQuery>`
 
 /** Caller-facing filters for {@link ContractsProvider.getContractsByFilters}. */
 export type ContractsFiltersParams = {
-  adminIds?: readonly string[] | null;
+  ownerIds?: readonly string[] | null;
   clientIds?: readonly string[] | null;
   contractIds?: readonly string[] | null;
   isActive?: boolean | null;
@@ -238,19 +238,19 @@ export class ContractsProvider {
   );
 
   public getContractsByFilters(params: ContractsFiltersParams) {
-    const isAdminIds = !!params.adminIds?.filter(Boolean).length;
+    const isOwnerIds = !!params.ownerIds?.filter(Boolean).length;
     const isClientIds = !!params.clientIds?.filter(Boolean).length;
     const isContractIds = !!params.contractIds?.filter(Boolean).length;
 
     const fullParams: IGetContractsByFiltersParams = {
-      isAdminIds: isAdminIds ? 1 : 0,
+      isOwnerIds: isOwnerIds ? 1 : 0,
       isClientIds: isClientIds ? 1 : 0,
       isContractIds: isContractIds ? 1 : 0,
       // pgtyped requires a non-empty array for `IN $$list`; the matching `is*`
       // flag short-circuits the predicate, so the placeholder is never compared.
       // Spread rather than pass the caller's readonly arrays straight through:
       // the generated params take mutable arrays.
-      adminIds: isAdminIds ? [...params.adminIds!] : [null],
+      ownerIds: isOwnerIds ? [...params.ownerIds!] : [null],
       clientIds: isClientIds ? [...params.clientIds!] : [null],
       contractIds: isContractIds ? [...params.contractIds!] : [null],
       isActive: params.isActive ?? null,

--- a/packages/server/src/modules/contracts/providers/contracts.provider.ts
+++ b/packages/server/src/modules/contracts/providers/contracts.provider.ts
@@ -11,6 +11,8 @@ import type {
   IGetAllOpenContractsResult,
   IGetContractsByAdminBusinessIdsQuery,
   IGetContractsByClientIdsQuery,
+  IGetContractsByFiltersParams,
+  IGetContractsByFiltersQuery,
   IGetContractsByIdsQuery,
   IInsertContractParams,
   IInsertContractQuery,
@@ -37,6 +39,18 @@ const getContractsByClientIds = sql<IGetContractsByClientIdsQuery>`
     SELECT *
     FROM accounter_schema.clients_contracts
     WHERE client_id IN $$clientIds;`;
+
+const getContractsByFilters = sql<IGetContractsByFiltersQuery>`
+    SELECT *
+    FROM accounter_schema.clients_contracts
+    WHERE ($isAdminIds = 0 OR owner_id IN $$adminIds)
+      AND ($isClientIds = 0 OR client_id IN $$clientIds)
+      AND ($isContractIds = 0 OR id IN $$contractIds)
+      -- a NULL is_active reads as inactive everywhere else (the resolver
+      -- returns is_active ?? false), so fold it in rather than dropping those
+      -- rows from an isActive: false search.
+      AND ($isActive::BOOLEAN IS NULL OR COALESCE(is_active, FALSE) = $isActive)
+    ORDER BY start_date DESC, id;`;
 
 const deleteContract = sql<IDeleteContractQuery>`
     DELETE FROM accounter_schema.clients_contracts
@@ -141,6 +155,14 @@ const insertContract = sql<IInsertContractQuery>`
           $ownerId)
         RETURNING *;`;
 
+/** Caller-facing filters for {@link ContractsProvider.getContractsByFilters}. */
+export type ContractsFiltersParams = {
+  adminIds?: readonly string[] | null;
+  clientIds?: readonly string[] | null;
+  contractIds?: readonly string[] | null;
+  isActive?: boolean | null;
+};
+
 @Injectable({
   scope: Scope.Operation,
   global: true,
@@ -214,6 +236,29 @@ export class ContractsProvider {
   public getContractsByClientIdLoader = new DataLoader((ids: readonly string[]) =>
     this.contractsByClients(ids),
   );
+
+  public getContractsByFilters(params: ContractsFiltersParams) {
+    const isAdminIds = !!params.adminIds?.filter(Boolean).length;
+    const isClientIds = !!params.clientIds?.filter(Boolean).length;
+    const isContractIds = !!params.contractIds?.filter(Boolean).length;
+
+    const fullParams: IGetContractsByFiltersParams = {
+      isAdminIds: isAdminIds ? 1 : 0,
+      isClientIds: isClientIds ? 1 : 0,
+      isContractIds: isContractIds ? 1 : 0,
+      // pgtyped requires a non-empty array for `IN $$list`; the matching `is*`
+      // flag short-circuits the predicate, so the placeholder is never compared.
+      adminIds: isAdminIds ? params.adminIds! : [null],
+      clientIds: isClientIds ? params.clientIds! : [null],
+      contractIds: isContractIds ? params.contractIds! : [null],
+      isActive: params.isActive ?? null,
+    };
+
+    return getContractsByFilters.run(fullParams, this.db).then(contracts => {
+      contracts.map(contract => this.getContractsByIdLoader.prime(contract.id, contract));
+      return contracts;
+    });
+  }
 
   public async createContract(params: IInsertContractParams) {
     const businessId = await this.getBusinessId();

--- a/packages/server/src/modules/contracts/providers/contracts.provider.ts
+++ b/packages/server/src/modules/contracts/providers/contracts.provider.ts
@@ -248,9 +248,11 @@ export class ContractsProvider {
       isContractIds: isContractIds ? 1 : 0,
       // pgtyped requires a non-empty array for `IN $$list`; the matching `is*`
       // flag short-circuits the predicate, so the placeholder is never compared.
-      adminIds: isAdminIds ? params.adminIds! : [null],
-      clientIds: isClientIds ? params.clientIds! : [null],
-      contractIds: isContractIds ? params.contractIds! : [null],
+      // Spread rather than pass the caller's readonly arrays straight through:
+      // the generated params take mutable arrays.
+      adminIds: isAdminIds ? [...params.adminIds!] : [null],
+      clientIds: isClientIds ? [...params.clientIds!] : [null],
+      contractIds: isContractIds ? [...params.contractIds!] : [null],
       isActive: params.isActive ?? null,
     };
 

--- a/packages/server/src/modules/contracts/resolvers/contracts.resolver.ts
+++ b/packages/server/src/modules/contracts/resolvers/contracts.resolver.ts
@@ -53,6 +53,20 @@ export const contractsResolvers: ContractsModule.Resolvers = {
         throw new GraphQLError(message);
       }
     },
+    contractsByFilters: async (_, { filters }, { injector }) => {
+      try {
+        return injector.get(ContractsProvider).getContractsByFilters({
+          adminIds: filters?.adminIds,
+          clientIds: filters?.clientIds,
+          contractIds: filters?.contractIds,
+          isActive: filters?.isActive,
+        });
+      } catch (e) {
+        const message = 'Error fetching contracts by filters';
+        console.error(message, e);
+        throw new GraphQLError(message);
+      }
+    },
   },
   Mutation: {
     createContract: async (_, { input }, { injector }) => {
@@ -122,6 +136,15 @@ export const contractsResolvers: ContractsModule.Resolvers = {
   },
   Contract: {
     id: dbContract => dbContract.id,
+    adminId: dbContract => {
+      // owner_id is NOT NULL in the schema; guard anyway so a row that predates
+      // the backfill surfaces as an explicit error instead of a null in a
+      // non-nullable field.
+      if (!dbContract.owner_id) {
+        throw new GraphQLError(`Contract ${dbContract.id} has no owning admin business`);
+      }
+      return dbContract.owner_id;
+    },
     client: async (dbContract, _, { injector }) => {
       return injector
         .get(ClientsProvider)

--- a/packages/server/src/modules/contracts/resolvers/contracts.resolver.ts
+++ b/packages/server/src/modules/contracts/resolvers/contracts.resolver.ts
@@ -58,7 +58,7 @@ export const contractsResolvers: ContractsModule.Resolvers = {
         // Awaited inside the `try` on purpose: returning the promise would let a
         // rejection escape the catch below and surface unwrapped.
         return await injector.get(ContractsProvider).getContractsByFilters({
-          adminIds: filters?.adminIds,
+          ownerIds: filters?.ownerIds,
           clientIds: filters?.clientIds,
           contractIds: filters?.contractIds,
           isActive: filters?.isActive,
@@ -138,12 +138,12 @@ export const contractsResolvers: ContractsModule.Resolvers = {
   },
   Contract: {
     id: dbContract => dbContract.id,
-    adminId: dbContract => {
+    ownerId: dbContract => {
       // owner_id is NOT NULL in the schema; guard anyway so a row that predates
       // the backfill surfaces as an explicit error instead of a null in a
       // non-nullable field.
       if (!dbContract.owner_id) {
-        throw new GraphQLError(`Contract ${dbContract.id} has no owning admin business`);
+        throw new GraphQLError(`Contract ${dbContract.id} has no owning business`);
       }
       return dbContract.owner_id;
     },

--- a/packages/server/src/modules/contracts/resolvers/contracts.resolver.ts
+++ b/packages/server/src/modules/contracts/resolvers/contracts.resolver.ts
@@ -55,7 +55,9 @@ export const contractsResolvers: ContractsModule.Resolvers = {
     },
     contractsByFilters: async (_, { filters }, { injector }) => {
       try {
-        return injector.get(ContractsProvider).getContractsByFilters({
+        // Awaited inside the `try` on purpose: returning the promise would let a
+        // rejection escape the catch below and surface unwrapped.
+        return await injector.get(ContractsProvider).getContractsByFilters({
           adminIds: filters?.adminIds,
           clientIds: filters?.clientIds,
           contractIds: filters?.contractIds,

--- a/packages/server/src/modules/contracts/typeDefs/contracts.graphql.ts
+++ b/packages/server/src/modules/contracts/typeDefs/contracts.graphql.ts
@@ -6,7 +6,7 @@ export default gql`
     contractsByClient(clientId: UUID!): [Contract!]! @requiresAuth
     contractsByAdmin(adminId: UUID!): [Contract!]! @requiresAuth
     contractsById(id: UUID!): Contract! @requiresAuth
-    " search contracts by admin (owner) business, client, contract id and active state "
+    " search contracts by owning (admin) business, client, contract id and active state "
     contractsByFilters(filters: ContractsFilters): [Contract!]! @requiresAuth
   }
 
@@ -24,8 +24,8 @@ export default gql`
 
   " filters for contracts search "
   input ContractsFilters {
-    " only contracts owned by any of these admin businesses "
-    adminIds: [UUID!]
+    " only contracts owned by any of these (admin) businesses "
+    ownerIds: [UUID!]
     " only contracts belonging to any of these clients "
     clientIds: [UUID!]
     " only these specific contracts "
@@ -37,8 +37,8 @@ export default gql`
   " a client contract "
   type Contract {
     id: UUID!
-    " the admin business owning the contract "
-    adminId: UUID!
+    " the (admin) business owning the contract "
+    ownerId: UUID!
     client: Client!
     purchaseOrders: [String!]!
     startDate: TimelessDate!

--- a/packages/server/src/modules/contracts/typeDefs/contracts.graphql.ts
+++ b/packages/server/src/modules/contracts/typeDefs/contracts.graphql.ts
@@ -6,6 +6,8 @@ export default gql`
     contractsByClient(clientId: UUID!): [Contract!]! @requiresAuth
     contractsByAdmin(adminId: UUID!): [Contract!]! @requiresAuth
     contractsById(id: UUID!): Contract! @requiresAuth
+    " search contracts by admin (owner) business, client, contract id and active state "
+    contractsByFilters(filters: ContractsFilters): [Contract!]! @requiresAuth
   }
 
   extend type Mutation {
@@ -20,9 +22,23 @@ export default gql`
       @requiresAnyRole(roles: ["business_owner", "accountant"])
   }
 
+  " filters for contracts search "
+  input ContractsFilters {
+    " only contracts owned by any of these admin businesses "
+    adminIds: [UUID!]
+    " only contracts belonging to any of these clients "
+    clientIds: [UUID!]
+    " only these specific contracts "
+    contractIds: [UUID!]
+    " restrict to active (true) or inactive (false) contracts. omit for both "
+    isActive: Boolean
+  }
+
   " a client contract "
   type Contract {
     id: UUID!
+    " the admin business owning the contract "
+    adminId: UUID!
     client: Client!
     purchaseOrders: [String!]!
     startDate: TimelessDate!

--- a/packages/server/src/modules/ledger/providers/ledger.provider.ts
+++ b/packages/server/src/modules/ledger/providers/ledger.provider.ts
@@ -379,9 +379,11 @@ export class LedgerProvider {
       isFinancialEntityIds: isFinancialEntityIds ? 1 : 0,
       // pgtyped requires a non-empty array for `IN $$list`; the matching `is*`
       // flag short-circuits the predicate, so the placeholder is never compared.
-      chargeIds: isChargeIds ? params.chargeIds! : [null],
-      ownerIds: isOwnerIds ? params.ownerIds! : [null],
-      financialEntityIds: isFinancialEntityIds ? params.financialEntityIds! : [null],
+      // Spread rather than pass the caller's readonly arrays straight through:
+      // the generated params take mutable arrays.
+      chargeIds: isChargeIds ? [...params.chargeIds!] : [null],
+      ownerIds: isOwnerIds ? [...params.ownerIds!] : [null],
+      financialEntityIds: isFinancialEntityIds ? [...params.financialEntityIds!] : [null],
       matchDebit1: accounts.includes('DEBIT_ACCOUNT_1') ? 1 : 0,
       matchDebit2: accounts.includes('DEBIT_ACCOUNT_2') ? 1 : 0,
       matchCredit1: accounts.includes('CREDIT_ACCOUNT_1') ? 1 : 0,

--- a/packages/server/src/modules/ledger/providers/ledger.provider.ts
+++ b/packages/server/src/modules/ledger/providers/ledger.provider.ts
@@ -14,6 +14,8 @@ import type {
   IGetLedgerRecordsByChargesIdsQuery,
   IGetLedgerRecordsByDatesParams,
   IGetLedgerRecordsByDatesQuery,
+  IGetLedgerRecordsByFiltersParams,
+  IGetLedgerRecordsByFiltersQuery,
   IGetLedgerRecordsByFinancialEntityIdsQuery,
   IGetLedgerRecordsByIdsQuery,
   IInsertLedgerRecordsParams,
@@ -51,6 +53,35 @@ const getLedgerRecordsByDates = sql<IGetLedgerRecordsByDatesQuery>`
     FROM accounter_schema.ledger_records
     WHERE invoice_date BETWEEN $fromDate AND $toDate
     AND owner_id = $ownerId;`;
+
+const getLedgerRecordsByFilters = sql<IGetLedgerRecordsByFiltersQuery>`
+    SELECT *
+    FROM accounter_schema.ledger_records
+    WHERE ($isChargeIds = 0 OR charge_id IN $$chargeIds)
+      AND ($isOwnerIds = 0 OR owner_id IN $$ownerIds)
+      AND ($isFinancialEntityIds = 0 OR (
+            ($matchDebit1 = 1 AND debit_entity1 IN $$financialEntityIds)
+         OR ($matchDebit2 = 1 AND debit_entity2 IN $$financialEntityIds)
+         OR ($matchCredit1 = 1 AND credit_entity1 IN $$financialEntityIds)
+         OR ($matchCredit2 = 1 AND credit_entity2 IN $$financialEntityIds)
+      ))
+      AND ($fromInvoiceDate::DATE IS NULL OR invoice_date >= $fromInvoiceDate)
+      AND ($toInvoiceDate::DATE IS NULL OR invoice_date <= $toInvoiceDate)
+      AND ($fromValueDate::DATE IS NULL OR value_date >= $fromValueDate)
+      AND ($toValueDate::DATE IS NULL OR value_date <= $toValueDate)
+      -- "any date" matches when *either* date falls inside the requested window,
+      -- so the two bounds must be applied to the same column rather than mixed
+      -- across columns (which would match a record whose invoice date is after
+      -- the window and whose value date is before it).
+      AND (
+        ($fromAnyDate::DATE IS NULL AND $toAnyDate::DATE IS NULL)
+        OR (($fromAnyDate::DATE IS NULL OR invoice_date >= $fromAnyDate)
+            AND ($toAnyDate::DATE IS NULL OR invoice_date <= $toAnyDate))
+        OR (($fromAnyDate::DATE IS NULL OR value_date >= $fromAnyDate)
+            AND ($toAnyDate::DATE IS NULL OR value_date <= $toAnyDate))
+      )
+    ORDER BY invoice_date, value_date, id
+    LIMIT $limit;`;
 
 const getLedgerBalanceToDate = sql<IGetLedgerBalanceToDateQuery>`
     WITH grouped_entities AS (SELECT credit_entity1 AS entity_id, credit_local_amount1 AS amount, invoice_date
@@ -228,6 +259,38 @@ const lockLedgerRecords = sql<ILockLedgerRecordsQuery>`
   RETURNING *
 `;
 
+/**
+ * Fallback cap for a filtered ledger search that names no `limit`. The table is
+ * the largest in the schema, so an unbounded read is a foot-gun — a caller that
+ * genuinely wants more rows asks for them explicitly.
+ */
+export const DEFAULT_LEDGER_RECORDS_LIMIT = 10_000;
+
+/** The account slots a ledger record can reference a financial entity in. */
+export const LEDGER_RECORD_ACCOUNTS = [
+  'DEBIT_ACCOUNT_1',
+  'DEBIT_ACCOUNT_2',
+  'CREDIT_ACCOUNT_1',
+  'CREDIT_ACCOUNT_2',
+] as const;
+
+export type LedgerRecordAccount = (typeof LEDGER_RECORD_ACCOUNTS)[number];
+
+/** Caller-facing filters for {@link LedgerProvider.getLedgerRecordsByFilters}. */
+export type LedgerRecordsFiltersParams = {
+  fromInvoiceDate?: TimelessDateString | null;
+  toInvoiceDate?: TimelessDateString | null;
+  fromValueDate?: TimelessDateString | null;
+  toValueDate?: TimelessDateString | null;
+  fromAnyDate?: TimelessDateString | null;
+  toAnyDate?: TimelessDateString | null;
+  financialEntityIds?: readonly string[] | null;
+  financialEntityAccounts?: readonly LedgerRecordAccount[] | null;
+  ownerIds?: readonly string[] | null;
+  chargeIds?: readonly string[] | null;
+  limit?: number | null;
+};
+
 @Injectable({
   scope: Scope.Operation,
   global: true,
@@ -297,6 +360,45 @@ export class LedgerProvider {
   public async getLedgerRecordsByDates(params: IGetLedgerRecordsByDatesParams) {
     const { ownerId } = await this.adminContextProvider.getVerifiedAdminContext();
     return getLedgerRecordsByDates.run(reassureOwnerIdExists(params, ownerId), this.db);
+  }
+
+  public getLedgerRecordsByFilters(params: LedgerRecordsFiltersParams) {
+    const isChargeIds = !!params.chargeIds?.filter(Boolean).length;
+    const isOwnerIds = !!params.ownerIds?.filter(Boolean).length;
+    const isFinancialEntityIds = !!params.financialEntityIds?.filter(Boolean).length;
+
+    // An empty/omitted account list means "any account slot" — narrowing to a
+    // subset is opt-in, so an unspecified filter must not silently match nothing.
+    const accounts = params.financialEntityAccounts?.length
+      ? params.financialEntityAccounts
+      : LEDGER_RECORD_ACCOUNTS;
+
+    const fullParams: IGetLedgerRecordsByFiltersParams = {
+      isChargeIds: isChargeIds ? 1 : 0,
+      isOwnerIds: isOwnerIds ? 1 : 0,
+      isFinancialEntityIds: isFinancialEntityIds ? 1 : 0,
+      // pgtyped requires a non-empty array for `IN $$list`; the matching `is*`
+      // flag short-circuits the predicate, so the placeholder is never compared.
+      chargeIds: isChargeIds ? params.chargeIds! : [null],
+      ownerIds: isOwnerIds ? params.ownerIds! : [null],
+      financialEntityIds: isFinancialEntityIds ? params.financialEntityIds! : [null],
+      matchDebit1: accounts.includes('DEBIT_ACCOUNT_1') ? 1 : 0,
+      matchDebit2: accounts.includes('DEBIT_ACCOUNT_2') ? 1 : 0,
+      matchCredit1: accounts.includes('CREDIT_ACCOUNT_1') ? 1 : 0,
+      matchCredit2: accounts.includes('CREDIT_ACCOUNT_2') ? 1 : 0,
+      fromInvoiceDate: params.fromInvoiceDate ?? null,
+      toInvoiceDate: params.toInvoiceDate ?? null,
+      fromValueDate: params.fromValueDate ?? null,
+      toValueDate: params.toValueDate ?? null,
+      fromAnyDate: params.fromAnyDate ?? null,
+      toAnyDate: params.toAnyDate ?? null,
+      limit: params.limit ?? DEFAULT_LEDGER_RECORDS_LIMIT,
+    };
+
+    return getLedgerRecordsByFilters.run(fullParams, this.db).then(records => {
+      records.map(record => this.getLedgerRecordsByIdLoader.prime(record.id, record));
+      return records;
+    });
   }
 
   public getLedgerBalanceToDate(date: TimelessDateString) {

--- a/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
+++ b/packages/server/src/modules/ledger/resolvers/ledger.resolver.ts
@@ -97,6 +97,19 @@ async function getInvoicePaymentCurrencyDiffErrors(
   }
 }
 
+// Reject an inverted date range before it reaches the DB — an inverted range
+// silently returns zero rows, which reads as "no ledger records" rather than as
+// the caller error it is.
+function assertLedgerDateRange(
+  label: string,
+  from: string | null | undefined,
+  to: string | null | undefined,
+): void {
+  if (from && to && from > to) {
+    throw new GraphQLError(`${label} "from" date must be before or equal to the "to" date`);
+  }
+}
+
 // Max charges regenerated in parallel by `regenerateLedgerRecords`. Keeps large
 // batch selections from saturating the DB connection pool.
 const REGENERATE_LEDGER_CONCURRENCY = 5;
@@ -394,6 +407,31 @@ export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'Generate
         .get(LedgerProvider)
         .getLedgerRecordsByFinancialEntityIdLoader.load(financialEntityId);
     },
+    ledgerRecordsByFilters: async (_, { filters }, { injector }) => {
+      assertLedgerDateRange('invoice', filters?.fromInvoiceDate, filters?.toInvoiceDate);
+      assertLedgerDateRange('value', filters?.fromValueDate, filters?.toValueDate);
+      assertLedgerDateRange('any', filters?.fromAnyDate, filters?.toAnyDate);
+
+      return await injector
+        .get(LedgerProvider)
+        .getLedgerRecordsByFilters({
+          fromInvoiceDate: filters?.fromInvoiceDate,
+          toInvoiceDate: filters?.toInvoiceDate,
+          fromValueDate: filters?.fromValueDate,
+          toValueDate: filters?.toValueDate,
+          fromAnyDate: filters?.fromAnyDate,
+          toAnyDate: filters?.toAnyDate,
+          financialEntityIds: filters?.financialEntityIds,
+          financialEntityAccounts: filters?.financialEntityAccounts,
+          ownerIds: filters?.ownerIds,
+          chargeIds: filters?.chargeIds,
+          limit: filters?.limit,
+        })
+        .catch(error => {
+          console.error('Failed to fetch ledger records by filters:', error);
+          throw new GraphQLError('Failed to fetch ledger records');
+        });
+    },
   },
   Mutation: {
     regenerateLedgerRecords: async (_, { chargeIds }, context, info) => {
@@ -446,6 +484,8 @@ export const ledgerResolvers: LedgerModule.Resolvers & Pick<Resolvers, 'Generate
   },
   LedgerRecord: {
     id: DbLedgerRecord => DbLedgerRecord.id,
+    ownerId: DbLedgerRecord => DbLedgerRecord.owner_id ?? null,
+    chargeId: DbLedgerRecord => DbLedgerRecord.charge_id,
     debitAmount1: DbLedgerRecord =>
       DbLedgerRecord.debit_foreign_amount1 == null
         ? null

--- a/packages/server/src/modules/ledger/typeDefs/ledger.graphql.ts
+++ b/packages/server/src/modules/ledger/typeDefs/ledger.graphql.ts
@@ -7,6 +7,8 @@ export default gql`
     ledgerRecordsByDates(fromDate: TimelessDate!, toDate: TimelessDate!): [LedgerRecord!]!
       @requiresAuth
     ledgerRecordsByFinancialEntity(financialEntityId: UUID!): [LedgerRecord!]! @requiresAuth
+    " search ledger records by a combination of date, financial entity, owner and charge filters "
+    ledgerRecordsByFilters(filters: LedgerRecordsFilters): [LedgerRecord!]! @requiresAuth
   }
 
   extend type Mutation {
@@ -19,9 +21,47 @@ export default gql`
       @requiresAnyRole(roles: ["business_owner", "accountant"])
   }
 
+  " the account slots a ledger record holds financial entities in "
+  enum LedgerRecordAccount {
+    DEBIT_ACCOUNT_1
+    DEBIT_ACCOUNT_2
+    CREDIT_ACCOUNT_1
+    CREDIT_ACCOUNT_2
+  }
+
+  " filters for ledger records search "
+  input LedgerRecordsFilters {
+    " only records with invoice date on/after this date "
+    fromInvoiceDate: TimelessDate
+    " only records with invoice date on/before this date "
+    toInvoiceDate: TimelessDate
+    " only records with value date on/after this date "
+    fromValueDate: TimelessDate
+    " only records with value date on/before this date "
+    toValueDate: TimelessDate
+    " only records where the invoice date OR the value date is on/after this date "
+    fromAnyDate: TimelessDate
+    " only records where the invoice date OR the value date is on/before this date "
+    toAnyDate: TimelessDate
+    " only records referencing any of these financial entities "
+    financialEntityIds: [UUID!]
+    " which account slots financialEntityIds are matched against. defaults to all of them "
+    financialEntityAccounts: [LedgerRecordAccount!]
+    " only records owned by any of these businesses "
+    ownerIds: [UUID!]
+    " only records belonging to any of these charges "
+    chargeIds: [UUID!]
+    " cap the number of returned records. defaults to 10000 "
+    limit: Int
+  }
+
   " represent atomic movement of funds "
   type LedgerRecord {
     id: UUID!
+    " the business owning the record "
+    ownerId: UUID
+    " the charge the record belongs to "
+    chargeId: UUID!
     debitAmount1: FinancialAmount
     debitAmount2: FinancialAmount
     creditAmount1: FinancialAmount


### PR DESCRIPTION
Adds designated, filterable read queries for ledger records and contracts, and exposes each as its own MCP tool.

## Server

**Ledger**

- New `ledgerRecordsByFilters(filters: LedgerRecordsFilters): [LedgerRecord!]!` query. Filters:
  - dates on all three axes — `fromInvoiceDate`/`toInvoiceDate`, `fromValueDate`/`toValueDate`, and `fromAnyDate`/`toAnyDate` (matches when *either* date falls inside the window; both bounds are applied to the same column so a record whose invoice date is after the window and whose value date is before it does not match)
  - `financialEntityIds`, optionally narrowed to a subset of account slots via `financialEntityAccounts` (`DEBIT_ACCOUNT_1`, `DEBIT_ACCOUNT_2`, `CREDIT_ACCOUNT_1`, `CREDIT_ACCOUNT_2`) — omitting it matches any of the four
  - `ownerIds`, `chargeIds`, and a bounded `limit` (defaults to 10 000 rather than running unbounded against the largest table in the schema)
- `LedgerRecord` gains `ownerId` and `chargeId`, so a filtered result groups by business or charge without a follow-up query.
- Inverted ranges are rejected per axis instead of silently returning zero rows.

**Contracts**

- New `contractsByFilters(filters: ContractsFilters): [Contract!]!` query, filtering by `adminIds` (owner business), `clientIds`, `contractIds` and `isActive`. A `NULL` `is_active` is folded into "inactive", matching how the field resolver already reads it.
- `Contract` gains `adminId`.

Both provider queries follow the existing `$isX = 0 OR col IN $$xs` pattern used by `getChargesByFilters`, and prime the by-id loaders with the rows they fetch.

## MCP server

Two new read-only tools, registered after the charge/transaction/document drill-down:

- **`accounter_get_ledger_records`** — the filters above, plus per-row `ownerId`/`chargeId` and the four debit/credit entries (account, amount, local-currency amount). Date ranges bounded to 1096 days, rows capped at 500 (default 200); one extra row is requested upstream so a full page reports as `truncated` instead of looking complete.
- **`accounter_get_contracts`** — filters by admin business, client, contract id and active state; each row reports its `adminId`. An explicit `adminIds` is intersected with the resolved read scope so it can never widen the request past the caller's own businesses.

Both take the shared optional `businessIds`, echo `scope.businessIds`, and go through the shared bounded output shaping. They are included in the cross-tool scope-contract test, so they cannot quietly opt out of the convention.

## Testing

- `yarn test` — 2876 passed. The one failing file (`packages/migrations/src/__tests__/rls-all-tables.test.ts`) needs a Postgres instance and fails identically on a clean checkout of this branch's base.
- New unit tests: 47 across `ledger.test.ts`, `contracts.test.ts` and the updated `scope-contract.test.ts` — normalization, filter forwarding, scope narrowing, truncation, and input validation (inverted ranges, impossible calendar dates, over-wide ranges, unknown account slots, out-of-scope ids).
- `yarn generate` (GraphQL), `yarn lint` and `yarn prettier --check` clean on the touched packages.

⚠️ The pgtyped (SQL) half of codegen could not run in this environment — no Postgres available — so the two new SQL queries have not been type-checked against a live schema. They follow existing patterns closely, but CI is the first place that verifies them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNKyQxvZrYNAJkghQyGhLV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNKyQxvZrYNAJkghQyGhLV)_