### PR TITLE
Fix charges table horizontal overflow

### DIFF
--- a/.changeset/shaky-glasses-work.md
+++ b/.changeset/shaky-glasses-work.md
@@ -1,0 +1,8 @@
+---
+'@accounter/client': patch
+---
+
+The All Charges screen scrolled sideways: the table forced itself to `max-w-fit` with
+`whitespace-nowrap` on every cell, so it grew to its content width and stretched the page. Expanding
+a charge made it worse — the nested section tables (transactions, documents, ledger) propagated
+their intrinsic width up through the expansion cell

--- a/packages/client/src/components/charges/charges-row.tsx
+++ b/packages/client/src/components/charges/charges-row.tsx
@@ -83,13 +83,19 @@ export const ChargeRow = ({ row, updateCharge }: Props): ReactElement => {
       {row.getIsExpanded() && (
         <TableRow>
           <TableCell colSpan={row.getVisibleCells().length}>
-            <Card className="w-full shadow-lg">
-              <ChargeExtendedInfo
-                chargeID={row.original.id}
-                onChange={fetchCharge}
-                fetching={fetching}
-              />
-            </Card>
+            {/* `w-0 min-w-full` keeps the (wide) extended info from contributing to the
+                outer table's intrinsic width — it renders at the row's width, its nested
+                tables wrap their cells, and anything still too wide scrolls in here
+                instead of stretching the page sideways. */}
+            <div className="w-0 min-w-full overflow-x-auto [&_th]:whitespace-normal [&_td]:whitespace-normal">
+              <Card className="w-full shadow-lg">
+                <ChargeExtendedInfo
+                  chargeID={row.original.id}
+                  onChange={fetchCharge}
+                  fetching={fetching}
+                />
+              </Card>
+            </div>
           </TableCell>
         </TableRow>
       )}

--- a/packages/client/src/components/charges/charges-table.tsx
+++ b/packages/client/src/components/charges/charges-table.tsx
@@ -363,14 +363,17 @@ export const ChargesTable = ({
 
   return (
     <BatchChargesExtendedInfoProvider chargeIds={chargeIds} active={isAllOpened}>
-      <div className="flex flex-col gap-2 w-auto max-w-fit">
+      <div className="flex flex-col gap-2 w-full">
         {showExport && (
           <div className="flex justify-end">
             <DownloadChargesCsv chargeIds={exportIds} />
           </div>
         )}
-        <div className="overflow-hidden rounded-md border w-auto max-w-fit [&>div]:w-auto [&>div]:max-w-fit">
-          <Table className="w-auto max-w-fit">
+        <div className="overflow-hidden rounded-md border w-full">
+          {/* Cells wrap (overriding the ui table's nowrap, and the nowrap of the sort
+              buttons in the headers) so the table fits the viewport instead of forcing
+              the page to scroll sideways. */}
+          <Table className="[&_th]:whitespace-normal [&_td]:whitespace-normal [&_th_button]:whitespace-normal">
             <TableHeader>
               {table.getHeaderGroups().map(headerGroup => (
                 <TableRow key={headerGroup.id}>
@@ -385,7 +388,7 @@ export const ChargesTable = ({
                 </TableRow>
               ))}
             </TableHeader>
-            <TableBody className="w-auto max-w-fit">
+            <TableBody>
               {table.getRowModel().rows?.length ? (
                 table
                   .getRowModel()


### PR DESCRIPTION
## What

The All Charges screen scrolled sideways: the table forced itself to `max-w-fit` with `whitespace-nowrap` on every cell, so it grew to its content width and stretched the page. Expanding a charge made it worse — the nested section tables (transactions, documents, ledger) propagated their intrinsic width up through the expansion cell.

## How

- **Collapsed table**: use the full container width and let cell/header content wrap (overriding the ui table's and the sort buttons' nowrap). Anything truly incompressible now scrolls inside the table's own `overflow-x-auto` container instead of the page.
- **Expansion row**: a `w-0 min-w-full` wrapper keeps the extended info from contributing to the outer table's intrinsic width, and cascades the same cell-wrapping into the nested section tables, with an internal scroll as last resort.

## Verified

Rendered the screen headlessly (Chrome via Playwright) against mocked data: no page overflow at 1280px or 1024px viewports, both collapsed and with a charge expanded (all sections hydrated, including the 12-column ledger table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)