### PR TITLE
refactor(client): replace leftover Mantine buttons with shadcn

### DIFF
--- a/.changeset/@accounter_client-4171-dependencies.md
+++ b/.changeset/@accounter_client-4171-dependencies.md
@@ -1,5 +1,0 @@
----
-"@accounter/client": patch
----
-dependencies updates:
-  - Updated dependency [`@tanstack/react-table@9.1.2` ↗︎](https://www.npmjs.com/package/@tanstack/react-table/v/9.1.2) (from `9.0.0`, in `dependencies`)

--- a/.changeset/@accounter_client-4171-dependencies.md
+++ b/.changeset/@accounter_client-4171-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`@tanstack/react-table@9.1.2` ↗︎](https://www.npmjs.com/package/@tanstack/react-table/v/9.1.2) (from `9.0.0`, in `dependencies`)

--- a/.changeset/mantine-shadcn-buttons.md
+++ b/.changeset/mantine-shadcn-buttons.md
@@ -1,0 +1,11 @@
+---
+'@accounter/client': patch
+---
+
+Replace the last remaining Mantine button-role components with shadcn equivalents. The charge
+actions menu and the business trip toggle menu now use a shadcn `DropdownMenu` with a ghost icon
+`Button` trigger instead of Mantine's `Menu` + `Burger`, matching the existing
+`ChargesBatchActionsMenu`. Deleting a charge from the menu now opens a controlled
+`ConfirmationModal` rather than wrapping the menu item in a dialog trigger. `ChargeLink` renders a
+real anchor styled with `Button asChild variant="link"` in place of Mantine's `NavLink`, keeping
+proper link semantics for screen readers, middle-click and context menus.

--- a/.changeset/mantine-shadcn-buttons.md
+++ b/.changeset/mantine-shadcn-buttons.md
@@ -7,5 +7,5 @@ actions menu and the business trip toggle menu now use a shadcn `DropdownMenu` w
 `Button` trigger instead of Mantine's `Menu` + `Burger`, matching the existing
 `ChargesBatchActionsMenu`. Deleting a charge from the menu now opens a controlled
 `ConfirmationModal` rather than wrapping the menu item in a dialog trigger. `ChargeLink` renders a
-real anchor styled with `Button asChild variant="link"` in place of Mantine's `NavLink`, keeping
+router `Link` styled with `Button asChild variant="link"` in place of Mantine's `NavLink`, keeping
 proper link semantics for screen readers, middle-click and context menus.

--- a/packages/client/src/components/charges/charge-actions-menu.tsx
+++ b/packages/client/src/components/charges/charge-actions-menu.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState, type ReactElement } from 'react';
-import { ArrowDownWideNarrow, Edit, FilePlus2, ListPlus, Trash } from 'lucide-react';
-import { Burger, Menu, Modal } from '@mantine/core';
+import { ArrowDownWideNarrow, Edit, FilePlus2, ListPlus, MoreVertical, Trash } from 'lucide-react';
+import { Modal } from '@mantine/core';
 import type { ChargeType } from '@/helpers/index.js';
 import { useDeleteCharge } from '../../hooks/use-delete-charge.js';
 import { Depreciation } from '../common/depreciation/index.js';
@@ -13,7 +13,16 @@ import {
   UploadDocumentsModal,
   UploadPayrollFile,
 } from '../common/index.js';
+import { Button } from '../ui/button.js';
 import { Dialog, DialogContent } from '../ui/dialog.js';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu.js';
 
 interface ChargeActionsMenuProps {
   chargeId: string;
@@ -22,8 +31,6 @@ interface ChargeActionsMenuProps {
   isIncome: boolean;
 }
 
-type ClickEvent = React.MouseEvent<HTMLAnchorElement, MouseEvent>;
-
 export function ChargeActionsMenu({
   chargeId,
   chargeType,
@@ -31,7 +38,7 @@ export function ChargeActionsMenu({
   isIncome,
 }: ChargeActionsMenuProps): ReactElement {
   const { deleteCharge } = useDeleteCharge();
-  const [opened, setOpened] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [depreciationOpened, setDepreciationOpened] = useState(false);
   const closeDepreciation = useCallback((): void => setDepreciationOpened(false), []);
   const [miscExpensesOpened, setMiscExpensesOpened] = useState(false);
@@ -43,133 +50,96 @@ export function ChargeActionsMenu({
 
   const [uploadDocumentsOpen, setUploadDocumentsOpen] = useState(false);
 
-  const closeMenu = useCallback((): void => {
-    setOpened(false);
-  }, []);
-
   const onDelete = useCallback(async (): Promise<void> => {
     await deleteCharge({
       chargeId,
     });
     onChange?.();
-    closeMenu();
-  }, [chargeId, deleteCharge, onChange, closeMenu]);
+  }, [chargeId, deleteCharge, onChange]);
 
   return (
     <>
-      <Menu shadow="md" width={200} opened={opened}>
-        <Menu.Target>
-          <Burger
-            opened={opened}
-            onClick={(event): void => {
-              event.stopPropagation();
-              setOpened(o => !o);
-            }}
-          />
-        </Menu.Target>
-
-        <Menu.Dropdown>
-          <Menu.Label>Charge</Menu.Label>
-          <Menu.Item
-            icon={<Edit size={14} />}
-            onClick={() => {
-              setEditingCharge(true);
-              closeMenu();
-            }}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Charge actions"
+            onClick={event => event.stopPropagation()}
           >
+            <MoreVertical className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent
+          align="start"
+          className="w-50"
+          onClick={event => event.stopPropagation()}
+        >
+          <DropdownMenuLabel>Charge</DropdownMenuLabel>
+          <DropdownMenuItem onSelect={() => setEditingCharge(true)}>
+            <Edit className="size-4" />
             Edit Charge
-          </Menu.Item>
-          <ConfirmationModal
-            onConfirm={onDelete}
-            title="Are you sure you want to delete this charge?"
-          >
-            <Menu.Item icon={<Trash size={14} />}>Delete Charge</Menu.Item>
-          </ConfirmationModal>
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setConfirmDeleteOpen(true)}>
+            <Trash className="size-4" />
+            Delete Charge
+          </DropdownMenuItem>
 
-          <Menu.Divider />
+          <DropdownMenuSeparator />
 
-          <Menu.Label>Documents</Menu.Label>
+          <DropdownMenuLabel>Documents</DropdownMenuLabel>
 
-          <Menu.Item
-            icon={<ListPlus size={14} />}
-            onClick={(event: ClickEvent): void => {
-              event.stopPropagation();
-              setInsertingDocument(true);
-              closeMenu();
-            }}
-          >
+          <DropdownMenuItem onSelect={() => setInsertingDocument(true)}>
+            <ListPlus className="size-4" />
             Insert Document
-          </Menu.Item>
-          <Menu.Item
-            icon={<FilePlus2 size={14} />}
-            onClick={(event: ClickEvent): void => {
-              event.stopPropagation();
-              setUploadDocumentsOpen(true);
-              closeMenu();
-            }}
-          >
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setUploadDocumentsOpen(true)}>
+            <FilePlus2 className="size-4" />
             Upload Documents
-          </Menu.Item>
+          </DropdownMenuItem>
           {isIncome && (
-            <Menu.Item
-              icon={<ListPlus size={14} />}
-              onClick={(event: ClickEvent): void => {
-                event.stopPropagation();
-                setPreviewIssueDocument(true);
-                closeMenu();
-              }}
-            >
+            <DropdownMenuItem onSelect={() => setPreviewIssueDocument(true)}>
+              <ListPlus className="size-4" />
               Issue Document
-            </Menu.Item>
+            </DropdownMenuItem>
           )}
 
-          <Menu.Divider />
+          <DropdownMenuSeparator />
 
-          <Menu.Label>Misc Expenses</Menu.Label>
-          <Menu.Item
-            icon={<ListPlus size={14} />}
-            onClick={(event: ClickEvent): void => {
-              event.stopPropagation();
-              closeMenu();
-              setMiscExpensesOpened(true);
-            }}
-          >
+          <DropdownMenuLabel>Misc Expenses</DropdownMenuLabel>
+          <DropdownMenuItem onSelect={() => setMiscExpensesOpened(true)}>
+            <ListPlus className="size-4" />
             Add expense
-          </Menu.Item>
+          </DropdownMenuItem>
           {chargeType === 'CommonCharge' && (
             <>
-              <Menu.Divider />
-              <Menu.Label>Depreciation</Menu.Label>
-              <Menu.Item
-                icon={<ArrowDownWideNarrow size={14} />}
-                onClick={(event: ClickEvent): void => {
-                  event.stopPropagation();
-                  setDepreciationOpened(true);
-                  closeMenu();
-                }}
-              >
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>Depreciation</DropdownMenuLabel>
+              <DropdownMenuItem onSelect={() => setDepreciationOpened(true)}>
+                <ArrowDownWideNarrow className="size-4" />
                 Depreciation
-              </Menu.Item>
+              </DropdownMenuItem>
             </>
           )}
           {chargeType === 'SalaryCharge' && (
             <>
-              <Menu.Divider />
-              <Menu.Label>Salaries</Menu.Label>
-              <Menu.Item
-                icon={<FilePlus2 size={14} />}
-                onClick={(event: ClickEvent): void => {
-                  event.stopPropagation();
-                  closeMenu();
-                  setUploadSalariesOpened(true);
-                }}
-              >
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel>Salaries</DropdownMenuLabel>
+              <DropdownMenuItem onSelect={() => setUploadSalariesOpened(true)}>
+                <FilePlus2 className="size-4" />
                 Payroll file upload
-              </Menu.Item>
+              </DropdownMenuItem>
             </>
           )}
-        </Menu.Dropdown>
-      </Menu>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <ConfirmationModal
+        open={confirmDeleteOpen}
+        setOpen={setConfirmDeleteOpen}
+        onConfirm={onDelete}
+        title="Are you sure you want to delete this charge?"
+      />
       <Modal
         withinPortal
         size="xl"

--- a/packages/client/src/components/charges/charge-actions-menu.tsx
+++ b/packages/client/src/components/charges/charge-actions-menu.tsx
@@ -76,7 +76,7 @@ export function ChargeActionsMenu({
           className="w-50"
           onClick={event => event.stopPropagation()}
         >
-          <DropdownMenuLabel>Charge</DropdownMenuLabel>
+          <DropdownMenuLabel variant="section">Charge</DropdownMenuLabel>
           <DropdownMenuItem onSelect={() => setEditingCharge(true)}>
             <Edit className="size-4" />
             Edit Charge
@@ -88,7 +88,7 @@ export function ChargeActionsMenu({
 
           <DropdownMenuSeparator />
 
-          <DropdownMenuLabel>Documents</DropdownMenuLabel>
+          <DropdownMenuLabel variant="section">Documents</DropdownMenuLabel>
 
           <DropdownMenuItem onSelect={() => setInsertingDocument(true)}>
             <ListPlus className="size-4" />
@@ -107,7 +107,7 @@ export function ChargeActionsMenu({
 
           <DropdownMenuSeparator />
 
-          <DropdownMenuLabel>Misc Expenses</DropdownMenuLabel>
+          <DropdownMenuLabel variant="section">Misc Expenses</DropdownMenuLabel>
           <DropdownMenuItem onSelect={() => setMiscExpensesOpened(true)}>
             <ListPlus className="size-4" />
             Add expense
@@ -115,7 +115,7 @@ export function ChargeActionsMenu({
           {chargeType === 'CommonCharge' && (
             <>
               <DropdownMenuSeparator />
-              <DropdownMenuLabel>Depreciation</DropdownMenuLabel>
+              <DropdownMenuLabel variant="section">Depreciation</DropdownMenuLabel>
               <DropdownMenuItem onSelect={() => setDepreciationOpened(true)}>
                 <ArrowDownWideNarrow className="size-4" />
                 Depreciation
@@ -125,7 +125,7 @@ export function ChargeActionsMenu({
           {chargeType === 'SalaryCharge' && (
             <>
               <DropdownMenuSeparator />
-              <DropdownMenuLabel>Salaries</DropdownMenuLabel>
+              <DropdownMenuLabel variant="section">Salaries</DropdownMenuLabel>
               <DropdownMenuItem onSelect={() => setUploadSalariesOpened(true)}>
                 <FilePlus2 className="size-4" />
                 Payroll file upload

--- a/packages/client/src/components/common/business-trip-report/parts/business-trip-toggle-menu.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/business-trip-toggle-menu.tsx
@@ -37,7 +37,7 @@ export function BusinessTripToggleMenu({ businessTripId }: Props): ReactElement 
           className="w-50"
           onClick={event => event.stopPropagation()}
         >
-          <DropdownMenuLabel>Summarize Trip</DropdownMenuLabel>
+          <DropdownMenuLabel variant="section">Summarize Trip</DropdownMenuLabel>
           <DropdownMenuItem onSelect={() => setConfirmCreditOpen(true)}>
             <HandCoins className="size-4" />
             Credit surplus T&S

--- a/packages/client/src/components/common/business-trip-report/parts/business-trip-toggle-menu.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/business-trip-toggle-menu.tsx
@@ -1,41 +1,57 @@
 import { useState, type ReactElement } from 'react';
-import { HandCoins } from 'lucide-react';
-import { Burger, Menu } from '@mantine/core';
+import { HandCoins, MoreVertical } from 'lucide-react';
 import { useCreditShareholdersBusinessTripTnS } from '../../../../hooks/use-credit-shareholders-business-trip-tns.js';
 import { ConfirmationModal } from '../../../common/index.js';
+import { Button } from '../../../ui/button.js';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '../../../ui/dropdown-menu.js';
 
 interface Props {
   businessTripId: string;
 }
 
 export function BusinessTripToggleMenu({ businessTripId }: Props): ReactElement {
-  const [opened, setOpened] = useState(false);
+  const [confirmCreditOpen, setConfirmCreditOpen] = useState(false);
   const { creditShareholders } = useCreditShareholdersBusinessTripTnS();
 
   return (
-    <Menu shadow="md" width={200} opened={opened}>
-      <Menu.Target>
-        <Burger
-          opened={opened}
-          onClick={(event): void => {
-            event.stopPropagation();
-            setOpened(o => !o);
-          }}
-        />
-      </Menu.Target>
-
-      <Menu.Dropdown>
-        <Menu.Label>Summarize Trip</Menu.Label>
-
-        <ConfirmationModal
-          onConfirm={() => {
-            creditShareholders({ businessTripId });
-          }}
-          title="Credit shareholders with travel and subsistence surplus?"
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Business trip actions"
+            onClick={event => event.stopPropagation()}
+          >
+            <MoreVertical className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="w-50"
+          onClick={event => event.stopPropagation()}
         >
-          <Menu.Item icon={<HandCoins size={14} />}>Credit surplus T&S</Menu.Item>
-        </ConfirmationModal>
-      </Menu.Dropdown>
-    </Menu>
+          <DropdownMenuLabel>Summarize Trip</DropdownMenuLabel>
+          <DropdownMenuItem onSelect={() => setConfirmCreditOpen(true)}>
+            <HandCoins className="size-4" />
+            Credit surplus T&S
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <ConfirmationModal
+        open={confirmCreditOpen}
+        setOpen={setConfirmCreditOpen}
+        onConfirm={() => {
+          creditShareholders({ businessTripId });
+        }}
+        title="Credit shareholders with travel and subsistence surplus?"
+      />
+    </>
   );
 }

--- a/packages/client/src/components/common/buttons/charge-link.tsx
+++ b/packages/client/src/components/common/buttons/charge-link.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
 import { ROUTES } from '@/router/routes.js';
 import { Button } from '../../ui/button.js';
 
@@ -11,14 +12,14 @@ export const ChargeLink = ({
 }): ReactElement => {
   return (
     <Button key={chargeId} asChild variant="link" className="h-auto justify-start p-0">
-      <a
-        href={ROUTES.CHARGES.DETAIL(chargeId)}
+      <Link
+        to={ROUTES.CHARGES.DETAIL(chargeId)}
         target="_blank"
         rel="noreferrer"
         onClick={event => event.stopPropagation()}
       >
         {label}
-      </a>
+      </Link>
     </Button>
   );
 };

--- a/packages/client/src/components/common/buttons/charge-link.tsx
+++ b/packages/client/src/components/common/buttons/charge-link.tsx
@@ -10,16 +10,15 @@ export const ChargeLink = ({
   label: string;
 }): ReactElement => {
   return (
-    <Button
-      key={chargeId}
-      variant="link"
-      className="h-auto justify-start p-0"
-      onClick={event => {
-        event.stopPropagation();
-        window.open(ROUTES.CHARGES.DETAIL(chargeId), '_blank', 'noreferrer');
-      }}
-    >
-      {label}
+    <Button key={chargeId} asChild variant="link" className="h-auto justify-start p-0">
+      <a
+        href={ROUTES.CHARGES.DETAIL(chargeId)}
+        target="_blank"
+        rel="noreferrer"
+        onClick={event => event.stopPropagation()}
+      >
+        {label}
+      </a>
     </Button>
   );
 };

--- a/packages/client/src/components/common/buttons/charge-link.tsx
+++ b/packages/client/src/components/common/buttons/charge-link.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
-import { NavLink } from '@mantine/core';
 import { ROUTES } from '@/router/routes.js';
+import { Button } from '../../ui/button.js';
 
 export const ChargeLink = ({
   chargeId,
@@ -10,13 +10,16 @@ export const ChargeLink = ({
   label: string;
 }): ReactElement => {
   return (
-    <NavLink
+    <Button
       key={chargeId}
-      label={label}
-      onClick={(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+      variant="link"
+      className="h-auto justify-start p-0"
+      onClick={event => {
         event.stopPropagation();
         window.open(ROUTES.CHARGES.DETAIL(chargeId), '_blank', 'noreferrer');
       }}
-    />
+    >
+      {label}
+    </Button>
   );
 };

--- a/packages/client/src/components/ui/dropdown-menu.tsx
+++ b/packages/client/src/components/ui/dropdown-menu.tsx
@@ -125,15 +125,25 @@ function DropdownMenuRadioItem({
 function DropdownMenuLabel({
   className,
   inset,
+  variant = 'default',
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
   inset?: boolean;
+  /**
+   * `default` renders a prominent label, for content headers such as the signed-in user's details.
+   * `section` renders a muted, smaller heading for a group of menu items.
+   */
+  variant?: 'default' | 'section';
 }) {
   return (
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
       data-inset={inset}
-      className={cn('px-2 py-1.5 text-sm font-medium data-[inset]:pl-8', className)}
+      className={cn(
+        'px-2 py-1.5 text-sm font-medium data-[inset]:pl-8',
+        variant === 'section' && 'text-xs font-normal text-gray-500 dark:text-gray-400',
+        className,
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
## What

The client had three Mantine button-role components left over from the shadcn migration. This replaces all of them.

I swept `packages/client/src` for every Mantine component that renders as a button or link (`Button`, `ActionIcon`, `UnstyledButton`, `CloseButton`, `FileButton`, `Burger`, `NavLink`, `Anchor`). No `Button`/`ActionIcon` remained — the leftovers were:

| File | Was | Now |
| --- | --- | --- |
| `charges/charge-actions-menu.tsx` | Mantine `Menu` + `Burger` trigger | shadcn `DropdownMenu` + ghost icon `Button` |
| `common/business-trip-report/parts/business-trip-toggle-menu.tsx` | Mantine `Menu` + `Burger` trigger | shadcn `DropdownMenu` + ghost icon `Button` |
| `common/buttons/charge-link.tsx` | Mantine `NavLink` | shadcn `Button variant="link"` |

The two `Burger`s were `Menu.Target` children, so replacing the button meant converting the surrounding menu too — leaving a shadcn `Button` as a Mantine `Menu.Target` would rely on Mantine's `cloneElement` ref plumbing and be fragile. Both conversions follow the existing `ChargesBatchActionsMenu` in the same folder.

Notable behavior details preserved:

- **Delete Charge** previously wrapped a `Menu.Item` in `ConfirmationModal`'s `DialogTrigger`. Radix menu items can't double as a dialog trigger, so the item now sets state and drives a controlled `ConfirmationModal` (`open`/`setOpen`) — same pattern the batch actions menu already uses.
- Menu items no longer need individual `stopPropagation` (Radix closes on select), but `DropdownMenuContent` keeps an `onClick` propagation guard so opening a menu inside a table row doesn't also fire the row's click handler.
- Menu width `200px` → `w-50`; icons switched from `size={14}` props to `className="size-4"`, matching the other shadcn menus.

## Out of scope

Non-button Mantine components (`Modal`, `Table`, `Select`, `Indicator`, `Text`, `MonthPickerInput`, …) are still used widely across the client and are untouched here — including the two `Modal`s that remain in `charge-actions-menu.tsx`.

## Verification

- `yarn generate` — clean
- `tsc --noEmit` on `@accounter/client` — clean
- `yarn eslint` + `prettier` on the changed files — clean
- `yarn test` — 2891 passed. One unrelated pre-existing failure: `packages/migrations/src/__tests__/rls-all-tables.test.ts` exits on missing DB env vars, which reproduces without these changes.

Not manually exercised in a running app — the two menus and the toast link are worth a click-through during review.

---
_Generated by [Claude Code](https://claude.ai/code/session_0154Z4nG6zHxAbrash6tEdg1)_