### PR TITLE
fix(tags): persist parent when creating a tag

### DIFF
--- a/packages/server/src/modules/tags/providers/tags.provider.ts
+++ b/packages/server/src/modules/tags/providers/tags.provider.ts
@@ -35,8 +35,8 @@ const getTagsByNames = sql<IGetTagsByNamesQuery>`
   WHERE name in $$tagNames;`;
 
 const addNewTag = sql<IAddNewTagQuery>`
-  INSERT INTO accounter_schema.tags (name, owner_id)
-  VALUES ($name, $ownerId)
+  INSERT INTO accounter_schema.tags (name, parent, owner_id)
+  VALUES ($name, $parentId, $ownerId)
   RETURNING *;
 `;
 
@@ -131,6 +131,7 @@ export class TagsProvider {
   }
 
   public clearCache() {
+    this.allTagsCache = null;
     this.getTagByIDLoader.clearAll();
     this.getTagByNameLoader.clearAll();
   }

--- a/packages/server/src/modules/tags/resolvers/tags.resolvers.ts
+++ b/packages/server/src/modules/tags/resolvers/tags.resolvers.ts
@@ -15,10 +15,10 @@ export const tagsResolvers: TagsModule.Resolvers & Pick<Resolvers, 'BatchUpdateC
       allTags: (_, __, { injector }) => injector.get(TagsProvider).getAllTags(),
     },
     Mutation: {
-      addTag: (_, { name }, { injector }) => {
+      addTag: (_, { name, parentId }, { injector }) => {
         return injector
           .get(TagsProvider)
-          .addNewTag({ name })
+          .addNewTag({ name, parentId: !parentId || parentId === EMPTY_UUID ? null : parentId })
           .catch(e => {
             console.error(JSON.stringify(e, null, 2));
             throw new GraphQLError(`Error adding tag "${name}"`);


### PR DESCRIPTION
## Problem

Creating a tag from the client (`add-tag.tsx` / `tags-list.tsx`) with a parent selected always produced a root-level tag — the chosen parent was silently dropped.

## Root cause

The parent was carried correctly all the way to the server, then dropped in two places:

1. `packages/server/src/modules/tags/resolvers/tags.resolvers.ts` — the `addTag` mutation resolver destructured only `{ name }` from its args and called `addNewTag({ name })`, discarding `parentId`.
2. `packages/server/src/modules/tags/providers/tags.provider.ts` — the `addNewTag` SQL inserted only `(name, owner_id)`, so even if the resolver had passed a parent there was no column to write it to.

The client (`TagDialog` → `useAddTag` → `AddTag($tagName, $parentTag)`) and the schema (`addTag(name: String!, parentId: UUID)`) were already correct.

## Changes

- Resolver now forwards `parentId`, normalizing an absent value or the `EMPTY_UUID` sentinel to `NULL` (matching the existing `updateTagParent` convention).
- `addNewTag` insert now writes the `parent` column.
- `TagsProvider.clearCache()` also resets the memoized `allTags` promise, so a read after a tag mutation within the same operation isn't served stale.

## Testing

Type/lint could not be run in this environment (dependencies are not installed and pgtyped codegen requires a live database). `yarn generate` will regenerate `IAddNewTagParams` with the new `parentId` param.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbSYt4d4iZjMiTuxnKKokF)_