### PR TITLE
feat(charges): add filters to the Missing Info Charges screen

### DIFF
--- a/.changeset/@accounter_client-4174-dependencies.md
+++ b/.changeset/@accounter_client-4174-dependencies.md
@@ -1,5 +1,0 @@
----
-"@accounter/client": patch
----
-dependencies updates:
-  - Updated dependency [`@tanstack/react-table@9.1.2` ↗︎](https://www.npmjs.com/package/@tanstack/react-table/v/9.1.2) (from `9.0.0`, in `dependencies`)

--- a/.changeset/@accounter_client-4174-dependencies.md
+++ b/.changeset/@accounter_client-4174-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`@tanstack/react-table@9.1.2` ↗︎](https://www.npmjs.com/package/@tanstack/react-table/v/9.1.2) (from `9.0.0`, in `dependencies`)

--- a/.changeset/missing-info-charges-filters.md
+++ b/.changeset/missing-info-charges-filters.md
@@ -12,6 +12,8 @@ missing-information switches — with one exception: the date range is optional 
 modal opens with empty From/To dates instead of the "last year" default, and old unresolved charges
 are not hidden.
 
+The merge-charges action was removed from this screen; merging stays available on All Charges.
+
 `chargesWithMissingRequiredInfo` now accepts `filters: ChargeFilter`. The `allCharges` filter,
 sort and pagination logic moved into a shared `fetchFilteredCharges` helper that the missing-info
 query reuses with the missing-info charge ids as an id restriction, so both screens filter, sort

--- a/.changeset/missing-info-charges-filters.md
+++ b/.changeset/missing-info-charges-filters.md
@@ -1,0 +1,24 @@
+---
+'@accounter/client': patch
+'@accounter/server': patch
+---
+
+Add filters to the Missing Info Charges screen.
+
+The screen previously listed every charge with missing required info and offered no way to narrow
+it. It now has the same `ChargeFilter` set as All Charges — owners, financial entities, tags,
+income/expense, charge types, business trips, sorting, accountant status, free text and the
+missing-information switches — with one exception: the date range is optional here, so the filter
+modal opens with empty From/To dates instead of the "last year" default, and old unresolved charges
+are not hidden.
+
+`chargesWithMissingRequiredInfo` now accepts `filters: ChargeFilter`. The `allCharges` filter,
+sort and pagination logic moved into a shared `fetchFilteredCharges` helper that the missing-info
+query reuses with the missing-info charge ids as an id restriction, so both screens filter, sort
+and paginate identically. The read scope is applied as the owner filter, so the pagination counts
+cover only the charges the request may see, and an unsorted request keeps the screen's
+newest-first order.
+
+Also fixes the `allCharges` `page` argument defaulting to `1` while the resolver paginates from
+`0`: a caller that omitted `page` (such as the charts screen) asked for the *second* page and got
+an empty result. Both queries now default to `page: 0`.

--- a/packages/client/src/components/charges/charges-filters.tsx
+++ b/packages/client/src/components/charges/charges-filters.tsx
@@ -45,6 +45,7 @@ interface ChargesFiltersFormProps {
   filter: ChargeFilter;
   setFilter: (filter: ChargeFilter) => void;
   closeModal: () => void;
+  withDefaultDateRange?: boolean;
 }
 
 const fieldsToSort: { label: string; value: ChargeSortByField }[] = [
@@ -86,6 +87,7 @@ function ChargesFiltersForm({
   filter,
   setFilter,
   closeModal,
+  withDefaultDateRange = true,
 }: ChargesFiltersFormProps): ReactElement {
   const { userContext } = useContext(UserContext);
   const form = useForm<ChargeFilter>({
@@ -97,8 +99,15 @@ function ChargesFiltersForm({
         field: ChargeSortByField.Date,
         asc: false,
       },
-      toAnyDate: format(new Date(), 'yyyy-MM-dd') as TimelessDateString,
-      fromAnyDate: format(sub(new Date(), { years: 1 }), 'yyyy-MM-dd') as TimelessDateString,
+      // Screens where the date range is optional (e.g. missing-info charges)
+      // start unbounded, so old unresolved charges aren't hidden by a default
+      // "last year" window.
+      ...(withDefaultDateRange
+        ? {
+            toAnyDate: format(new Date(), 'yyyy-MM-dd') as TimelessDateString,
+            fromAnyDate: format(sub(new Date(), { years: 1 }), 'yyyy-MM-dd') as TimelessDateString,
+          }
+        : {}),
       ...filter,
     },
   });
@@ -610,6 +619,7 @@ interface ChargesFiltersProps {
   totalPages?: number;
   setPage: Dispatch<SetStateAction<number>>;
   initiallyOpened?: boolean;
+  withDefaultDateRange?: boolean;
 }
 
 export function ChargesFilters({
@@ -619,6 +629,7 @@ export function ChargesFilters({
   setPage,
   totalPages = 1,
   initiallyOpened = false,
+  withDefaultDateRange = true,
 }: ChargesFiltersProps): ReactElement {
   const [opened, setOpened] = useState(initiallyOpened);
   const [isFiltered, setIsFiltered] = useState(!isObjectEmpty(filter));
@@ -665,6 +676,7 @@ export function ChargesFilters({
             filter={filter}
             setFilter={onSetFilter}
             closeModal={(): void => setOpened(false)}
+            withDefaultDateRange={withDefaultDateRange}
           />
         }
         modalSize="xl"

--- a/packages/client/src/components/screens/charges/missing-info-charges.tsx
+++ b/packages/client/src/components/screens/charges/missing-info-charges.tsx
@@ -1,19 +1,22 @@
-import { useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Loader2, PanelTopClose, PanelTopOpen } from 'lucide-react';
 import { useQuery } from 'urql';
+import { LoadingOverlay } from '@mantine/core';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { ChargesTable } from '@/components/charges/charges-table.js';
-import { MissingInfoChargesDocument } from '../../../gql/graphql.js';
+import { MissingInfoChargesDocument, type ChargeFilter } from '../../../gql/graphql.js';
+import { useStableValue } from '../../../hooks/use-stable-value.js';
 import { useUrlQuery } from '../../../hooks/use-url-query.js';
 import { FiltersContext } from '../../../providers/filters-context.js';
+import { ChargesFilters } from '../../charges/charges-filters.js';
 import { MergeChargesButton, Tooltip } from '../../common/index.js';
 import { PageLayout } from '../../layout/page-layout.js';
 import { Button } from '../../ui/button.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
-  query MissingInfoCharges($page: Int, $limit: Int) {
-    chargesWithMissingRequiredInfo(page: $page, limit: $limit) {
+  query MissingInfoCharges($page: Int, $limit: Int, $filters: ChargeFilter) {
+    chargesWithMissingRequiredInfo(page: $page, limit: $limit, filters: $filters) {
       nodes {
         id
         ...ChargeForChargesTableFields
@@ -30,15 +33,41 @@ export const MissingInfoCharges = (): ReactElement => {
   const [isAllOpened, setIsAllOpened] = useState<boolean>(false);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const { get } = useUrlQuery();
-  const [activePage, setActivePage] = useState(get('page') ? Number(get('page')) : 1);
+  const [activePage, setActivePage] = useState(get('page') ? Number(get('page')) : 0);
+  const uriFilters = get('chargesFilters');
+  const initialFilters = useMemo(() => {
+    if (uriFilters) {
+      try {
+        return JSON.parse(decodeURIComponent(uriFilters)) as ChargeFilter;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (error) {
+        return undefined;
+      }
+    }
+    return undefined;
+  }, [uriFilters]);
+  const [filter, setFilter] = useState<ChargeFilter | undefined>(initialFilters);
 
-  const [{ data, fetching }, refetch] = useQuery({
+  // Unlike All Charges, filters here are optional: the unfiltered list of
+  // charges with missing info loads on mount.
+  const [{ data, fetching }, fetchCharges] = useQuery({
     query: MissingInfoChargesDocument,
     variables: {
+      filters: filter,
       page: activePage,
       limit: 100,
     },
   });
+
+  // urql returns a fresh `data` object on every (re)fetch. Keep a stable,
+  // deeply-equal reference for the charge nodes so the table and its rows only
+  // re-render when the data actually changed — avoiding the "blink" when a
+  // refetch returns identical results.
+  const chargeNodes = useStableValue(data?.chargesWithMissingRequiredInfo?.nodes);
+
+  const resetMergeList = useCallback((): void => {
+    setRowSelection({});
+  }, []);
 
   // Derive the merge button's input from the row-selection map. Each selected charge gets an
   // `onChange` that refetches the list, so the table refreshes once a merge completes.
@@ -49,19 +78,28 @@ export const MissingInfoCharges = (): ReactElement => {
         .map(([id]) => ({
           id,
           onChange: (): void => {
-            refetch({ requestPolicy: 'network-only' });
+            fetchCharges({ requestPolicy: 'network-only' });
           },
         })),
-    [rowSelection, refetch],
+    [rowSelection, fetchCharges],
   );
 
-  function onResetMerge(): void {
-    setRowSelection({});
-  }
+  // Only the page count is consumed from the query result here. Depend on it
+  // directly (instead of the whole `data`/`fetching`) so the filters bar isn't
+  // rebuilt on every background refetch.
+  const totalPages = data?.chargesWithMissingRequiredInfo?.pageInfo.totalPages;
 
   useEffect(() => {
     setFiltersContext(
       <div className="flex flex-row gap-x-5">
+        <ChargesFilters
+          filter={filter}
+          setFilter={setFilter}
+          activePage={activePage}
+          setPage={setActivePage}
+          totalPages={totalPages}
+          withDefaultDateRange={false}
+        />
         <Tooltip content="Expand all accounts">
           <Button
             variant="outline"
@@ -76,18 +114,20 @@ export const MissingInfoCharges = (): ReactElement => {
             )}
           </Button>
         </Tooltip>
-        <MergeChargesButton selected={mergeSelectedCharges} resetMergeList={onResetMerge} />
+        <MergeChargesButton selected={mergeSelectedCharges} resetMergeList={resetMergeList} />
       </div>,
     );
   }, [
-    data,
-    fetching,
+    totalPages,
+    filter,
     activePage,
     isAllOpened,
     setFiltersContext,
     setActivePage,
+    setFilter,
     setIsAllOpened,
     mergeSelectedCharges,
+    resetMergeList,
   ]);
 
   return (
@@ -95,15 +135,21 @@ export const MissingInfoCharges = (): ReactElement => {
       title="Missing Info Charges"
       description="Review charges with missing required details"
     >
-      {!data?.chargesWithMissingRequiredInfo.nodes || fetching ? (
+      {fetching && !data ? (
         <Loader2 className="h-10 w-10 animate-spin mr-2 self-center" />
       ) : (
-        <ChargesTable
-          rowSelection={rowSelection}
-          onRowSelectionChange={setRowSelection}
-          data={data?.chargesWithMissingRequiredInfo?.nodes}
-          isAllOpened={isAllOpened}
-        />
+        // Keep the current table mounted while a filter/page change refetches,
+        // but overlay a spinner so it's clear the charges are being reloaded
+        // (the stale rows stay visible underneath instead of blinking away).
+        <div className="relative">
+          <LoadingOverlay visible={fetching} overlayBlur={1} />
+          <ChargesTable
+            rowSelection={rowSelection}
+            onRowSelectionChange={setRowSelection}
+            data={chargeNodes ?? []}
+            isAllOpened={isAllOpened}
+          />
+        </div>
       )}
     </PageLayout>
   );

--- a/packages/client/src/components/screens/charges/missing-info-charges.tsx
+++ b/packages/client/src/components/screens/charges/missing-info-charges.tsx
@@ -1,15 +1,14 @@
-import { useCallback, useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
+import { useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Loader2, PanelTopClose, PanelTopOpen } from 'lucide-react';
 import { useQuery } from 'urql';
 import { LoadingOverlay } from '@mantine/core';
-import type { RowSelectionState } from '@tanstack/react-table';
 import { ChargesTable } from '@/components/charges/charges-table.js';
 import { MissingInfoChargesDocument, type ChargeFilter } from '../../../gql/graphql.js';
 import { useStableValue } from '../../../hooks/use-stable-value.js';
 import { useUrlQuery } from '../../../hooks/use-url-query.js';
 import { FiltersContext } from '../../../providers/filters-context.js';
 import { ChargesFilters } from '../../charges/charges-filters.js';
-import { MergeChargesButton, Tooltip } from '../../common/index.js';
+import { Tooltip } from '../../common/index.js';
 import { PageLayout } from '../../layout/page-layout.js';
 import { Button } from '../../ui/button.js';
 
@@ -31,7 +30,6 @@ import { Button } from '../../ui/button.js';
 export const MissingInfoCharges = (): ReactElement => {
   const { setFiltersContext } = useContext(FiltersContext);
   const [isAllOpened, setIsAllOpened] = useState<boolean>(false);
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const { get } = useUrlQuery();
   const [activePage, setActivePage] = useState(get('page') ? Number(get('page')) : 0);
   const uriFilters = get('chargesFilters');
@@ -50,7 +48,7 @@ export const MissingInfoCharges = (): ReactElement => {
 
   // Unlike All Charges, filters here are optional: the unfiltered list of
   // charges with missing info loads on mount.
-  const [{ data, fetching }, fetchCharges] = useQuery({
+  const [{ data, fetching }] = useQuery({
     query: MissingInfoChargesDocument,
     variables: {
       filters: filter,
@@ -64,25 +62,6 @@ export const MissingInfoCharges = (): ReactElement => {
   // re-render when the data actually changed — avoiding the "blink" when a
   // refetch returns identical results.
   const chargeNodes = useStableValue(data?.chargesWithMissingRequiredInfo?.nodes);
-
-  const resetMergeList = useCallback((): void => {
-    setRowSelection({});
-  }, []);
-
-  // Derive the merge button's input from the row-selection map. Each selected charge gets an
-  // `onChange` that refetches the list, so the table refreshes once a merge completes.
-  const mergeSelectedCharges = useMemo(
-    () =>
-      Object.entries(rowSelection)
-        .filter(([, isSelected]) => isSelected)
-        .map(([id]) => ({
-          id,
-          onChange: (): void => {
-            fetchCharges({ requestPolicy: 'network-only' });
-          },
-        })),
-    [rowSelection, fetchCharges],
-  );
 
   // Only the page count is consumed from the query result here. Depend on it
   // directly (instead of the whole `data`/`fetching`) so the filters bar isn't
@@ -114,7 +93,6 @@ export const MissingInfoCharges = (): ReactElement => {
             )}
           </Button>
         </Tooltip>
-        <MergeChargesButton selected={mergeSelectedCharges} resetMergeList={resetMergeList} />
       </div>,
     );
   }, [
@@ -126,8 +104,6 @@ export const MissingInfoCharges = (): ReactElement => {
     setActivePage,
     setFilter,
     setIsAllOpened,
-    mergeSelectedCharges,
-    resetMergeList,
   ]);
 
   return (
@@ -143,12 +119,7 @@ export const MissingInfoCharges = (): ReactElement => {
         // (the stale rows stay visible underneath instead of blinking away).
         <div className="relative">
           <LoadingOverlay visible={fetching} overlayBlur={1} />
-          <ChargesTable
-            rowSelection={rowSelection}
-            onRowSelectionChange={setRowSelection}
-            data={chargeNodes ?? []}
-            isAllOpened={isAllOpened}
-          />
+          <ChargesTable data={chargeNodes ?? []} isAllOpened={isAllOpened} />
         </div>
       )}
     </PageLayout>

--- a/packages/server/src/modules/charges/helpers/filtered-charges.helper.ts
+++ b/packages/server/src/modules/charges/helpers/filtered-charges.helper.ts
@@ -1,0 +1,126 @@
+import type { Injector } from 'graphql-modules';
+import type { ChargeFilter } from '../../../__generated__/types.js';
+import { ChargeSortByField, ChargeTypeEnum } from '../../../shared/enums.js';
+import { errorSimplifier } from '../../../shared/errors.js';
+import { ChargesProvider } from '../providers/charges.provider.js';
+import type { accountant_statusArray, IGetChargesByFiltersResult } from '../types.js';
+import { getChargeType, normalizeDbType } from './charge-type.js';
+
+type PaginatedChargesResult = {
+  __typename: 'PaginatedCharges';
+  nodes: IGetChargesByFiltersResult[];
+  pageInfo: {
+    totalPages: number;
+    totalRecords: number;
+  };
+};
+
+type FetchFilteredChargesParams = {
+  filters?: ChargeFilter | null;
+  page: number;
+  limit: number;
+  /**
+   * Narrows the result to these charge ids (on top of `filters`). An empty
+   * array means "no charge qualifies" and short-circuits — the provider reads
+   * an empty id list as "no id filter at all" and would return everything.
+   */
+  restrictToIds?: string[];
+};
+
+/**
+ * Shared charge listing: maps a `ChargeFilter` onto the provider parameters,
+ * applies the post-fetch concrete-type narrowing and paginates. Used by both
+ * `allCharges` and `chargesWithMissingRequiredInfo` so the two screens offer
+ * the exact same filter set.
+ *
+ * `page` is zero-based: page 0 is the first page.
+ */
+export async function fetchFilteredCharges(
+  injector: Injector,
+  { filters, page, limit, restrictToIds }: FetchFilteredChargesParams,
+): Promise<PaginatedChargesResult> {
+  const emptyResult: PaginatedChargesResult = {
+    __typename: 'PaginatedCharges',
+    nodes: [],
+    pageInfo: { totalPages: 0, totalRecords: 0 },
+  };
+
+  if (restrictToIds?.length === 0) {
+    return emptyResult;
+  }
+
+  // handle sort column
+  let sortColumn: 'event_date' | 'event_amount' | 'abs_event_amount' = 'event_date';
+  switch (filters?.sortBy?.field) {
+    case ChargeSortByField.Amount:
+      sortColumn = 'event_amount';
+      break;
+    case ChargeSortByField.AbsAmount:
+      sortColumn = 'abs_event_amount';
+      break;
+    case ChargeSortByField.Date:
+      sortColumn = 'event_date';
+      break;
+  }
+
+  const charges = await injector
+    .get(ChargesProvider)
+    .getChargesByFilters({
+      IDs: restrictToIds,
+      ownerIds: filters?.byOwners,
+      // Both date families are forwarded: `fromDate`/`toDate` test the
+      // charge's main date (documents min/max, else transaction event
+      // dates) — containment — while `fromAnyDate`/`toAnyDate` test whether
+      // the charge's span across *all* date sources overlaps the range. The
+      // SQL has always supported both; only the `*AnyDate` pair was wired
+      // up here, so a caller passing `fromDate`/`toDate` (as the MCP charge
+      // tools now can) got an unfiltered result instead of a narrower one.
+      fromDate: filters?.fromDate,
+      toDate: filters?.toDate,
+      fromAnyDate: filters?.fromAnyDate,
+      toAnyDate: filters?.toAnyDate,
+      sortColumn,
+      asc: filters?.sortBy?.asc !== false,
+      chargeType: filters?.chargesType,
+      businessIds: filters?.byBusinesses,
+      businessTripIds: filters?.byBusinessTrips,
+      withMissingCounterparty: filters?.withMissingCounterparty,
+      withoutInvoice: filters?.withoutInvoice,
+      withoutReceipt: filters?.withoutReceipt,
+      withoutDocuments: filters?.withoutDocuments,
+      withOpenDocuments: filters?.withOpenDocuments,
+      withoutTransactions: filters?.withoutTransactions,
+      withoutLedger: filters?.withoutLedger,
+      freeText: filters?.freeText?.trim().toLowerCase(),
+      tags: filters?.byTags,
+      accountantStatuses: filters?.accountantStatus as accountant_statusArray | undefined,
+    })
+    .catch(error => {
+      throw errorSimplifier('Error fetching charges', error);
+    });
+
+  // charge __typename is resolved dynamically, so filter by concrete type post-fetch
+  let filteredCharges = charges;
+  if (filters?.byChargeTypes?.length) {
+    const wantedTypes = new Set<ChargeTypeEnum>(filters.byChargeTypes?.map(normalizeDbType));
+    const chargeTypes = await Promise.all(
+      charges.map(charge =>
+        getChargeType(charge, injector).catch(error => {
+          throw errorSimplifier('Failed to determine charge type', error);
+        }),
+      ),
+    );
+    filteredCharges = charges.filter((_, index) => wantedTypes.has(chargeTypes[index]));
+  }
+
+  const pageCharges = filteredCharges.slice(page * limit, (page + 1) * limit);
+
+  return {
+    __typename: 'PaginatedCharges',
+    nodes: pageCharges,
+    pageInfo: {
+      totalPages: Math.ceil(filteredCharges.length / limit),
+      totalRecords: filteredCharges.length,
+    },
+  };
+}

--- a/packages/server/src/modules/charges/resolvers/__tests__/missing-info-charges-filters.test.ts
+++ b/packages/server/src/modules/charges/resolvers/__tests__/missing-info-charges-filters.test.ts
@@ -1,0 +1,121 @@
+import type { Injector } from 'graphql-modules';
+import { describe, expect, it, vi } from 'vitest';
+import { ScopeProvider } from '../../../auth/providers/scope.provider.js';
+import { DocumentsProvider } from '../../../documents/providers/documents.provider.js';
+import { TransactionsProvider } from '../../../transactions/providers/transactions.provider.js';
+import { ChargesProvider } from '../../providers/charges.provider.js';
+import { chargesResolvers } from '../charges.resolver.js';
+
+/**
+ * `chargesWithMissingRequiredInfo` filter forwarding.
+ *
+ * The Missing Info screen offers the same filter set as All Charges, so the
+ * resolver narrows the missing-info charge ids through the shared
+ * `ChargeFilter` path. Two things must hold: the caller's filters reach the
+ * provider alongside the id restriction, and an empty id set returns nothing —
+ * the provider reads an empty `IDs` list as "no id filter" and would otherwise
+ * return every charge.
+ */
+
+type Options = {
+  missingInfoChargeIds?: string[];
+  readScope?: string[];
+};
+
+function contextWithProviders(
+  getChargesByFilters: ReturnType<typeof vi.fn>,
+  { missingInfoChargeIds = ['charge-1'], readScope = ['owner-1'] }: Options = {},
+) {
+  const injector = {
+    get: (token: unknown) => {
+      switch (token) {
+        case ChargesProvider:
+          return {
+            getChargesByFilters,
+            getChargesByMissingRequiredInfo: async () =>
+              missingInfoChargeIds.map(id => ({ id })),
+          };
+        case TransactionsProvider:
+          return { getTransactionsByMissingRequiredInfo: async () => [] };
+        case DocumentsProvider:
+          return { getDocumentsByMissingRequiredInfo: async () => [] };
+        case ScopeProvider:
+          return { getReadScope: async () => readScope };
+        default:
+          throw new Error('unexpected provider requested');
+      }
+    },
+  } as unknown as Injector;
+  return { injector } as never;
+}
+
+// The resolver map is typed against the generated module types; the query is
+// invoked directly here, which is enough to observe the provider parameters.
+const chargesWithMissingRequiredInfo = chargesResolvers.Query!
+  .chargesWithMissingRequiredInfo as unknown as (
+  parent: unknown,
+  args: Record<string, unknown>,
+  context: unknown,
+) => Promise<{ nodes: unknown[]; pageInfo: { totalPages: number; totalRecords: number } }>;
+
+describe('Query.chargesWithMissingRequiredInfo filter forwarding', () => {
+  it('forwards the caller filters alongside the missing-info id restriction', async () => {
+    const getChargesByFilters = vi.fn().mockResolvedValue([]);
+    await chargesWithMissingRequiredInfo(
+      null,
+      {
+        filters: { byTags: ['tag-1'], freeText: 'Coffee', withoutInvoice: true },
+        page: 0,
+        limit: 10,
+      },
+      contextWithProviders(getChargesByFilters, { missingInfoChargeIds: ['charge-1', 'charge-2'] }),
+    );
+
+    expect(getChargesByFilters).toHaveBeenCalledTimes(1);
+    const params = getChargesByFilters.mock.calls[0]![0] as Record<string, unknown>;
+    expect(params.IDs).toEqual(['charge-1', 'charge-2']);
+    expect(params).toMatchObject({ tags: ['tag-1'], withoutInvoice: true });
+    expect(params.freeText).toBe('coffee');
+  });
+
+  // Reads are RLS-scoped anyway, but passing the scope as the owner filter
+  // keeps the pagination counts over visible charges only.
+  it('applies the read scope as the owner filter', async () => {
+    const getChargesByFilters = vi.fn().mockResolvedValue([]);
+    await chargesWithMissingRequiredInfo(
+      null,
+      { filters: undefined, page: 0, limit: 10 },
+      contextWithProviders(getChargesByFilters, { readScope: ['owner-1', 'owner-2'] }),
+    );
+
+    const params = getChargesByFilters.mock.calls[0]![0] as Record<string, unknown>;
+    expect(params.ownerIds).toEqual(['owner-1', 'owner-2']);
+  });
+
+  // The screen used to sort newest-first in JS; the shared path defaults to
+  // ascending, so an unsorted request must keep asking for DESC explicitly.
+  it('keeps the newest-first default when no sort is requested', async () => {
+    const getChargesByFilters = vi.fn().mockResolvedValue([]);
+    await chargesWithMissingRequiredInfo(
+      null,
+      { filters: undefined, page: 0, limit: 10 },
+      contextWithProviders(getChargesByFilters),
+    );
+
+    const params = getChargesByFilters.mock.calls[0]![0] as Record<string, unknown>;
+    expect(params).toMatchObject({ sortColumn: 'event_date', asc: false });
+  });
+
+  it('returns nothing when no charge has missing info', async () => {
+    const getChargesByFilters = vi.fn().mockResolvedValue([]);
+    const result = await chargesWithMissingRequiredInfo(
+      null,
+      { filters: undefined, page: 0, limit: 10 },
+      contextWithProviders(getChargesByFilters, { missingInfoChargeIds: [] }),
+    );
+
+    expect(getChargesByFilters).not.toHaveBeenCalled();
+    expect(result.nodes).toEqual([]);
+    expect(result.pageInfo).toMatchObject({ totalPages: 0, totalRecords: 0 });
+  });
+});

--- a/packages/server/src/modules/charges/resolvers/charges.resolver.ts
+++ b/packages/server/src/modules/charges/resolvers/charges.resolver.ts
@@ -23,20 +23,14 @@ import {
   batchUpdateChargesTags,
   batchUpdateChargesYearsSpread,
 } from '../helpers/batch-update-charges.js';
-import { getChargeType, normalizeDbType } from '../helpers/charge-type.js';
-import {
-  getChargeBusinesses,
-  getChargeDocumentsMeta,
-  getChargeLedgerMeta,
-  getChargeTransactionsMeta,
-  isEnrichedFilteredCharge,
-} from '../helpers/common.helper.js';
+import { getChargeType } from '../helpers/charge-type.js';
+import { getChargeBusinesses, isEnrichedFilteredCharge } from '../helpers/common.helper.js';
 import { deleteCharges } from '../helpers/delete-charges.helper.js';
+import { fetchFilteredCharges } from '../helpers/filtered-charges.helper.js';
 import { mergeChargesExecutor } from '../helpers/merge-charges.helper.js';
 import { ChargeSpreadProvider } from '../providers/charge-spread.provider.js';
 import { ChargesProvider } from '../providers/charges.provider.js';
 import type {
-  accountant_statusArray,
   ChargesModule,
   IBatchUpdateChargesParams,
   IGetChargesByIdsResult,
@@ -172,81 +166,9 @@ export const chargesResolvers: ChargesModule.Resolvers &
       }
     },
     allCharges: async (_, { filters, page, limit }, { injector }) => {
-      // handle sort column
-      let sortColumn: 'event_date' | 'event_amount' | 'abs_event_amount' = 'event_date';
-      switch (filters?.sortBy?.field) {
-        case ChargeSortByField.Amount:
-          sortColumn = 'event_amount';
-          break;
-        case ChargeSortByField.AbsAmount:
-          sortColumn = 'abs_event_amount';
-          break;
-        case ChargeSortByField.Date:
-          sortColumn = 'event_date';
-          break;
-      }
-
-      const charges = await injector
-        .get(ChargesProvider)
-        .getChargesByFilters({
-          ownerIds: filters?.byOwners,
-          // Both date families are forwarded: `fromDate`/`toDate` test the
-          // charge's main date (documents min/max, else transaction event
-          // dates) — containment — while `fromAnyDate`/`toAnyDate` test whether
-          // the charge's span across *all* date sources overlaps the range. The
-          // SQL has always supported both; only the `*AnyDate` pair was wired
-          // up here, so a caller passing `fromDate`/`toDate` (as the MCP charge
-          // tools now can) got an unfiltered result instead of a narrower one.
-          fromDate: filters?.fromDate,
-          toDate: filters?.toDate,
-          fromAnyDate: filters?.fromAnyDate,
-          toAnyDate: filters?.toAnyDate,
-          sortColumn,
-          asc: filters?.sortBy?.asc !== false,
-          chargeType: filters?.chargesType,
-          businessIds: filters?.byBusinesses,
-          businessTripIds: filters?.byBusinessTrips,
-          withMissingCounterparty: filters?.withMissingCounterparty,
-          withoutInvoice: filters?.withoutInvoice,
-          withoutReceipt: filters?.withoutReceipt,
-          withoutDocuments: filters?.withoutDocuments,
-          withOpenDocuments: filters?.withOpenDocuments,
-          withoutTransactions: filters?.withoutTransactions,
-          withoutLedger: filters?.withoutLedger,
-          freeText: filters?.freeText?.trim().toLowerCase(),
-          tags: filters?.byTags,
-          accountantStatuses: filters?.accountantStatus as accountant_statusArray | undefined,
-        })
-        .catch(error => {
-          throw errorSimplifier('Error fetching charges', error);
-        });
-
-      // charge __typename is resolved dynamically, so filter by concrete type post-fetch
-      let filteredCharges = charges;
-      if (filters?.byChargeTypes?.length) {
-        const wantedTypes = new Set<ChargeTypeEnum>(filters.byChargeTypes?.map(normalizeDbType));
-        const chargeTypes = await Promise.all(
-          charges.map(charge =>
-            getChargeType(charge, injector).catch(error => {
-              throw errorSimplifier('Failed to determine charge type', error);
-            }),
-          ),
-        );
-        filteredCharges = charges.filter((_, index) => wantedTypes.has(chargeTypes[index]));
-      }
-
-      const pageCharges = filteredCharges.slice(page * limit, (page + 1) * limit);
-
-      return {
-        __typename: 'PaginatedCharges',
-        nodes: pageCharges,
-        pageInfo: {
-          totalPages: Math.ceil(filteredCharges.length / limit),
-          totalRecords: filteredCharges.length,
-        },
-      };
+      return fetchFilteredCharges(injector, { filters, page, limit });
     },
-    chargesWithMissingRequiredInfo: async (_, { page, limit }, { injector }) => {
+    chargesWithMissingRequiredInfo: async (_, { filters, page, limit }, { injector }) => {
       try {
         const chargeIds = new Set<string>();
         // get by transactions
@@ -285,86 +207,32 @@ export const chargesResolvers: ChargesModule.Resolvers &
             });
           });
 
-        await Promise.all([getByTransactionsPromise, getByDocumentsPromise, getByChargesPromise]);
+        // The read scope is enforced by RLS on every query, but it is also
+        // applied here as the owner filter so the pagination counts below are
+        // computed over the charges this request may actually see.
+        const [readScope] = await Promise.all([
+          injector
+            .get(ScopeProvider)
+            .getReadScope(filters?.byOwners ? [...filters.byOwners] : undefined),
+          getByTransactionsPromise,
+          getByDocumentsPromise,
+          getByChargesPromise,
+        ]);
 
-        const charges = await Promise.all(
-          Array.from(chargeIds).map(async id => {
-            const [
-              charge,
-              { transactionsMinDebitDate, transactionsMinEventDate },
-              { ledgerMinInvoiceDate, ledgerMinValueDate },
-              { documentsMinDate },
-            ] = await Promise.all([
-              injector
-                .get(ChargesProvider)
-                .getChargeByIdLoader.load(id)
-                .then(charge => {
-                  if (!charge) {
-                    throw new GraphQLError(`Charge ID="${id}" not found`);
-                  }
-                  return charge;
-                })
-                .catch(e => {
-                  const message = `Error loading charge ID="${id}"`;
-                  console.error(`${message}: ${e}`);
-                  throw new GraphQLError(message);
-                }),
-              getChargeTransactionsMeta(id, injector),
-              getChargeLedgerMeta(id, injector),
-              getChargeDocumentsMeta(id, injector),
-            ]);
-            return {
-              ...charge,
-              transactionsMinDebitDate,
-              transactionsMinEventDate,
-              ledgerMinInvoiceDate,
-              ledgerMinValueDate,
-              documentsMinDate,
-            };
-          }),
-        );
-
-        const readScope = await injector.get(ScopeProvider).getReadScope();
-
-        const pageCharges = charges
-          .filter(charge => !!charge.owner_id && readScope.includes(charge.owner_id))
-          .sort((chargeA, chargeB) => {
-            const dateA =
-              (
-                chargeA.documentsMinDate ||
-                chargeA.transactionsMinDebitDate ||
-                chargeA.transactionsMinEventDate ||
-                chargeA.ledgerMinValueDate ||
-                chargeA.ledgerMinInvoiceDate
-              )?.getTime() ?? 0;
-            const dateB =
-              (
-                chargeB.documentsMinDate ||
-                chargeB.transactionsMinDebitDate ||
-                chargeB.transactionsMinEventDate ||
-                chargeB.ledgerMinValueDate ||
-                chargeB.ledgerMinInvoiceDate
-              )?.getTime() ?? 0;
-
-            if (dateA > dateB) {
-              return -1;
-            }
-            if (dateA < dateB) {
-              return 1;
-            }
-
-            return chargeA.id.localeCompare(chargeB.id);
-          })
-          .slice(page * limit - limit, page * limit);
-
-        return {
-          __typename: 'PaginatedCharges',
-          nodes: pageCharges,
-          pageInfo: {
-            totalPages: Math.ceil(charges.length / limit),
-            totalRecords: charges.length,
+        // The charge list is narrowed to the missing-info ids, and otherwise
+        // filtered / sorted / paginated exactly like `allCharges`. Unsorted
+        // requests keep this screen's newest-first default (the shared path
+        // would otherwise fall back to ascending).
+        return fetchFilteredCharges(injector, {
+          filters: {
+            ...filters,
+            byOwners: readScope,
+            sortBy: filters?.sortBy ?? { field: ChargeSortByField.Date, asc: false },
           },
-        };
+          page,
+          limit,
+          restrictToIds: Array.from(chargeIds),
+        });
       } catch (error) {
         throw errorSimplifier('Failed to fetch charges with missing required info', error);
       }

--- a/packages/server/src/modules/charges/typeDefs/charges.graphql.ts
+++ b/packages/server/src/modules/charges/typeDefs/charges.graphql.ts
@@ -6,8 +6,11 @@ export default gql`
     chargesByIDs(chargeIDs: [UUID!]!): [Charge!]! @requiresAuth
     allCharges(filters: ChargeFilter, page: Int = 1, limit: Int = 999999): PaginatedCharges!
       @requiresAuth
-    chargesWithMissingRequiredInfo(page: Int = 1, limit: Int = 999999): PaginatedCharges!
-      @requiresAuth
+    chargesWithMissingRequiredInfo(
+      filters: ChargeFilter
+      page: Int = 0
+      limit: Int = 999999
+    ): PaginatedCharges! @requiresAuth
   }
 
   extend type Mutation {

--- a/packages/server/src/modules/charges/typeDefs/charges.graphql.ts
+++ b/packages/server/src/modules/charges/typeDefs/charges.graphql.ts
@@ -4,7 +4,7 @@ export default gql`
   extend type Query {
     charge(chargeId: UUID!): Charge! @requiresAuth
     chargesByIDs(chargeIDs: [UUID!]!): [Charge!]! @requiresAuth
-    allCharges(filters: ChargeFilter, page: Int = 1, limit: Int = 999999): PaginatedCharges!
+    allCharges(filters: ChargeFilter, page: Int = 0, limit: Int = 999999): PaginatedCharges!
       @requiresAuth
     chargesWithMissingRequiredInfo(
       filters: ChargeFilter


### PR DESCRIPTION
The Missing Info Charges screen had no filters at all — only the "expand all" toggle and the merge button. It now offers the same `ChargeFilter` set as All Charges, with one exception: **the date range is optional here**, so old unresolved charges aren't hidden behind the default "last year" window.

## Server

- `chargesWithMissingRequiredInfo` accepts `filters: ChargeFilter`, and its `page` argument moves from 1-based to 0-based to match `allCharges` (the client screen was its only consumer).
- The `allCharges` body — filter → provider param mapping, the post-fetch `byChargeTypes` narrowing, pagination — moved to a shared `fetchFilteredCharges` helper (`packages/server/src/modules/charges/helpers/filtered-charges.helper.ts`) with an optional `restrictToIds`. `allCharges` is now a thin call into it (no behavior change); the missing-info query collects its charge ids as before and runs them through the same path.
- An empty id set short-circuits to an empty result: the provider reads an empty `IDs` list as "no id filter" and would otherwise return every charge.
- The read scope is passed as the owner filter (intersected with `byOwners`, throwing on out-of-scope owners like the transactions resolver) instead of filtering the result page, so `totalPages` / `totalRecords` cover only visible charges. RLS still enforces the scope independently.
- Unsorted requests keep the screen's previous newest-first ordering — the shared path defaults to ascending otherwise. The per-charge loader + JS date sort it replaces is gone; the enriched rows sort in SQL.

## Client

- `ChargesFilters` takes `withDefaultDateRange` (default `true`). When false the form omits the `fromAnyDate` / `toAnyDate` defaults, so both date inputs start empty. All Charges is unaffected.
- `missing-info-charges.tsx` renders the filters bar with `withDefaultDateRange={false}`, reads/writes filters via the `chargesFilters` URL param, starts at page 0, and adopts the `useStableValue` + `LoadingOverlay` refetch behavior from All Charges. The query is **not** paused and there's no "Please apply filters" fallback — filters are optional, so the unfiltered list loads on mount.

## Verification

- `yarn generate`, `yarn lint` (0 errors), `yarn prettier:fix`, and client `tsc --noEmit` all clean.
- `yarn test`: 2923 passed. The one failing suite (`packages/migrations/src/__tests__/rls-all-tables.test.ts`) fails identically on the untouched base — it exits on missing DB env vars.
- New `missing-info-charges-filters.test.ts` covers filter forwarding, the id restriction, read-scope owners, the newest-first default and the empty-id short-circuit.
- ⚠️ A full server `tsc --noEmit` could not run in this environment: without Postgres, pgtyped SQL codegen never ran, so ~886 "no exported member" errors are present on the base commit as well. Worth a typecheck against a real DB before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D62BpS8D47Am5kZfBDYG4G)_