### PR TITLE
Add "Copy Charge Link" action to charge actions menu

### DIFF
--- a/.changeset/charge-actions-copy-link.md
+++ b/.changeset/charge-actions-copy-link.md
@@ -1,0 +1,7 @@
+---
+'@accounter/client': minor
+---
+
+Add a "Copy Charge Link" action to the charge actions menu. It copies the charge's detail page URL
+(`<origin>/charges/<chargeId>`) to the clipboard, making the link previously only reachable from the
+edit-charge modal header available directly from the menu.

--- a/packages/client/src/components/charges/charge-actions-menu.tsx
+++ b/packages/client/src/components/charges/charge-actions-menu.tsx
@@ -1,7 +1,17 @@
 import { useCallback, useState, type ReactElement } from 'react';
-import { ArrowDownWideNarrow, Edit, FilePlus2, ListPlus, MoreVertical, Trash } from 'lucide-react';
+import {
+  ArrowDownWideNarrow,
+  Edit,
+  FilePlus2,
+  Link,
+  ListPlus,
+  MoreVertical,
+  Trash,
+} from 'lucide-react';
 import { Modal } from '@mantine/core';
 import type { ChargeType } from '@/helpers/index.js';
+import { ROUTES } from '@/router/routes.js';
+import { writeToClipboard } from '../../helpers/index.js';
 import { useDeleteCharge } from '../../hooks/use-delete-charge.js';
 import { Depreciation } from '../common/depreciation/index.js';
 import {
@@ -50,6 +60,10 @@ export function ChargeActionsMenu({
 
   const [uploadDocumentsOpen, setUploadDocumentsOpen] = useState(false);
 
+  const onCopyLink = useCallback((): void => {
+    writeToClipboard(`${window.location.origin}${ROUTES.CHARGES.DETAIL(chargeId)}`);
+  }, [chargeId]);
+
   const onDelete = useCallback(async (): Promise<void> => {
     await deleteCharge({
       chargeId,
@@ -80,6 +94,10 @@ export function ChargeActionsMenu({
           <DropdownMenuItem onSelect={() => setEditingCharge(true)}>
             <Edit className="size-4" />
             Edit Charge
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onCopyLink}>
+            <Link className="size-4" />
+            Copy Charge Link
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setConfirmDeleteOpen(true)}>
             <Trash className="size-4" />


### PR DESCRIPTION
## What

Adds a **Copy Charge Link** item to the charge actions menu (`charge-actions-menu.tsx`), under the "Charge" section next to *Edit Charge*.

Clicking it copies `${window.location.origin}${ROUTES.CHARGES.DETAIL(chargeId)}` to the clipboard via the existing `writeToClipboard` helper and closes the menu — the same link that was previously only reachable through the `CopyToClipboardButton` in the edit-charge modal header (`edit-charge-modal.tsx`).

## Notes

- Uses the shared `writeToClipboard` helper rather than embedding `CopyToClipboardButton`, so the action renders as a normal `Menu.Item` with a `Link` icon consistent with the rest of the menu.
- No schema or server changes; a changeset (`@accounter/client`, minor) is included.


---
_Generated by [Claude Code](https://claude.ai/code/session_019kasmwYYNdVj2LmcsCAXkz)_