### PR TITLE
fix(ci): cache every GraphQL codegen output

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -84,14 +84,25 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: graphql-cache
       with:
+        # Every `generate:graphql` output must be listed: on an exact cache hit the
+        # generate step is skipped, so anything missing here is simply absent for the
+        # rest of the job. `packages/server/src/__generated__` was missing, which broke
+        # any module value-importing from it (e.g. the `TransactionDirection` enum).
         path: |
           schema.graphql
+          packages/server/src/__generated__
           packages/server/src/modules/**/__generated__
           packages/client/src/gql
+          packages/gmail-listener/src/gql
+          packages/email-ingestion-gateway/src/gql
+          packages/mcp-server/src/gql
+          packages/scraper-app/src/server/gql
         key:
           graphql-codegen-${{ runner.os }}-${{ hashFiles('packages/server/src/modules/**/*.ts',
           'codegen.ts', 'graphql.config.js', 'packages/client/src/**/*.{,c,m}{j,t}s{,x}',
-          'yarn.lock') }}
+          'packages/gmail-listener/src/**/*.ts', 'packages/email-ingestion-gateway/src/**/*.ts',
+          'packages/mcp-server/src/**/*.ts', 'packages/scraper-app/src/**/*.{ts,tsx}', 'yarn.lock')
+          }}
         restore-keys: |
           graphql-codegen-${{ runner.os }}-
 


### PR DESCRIPTION
## The failure

```
FAIL |unit| packages/server/src/modules/transactions/resolvers/__tests__/common-transaction-fields.test.ts
Error: Cannot find module '../../../__generated__/types.js' imported from
  packages/server/src/modules/transactions/resolvers/common.ts
```

## Root cause

The `graphql-codegen-*` cache guards the generate step with `if: cache-hit != 'true'`. On an **exact** key hit the step is skipped, so every codegen output not listed in the cache `path` is simply **absent** for the rest of the job.

`packages/server/src/__generated__` was never in that list — only `packages/server/src/modules/**/__generated__` was. So on a cache hit, `packages/server/src/__generated__/types.ts` neither existed nor got regenerated.

It stayed invisible because almost every import of that file is `import type`, which TypeScript erases. `transactions/resolvers/common.ts` is different — it imports the **value** `TransactionDirection`:

```ts
import { TransactionDirection } from '../../../__generated__/types.js';
// …
parseFloat(res.amount) > 0 ? TransactionDirection.Credit : TransactionDirection.Debit,
```

The test added in #4163 is the first unit test to reach that module, so it fails at runtime whenever the cache hits. That also explains the intermittency: on a cache **miss** the generate step runs and everything passes.

### Reproduced locally

```
$ mv packages/server/src/__generated__ /tmp/   # exactly what a cache hit leaves behind
$ yarn vitest run --project unit .../common-transaction-fields.test.ts
FAIL  Cannot find module '../../../__generated__/types.js' imported from …/resolvers/common.ts
$ mv /tmp/__generated__ packages/server/src/
$ yarn vitest run --project unit .../common-transaction-fields.test.ts
Test Files  1 passed (1)   Tests  2 passed (2)
```

## The fix

Cache every `generate:graphql` output. Beyond the server root types, the same gap existed for the `gmail-listener`, `email-ingestion-gateway`, `mcp-server` and `scraper-app` `gql` outputs — all imported at runtime by their packages, all latent versions of this bug.

The cache key now also hashes those packages' sources, so a restored cache cannot serve artifacts staler than the inputs that produced them.

Also drops `packages/scraper-app/src/server/gql/index.ts` from the **PgTyped** cache: it is a `generate:graphql` output (see `codegen.ts`), not a PgTyped one (`docker/pgconfig.json` only writes `packages/server/src/**/__generated__/*.types.ts`). Since the PgTyped cache restores *after* the GraphQL one, leaving it there could overwrite a freshly generated file with a stale copy.

## ⚠️ One hunk could not be pushed

This PR contains only the `.github/actions/setup/action.yml` half. The commit for `.github/workflows/server-tests.yml` — **the file that actually runs the failing job** — was rejected:

```
refusing to allow an OAuth App to create or update workflow
`.github/workflows/server-tests.yml` without `workflow` scope
```

`server-tests.yml` carries its own inline copy of both cache blocks and does not use the composite action, so **this PR alone does not fix the failure**. The identical change has to be applied there by someone with `workflow` scope; the exact patch is attached in the session and the two blocks are identical to the ones in this diff.

Worth considering separately: `transactions/resolvers/common.ts` could import `TransactionDirection` from `../../../shared/enums.js` directly — the generated file only re-exports it from there — which would make that module independent of codegen entirely. Left out here to keep this change to the CI bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D62BpS8D47Am5kZfBDYG4G)_