### PR TITLE
fix(server): import TransactionDirection from its source, not the generated types

### DIFF
--- a/.changeset/transactions-common-enum-import.md
+++ b/.changeset/transactions-common-enum-import.md
@@ -1,0 +1,19 @@
+---
+'@accounter/server': patch
+---
+
+Import `TransactionDirection` in `transactions/resolvers/common.ts` from `shared/enums.js` instead
+of from `__generated__/types.js`.
+
+The generated module only re-exports the enum from `shared/enums.js`, but it is a build artifact —
+so a *value* import of it (unlike the `import type` used everywhere else) made this module, and
+every test that reaches it, fail to resolve whenever GraphQL codegen had not produced
+`packages/server/src/__generated__/types.ts`:
+
+```
+Cannot find module '../../../__generated__/types.js' imported from
+  packages/server/src/modules/transactions/resolvers/common.ts
+```
+
+Behavior is unchanged — it is the same enum object — and this was the only runtime import of the
+generated types in the server package.

--- a/packages/server/src/modules/transactions/resolvers/common.ts
+++ b/packages/server/src/modules/transactions/resolvers/common.ts
@@ -1,4 +1,8 @@
-import { TransactionDirection } from '../../../__generated__/types.js';
+// `TransactionDirection` is imported from its own source rather than from
+// `__generated__/types.js` (which only re-exports it): the generated file is a
+// build artifact, so a *value* import of it makes this module — and every test
+// that reaches it — fail to resolve whenever codegen has not run.
+import { TransactionDirection } from '../../../shared/enums.js';
 import { dateToTimelessDateString, formatFinancialAmount } from '../../../shared/helpers/index.js';
 import { effectiveDateSupplement } from '../helpers/effective-date.helper.js';
 import { TransactionsProvider } from '../providers/transactions.provider.js';


### PR DESCRIPTION
Fixes the still-failing unit suite:

```
FAIL |unit| packages/server/src/modules/transactions/resolvers/__tests__/common-transaction-fields.test.ts
Error: Cannot find module '../../../__generated__/types.js' imported from
  packages/server/src/modules/transactions/resolvers/common.ts
```

## Why #4177 didn't fix it

#4177 landed only `.github/actions/setup/action.yml`. The commit for `.github/workflows/server-tests.yml` was rejected (`refusing to allow an OAuth App to create or update workflow … without workflow scope`), and **that** is the file running this job — it still carries the old cache block on `main`, missing `packages/server/src/__generated__` from its cache `path`. So on an exact cache hit the generate step is skipped and the file is absent, exactly as before.

## This fix

Rather than depend on that workflow change landing, remove the fragile dependency itself.

`transactions/resolvers/common.ts` was **the only place in the server that imports a value** from `__generated__/types.js`:

```ts
import { TransactionDirection } from '../../../__generated__/types.js';
```

Everywhere else consumes the generated types via `import type`, which TypeScript erases — which is precisely why nothing else ever broke. A value import survives to runtime and must resolve on disk, so this one module (and every test reaching it) breaks whenever codegen hasn't run.

The generated module doesn't define the enum, it only re-exports it:

```ts
// packages/server/src/__generated__/types.ts
import { TransactionDirection } from '../shared/enums.js';   // line 5
export { TransactionDirection };                             // line 6202
```

So importing from `../../../shared/enums.js` is the same enum object — no behavior change — and matches how the rest of the codebase reads shared enums (e.g. `charges.resolver.ts` imports `ChargeTypeEnum` / `ChargeSortByField` from there).

## Verification

I reproduced CI's cache-hit state exactly — deleted `packages/server/src/__generated__` — and ran the whole unit project:

```
$ rm -r packages/server/src/__generated__
$ yarn test
Test Files  1 failed | 241 passed (242)
Tests  2939 passed | 6 skipped (2945)
```

The single failure is `packages/migrations/src/__tests__/rls-all-tables.test.ts`, which exits on missing `POSTGRES_*` env vars — it fails the same way on `main` in this sandbox and is supplied by CI. `common-transaction-fields.test.ts` passes with the generated file absent, which is the condition that was failing.

Also verified with the generated file restored: transactions tests pass, ESLint clean, and `tsc` reports nothing for the touched file.

## Still worth doing separately

The CI cache bug itself remains: `.github/workflows/server-tests.yml` still omits `packages/server/src/__generated__` (and the `gmail-listener` / `email-ingestion-gateway` / `mcp-server` / `scraper-app` gql outputs) from its cache `path`, so a cache hit still leaves those absent. This PR removes the only runtime dependency on them in the test path, but the workflow hunk from #4177 should still be applied by someone with `workflow` scope — the diff is in that PR's description.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D62BpS8D47Am5kZfBDYG4G)_