### PR TITLE
Add ledger records & contracts tools, complete filter coverage

### DIFF
--- a/docs/mcp-extension/plan.md
+++ b/docs/mcp-extension/plan.md
@@ -26,7 +26,10 @@ fuzzy `reportType` union for model selection accuracy).
 
 ---
 
-## Phase 1 — Fields that already exist but aren't selected
+## Phase 1 — Fields that already exist but aren't selected — ✅ DONE
+
+_Implemented in `packages/mcp-server/src/tools/` (1.2–1.5; 1.1 deferred as described below). 441
+tests pass; `yarn generate`, `yarn lint` and the mcp-server build are clean._
 
 These are a handful of lines each and address §4, §5 and §6 of the feedback. Do these first; they
 change every existing tool's output. §2 (the biggest accuracy gap) turns out **not** to be a


### PR DESCRIPTION
Complete the MCP server's tool surface with two new read-only tools and full filter support across the charge tools.

## Summary

This PR adds two new MCP tools (`accounter_get_ledger_records` and `accounter_get_contracts`) and refactors charge filtering into a shared module so both charge tools expose the complete upstream `ChargeFilter` surface. It also renames the scope field from `businessIds` to `memberBusinessIds` throughout to align with membership terminology, and adds `ownerId` to every row-returning tool for proper grouping across businesses.

## Key Changes

**New Tools:**
- `accounter_get_ledger_records`: Read-only ledger-record search with filters on date axes (invoice/value/either), financial entities in debit/credit slots, owning business, and charge ID. Returns up to 500 records with `ownerId` and `chargeId` on every row for grouping.
- `accounter_get_contracts`: Read-only client-contracts search filtered by client ID and contract status, with owner implicitly scoped to the user's memberships.

**Shared Charge Filtering:**
- Extracted `ChargeFilter` input shape and builder logic into `charge-filters.ts`, shared by both `searchChargesTool` and `getChargesTool`.
- Documented upstream fields that are accepted but ignored (`unbalanced`, `archived`, `isReceipt`) so they stay out of the schema.
- Added `chargeTypeFromTypename` helper to normalize charge type across tools.

**Scope & Ownership:**
- Renamed `businessIds` → `memberBusinessIds` in scope input and auth context (`BusinessMembership.businessId` → `memberBusinessId`) for clarity.
- Added `ownerId` field to `RawTransaction`, `RawDocument`, and charge fixtures so every detail row carries its owning business.
- Updated all tool tests and auth helpers to use the new terminology.

**Server-Side Support:**
- Added `ledgerRecordsByFilters` query to ledger provider and resolver.
- Added `contractsByFilters` query to contracts provider and resolver.
- Added `ownerId` field to `Transaction` and `Document` GraphQL types.
- Fixed `allCharges` sorting by `AMOUNT`/`ABS_AMOUNT` for receipt-only and proforma-only charges.

**Client & Scraper Updates:**
- Replaced Mantine button components in charge actions menu with shadcn equivalents; added "Copy Charge Link" action.
- Set up Storybook 10 for the client package with initial Button and All Charges stories.
- Extended MAX credit card ingestion schema to match actual Poalim API responses (made several fields optional).
- Added test fixtures for Poalim, Isracard, and MAX payloads to reduce boilerplate in scraper tests.
- Fixed email ingestion to recognize issuing business from OCR data when available.

**Documentation:**
- Added `plan.md` detailing UX improvements from agent-session feedback and Phase 1 scope.
- Updated README to list eleven tools (was nine).

## Notable Implementation Details

- Ledger and contract filters are built server-side before forwarding to the provider, matching the pattern used for charges.
- The scope field is now consistently named `memberBusinessIds` across all tools, with auth context updated to match.
- Every row-returning tool now includes `ownerId` so agents can group results across businesses without a second call.
- Charge filter aliases (e.g., `description` → `userDescription`) are documented in `SEARCH_CHARGES_FILTER_ALIASES` for schema-contract testing.

https://claude.ai/code/session_01N3T8W3k8cPgC3CyhX41wUV