### PR TITLE
fix(charges): remove deleted charge row from the charges table

### DIFF
--- a/.changeset/charges-table-remove-deleted-row.md
+++ b/.changeset/charges-table-remove-deleted-row.md
@@ -1,0 +1,8 @@
+---
+'@accounter/client': patch
+---
+
+Remove a charge's row from the charges table after it is deleted. Deleting from the charge actions
+menu previously triggered the row's refetch, which failed because the charge no longer existed and
+left the stale row in the table. The menu now reports a successful deletion separately, and the
+table drops the charge from its rows and from the row selection.

--- a/packages/client/src/components/charges/charge-actions-menu.tsx
+++ b/packages/client/src/components/charges/charge-actions-menu.tsx
@@ -38,6 +38,12 @@ interface ChargeActionsMenuProps {
   chargeId: string;
   chargeType: ChargeType;
   onChange?: () => void;
+  /**
+   * Called after the charge was successfully deleted. Hosts that list charges should use it to drop
+   * the charge from their list — falling back to `onChange` would refetch a charge that no longer
+   * exists.
+   */
+  onDelete?: () => void;
   isIncome: boolean;
 }
 
@@ -45,6 +51,7 @@ export function ChargeActionsMenu({
   chargeId,
   chargeType,
   onChange,
+  onDelete,
   isIncome,
 }: ChargeActionsMenuProps): ReactElement {
   const { deleteCharge } = useDeleteCharge();
@@ -64,12 +71,17 @@ export function ChargeActionsMenu({
     writeToClipboard(`${window.location.origin}${ROUTES.CHARGES.DETAIL(chargeId)}`);
   }, [chargeId]);
 
-  const onDelete = useCallback(async (): Promise<void> => {
-    await deleteCharge({
+  const handleDelete = useCallback(async (): Promise<void> => {
+    const deleted = await deleteCharge({
       chargeId,
     });
+    if (deleted && onDelete) {
+      // The charge is gone — let the host remove it rather than refetch it.
+      onDelete();
+      return;
+    }
     onChange?.();
-  }, [chargeId, deleteCharge, onChange]);
+  }, [chargeId, deleteCharge, onChange, onDelete]);
 
   return (
     <>
@@ -155,7 +167,7 @@ export function ChargeActionsMenu({
       <ConfirmationModal
         open={confirmDeleteOpen}
         setOpen={setConfirmDeleteOpen}
-        onConfirm={onDelete}
+        onConfirm={handleDelete}
         title="Are you sure you want to delete this charge?"
       />
       <Modal

--- a/packages/client/src/components/charges/charges-row.tsx
+++ b/packages/client/src/components/charges/charges-row.tsx
@@ -27,10 +27,11 @@ import {
 
 type Props = {
   updateCharge: (charge: ChargeRowType) => void;
+  removeCharge: (chargeId: string) => void;
   row: Row<TableFeaturesConfig, ChargeRowType>;
 };
 
-export const ChargeRow = ({ row, updateCharge }: Props): ReactElement => {
+export const ChargeRow = ({ row, updateCharge, removeCharge }: Props): ReactElement => {
   const [{ data: newData, fetching }, fetchCharge] = useQuery({
     query: RefetchChargeForChargesTableDocument,
     pause: true,
@@ -62,6 +63,9 @@ export const ChargeRow = ({ row, updateCharge }: Props): ReactElement => {
   // charge after an edit.
   // eslint-disable-next-line react-hooks/immutability -- intentional react-table row-model mutation
   row.original.onChange = fetchCharge;
+  // Same threading for the delete path — the row is dropped from the table instead of refetched.
+  // eslint-disable-next-line react-hooks/immutability -- intentional react-table row-model mutation
+  row.original.onDelete = () => removeCharge(row.original.id);
 
   return (
     <>

--- a/packages/client/src/components/charges/charges-table.tsx
+++ b/packages/client/src/components/charges/charges-table.tsx
@@ -112,6 +112,8 @@ import { shouldHaveCounterparty, shouldHaveTaxCategory, shouldHaveVat } from './
 export interface ChargeRow {
   id: string;
   onChange: () => void;
+  /** Drops this charge's row from the table after it was deleted on the server. */
+  onDelete: () => void;
   type: ChargeType;
   date?: DateProps;
   amount?: AmountProps['amount'];
@@ -139,6 +141,7 @@ export function convertChargeFragmentToTableRow(
   return {
     id: fragmentData.id,
     onChange: () => {},
+    onDelete: () => {},
     type: fragmentData.__typename as ChargeType,
     date: getDateProps({
       minDebitDate: fragmentData.minDebitDate,
@@ -307,6 +310,23 @@ export const ChargesTable = ({
     setCharges(old => old.map(row => (row.id === updatedCharge.id ? updatedCharge : row)));
   }, []);
 
+  // Drop a deleted charge's row from the table. The charge no longer exists on the server, so
+  // refetching it (the usual `onChange` path) would only fail and leave a stale row behind.
+  // Its selection entry goes with it, so batch actions can't target a deleted charge.
+  const removeCharge = useCallback(
+    (chargeId: string) => {
+      setCharges(old => old.filter(row => row.id !== chargeId));
+      setRowSelection(old => {
+        if (!(chargeId in old)) {
+          return old;
+        }
+        const { [chargeId]: _removed, ...rest } = old;
+        return rest;
+      });
+    },
+    [setRowSelection],
+  );
+
   // Update charges when data changes
   useEffect(() => {
     setCharges(
@@ -392,7 +412,14 @@ export const ChargesTable = ({
               {table.getRowModel().rows?.length ? (
                 table
                   .getRowModel()
-                  .rows.map(row => <ChargeRow key={row.id} row={row} updateCharge={updateCharge} />)
+                  .rows.map(row => (
+                    <ChargeRow
+                      key={row.id}
+                      row={row}
+                      updateCharge={updateCharge}
+                      removeCharge={removeCharge}
+                    />
+                  ))
               ) : (
                 <TableRow>
                   <TableCell colSpan={columns.length} className="h-24 text-center">

--- a/packages/client/src/components/charges/columns.tsx
+++ b/packages/client/src/components/charges/columns.tsx
@@ -130,6 +130,7 @@ export const columns: ColumnDef<TableFeaturesConfig, ChargeRow>[] = [
             chargeId={row.original.id}
             chargeType={row.original.type}
             onChange={row.original.onChange}
+            onDelete={row.original.onDelete}
             isIncome={(row.original.amount?.value ?? 0) > 0}
           />
           <Tooltip content="Expand info">


### PR DESCRIPTION
## Problem

Deleting a charge from the charge actions menu called the row's `onChange`, which is the row's
refetch handler. The refetch failed (the charge no longer exists) and the row stayed in the table,
since the table's row data was never updated.

## Fix

- `charge-actions-menu.tsx` — the delete handler now checks the mutation result and calls a new
  optional `onDelete` prop on success. It falls back to `onChange` when the deletion failed or when
  the host supplies no `onDelete`, so other consumers keep their current behavior.
- `charges-table.tsx` — `ChargeRow` gains an `onDelete` field, and the table adds a `removeCharge`
  callback that filters the charge out of its row data and drops its `rowSelection` entry (so batch
  actions and CSV export can't target a deleted charge).
- `charges-row.tsx` — threads `row.original.onDelete = () => removeCharge(row.original.id)` onto the
  row model, next to the existing `onChange` refetch.
- `columns.tsx` — passes `row.original.onDelete` through to the actions menu.

## Verification

Typecheck passes, `yarn lint` reports 0 errors, prettier clean. Not exercised in the running app —
the change is local table state only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)