### PR TITLE
fix(documents): drop the charge row when deleting its last document empties it

### DIFF
--- a/.changeset/@accounter_client-4209-dependencies.md
+++ b/.changeset/@accounter_client-4209-dependencies.md
@@ -1,0 +1,8 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`@atlaskit/pragmatic-drag-and-drop@3.0.0` ↗︎](https://www.npmjs.com/package/@atlaskit/pragmatic-drag-and-drop/v/3.0.0) (from `2.0.2`, in `dependencies`)
+  - Updated dependency [`@hookform/resolvers@5.8.0` ↗︎](https://www.npmjs.com/package/@hookform/resolvers/v/5.8.0) (from `5.7.1`, in `dependencies`)
+  - Updated dependency [`html2canvas-pro@2.3.7` ↗︎](https://www.npmjs.com/package/html2canvas-pro/v/2.3.7) (from `2.3.3`, in `dependencies`)
+  - Updated dependency [`zustand@5.0.15` ↗︎](https://www.npmjs.com/package/zustand/v/5.0.15) (from `5.0.14`, in `dependencies`)

--- a/.changeset/@accounter_gmail-listener-4209-dependencies.md
+++ b/.changeset/@accounter_gmail-listener-4209-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/gmail-listener": patch
+---
+dependencies updates:
+  - Updated dependency [`@google-cloud/pubsub@6.0.1` ↗︎](https://www.npmjs.com/package/@google-cloud/pubsub/v/6.0.1) (from `6.0.0`, in `dependencies`)

--- a/.changeset/@accounter_green-invoice-graphql-4209-dependencies.md
+++ b/.changeset/@accounter_green-invoice-graphql-4209-dependencies.md
@@ -1,0 +1,10 @@
+---
+"@accounter/green-invoice-graphql": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-mesh/config@0.111.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/config/v/0.111.0) (from `0.109.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/http@0.109.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/http/v/0.109.0) (from `0.107.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/json-schema@0.112.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/json-schema/v/0.112.0) (from `0.110.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/store@0.107.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/store/v/0.107.0) (from `0.105.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/types@0.107.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/types/v/0.107.0) (from `0.105.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/utils@0.107.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.107.0) (from `0.105.1`, in `dependencies`)

--- a/.changeset/@accounter_hashavshevet-mesh-4209-dependencies.md
+++ b/.changeset/@accounter_hashavshevet-mesh-4209-dependencies.md
@@ -1,0 +1,11 @@
+---
+"@accounter/hashavshevet-mesh": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-mesh/config@0.111.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/config/v/0.111.0) (from `0.109.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/http@0.109.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/http/v/0.109.0) (from `0.107.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/json-schema@0.112.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/json-schema/v/0.112.0) (from `0.110.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/store@0.107.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/store/v/0.107.0) (from `0.105.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/transform-resolvers-composition@0.107.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/transform-resolvers-composition/v/0.107.0) (from `0.105.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/types@0.107.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/types/v/0.107.0) (from `0.105.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/utils@0.107.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.107.0) (from `0.105.1`, in `dependencies`)

--- a/.changeset/@accounter_israeli-vat-scraper-4209-dependencies.md
+++ b/.changeset/@accounter_israeli-vat-scraper-4209-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/israeli-vat-scraper": patch
+---
+dependencies updates:
+  - Updated dependency [`puppeteer@25.7.0` ↗︎](https://www.npmjs.com/package/puppeteer/v/25.7.0) (from `25.6.0`, in `dependencies`)

--- a/.changeset/@accounter_modern-poalim-scraper-4209-dependencies.md
+++ b/.changeset/@accounter_modern-poalim-scraper-4209-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/modern-poalim-scraper": patch
+---
+dependencies updates:
+  - Updated dependency [`puppeteer@25.7.0` ↗︎](https://www.npmjs.com/package/puppeteer/v/25.7.0) (from `25.6.0`, in `dependencies`)

--- a/.changeset/@accounter_payper-mesh-4209-dependencies.md
+++ b/.changeset/@accounter_payper-mesh-4209-dependencies.md
@@ -1,0 +1,11 @@
+---
+"@accounter/payper-mesh": patch
+---
+dependencies updates:
+  - Updated dependency [`@graphql-mesh/config@0.111.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/config/v/0.111.0) (from `0.109.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/http@0.109.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/http/v/0.109.0) (from `0.107.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/json-schema@0.112.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/json-schema/v/0.112.0) (from `0.110.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/store@0.107.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/store/v/0.107.0) (from `0.105.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/transform-rename@0.108.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/transform-rename/v/0.108.0) (from `0.106.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/types@0.107.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/types/v/0.107.0) (from `0.105.1`, in `dependencies`)
+  - Updated dependency [`@graphql-mesh/utils@0.107.0` ↗︎](https://www.npmjs.com/package/@graphql-mesh/utils/v/0.107.0) (from `0.105.1`, in `dependencies`)

--- a/.changeset/@accounter_scraper-app-4209-dependencies.md
+++ b/.changeset/@accounter_scraper-app-4209-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/scraper-app": patch
+---
+dependencies updates:
+  - Updated dependency [`fastify@5.12.0` ↗︎](https://www.npmjs.com/package/fastify/v/5.12.0) (from `5.11.3`, in `dependencies`)

--- a/.changeset/@accounter_server-4209-dependencies.md
+++ b/.changeset/@accounter_server-4209-dependencies.md
@@ -1,0 +1,8 @@
+---
+"@accounter/server": patch
+---
+dependencies updates:
+  - Updated dependency [`@ai-sdk/anthropic@4.0.38` ↗︎](https://www.npmjs.com/package/@ai-sdk/anthropic/v/4.0.38) (from `4.0.36`, in `dependencies`)
+  - Updated dependency [`@graphql-yoga/plugin-defer-stream@3.21.3` ↗︎](https://www.npmjs.com/package/@graphql-yoga/plugin-defer-stream/v/3.21.3) (from `3.21.2`, in `dependencies`)
+  - Updated dependency [`ai@7.0.64` ↗︎](https://www.npmjs.com/package/ai/v/7.0.64) (from `7.0.59`, in `dependencies`)
+  - Updated dependency [`graphql-yoga@5.21.3` ↗︎](https://www.npmjs.com/package/graphql-yoga/v/5.21.3) (from `5.21.2`, in `dependencies`)

--- a/.changeset/document-delete-empty-charge-sync.md
+++ b/.changeset/document-delete-empty-charge-sync.md
@@ -11,3 +11,7 @@ instead of a bare `Boolean`, and `UpdateDocumentSuccessfulResult` carries a `del
 the unlink path. The charge expansion forwards that signal up to the charges table, which removes
 the charge instead of refetching it, and the edit-document drawer now closes after a successful
 delete or unlink.
+
+Also fixes a hang on that unlink path: the deferred `postUpdateActions` closure in `updateDocument`
+ended by calling itself, so unlinking a charge's last document never resolved and re-ran the charge
+deletion in a loop.

--- a/.changeset/document-delete-empty-charge-sync.md
+++ b/.changeset/document-delete-empty-charge-sync.md
@@ -1,0 +1,13 @@
+---
+'@accounter/client': patch
+'@accounter/server': patch
+---
+
+Drop the charge row when deleting or unlinking its last document empties it. The server already
+deletes a charge that is left with no documents and no transactions, but it never told the client,
+which then refetched a charge that no longer exists and kept rendering a stale "shadow charge".
+`deleteDocument` now returns a `DeleteDocumentResult` (`success`, `chargeId`, `deletedChargeId`)
+instead of a bare `Boolean`, and `UpdateDocumentSuccessfulResult` carries a `deletedChargeId` for
+the unlink path. The charge expansion forwards that signal up to the charges table, which removes
+the charge instead of refetching it, and the edit-document drawer now closes after a successful
+delete or unlink.

--- a/packages/client/src/components/charges/charge-extended-info.tsx
+++ b/packages/client/src/components/charges/charge-extended-info.tsx
@@ -130,12 +130,19 @@ import { SalariesTable } from './extended-info/salaries-info.js';
 interface Props {
   chargeID: string;
   onChange?: () => void;
+  /**
+   * Called when a mutation inside the expansion emptied this charge and the server deleted it.
+   * Consumers should drop the charge from their list — refetching it would fail, since
+   * `Query.charge` throws for a deleted id, leaving a stale "shadow charge" on screen.
+   */
+  onChargeDeleted?: (chargeId: string) => void;
   fetching: boolean;
 }
 
 export function ChargeExtendedInfo({
   chargeID,
   onChange = (): void => void 0,
+  onChargeDeleted,
   fetching: parentFetching,
 }: Props): ReactElement {
   const [accordionItems, setAccordionItems] = useState<string[]>([]);
@@ -176,6 +183,24 @@ export function ChargeExtendedInfo({
     }
     onChange();
   }, [batch, refetchExtensionInfo, onChange]);
+
+  // The charge itself was deleted (it was emptied by removing its last document): never refetch it
+  // — `Query.charge` throws for a deleted id, so the refetch yields no data and the consumer keeps
+  // rendering the stale row. Hand the deletion to the consumer instead, and in batch mode fall back
+  // to re-running the shared query so the charge drops out of the batch.
+  const onExtendedChargeDeleted = useCallback(
+    (deletedChargeId: string) => {
+      if (onChargeDeleted) {
+        onChargeDeleted(deletedChargeId);
+        return;
+      }
+      if (batch.active) {
+        batch.refetch();
+      }
+      onChange();
+    },
+    [batch, onChange, onChargeDeleted],
+  );
 
   useEffect(() => {
     const incoming = incomingCharge;
@@ -449,6 +474,7 @@ export function ChargeExtendedInfo({
                           ?.additionalDocuments
                       }
                       onChange={onExtendedChange}
+                      onChargeDeleted={onExtendedChargeDeleted}
                     />
                   )}
                 </AccordionContent>
@@ -545,7 +571,11 @@ export function ChargeExtendedInfo({
           {galleryIsReady && (
             <Box maw="1/6">
               <Collapse in={opened} transitionDuration={500} transitionTimingFunction="linear">
-                <DocumentsGallery chargeProps={charge} onChange={onExtendedChange} />
+                <DocumentsGallery
+                  chargeProps={charge}
+                  onChange={onExtendedChange}
+                  onChargeDeleted={onExtendedChargeDeleted}
+                />
               </Collapse>
             </Box>
           )}

--- a/packages/client/src/components/charges/charges-row.tsx
+++ b/packages/client/src/components/charges/charges-row.tsx
@@ -96,6 +96,7 @@ export const ChargeRow = ({ row, updateCharge, removeCharge }: Props): ReactElem
                 <ChargeExtendedInfo
                   chargeID={row.original.id}
                   onChange={fetchCharge}
+                  onChargeDeleted={removeCharge}
                   fetching={fetching}
                 />
               </Card>

--- a/packages/client/src/components/common/buttons/delete-document-button.tsx
+++ b/packages/client/src/components/common/buttons/delete-document-button.tsx
@@ -7,15 +7,39 @@ import { ConfirmationModal } from '../index.js';
 interface Props {
   documentId: string;
   onChange: () => void;
+  onDone?: () => void;
+  /**
+   * Called when deleting the document left its charge empty, so the server deleted the charge too.
+   * The consumer should drop the charge instead of refetching it — `Query.charge` throws for a
+   * deleted id, which would leave a stale "shadow charge" on screen.
+   */
+  onChargeDeleted?: (chargeId: string) => void;
 }
 
-export function DeleteDocumentButton({ documentId, onChange }: Props): ReactElement {
+export function DeleteDocumentButton({
+  documentId,
+  onChange,
+  onDone,
+  onChargeDeleted,
+}: Props): ReactElement {
   const { deleteDocument } = useDeleteDocument();
 
   function onDelete(): void {
     deleteDocument({
       documentId,
-    }).then(onChange);
+    }).then(result => {
+      if (!result) {
+        // failed: the hook already reported it, keep the modal open
+        return;
+      }
+      if (result.deletedChargeId && onChargeDeleted) {
+        onChargeDeleted(result.deletedChargeId);
+      } else {
+        // no charge was deleted, or the consumer refreshes from a list that isn't charge-scoped
+        onChange();
+      }
+      onDone?.();
+    });
   }
 
   return (

--- a/packages/client/src/components/common/buttons/unlink-document-button.tsx
+++ b/packages/client/src/components/common/buttons/unlink-document-button.tsx
@@ -8,16 +8,40 @@ import { ConfirmationModal } from '../index.js';
 interface Props {
   documentId: string;
   onChange: () => void;
+  onDone?: () => void;
+  /**
+   * Called when unlinking left the former charge empty, so the server deleted it. The consumer
+   * should drop that charge instead of refetching it — `Query.charge` throws for a deleted id,
+   * which would leave a stale "shadow charge" on screen.
+   */
+  onChargeDeleted?: (chargeId: string) => void;
 }
 
-export function UnlinkDocumentButton({ documentId, onChange }: Props): ReactElement {
+export function UnlinkDocumentButton({
+  documentId,
+  onChange,
+  onDone,
+  onChargeDeleted,
+}: Props): ReactElement {
   const { updateDocument } = useUpdateDocument();
 
   function onUnlink(): void {
     updateDocument({
       documentId,
       fields: { chargeId: EMPTY_UUID },
-    }).then(onChange);
+    }).then(result => {
+      if (!result) {
+        // failed: the hook already reported it, keep the modal open
+        return;
+      }
+      if (result.deletedChargeId && onChargeDeleted) {
+        onChargeDeleted(result.deletedChargeId);
+      } else {
+        // no charge was deleted, or the consumer refreshes from a list that isn't charge-scoped
+        onChange();
+      }
+      onDone?.();
+    });
   }
 
   return (

--- a/packages/client/src/components/common/modals/edit-document-modal.tsx
+++ b/packages/client/src/components/common/modals/edit-document-modal.tsx
@@ -12,9 +12,16 @@ interface Props {
   documentId?: string;
   onDone: () => void;
   onChange: () => void;
+  /** Called when removing the document emptied its charge and the server deleted the charge too. */
+  onChargeDeleted?: (chargeId: string) => void;
 }
 
-export const EditDocumentModal = ({ onDone, onChange, documentId }: Props): ReactElement | null => {
+export const EditDocumentModal = ({
+  onDone,
+  onChange,
+  onChargeDeleted,
+  documentId,
+}: Props): ReactElement | null => {
   if (!documentId) return null;
   return (
     <PopUpDrawer
@@ -30,8 +37,18 @@ export const EditDocumentModal = ({ onDone, onChange, documentId }: Props): Reac
             <Tooltip content="Copy ID">
               <CopyToClipboardButton content={documentId} />
             </Tooltip>
-            <UnlinkDocumentButton documentId={documentId} onChange={onChange} />
-            <DeleteDocumentButton documentId={documentId} onChange={onChange} />
+            <UnlinkDocumentButton
+              documentId={documentId}
+              onChange={onChange}
+              onDone={onDone}
+              onChargeDeleted={onChargeDeleted}
+            />
+            <DeleteDocumentButton
+              documentId={documentId}
+              onChange={onChange}
+              onDone={onDone}
+              onChargeDeleted={onChargeDeleted}
+            />
           </div>
         </div>
       }

--- a/packages/client/src/components/documents-table/documents-gallery.tsx
+++ b/packages/client/src/components/documents-table/documents-gallery.tsx
@@ -22,9 +22,15 @@ import { EditDocumentModal } from '../common/index.js';
 type Props = {
   chargeProps: FragmentType<typeof DocumentsGalleryFieldsFragmentDoc>;
   onChange: () => void;
+  /** Called when removing a document emptied the charge and the server deleted the charge too. */
+  onChargeDeleted?: (chargeId: string) => void;
 };
 
-export const DocumentsGallery = ({ chargeProps, onChange }: Props): ReactElement => {
+export const DocumentsGallery = ({
+  chargeProps,
+  onChange,
+  onChargeDeleted,
+}: Props): ReactElement => {
   const { additionalDocuments } = getFragmentData(DocumentsGalleryFieldsFragmentDoc, chargeProps);
   const [openModal, setOpenModal] = useState<string | undefined>(undefined);
 
@@ -62,6 +68,7 @@ export const DocumentsGallery = ({ chargeProps, onChange }: Props): ReactElement
             documentId={openModal}
             onDone={(): void => setOpenModal(undefined)}
             onChange={onChange}
+            onChargeDeleted={onChargeDeleted}
           />
         </>
       ) : (

--- a/packages/client/src/components/documents-table/index.tsx
+++ b/packages/client/src/components/documents-table/index.tsx
@@ -19,12 +19,15 @@ import { columns, type DocumentsTableRowType } from './columns.js';
 type Props = {
   documentsProps: FragmentType<typeof TableDocumentsRowFieldsFragmentDoc>[];
   onChange?: () => void;
+  /** Called when removing a document emptied its charge and the server deleted the charge too. */
+  onChargeDeleted?: (chargeId: string) => void;
   limited?: boolean;
 };
 
 export const DocumentsTable = ({
   documentsProps,
   onChange,
+  onChargeDeleted,
   limited = false,
 }: Props): ReactElement => {
   const [editDocumentId, setEditDocumentId] = useState<string | undefined>(undefined);
@@ -134,6 +137,7 @@ export const DocumentsTable = ({
         documentId={editDocumentId}
         onDone={(): void => setEditDocumentId(undefined)}
         onChange={() => onChange?.()}
+        onChargeDeleted={onChargeDeleted}
       />
     </>
   );

--- a/packages/client/src/hooks/use-delete-document.ts
+++ b/packages/client/src/hooks/use-delete-document.ts
@@ -1,19 +1,31 @@
 import { useCallback } from 'react';
 import { toast } from 'sonner';
 import { useMutation } from 'urql';
-import { DeleteDocumentDocument, type DeleteDocumentMutationVariables } from '../gql/graphql.js';
+import {
+  DeleteDocumentDocument,
+  type DeleteDocumentMutation,
+  type DeleteDocumentMutationVariables,
+} from '../gql/graphql.js';
 import { handleCommonErrors } from '../helpers/error-handling.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
   mutation DeleteDocument($documentId: UUID!) {
-    deleteDocument(documentId: $documentId)
+    deleteDocument(documentId: $documentId) {
+      success
+      chargeId
+      deletedChargeId
+    }
   }
 `;
 
+type DeleteDocumentResult = DeleteDocumentMutation['deleteDocument'];
+
 type UseDeleteDocument = {
   fetching: boolean;
-  deleteDocument: (variables: DeleteDocumentMutationVariables) => Promise<boolean>;
+  deleteDocument: (
+    variables: DeleteDocumentMutationVariables,
+  ) => Promise<DeleteDocumentResult | void>;
 };
 
 const NOTIFICATION_ID = 'deleteDocument';
@@ -34,9 +46,14 @@ export const useDeleteDocument = (): UseDeleteDocument => {
         const res = await mutate(variables);
         const data = handleCommonErrors(res, message, notificationId);
         if (data) {
+          if (data.deleteDocument.success === false) {
+            throw new Error('Unsuccessful deletion');
+          }
           toast.success('Success', {
             id: notificationId,
-            description: 'Document was deleted',
+            description: data.deleteDocument.deletedChargeId
+              ? 'Document was deleted, along with its now-empty charge'
+              : 'Document was deleted',
           });
           return data.deleteDocument;
         }
@@ -49,7 +66,7 @@ export const useDeleteDocument = (): UseDeleteDocument => {
           closeButton: true,
         });
       }
-      return false;
+      return void 0;
     },
     [mutate],
   );

--- a/packages/client/src/hooks/use-update-document.ts
+++ b/packages/client/src/hooks/use-update-document.ts
@@ -20,6 +20,7 @@ import { handleCommonErrors } from '../helpers/error-handling.js';
         document {
           id
         }
+        deletedChargeId
       }
     }
   }

--- a/packages/server/src/modules/documents/resolvers/__tests__/update-document-unlink.test.ts
+++ b/packages/server/src/modules/documents/resolvers/__tests__/update-document-unlink.test.ts
@@ -1,0 +1,107 @@
+import type { Injector } from 'graphql-modules';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EMPTY_UUID } from '../../../../shared/constants.js';
+import { degradeChargesAccountantApproval } from '../../../accountant-approval/helpers/degrade-charges.helper.js';
+import { deleteCharges } from '../../../charges/helpers/delete-charges.helper.js';
+import { ChargesProvider } from '../../../charges/providers/charges.provider.js';
+import { TransactionsProvider } from '../../../transactions/providers/transactions.provider.js';
+import { DocumentsProvider } from '../../providers/documents.provider.js';
+import { documentsResolvers } from '../documents.resolver.js';
+
+/**
+ * `updateDocument` unlink path (`fields.chargeId === EMPTY_UUID`).
+ *
+ * Unlinking a charge's only document leaves that charge empty, so the resolver moves the document
+ * to a freshly generated charge and deletes the former one — reporting it back as
+ * `deletedChargeId` so the client drops the row instead of refetching a charge that no longer
+ * exists. The deletion is deferred through a mutable `postUpdateActions` closure, which once ended
+ * by calling itself: the tail call read the variable it had just been assigned to, so the mutation
+ * never resolved and re-ran `deleteCharges` forever (the helper is idempotent, so nothing ever
+ * threw to break the loop). The call-count assertion is what pins that down.
+ */
+
+// The resolver module pulls in the Green Invoice client, whose generated mesh artifacts only exist
+// after `yarn build:tools`. Nothing on the unlink path touches it, so stub the provider token out
+// rather than making this unit test depend on a build step.
+vi.mock('../../../app-providers/green-invoice-client.js', () => ({
+  GreenInvoiceClientProvider: class GreenInvoiceClientProvider {},
+}));
+
+vi.mock('../../../charges/helpers/delete-charges.helper.js', () => ({
+  deleteCharges: vi.fn(),
+}));
+
+vi.mock('../../../accountant-approval/helpers/degrade-charges.helper.js', () => ({
+  degradeChargesAccountantApproval: vi.fn(),
+}));
+
+const DOCUMENT_ID = 'dd000000-0000-4000-8000-000000000001';
+const FORMER_CHARGE_ID = 'cc000000-0000-4000-8000-000000000001';
+const NEW_CHARGE_ID = 'cc000000-0000-4000-8000-000000000002';
+const OWNER_ID = 'bb000000-0000-4000-8000-000000000001';
+
+function contextWithSoleDocument({ transactions = [] }: { transactions?: unknown[] } = {}) {
+  const document = { id: DOCUMENT_ID, charge_id: FORMER_CHARGE_ID };
+  const updateDocument = vi.fn().mockResolvedValue([document]);
+  const generateCharge = vi.fn().mockResolvedValue({ id: NEW_CHARGE_ID, owner_id: OWNER_ID });
+
+  const injector = {
+    get: (token: unknown) => {
+      if (token === DocumentsProvider) {
+        return {
+          getDocumentsByIdLoader: { load: vi.fn().mockResolvedValue(document) },
+          getDocumentsByChargeIdLoader: { load: vi.fn().mockResolvedValue([document]) },
+          updateDocument,
+        };
+      }
+      if (token === ChargesProvider) {
+        return {
+          getChargeByIdLoader: {
+            load: vi.fn().mockResolvedValue({ id: FORMER_CHARGE_ID, owner_id: OWNER_ID }),
+          },
+          generateCharge,
+        };
+      }
+      if (token === TransactionsProvider) {
+        return { transactionsByChargeIDLoader: { load: vi.fn().mockResolvedValue(transactions) } };
+      }
+      throw new Error('unexpected provider requested');
+    },
+  } as unknown as Injector;
+
+  return { context: { injector } as never, updateDocument, generateCharge };
+}
+
+function unlinkDocument(context: unknown): Promise<unknown> {
+  const resolver = documentsResolvers.Mutation!.updateDocument!;
+  const resolve = typeof resolver === 'function' ? resolver : resolver.resolve;
+  return (
+    resolve as (parent: unknown, args: unknown, context: unknown, info: unknown) => Promise<unknown>
+  )({}, { documentId: DOCUMENT_ID, fields: { chargeId: EMPTY_UUID } }, context, {});
+}
+
+describe('Mutation.updateDocument — unlinking the charge’s last document', () => {
+  beforeEach(() => {
+    vi.mocked(deleteCharges).mockReset().mockResolvedValue(undefined);
+    vi.mocked(degradeChargesAccountantApproval).mockReset().mockResolvedValue(new Map());
+  });
+
+  it('deletes the emptied former charge exactly once and reports it back', async () => {
+    const { context } = contextWithSoleDocument();
+
+    const result = await unlinkDocument(context);
+
+    expect(deleteCharges).toHaveBeenCalledTimes(1);
+    expect(deleteCharges).toHaveBeenCalledWith([FORMER_CHARGE_ID], expect.anything());
+    expect(result).toMatchObject({ deletedChargeId: FORMER_CHARGE_ID });
+  }, 5000);
+
+  it('keeps a charge that still holds a transaction', async () => {
+    const { context } = contextWithSoleDocument({ transactions: [{ id: 'tx1' }] });
+
+    const result = await unlinkDocument(context);
+
+    expect(deleteCharges).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ deletedChargeId: null });
+  }, 5000);
+});

--- a/packages/server/src/modules/documents/resolvers/documents.resolver.ts
+++ b/packages/server/src/modules/documents/resolvers/documents.resolver.ts
@@ -275,7 +275,6 @@ export const documentsResolvers: DocumentsModule.Resolvers &
                     `Failed to delete the empty former charge ID="${charge.id}"`,
                   );
                 }
-                return postUpdateActions();
               };
             }
           }

--- a/packages/server/src/modules/documents/resolvers/documents.resolver.ts
+++ b/packages/server/src/modules/documents/resolvers/documents.resolver.ts
@@ -214,6 +214,9 @@ export const documentsResolvers: DocumentsModule.Resolvers &
     },
     updateDocument: async (_, { fields, documentId }, { injector }) => {
       let postUpdateActions = async (): Promise<void> => void 0;
+      // set when the former charge is emptied by this update and therefore deleted, so the
+      // client can drop its row instead of refetching a charge that no longer exists
+      let deletedChargeId: string | null = null;
 
       try {
         let chargeId: string | undefined = undefined;
@@ -262,6 +265,7 @@ export const documentsResolvers: DocumentsModule.Resolvers &
               postUpdateActions = async () => {
                 try {
                   await deleteCharges([charge.id], injector);
+                  deletedChargeId = charge.id;
                 } catch (e) {
                   if (e instanceof GraphQLError) {
                     throw e;
@@ -320,6 +324,7 @@ export const documentsResolvers: DocumentsModule.Resolvers &
 
         return {
           document: res[0],
+          deletedChargeId,
         };
       } catch (e) {
         if (e instanceof GraphQLError) {
@@ -342,6 +347,7 @@ export const documentsResolvers: DocumentsModule.Resolvers &
         const res = await injector.get(DocumentsProvider).deleteDocument({ documentId });
         if (res.length === 1) {
           await degradeChargesAccountantApproval(injector, [document.charge_id]);
+          let deletedChargeId: string | null = null;
           if (document.charge_id) {
             const [charge, transactions, documents] = await Promise.all([
               injector.get(ChargesProvider).getChargeByIdLoader.load(document.charge_id),
@@ -352,9 +358,14 @@ export const documentsResolvers: DocumentsModule.Resolvers &
             ]);
             if (charge && documents.length === 0 && transactions.length === 0) {
               await deleteCharges([charge.id], injector);
+              deletedChargeId = charge.id;
             }
           }
-          return true;
+          return {
+            success: true,
+            chargeId: document.charge_id ?? null,
+            deletedChargeId,
+          };
         }
         throw new GraphQLError(
           res.length === 0

--- a/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
+++ b/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
@@ -38,7 +38,7 @@ export default gql`
     updateDocument(documentId: UUID!, fields: UpdateDocumentFieldsInput!): UpdateDocumentResult!
       @requiresAuth
       @requiresAnyRole(roles: ["business_owner", "accountant"])
-    deleteDocument(documentId: UUID!): Boolean!
+    deleteDocument(documentId: UUID!): DeleteDocumentResult!
       @requiresAuth
       @requiresAnyRole(roles: ["business_owner", "accountant"])
     uploadDocument(file: FileScalar!, chargeId: UUID): UploadDocumentResult!
@@ -327,6 +327,17 @@ export default gql`
   " result type for updateDocument" # eslint-disable-next-line @graphql-eslint/strict-id-in-types -- no current solution for this
   type UpdateDocumentSuccessfulResult {
     document: Document
+    " set when the document's former charge became empty by the update and was deleted "
+    deletedChargeId: UUID
+  }
+
+  " result type for deleteDocument" # eslint-disable-next-line @graphql-eslint/strict-id-in-types -- no current solution for this
+  type DeleteDocumentResult {
+    success: Boolean!
+    " the charge the deleted document belonged to, if any "
+    chargeId: UUID
+    " set when that charge became empty and was deleted along with the document "
+    deletedChargeId: UUID
   }
 
   " input variables for insertDocument "


### PR DESCRIPTION
## Problem

When a user deletes a document from the charge expansion, `deleteDocument` checks whether the parent charge is now empty (no documents, no transactions) and, if so, deletes the charge. The client was never told: the mutation returned a bare `Boolean!`, so the UI just refetched — and `Query.charge` **throws** for a deleted id, so the refetch produced no data and `ChargeRow`'s update effect never fired. The table kept rendering the stale row: a "shadow charge" for an entity that no longer exists. The edit-document drawer also stayed open on a deleted document id.

The unlink path (`updateDocument` with `chargeId: EMPTY_UUID`) deletes the emptied former charge too and had the identical bug.

Note there is no urql cache exchange in this app, so `additionalTypenames`-style invalidation isn't available — refresh is manual callback propagation, and the fix has to be an explicit signal.

## Server

- `deleteDocument(documentId: UUID!)` now returns `DeleteDocumentResult!` instead of `Boolean!`:
  ```graphql
  type DeleteDocumentResult {
    success: Boolean!
    chargeId: UUID          # the charge the deleted document belonged to
    deletedChargeId: UUID   # set when that charge became empty and was deleted too
  }
  ```
  Errors keep throwing `GraphQLError`, as before — no `CommonError` union, matching the existing `deleteDocument` / `deleteCharge` convention.
- `UpdateDocumentSuccessfulResult` gains `deletedChargeId: UUID`, set when the unlink emptied and deleted the former charge.

The emptiness checks themselves are unchanged; the resolvers only record what they already did. The duplicated "is this charge empty" logic is intentionally left alone — the documents/transactions resolvers count documents+transactions while `isChargeEmpty` in the charges module also counts ledger records and misc expenses, so unifying them would change behavior.

## Client

The signal is threaded down the existing callback chain, with every new prop optional so the other hosts (all-documents screen, charge-matches row extension, recent-business-docs, VAT report tables) keep their current refetch behavior:

- `use-delete-document` selects the new fields and returns the result object; a falsy `success` is now an error toast instead of a success toast.
- `use-update-document` selects `deletedChargeId`.
- `DeleteDocumentButton` / `UnlinkDocumentButton` branch on `deletedChargeId`: call `onChargeDeleted(id)` when a handler is supplied, otherwise fall back to the plain `onChange` refetch — and close the drawer via `onDone` on success.
- `EditDocumentModal`, `DocumentsTable` and `DocumentsGallery` forward `onChargeDeleted`.
- `ChargeExtendedInfo` adds `onChargeDeleted` and an `onExtendedChargeDeleted` callback that never refetches the deleted charge (falling back to `batch.refetch()` in expand-all mode when no handler is given).
- `ChargeRow` passes the charges table's existing `removeCharge` — the same path the delete-charge action already uses.

## Verification

- `yarn generate:graphql` regenerates cleanly; `yarn workspace @accounter/client build` (runs `tsc`) passes.
- `yarn lint` — 0 errors; `yarn prettier:check` clean for the touched files.
- `yarn test` — 3209 passed. The one failing suite (`packages/migrations/src/__tests__/rls-all-tables.test.ts`) needs DB env vars unavailable in this container and is unrelated.
- SQL codegen and the server typecheck could not run here (no Docker/Postgres, so pgtyped output is missing and the server tree has ~1100 pre-existing missing-module errors). Worth a local `yarn generate && yarn build` before merge.

Manual checks worth running: charge with one document and no transactions → delete → row disappears, no `Charge ID="…" not found`; charge with two documents → delete one → row stays; same via unlink; same in expand-all mode; and the All Documents screen unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Te5VzuQ9zmjYzSmsCApvqW)_