### PR TITLE
Fix infinite render loop in pagination footer effects

### DIFF
--- a/.changeset/table-screens-filters-footer-render-loop.md
+++ b/.changeset/table-screens-filters-footer-render-loop.md
@@ -1,0 +1,17 @@
+---
+'@accounter/client': patch
+---
+
+Fix the crash ("Minified React error #185 — Maximum update depth exceeded") that made the tax
+categories and sort codes screens unusable, and that the yearly ledger and all documents screens were
+one step away from hitting.
+
+Every screen that publishes a pagination bar into `FiltersContext` listed the `useTable` handle — and,
+on the tax categories and sort codes screens, `table.getPageOptions()` — in its footer effect's
+dependency array. TanStack Table v9's `useTable` memoizes on the options object literal passed at the
+call site, so it hands back a fresh object on every render, and `getPageOptions()` allocates a fresh
+array on every call. The effect therefore re-ran on every render, and because `setFiltersContext` is
+state owned by the dashboard layout, each run re-rendered the screen — an unbreakable loop.
+
+Those effects now depend on the pagination primitives the bar actually renders from (page index, page
+size, page count) rather than on the per-render handles.

--- a/packages/client/src/components/reports/yearly-ledger/index.tsx
+++ b/packages/client/src/components/reports/yearly-ledger/index.tsx
@@ -189,7 +189,12 @@ export const YearlyLedgerReport = (): ReactElement => {
     },
   });
 
-  const currentPage = table.state.pagination.pageIndex;
+  // `useTable` hands back a fresh object on every render, so it must not be an effect dependency:
+  // the effect would re-run on every render, and setting the filters context re-renders this
+  // screen, looping forever ("Maximum update depth exceeded"). Depend instead on the pagination
+  // primitives the bar actually reads.
+  const { pageIndex, pageSize } = table.state.pagination;
+  const pageCount = table.getPageCount();
 
   useEffect(() => {
     setFiltersContext(
@@ -209,7 +214,7 @@ export const YearlyLedgerReport = (): ReactElement => {
         </div>
       </div>,
     );
-  }, [year, fetching, setFiltersContext, reportData, table, currentPage]);
+  }, [year, fetching, setFiltersContext, reportData, pageIndex, pageSize, pageCount]);
 
   return (
     <PageLayout title="Yearly Ledger Report">

--- a/packages/client/src/components/screens/documents/all-documents/index.tsx
+++ b/packages/client/src/components/screens/documents/all-documents/index.tsx
@@ -321,7 +321,12 @@ export const DocumentsReport = (): ReactElement => {
     },
   });
 
-  const currentPage = table.state.pagination.pageIndex;
+  // `useTable` hands back a fresh object on every render, so it must not be an effect dependency:
+  // the effect would re-run on every render, and setting the filters context re-renders this
+  // screen, looping forever ("Maximum update depth exceeded"). Depend instead on the pagination
+  // primitives the bar actually reads.
+  const { pageIndex, pageSize } = table.state.pagination;
+  const pageCount = table.getPageCount();
 
   useEffect(() => {
     setFiltersContext(
@@ -330,7 +335,7 @@ export const DocumentsReport = (): ReactElement => {
         <DocumentsFilters filter={filter} setFilter={setFilter} initiallyOpened={!filter} />
       </div>,
     );
-  }, [table, fetching, filter, setFiltersContext, setFilter, initialFilters, currentPage]);
+  }, [fetching, filter, setFiltersContext, setFilter, pageIndex, pageSize, pageCount]);
 
   return (
     <PageLayout

--- a/packages/client/src/components/screens/sort-codes/__tests__/index.test.tsx
+++ b/packages/client/src/components/screens/sort-codes/__tests__/index.test.tsx
@@ -3,7 +3,7 @@
 import { useState, type ReactElement } from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import { FiltersContext } from '../../../../providers/filters-context.js';
 import { SortCodes } from '../index.js';
 
@@ -62,6 +62,7 @@ function Harness(): ReactElement {
 describe('SortCodes screen', () => {
   let container: HTMLDivElement;
   let root: Root;
+  let consoleError: MockInstance<typeof console.error>;
 
   beforeEach(() => {
     renderCount = 0;
@@ -70,6 +71,9 @@ describe('SortCodes screen', () => {
       { data: { allSortCodes }, fetching: false, error: undefined },
       refetchMock,
     ]);
+    // Set up (and tear down) in the hooks so a failing assertion cannot leak the
+    // spy into later tests.
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     container = document.createElement('div');
     document.body.append(container);
     root = createRoot(container);
@@ -78,6 +82,7 @@ describe('SortCodes screen', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    consoleError.mockRestore();
   });
 
   // Regression: the footer effect used to depend on the `useTable` handle and on
@@ -85,8 +90,6 @@ describe('SortCodes screen', () => {
   // effect re-ran forever against the parent's `setFiltersContext` state, and
   // React bailed out with "Maximum update depth exceeded" (minified error #185).
   it('renders without exceeding the maximum update depth', () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-
     expect(() => {
       act(() => root.render(<Harness />));
     }).not.toThrow();
@@ -95,7 +98,6 @@ describe('SortCodes screen', () => {
       call.some(arg => String(arg).includes('Maximum update depth exceeded')),
     );
     expect(loopErrors).toHaveLength(0);
-    consoleError.mockRestore();
 
     expect(renderCount).toBeLessThan(MAX_RENDERS);
     expect(container.textContent).toContain('Sort Codes (120)');

--- a/packages/client/src/components/screens/sort-codes/__tests__/index.test.tsx
+++ b/packages/client/src/components/screens/sort-codes/__tests__/index.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+
+import { useState, type ReactElement } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FiltersContext } from '../../../../providers/filters-context.js';
+import { SortCodes } from '../index.js';
+
+const { useQueryMock, refetchMock } = vi.hoisted(() => ({
+  useQueryMock: vi.fn(),
+  refetchMock: vi.fn(),
+}));
+
+vi.mock('urql', () => ({
+  useQuery: useQueryMock,
+}));
+
+vi.mock('../../../common/index.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../../common/data-table-pagination.js')>(
+      '../../../common/data-table-pagination.js',
+    );
+  return {
+    // Keep the real pagination bar: it is what the screen pushes into the
+    // filters context, and the render loop went through it.
+    DataTablePagination: actual.DataTablePagination,
+    EditSortCode: () => null,
+    InsertSortCode: () => null,
+  };
+});
+
+const allSortCodes = Array.from({ length: 120 }, (_, index) => ({
+  id: `sort-code-${index}`,
+  ownerId: 'owner-1',
+  key: index,
+  name: `Sort Code ${index}`,
+  defaultIrsCode: null,
+}));
+
+/** A render loop never settles, so it would hang the runner instead of failing.
+ * Bail out well above the handful of renders a healthy mount needs. */
+const MAX_RENDERS = 50;
+let renderCount = 0;
+
+/** Mirrors DashboardLayoutRoute: the filters context is parent state, so every
+ * `setFiltersContext` call re-renders the screen below it. */
+function Harness(): ReactElement {
+  renderCount += 1;
+  if (renderCount > MAX_RENDERS) {
+    throw new Error(`Render loop detected: the screen re-rendered more than ${MAX_RENDERS} times`);
+  }
+  const [filtersContext, setFiltersContext] = useState<ReactElement | null>(null);
+  return (
+    <FiltersContext.Provider value={{ filtersContext, setFiltersContext }}>
+      {filtersContext}
+      <SortCodes />
+    </FiltersContext.Provider>
+  );
+}
+
+describe('SortCodes screen', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    renderCount = 0;
+    useQueryMock.mockReset();
+    useQueryMock.mockReturnValue([
+      { data: { allSortCodes }, fetching: false, error: undefined },
+      refetchMock,
+    ]);
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  // Regression: the footer effect used to depend on the `useTable` handle and on
+  // `table.getPageOptions()`. Both are freshly allocated on every render, so the
+  // effect re-ran forever against the parent's `setFiltersContext` state, and
+  // React bailed out with "Maximum update depth exceeded" (minified error #185).
+  it('renders without exceeding the maximum update depth', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      act(() => root.render(<Harness />));
+    }).not.toThrow();
+
+    const loopErrors = consoleError.mock.calls.filter(call =>
+      call.some(arg => String(arg).includes('Maximum update depth exceeded')),
+    );
+    expect(loopErrors).toHaveLength(0);
+    consoleError.mockRestore();
+
+    expect(renderCount).toBeLessThan(MAX_RENDERS);
+    expect(container.textContent).toContain('Sort Codes (120)');
+  });
+
+  it('publishes the pagination bar into the filters context', () => {
+    act(() => root.render(<Harness />));
+
+    // 120 rows at a page size of 100 => 2 pages, rendered by DataTablePagination.
+    expect(container.textContent).toContain('Page 1 of 2');
+  });
+});

--- a/packages/client/src/components/screens/sort-codes/index.tsx
+++ b/packages/client/src/components/screens/sort-codes/index.tsx
@@ -117,7 +117,12 @@ export const SortCodes = (): ReactElement => {
     },
   });
 
-  const pagination = table.getPageOptions();
+  // `useTable` hands back a fresh object on every render and `getPageOptions()` a fresh array, so
+  // neither can be an effect dependency: the effect would re-run on every render, and setting the
+  // filters context re-renders this screen, looping forever ("Maximum update depth exceeded").
+  // The pagination bar only reads these primitives, so depend on them instead.
+  const { pageIndex, pageSize } = table.state.pagination;
+  const pageCount = table.getPageCount();
 
   useEffect(() => {
     setFiltersContext(
@@ -125,7 +130,7 @@ export const SortCodes = (): ReactElement => {
         <DataTablePagination table={table} />
       </div>,
     );
-  }, [setFiltersContext, table, pagination]);
+  }, [setFiltersContext, pageIndex, pageSize, pageCount]);
 
   useEffect(() => {
     if (error) {

--- a/packages/client/src/components/tax-categories/__tests__/index.test.tsx
+++ b/packages/client/src/components/tax-categories/__tests__/index.test.tsx
@@ -3,7 +3,7 @@
 import { useState, type ReactElement } from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import { FiltersContext } from '../../../providers/filters-context.js';
 import { TaxCategories } from '../index.js';
 
@@ -63,6 +63,7 @@ function Harness(): ReactElement {
 describe('TaxCategories screen', () => {
   let container: HTMLDivElement;
   let root: Root;
+  let consoleError: MockInstance<typeof console.error>;
 
   beforeEach(() => {
     renderCount = 0;
@@ -71,6 +72,9 @@ describe('TaxCategories screen', () => {
       { data: { taxCategories }, fetching: false, error: undefined },
       refetchMock,
     ]);
+    // Set up (and tear down) in the hooks so a failing assertion cannot leak the
+    // spy into later tests.
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     container = document.createElement('div');
     document.body.append(container);
     root = createRoot(container);
@@ -79,6 +83,7 @@ describe('TaxCategories screen', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    consoleError.mockRestore();
   });
 
   // Regression: the footer effect used to depend on the `useTable` handle and on
@@ -86,8 +91,6 @@ describe('TaxCategories screen', () => {
   // effect re-ran forever against the parent's `setFiltersContext` state, and
   // React bailed out with "Maximum update depth exceeded" (minified error #185).
   it('renders without exceeding the maximum update depth', () => {
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-
     expect(() => {
       act(() => root.render(<Harness />));
     }).not.toThrow();
@@ -96,7 +99,6 @@ describe('TaxCategories screen', () => {
       call.some(arg => String(arg).includes('Maximum update depth exceeded')),
     );
     expect(loopErrors).toHaveLength(0);
-    consoleError.mockRestore();
 
     expect(renderCount).toBeLessThan(MAX_RENDERS);
     expect(container.textContent).toContain('Tax Categories (45)');

--- a/packages/client/src/components/tax-categories/__tests__/index.test.tsx
+++ b/packages/client/src/components/tax-categories/__tests__/index.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+
+import { useState, type ReactElement } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FiltersContext } from '../../../providers/filters-context.js';
+import { TaxCategories } from '../index.js';
+
+const { useQueryMock, refetchMock } = vi.hoisted(() => ({
+  useQueryMock: vi.fn(),
+  refetchMock: vi.fn(),
+}));
+
+vi.mock('urql', () => ({
+  useQuery: useQueryMock,
+}));
+
+vi.mock('../../common/modals/edit-tax-category.js', () => ({
+  EditTaxCategory: () => null,
+}));
+
+vi.mock('../../common/index.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../common/data-table-pagination.js')>(
+      '../../common/data-table-pagination.js',
+    );
+  return {
+    // Keep the real pagination bar: it is what the screen pushes into the
+    // filters context, and the render loop went through it.
+    DataTablePagination: actual.DataTablePagination,
+    InsertTaxCategory: () => null,
+  };
+});
+
+const taxCategories = Array.from({ length: 45 }, (_, index) => ({
+  id: `tax-category-${index}`,
+  name: `Tax Category ${index}`,
+  sortCode: { id: index, key: index, name: `Sort Code ${index}` },
+}));
+
+/** A render loop never settles, so it would hang the runner instead of failing.
+ * Bail out well above the handful of renders a healthy mount needs. */
+const MAX_RENDERS = 50;
+let renderCount = 0;
+
+/** Mirrors DashboardLayoutRoute: the filters context is parent state, so every
+ * `setFiltersContext` call re-renders the screen below it. */
+function Harness(): ReactElement {
+  renderCount += 1;
+  if (renderCount > MAX_RENDERS) {
+    throw new Error(`Render loop detected: the screen re-rendered more than ${MAX_RENDERS} times`);
+  }
+  const [filtersContext, setFiltersContext] = useState<ReactElement | null>(null);
+  return (
+    <FiltersContext.Provider value={{ filtersContext, setFiltersContext }}>
+      {filtersContext}
+      <TaxCategories />
+    </FiltersContext.Provider>
+  );
+}
+
+describe('TaxCategories screen', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    renderCount = 0;
+    useQueryMock.mockReset();
+    useQueryMock.mockReturnValue([
+      { data: { taxCategories }, fetching: false, error: undefined },
+      refetchMock,
+    ]);
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  // Regression: the footer effect used to depend on the `useTable` handle and on
+  // `table.getPageOptions()`. Both are freshly allocated on every render, so the
+  // effect re-ran forever against the parent's `setFiltersContext` state, and
+  // React bailed out with "Maximum update depth exceeded" (minified error #185).
+  it('renders without exceeding the maximum update depth', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      act(() => root.render(<Harness />));
+    }).not.toThrow();
+
+    const loopErrors = consoleError.mock.calls.filter(call =>
+      call.some(arg => String(arg).includes('Maximum update depth exceeded')),
+    );
+    expect(loopErrors).toHaveLength(0);
+    consoleError.mockRestore();
+
+    expect(renderCount).toBeLessThan(MAX_RENDERS);
+    expect(container.textContent).toContain('Tax Categories (45)');
+  });
+
+  it('publishes the pagination bar into the filters context', () => {
+    act(() => root.render(<Harness />));
+
+    // 45 rows at a page size of 30 => 2 pages, rendered by DataTablePagination.
+    expect(container.textContent).toContain('Page 1 of 2');
+  });
+});

--- a/packages/client/src/components/tax-categories/index.tsx
+++ b/packages/client/src/components/tax-categories/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, type ReactElement } from 'react';
+import { useContext, useEffect, useMemo, type ReactElement } from 'react';
 import { ArrowUpDown, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useQuery } from 'urql';
@@ -79,7 +79,7 @@ export const TaxCategories = (): ReactElement => {
   });
   const { setFiltersContext } = useContext(FiltersContext);
 
-  const taxCategories = data?.taxCategories ?? [];
+  const taxCategories = useMemo(() => data?.taxCategories ?? [], [data?.taxCategories]);
 
   const table = useTable({
     features: tableFeaturesConfig,
@@ -93,7 +93,12 @@ export const TaxCategories = (): ReactElement => {
     },
   });
 
-  const pagination = table.getPageOptions();
+  // `useTable` hands back a fresh object on every render and `getPageOptions()` a fresh array, so
+  // neither can be an effect dependency: the effect would re-run on every render, and setting the
+  // filters context re-renders this screen, looping forever ("Maximum update depth exceeded").
+  // The pagination bar only reads these primitives, so depend on them instead.
+  const { pageIndex, pageSize } = table.state.pagination;
+  const pageCount = table.getPageCount();
 
   useEffect(() => {
     setFiltersContext(
@@ -103,7 +108,7 @@ export const TaxCategories = (): ReactElement => {
         </div>
       </div>,
     );
-  }, [setFiltersContext, table, pagination]);
+  }, [setFiltersContext, pageIndex, pageSize, pageCount]);
 
   useEffect(() => {
     if (error) {


### PR DESCRIPTION
## Summary

Fix a regression where table screens with pagination footers were entering infinite render loops due to effect dependencies on freshly-allocated objects. The issue manifested as "Maximum update depth exceeded" errors when the footer effect tried to update the filters context.

## Changes

- **TaxCategories screen**: Replace `table` and `pagination` effect dependencies with primitive values (`pageIndex`, `pageSize`, `pageCount`) that the pagination bar actually reads. Also memoize `taxCategories` data to prevent unnecessary re-renders.

- **SortCodes screen**: Replace `table` and `pagination` effect dependencies with primitive values (`pageIndex`, `pageSize`, `pageCount`).

- **YearlyLedgerReport screen**: Replace `table` and `currentPage` effect dependencies with primitive values (`pageIndex`, `pageSize`, `pageCount`).

- **DocumentsReport screen**: Replace `table` and `currentPage` effect dependencies with primitive values (`pageIndex`, `pageSize`, `pageCount`). Remove unused `initialFilters` dependency.

- **Test coverage**: Add regression tests for TaxCategories and SortCodes screens that verify:
  - No "Maximum update depth exceeded" errors occur during render
  - Render count stays well below the loop detection threshold
  - Pagination bar is correctly published to the filters context

## Implementation Details

The root cause: `useTable()` returns a fresh object on every render, and `table.getPageOptions()` returns a fresh array. When these were used as effect dependencies, the effect re-ran on every render, calling `setFiltersContext()` which re-renders the parent, creating an infinite loop.

The fix: Extract only the primitive pagination values (`pageIndex`, `pageSize`, `pageCount`) that the `DataTablePagination` component actually reads, and depend on those instead. This breaks the cycle while maintaining correct behavior.

https://claude.ai/code/session_01YTarn5ZYBwthgu2cv6D9HJ