### PR TITLE
feat(client): collapse charge row on accountant status change

### DIFF
--- a/.changeset/collapse-charge-on-status-change.md
+++ b/.changeset/collapse-charge-on-status-change.md
@@ -1,0 +1,6 @@
+---
+'@accounter/client': patch
+---
+
+Collapse a charge's expanded row when its accountant approval status is changed from the charges
+table

--- a/packages/client/src/components/charges/columns.tsx
+++ b/packages/client/src/components/charges/columns.tsx
@@ -50,6 +50,9 @@ export const columns: ColumnDef<TableFeaturesConfig, ChargeRow>[] = [
           chargeId={row.original.id}
           value={row.original.accountantApproval}
           onChange={row.original.onChange}
+          // Once the accountant status is set, the charge is handled — collapse its detail panel so
+          // the table returns to the next charge that still needs attention.
+          onStatusChange={() => row.toggleExpanded(false)}
         />
       </div>
     ),


### PR DESCRIPTION
Changing a charge's accountant approval status from the charges table now collapses that charge's expanded detail panel.

`UpdateAccountantStatus` already exposes an `onStatusChange` callback that fires only after the mutation succeeds; the charges table column now passes `() => row.toggleExpanded(false)` to it. Once a charge is marked, its panel closes and the table moves on to the next charge needing attention.

Includes a patch changeset for `@accounter/client`.

Note: `yarn lint` / `yarn prettier:check` could not run in this environment (no `node_modules` state file — dependencies aren't installed here), so CI is the first check of this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_016115QURVyUYEZdMQJ27REu)_