### PR TITLE
Add domain terminology glossary tool

### DIFF
--- a/.changeset/mcp-terminology-tool.md
+++ b/.changeset/mcp-terminology-tool.md
@@ -1,0 +1,42 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Add `accounter_explain_terminology`, a read-only glossary of Accounter's core domain vocabulary.
+
+Every other tool returns data; none explain what the data means, and the gaps are load-bearing. A
+"charge" is an aggregate grouping transactions, documents and ledger records for one economic event,
+not a bank charge. `byOwners` and `byBusinesses` ask opposite questions — owner versus counterparty —
+a distinction that has already caused a scoping bug here. `INTERNAL` and `CONVERSION` charges are
+money moving between the caller's own accounts and double-count in any spend total. Ledger slot 2 is
+the VAT split, so summing slot 1 alone drops the VAT leg. Only _business_ entities are required to
+balance; tax categories are expected to carry the residue. None of that is inferable from the schema,
+and it cannot live in per-tool `description` strings, which every caller pays for on every
+`tools/list` and which cannot carry concepts spanning tools.
+
+The tool carries 62 entries across six topics (`charge`, `transaction`, `document`, `ledger`,
+`entity`, `scope`). Called with no arguments it returns a one-line index of every term (~10 KB) so
+orientation is cheap; `terms` looks up specific ones and `topics` returns a whole area in full
+(~40 KB for everything, inside the 60 KB payload guard). Term matching folds case and separators, so
+enum tokens (`INTERNAL`), GraphQL type names (`InternalTransferCharge`) and field names
+(`effectiveDate`) all resolve, with a substring fallback. An unmatched term is reported under
+`unmatched` with suggestions rather than failing the call — a glossary that errors on an unknown word
+is useless for the case it exists for.
+
+Two properties set it apart from the other tools, both deliberate:
+
+- **Pure.** The handler never touches the upstream client, so there is no GraphQL call and no
+  `x-business-scope` to forward. The registry-wide guard in `scope-forwarding.test.ts` grows a named
+  `PURE_TOOLS` set rather than a loosened assertion, so a _data_ tool that drops scope still fails.
+- **Unscoped.** `requiresBusinessScope: false` with `dataClassification: 'public'` — static reference
+  text with no customer data, readable by a caller with zero memberships, the same reasoning that
+  applies to membership discovery.
+
+It registers second in `tools/list`, behind `accounter_list_business_memberships` and ahead of the
+data tools, so the discovery-first contract is unchanged.
+
+A glossary's failure mode is going stale silently, so the content is pinned to the package's own
+constants: `terminology-contract.test.ts` asserts that every `CHARGE_TYPES` token,
+`KNOWN_CHARGE_TYPENAMES` value and `ACCOUNTANT_STATUSES` token resolves to an entry, that every
+cross-reference names a real term and a registered tool, and that no alias is claimed by two entries.
+A charge type added upstream now fails the suite instead of quietly going undefined.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -18,7 +18,7 @@ Phase 1 (read-only) is feature-complete. The server provides: strict startup env
 transport with `/health`, `/metrics`, the OAuth protected-resource metadata endpoint, and the MCP
 route (`POST /mcp`, JSON-RPC 2.0) with graceful shutdown; Auth0 bearer-token verification; identity
 mapping to an internal user + business-membership context with memberships resolved from the
-Accounter GraphQL server; a curated registry of eleven read-only tools
+Accounter GraphQL server; a curated registry of twelve read-only tools
 (`accounter_list_business_memberships`, `accounter_search_charges`, `accounter_get_charges`,
 `accounter_get_transactions`, `accounter_get_documents`, `accounter_get_ledger_records`,
 `accounter_get_contracts`, `accounter_list_tags`, `accounter_list_tax_categories`,
@@ -90,6 +90,21 @@ scope, because it _is_ the scope.
   businesses last. Pure: memberships are already on the auth context, so it makes no upstream call.
   A caller with no memberships gets an empty list, not an error. This is the scope-discovery entry
   point; to browse the full business directory use `accounter_list_businesses`.
+- **`accounter_explain_terminology`** — the connector's **glossary**: what charges, transactions,
+  documents, ledger records, businesses and tax categories actually mean in Accounter, including the
+  distinctions that are not inferable from the schema (a charge is an aggregate, not a bank charge;
+  `byOwners` is the owner predicate while `byBusinesses` is the counterparty one; `INTERNAL` and
+  `CONVERSION` charges double-count in spend totals; ledger slot 2 is the VAT split; only _business_
+  entities are required to balance). Called with no arguments it returns a one-line index of every
+  term; `terms` looks up specific ones (matching canonical names, enum tokens, GraphQL type names
+  and field names, case- and separator-insensitive, with a substring fallback) and `topics` returns
+  a whole area in full. An unmatched term is reported under `unmatched` with suggestions rather than
+  failing the call. Like discovery it is **pure** — static content, no upstream call, no
+  `x-business-scope` — and unlike every other tool it needs **no business scope** at all
+  (`requiresBusinessScope: false`, `dataClassification: 'public'`), so a caller with zero
+  memberships can still read it. Content is pinned to the package's own enum constants by
+  `terminology-contract.test.ts`, so a charge type added upstream fails the suite instead of quietly
+  going undefined.
 - **`accounter_search_charges`** — read-only charges search/browse within the caller's authorized
   businesses. Accepts optional `memberBusinessIds` (subset of memberships) plus **every
   `ChargeFilter` predicate upstream honors**, flat: `fromDate`/`toDate` (overlap — any
@@ -429,8 +444,8 @@ The automated equivalent of steps 1–7 (with the Auth0 verifier and upstream mo
 
 Phase 1 is intentionally **read-only** and single-purpose:
 
-- Only the four read-only tools above are exposed; there is no generic "run any query" surface and
-  **no mutations/subscriptions** (the upstream client refuses them).
+- Only the read-only tools above are exposed; there is no generic "run any query" surface and **no
+  mutations/subscriptions** (the upstream client refuses them).
 - Responses are **bounded** (date ranges ≤ 366 days, page size ≤ 50, list caps of 500, a
   payload-size guard) — very large result sets are truncated with a `truncated`/`continuation` hint
   rather than streamed in full.

--- a/packages/mcp-server/src/tools/__tests__/scope-forwarding.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/scope-forwarding.test.ts
@@ -5,6 +5,7 @@ import { BUSINESS_SCOPE_HEADER, UpstreamGraphQLClient } from '../../upstream/gra
 import { LIST_BUSINESS_MEMBERSHIPS_TOOL_NAME } from '../businesses.js';
 import { executeRegisteredTool } from '../execute.js';
 import { toolRegistry } from '../registry-instance.js';
+import { EXPLAIN_TERMINOLOGY_TOOL_NAME } from '../terminology.js';
 
 /**
  * The cross-cutting guard: iterate the *production registry* rather than a
@@ -15,6 +16,20 @@ import { toolRegistry } from '../registry-instance.js';
  * headers (not the context object) means a handler that hand-builds
  * `{ correlationId, authorization }` and drops the scope fails here.
  */
+
+/**
+ * The tools that legitimately make no upstream call, and so have no scope to
+ * forward or echo. Membership discovery *is* the scope; the glossary is static
+ * reference content with no business data at all.
+ *
+ * Kept as an explicit named set rather than loosening the assertion, so a *data*
+ * tool that forgets to forward scope still fails — which is the whole point of
+ * iterating the production registry here.
+ */
+const PURE_TOOLS = new Set<string>([
+  LIST_BUSINESS_MEMBERSHIPS_TOOL_NAME,
+  EXPLAIN_TERMINOLOGY_TOOL_NAME,
+]);
 
 const B1 = 'aa000000-0000-4000-8000-000000000001';
 const B2 = 'aa000000-0000-4000-8000-000000000002';
@@ -106,8 +121,8 @@ describe('registry-wide business-scope forwarding', () => {
       expect(result.isError, `${name} should succeed`).toBeUndefined();
       const structured = result.structuredContent as Record<string, unknown>;
 
-      if (name === LIST_BUSINESS_MEMBERSHIPS_TOOL_NAME) {
-        // Discovery is pure and *is* the scope — no upstream call, no echo.
+      if (PURE_TOOLS.has(name)) {
+        // No upstream call means there is nothing to forward and nothing to echo.
         expect(headersSeen).toHaveLength(0);
         expect(structured).not.toHaveProperty('scope');
         return;

--- a/packages/mcp-server/src/tools/__tests__/terminology-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/terminology-contract.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { ACCOUNTANT_STATUSES, CHARGE_TYPES } from '../charge-filters.js';
+import { KNOWN_CHARGE_TYPENAMES } from '../entity-shapes.js';
+import { toolRegistry } from '../registry-instance.js';
+import { explainTerminologyTool } from '../terminology.js';
+import { GLOSSARY, GLOSSARY_TOPICS } from '../terminology-data.js';
+
+/**
+ * Drift guards for the glossary.
+ *
+ * A glossary's failure mode is going stale silently: upstream adds a charge type
+ * or renames an enum, the vocabulary keeps answering confidently, and the model
+ * is told something false. So the content is pinned to the constants that already
+ * exist in this package rather than to hand-copied strings — when the schema
+ * moves, `schema-contract.test.ts` fails on the filter and this one fails on the
+ * definition.
+ */
+
+/** Same folding the tool uses to resolve a spelling. */
+function fold(value: string): string {
+  return value.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, '');
+}
+
+const SPELLINGS = new Map<string, string>();
+for (const entry of GLOSSARY) {
+  for (const spelling of [entry.term, ...(entry.aliases ?? [])]) {
+    SPELLINGS.set(fold(spelling), entry.term);
+  }
+}
+
+const TERMS = new Set(GLOSSARY.map(entry => entry.term));
+
+function resolves(spelling: string): boolean {
+  return SPELLINGS.has(fold(spelling));
+}
+
+describe('glossary covers the enum vocabularies the tools advertise', () => {
+  it.each(CHARGE_TYPES)('defines charge type %s', chargeType => {
+    expect(resolves(chargeType)).toBe(true);
+  });
+
+  // A charge type added upstream fails here instead of quietly having no definition.
+  it.each(KNOWN_CHARGE_TYPENAMES)('defines charge typename %s', typename => {
+    expect(resolves(typename)).toBe(true);
+  });
+
+  it.each(ACCOUNTANT_STATUSES)('defines accountant status %s', status => {
+    expect(resolves(status)).toBe(true);
+  });
+
+  it.each(['DEBIT_ACCOUNT_1', 'DEBIT_ACCOUNT_2', 'CREDIT_ACCOUNT_1', 'CREDIT_ACCOUNT_2'])(
+    'defines ledger account slot %s',
+    slot => {
+      expect(resolves(slot)).toBe(true);
+    },
+  );
+
+  it('defines the owner/counterparty filter pair that has already caused a scoping bug', () => {
+    expect(resolves('byOwners')).toBe(true);
+    expect(resolves('byBusinesses')).toBe(true);
+    expect(resolves('memberBusinessIds')).toBe(true);
+  });
+});
+
+describe('glossary is internally consistent', () => {
+  it('has unique terms', () => {
+    expect(TERMS.size).toBe(GLOSSARY.length);
+  });
+
+  it('has no colliding spellings across entries', () => {
+    const seen = new Map<string, string>();
+    for (const entry of GLOSSARY) {
+      for (const spelling of [entry.term, ...(entry.aliases ?? [])]) {
+        const folded = fold(spelling);
+        const owner = seen.get(folded);
+        expect(
+          owner === undefined || owner === entry.term,
+          `"${spelling}" is claimed by both "${owner}" and "${entry.term}"`,
+        ).toBe(true);
+        seen.set(folded, entry.term);
+      }
+    }
+  });
+
+  it('only cross-references terms that exist', () => {
+    for (const entry of GLOSSARY) {
+      for (const related of entry.seeAlso ?? []) {
+        expect(TERMS.has(related), `${entry.term} -> ${related}`).toBe(true);
+      }
+    }
+  });
+
+  it('only cross-references tools that are registered', () => {
+    for (const entry of GLOSSARY) {
+      for (const tool of entry.tools ?? []) {
+        expect(toolRegistry.has(tool), `${entry.term} -> ${tool}`).toBe(true);
+      }
+    }
+  });
+
+  it('uses only declared topics, and every topic has entries', () => {
+    const used = new Set(GLOSSARY.map(entry => entry.topic));
+    for (const topic of GLOSSARY_TOPICS) {
+      expect(used.has(topic), `topic "${topic}" has no entries`).toBe(true);
+    }
+    expect(used.size).toBe(GLOSSARY_TOPICS.length);
+  });
+
+  it('gives every entry a single-line summary and a non-empty detail', () => {
+    for (const entry of GLOSSARY) {
+      expect(entry.summary.trim().length, entry.term).toBeGreaterThan(0);
+      expect(entry.summary, entry.term).not.toContain('\n');
+      expect(entry.detail.trim().length, entry.term).toBeGreaterThan(0);
+      // The detail must add something beyond restating the summary.
+      expect(entry.detail.length, entry.term).toBeGreaterThan(entry.summary.length);
+    }
+  });
+});
+
+describe('glossary tool registration', () => {
+  it('is advertised second, right behind discovery', () => {
+    expect(toolRegistry.describe()[1]?.name).toBe(explainTerminologyTool.name);
+  });
+
+  it('is callable cold — no required parameters', () => {
+    const descriptor = toolRegistry.describe().find(tool => tool.name === explainTerminologyTool.name);
+
+    expect(descriptor?.inputSchema).toMatchObject({ type: 'object', additionalProperties: false });
+    expect(descriptor?.inputSchema.required).toBeUndefined();
+  });
+
+  it('needs no business scope and carries no business data', () => {
+    expect(explainTerminologyTool.policy.requiresBusinessScope).toBe(false);
+    expect(explainTerminologyTool.policy.dataClassification).toBe('public');
+    expect(explainTerminologyTool.policy.requiredRoles).toBeUndefined();
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/terminology.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/terminology.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { executeRegisteredTool } from '../execute.js';
+import { MAX_TOOL_RESULT_BYTES } from '../output.js';
+import type { ToolResult } from '../registry.js';
+import { explainTerminologyTool, MAX_REQUESTED_TERMS } from '../terminology.js';
+import { GLOSSARY } from '../terminology-data.js';
+
+/**
+ * Behavioral suite for the glossary tool, driven through the real
+ * validate -> authorize -> execute pipeline rather than by calling the handler,
+ * so policy and strict-input behavior are covered too.
+ */
+
+const PRINCIPAL: AuthPrincipal = {
+  subject: 'user-1',
+  issuer: 'https://tenant.auth0.com/',
+  audience: 'aud',
+  scopes: [],
+  email: null,
+  expiresAt: undefined,
+  claims: { sub: 'user-1' },
+};
+
+function authContext(memberBusinessIds: string[]): McpAuthContext {
+  return buildAuthContext(
+    PRINCIPAL,
+    memberBusinessIds.map(memberBusinessId => ({ memberBusinessId, roleId: 'accountant' })),
+  );
+}
+
+/** A client whose fetch must never be called — the tool is pure. */
+function spyingClient() {
+  const fetchImpl = vi.fn(
+    async () => ({ ok: true, status: 200, json: async () => ({ data: {} }) }) as unknown as Response,
+  );
+  const client = new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+  return { client, fetchImpl };
+}
+
+interface StructuredResult {
+  mode?: string;
+  terms?: Array<{ term: string; topic: string; summary: string; detail?: string }>;
+  unmatched?: Array<{ term: string; suggestions: string[] }>;
+  returnedCount?: number;
+  totalCount?: number;
+  truncated?: boolean;
+  code?: string;
+  [key: string]: unknown;
+}
+
+async function run(rawArgs: unknown, memberBusinessIds: string[] = ['b1']) {
+  const { client, fetchImpl } = spyingClient();
+  const result = await executeRegisteredTool({
+    tool: explainTerminologyTool,
+    rawArgs,
+    auth: authContext(memberBusinessIds),
+    correlationId: 'c',
+    client,
+    authorization: 'Bearer t',
+  });
+  return { result, fetchImpl, structured: result.structuredContent as StructuredResult };
+}
+
+function termsIn(result: ToolResult): string[] {
+  return ((result.structuredContent as StructuredResult).terms ?? []).map(item => item.term);
+}
+
+describe('accounter_explain_terminology — index mode', () => {
+  it('returns every term as a one-liner when called with no arguments', async () => {
+    const { result, structured } = await run({});
+
+    expect(result.isError).toBeUndefined();
+    expect(structured.mode).toBe('index');
+    expect(structured.totalCount).toBe(GLOSSARY.length);
+    expect(structured.terms).toHaveLength(GLOSSARY.length);
+    expect(structured.truncated).toBe(false);
+  });
+
+  it('omits detail in index mode so the orientation call stays cheap', async () => {
+    const { structured } = await run({});
+
+    for (const item of structured.terms ?? []) {
+      expect(item.detail).toBeUndefined();
+      expect(item.summary.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('is callable with no arguments at all (null arguments)', async () => {
+    const { result, structured } = await run(undefined);
+
+    expect(result.isError).toBeUndefined();
+    expect(structured.mode).toBe('index');
+  });
+});
+
+describe('accounter_explain_terminology — term lookup', () => {
+  it('resolves a canonical term with full detail', async () => {
+    const { structured } = await run({ terms: ['charge'] });
+
+    expect(structured.mode).toBe('full');
+    expect(structured.terms).toHaveLength(1);
+    expect(structured.terms?.[0]?.term).toBe('charge');
+    expect(structured.terms?.[0]?.detail).toContain('NOT a bank charge');
+  });
+
+  it('resolves an enum-token alias to its entry', async () => {
+    const { result } = await run({ terms: ['INTERNAL'] });
+
+    expect(termsIn(result)).toEqual(['internal-transfer-charge']);
+  });
+
+  it('resolves a GraphQL type name to its entry', async () => {
+    const { result } = await run({ terms: ['CreditcardBankCharge'] });
+
+    expect(termsIn(result)).toEqual(['creditcard-bank-charge']);
+  });
+
+  it('ignores case, spaces, hyphens and underscores', async () => {
+    const spellings = ['value date', 'Value-Date', 'valueDate', 'VALUE_DATE'];
+
+    for (const spelling of spellings) {
+      const { result } = await run({ terms: [spelling] });
+      expect(termsIn(result), spelling).toEqual(['value-date']);
+    }
+  });
+
+  it('falls back to a substring match', async () => {
+    const { result } = await run({ terms: ['allocation'] });
+
+    expect(termsIn(result)).toEqual(['allocation-number']);
+  });
+
+  it('returns entries in glossary order regardless of request order', async () => {
+    const { result } = await run({ terms: ['owner', 'charge'] });
+
+    // `charge` is in the first topic block, `owner` in the last.
+    expect(termsIn(result)).toEqual(['charge', 'owner']);
+  });
+
+  it('de-duplicates when several requested spellings hit one entry', async () => {
+    const { result } = await run({ terms: ['INTERNAL', 'InternalTransferCharge'] });
+
+    expect(termsIn(result)).toEqual(['internal-transfer-charge']);
+  });
+});
+
+describe('accounter_explain_terminology — unmatched terms', () => {
+  it('reports an unknown term without failing the call', async () => {
+    const { result, structured } = await run({ terms: ['charge', 'zzzznotathing'] });
+
+    expect(result.isError).toBeUndefined();
+    expect(termsIn(result)).toEqual(['charge']);
+    expect(structured.unmatched).toEqual([{ term: 'zzzznotathing', suggestions: [] }]);
+  });
+
+  it('suggests near matches by shared prefix', async () => {
+    const { structured } = await run({ terms: ['chaxxxx'] });
+
+    expect(structured.unmatched?.[0]?.term).toBe('chaxxxx');
+    expect(structured.unmatched?.[0]?.suggestions.length).toBeGreaterThan(0);
+    expect(structured.unmatched?.[0]?.suggestions[0]).toContain('charge');
+  });
+
+  it('tolerates trailing noise on a long term rather than giving up', async () => {
+    const { result, structured } = await run({ terms: ['ledgerrr'] });
+
+    expect(termsIn(result)).toEqual(['ledger-record']);
+    expect(structured.unmatched).toEqual([]);
+  });
+
+  it('does not let a short alias match an unrelated longer word', async () => {
+    // `fee` is an alias of `is-fee`; `feedback` must not resolve to it.
+    const { structured } = await run({ terms: ['feedback'] });
+
+    expect(structured.terms).toEqual([]);
+    expect(structured.unmatched?.[0]?.term).toBe('feedback');
+  });
+
+  it('mentions unmatched terms in the human-readable summary', async () => {
+    const { result } = await run({ terms: ['zzzznotathing'] });
+
+    expect(result.content[0]?.text).toContain('Not found');
+    expect(result.content[0]?.text).toContain('zzzznotathing');
+  });
+});
+
+describe('accounter_explain_terminology — topics', () => {
+  it('returns a whole topic in full', async () => {
+    const { structured } = await run({ topics: ['ledger'] });
+
+    const expected = GLOSSARY.filter(entry => entry.topic === 'ledger').map(entry => entry.term);
+    expect(structured.terms?.map(item => item.term)).toEqual(expected);
+    expect(structured.terms?.every(item => typeof item.detail === 'string')).toBe(true);
+  });
+
+  it('unions terms and topics without duplicating', async () => {
+    const { result } = await run({ topics: ['scope'], terms: ['owner', 'charge'] });
+
+    const scopeTerms = GLOSSARY.filter(entry => entry.topic === 'scope').map(entry => entry.term);
+    expect(termsIn(result)).toEqual(['charge', ...scopeTerms]);
+  });
+
+  it('rejects an unknown topic', async () => {
+    const { result, structured } = await run({ topics: ['nope'] });
+
+    expect(result.isError).toBe(true);
+    expect(structured.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('accounter_explain_terminology — contract', () => {
+  it('rejects unknown input fields', async () => {
+    const { result, structured } = await run({ term: 'charge' });
+
+    expect(result.isError).toBe(true);
+    expect(structured.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects more terms than the cap', async () => {
+    const tooMany = Array.from({ length: MAX_REQUESTED_TERMS + 1 }, () => 'charge');
+    const { result, structured } = await run({ terms: tooMany });
+
+    expect(result.isError).toBe(true);
+    expect(structured.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('makes no upstream call', async () => {
+    const { fetchImpl } = await run({ topics: ['charge', 'ledger'] });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('does not echo a business scope (there is none to echo)', async () => {
+    const { structured } = await run({});
+
+    expect(structured).not.toHaveProperty('scope');
+  });
+
+  it('works for a caller with zero memberships', async () => {
+    const { result, structured } = await run({ terms: ['charge'] }, []);
+
+    expect(result.isError).toBeUndefined();
+    expect(structured.terms).toHaveLength(1);
+  });
+
+  it('fits the whole glossary in one full-detail response', async () => {
+    const { result, structured } = await run({
+      topics: ['charge', 'transaction', 'document', 'ledger', 'entity', 'scope'],
+    });
+
+    expect(structured.terms).toHaveLength(GLOSSARY.length);
+    expect(structured.truncated).toBe(false);
+    expect(Buffer.byteLength(JSON.stringify(result.structuredContent), 'utf8')).toBeLessThanOrEqual(
+      MAX_TOOL_RESULT_BYTES,
+    );
+  });
+});

--- a/packages/mcp-server/src/tools/registry-instance.ts
+++ b/packages/mcp-server/src/tools/registry-instance.ts
@@ -7,6 +7,7 @@ import { getLedgerRecordsTool } from './ledger.js';
 import { listBusinessesTool, listTagsTool, listTaxCategoriesTool } from './lookups.js';
 import { ToolRegistry } from './registry.js';
 import { balanceReportTool } from './reports.js';
+import { explainTerminologyTool } from './terminology.js';
 import { getTransactionsTool } from './transaction-details.js';
 
 /**
@@ -23,6 +24,11 @@ export const toolRegistry = new ToolRegistry();
 // `listedTools` is now empty (the internal smoke tool is dispatchable but no
 // longer advertised), so this is genuinely the first tool the model sees.
 toolRegistry.register(listBusinessMembershipsTool);
+// Vocabulary second: it is the other zero-cost orientation call (pure, unscoped,
+// no upstream hop), and it is what stops the model reading `byBusinesses` as the
+// owner predicate or summing INTERNAL/CONVERSION charges into a spend total.
+// Ahead of the data tools so it is read before the filters it explains are used.
+toolRegistry.register(explainTerminologyTool);
 toolRegistry.register(searchChargesTool);
 // Charge detail (by id) sits next to search: the model searches, then drills
 // into specific charges — which nest their transactions and documents.

--- a/packages/mcp-server/src/tools/terminology-data.ts
+++ b/packages/mcp-server/src/tools/terminology-data.ts
@@ -1,0 +1,742 @@
+/**
+ * The Accounter domain glossary — content only.
+ *
+ * Kept separate from `terminology.ts` (the tool) so the vocabulary can grow
+ * without touching the query logic, and so the contract suite can assert
+ * properties of the data on its own.
+ *
+ * Scope is deliberately **core domain modelling**: what a charge/transaction/
+ * document/ledger record *is* in this system, and the distinctions a model
+ * cannot infer from the GraphQL schema alone. Israeli tax-*reporting* machinery
+ * (PCN874, the SHAAM uniform format, Form 6111, Hashavshevet, Green Invoice) is
+ * out of scope here; VAT appears only where it is part of the core shape — an
+ * amount on a charge/document, and the second ledger account slot.
+ *
+ * Every entry is written for a reader who has just seen the term in a tool
+ * result or an input schema and needs to know what it means and what it is
+ * *not*. Prefer stating the trap over restating the field name.
+ *
+ * Budget: at 62 entries the index is ~10 KB and the full glossary ~40 KB against
+ * the 60 KB `MAX_TOOL_RESULT_BYTES` guard, so there is room for roughly 30 more
+ * before a request for every topic starts truncating. `terminology.test.ts`
+ * asserts the whole glossary still fits in one response, so overshooting fails
+ * the suite rather than silently dropping the last entries.
+ */
+
+/** Topic buckets. Also the `topics` filter vocabulary and the index ordering. */
+export const GLOSSARY_TOPICS = [
+  'charge',
+  'transaction',
+  'document',
+  'ledger',
+  'entity',
+  'scope',
+] as const;
+
+export type GlossaryTopic = (typeof GLOSSARY_TOPICS)[number];
+
+export interface GlossaryEntry {
+  /** Canonical term, lowercase kebab-case. Unique across the glossary. */
+  term: string;
+  topic: GlossaryTopic;
+  /** Single line, no newlines — this is all index mode returns. */
+  summary: string;
+  /** The non-obvious part: what it means here, and what it is not. */
+  detail: string;
+  /**
+   * Alternate spellings that must resolve here: enum tokens (`INTERNAL`),
+   * GraphQL `__typename`s (`InternalTransferCharge`), field names
+   * (`effectiveDate`), Hebrew, UI labels. Matching normalizes case and strips
+   * non-alphanumerics, so `value-date`/`valueDate`/`value date` already collapse
+   * together and do not need listing.
+   */
+  aliases?: readonly string[];
+  /** Related `term` values. Every one must exist (enforced by contract test). */
+  seeAlso?: readonly string[];
+  /** Tools that surface the concept. Must be registered (enforced). */
+  tools?: readonly string[];
+}
+
+const CHARGE_ENTRIES: readonly GlossaryEntry[] = [
+  {
+    term: 'charge',
+    topic: 'charge',
+    summary:
+      'The central aggregate: one business event, grouping its transactions, documents, ledger records and misc expenses.',
+    detail:
+      'A charge is NOT a bank charge or a single payment. It is the unit of work in Accounter — a container that ties together everything describing one economic event for one owning business: the bank/card transactions that moved the money, the documents (invoice, receipt) that justify it, the double-entry ledger records derived from both, and any manual misc expenses. Charges are created automatically when a scraped transaction or an ingested document arrives, then merged so that an invoice and its payment end up on the same charge. Most questions ("what did we spend on X", "what is unbilled") are charge-level questions; drop to transactions or documents only when you need the individual rows.',
+    aliases: ['charges', 'Charge'],
+    seeAlso: ['charge-type', 'transaction', 'document', 'ledger-record', 'owner', 'counterparty'],
+    tools: ['accounter_search_charges', 'accounter_get_charges'],
+  },
+  {
+    term: 'charge-type',
+    topic: 'charge',
+    summary:
+      'Classifies what kind of event a charge is; often derived at query time rather than stored, and exposed as both an enum token and a GraphQL __typename.',
+    detail:
+      'Each charge carries a type from a fixed vocabulary (COMMON, CONVERSION, PAYROLL, INTERNAL, DIVIDEND, BUSINESS_TRIP, VAT, BANK_DEPOSIT, FOREIGN_SECURITIES, CREDITCARD_BANK, FINANCIAL). Two things are non-obvious. First, the type is frequently NULL in storage and DERIVED at read time from the charge contents — trip link, then deposit/securities business, then more than one account (internal transfer), then dividend/VAT/credit-card businesses, else COMMON — so it can change as a charge gains transactions. Second, the same concept appears under two spellings: the filter enum token (INTERNAL) and the GraphQL object type (InternalTransferCharge). The `chargeType` field on a result row uses the enum spelling and can be handed straight back to the `byChargeTypes` filter.',
+    aliases: ['chargeType', 'byChargeTypes', 'ChargeType'],
+    seeAlso: [
+      'common-charge',
+      'conversion-charge',
+      'internal-transfer-charge',
+      'payroll-charge',
+      'financial-charge',
+    ],
+    tools: ['accounter_search_charges', 'accounter_get_charges'],
+  },
+  {
+    term: 'common-charge',
+    topic: 'charge',
+    summary:
+      'COMMON / CommonCharge — the default: an ordinary expense or income with documents and a payment.',
+    detail:
+      'The everyday case, and the bulk of any dataset: a supplier invoice plus the bank line that paid it, or a customer invoice plus the receipt. It is the fallback type when no more specific classification applies. COMMON and CREDITCARD_BANK share one ledger generator.',
+    aliases: ['COMMON', 'CommonCharge'],
+    seeAlso: ['charge-type', 'creditcard-bank-charge'],
+  },
+  {
+    term: 'conversion-charge',
+    topic: 'charge',
+    summary:
+      'CONVERSION / ConversionCharge — a currency exchange inside your own accounts, not income or expense.',
+    detail:
+      'Buying or selling currency: two opposite-signed transactions in different currencies. The transactions carry both the bank rate actually used and the official Bank of Israel rate, and the gap between them lands in an exchange-rate tax category. IMPORTANT for aggregation: a conversion is money changing shape, not money earned or spent — including CONVERSION charges in a spend or revenue total double-counts. Exclude it (along with INTERNAL) via `byChargeTypes` when summing real economic activity.',
+    aliases: ['CONVERSION', 'ConversionCharge'],
+    seeAlso: ['charge-type', 'internal-transfer-charge', 'conversion-transaction'],
+    tools: ['accounter_search_charges'],
+  },
+  {
+    term: 'payroll-charge',
+    topic: 'charge',
+    summary:
+      'PAYROLL / SalaryCharge — one month of payroll: salary records plus the net-pay, social-security and fund transactions.',
+    detail:
+      'Groups the month salary records with every transaction they produce: net pay to employees, social security (bituach leumi), income-tax withholding, pension fund, training fund, compensation. Unlike most charges, its total is taken from the transactions rather than from documents, and it is exempt from the "missing documents" validation — payroll has no supplier invoice.',
+    aliases: ['PAYROLL', 'SalaryCharge', 'salary charge'],
+    seeAlso: ['charge-type', 'charge-validation'],
+  },
+  {
+    term: 'internal-transfer-charge',
+    topic: 'charge',
+    summary:
+      'INTERNAL / InternalTransferCharge — money moving between two accounts you already own.',
+    detail:
+      'Auto-detected when a charge touches more than one of your own financial accounts. Like CONVERSION, this is NOT economic activity: the money never left the business. Including INTERNAL charges in a spend or income total double-counts, so exclude it via `byChargeTypes` when aggregating. Its ledger is expected to balance exactly, with no allow-list exceptions.',
+    aliases: ['INTERNAL', 'InternalTransferCharge', 'internal transfer'],
+    seeAlso: ['charge-type', 'conversion-charge', 'ledger-balance'],
+    tools: ['accounter_search_charges'],
+  },
+  {
+    term: 'dividend-charge',
+    topic: 'charge',
+    summary:
+      'DIVIDEND / DividendCharge — a dividend distribution, split into the withholding-tax portion and the payment.',
+    detail:
+      'The charge transactions are separated by counterparty into the amount actually paid to the shareholder and the tax withheld at source and paid to the authority. The withheld portion is posted to the second credit slot of the ledger record rather than as its own record.',
+    aliases: ['DIVIDEND', 'DividendCharge'],
+    seeAlso: ['charge-type', 'ledger-vat-split'],
+  },
+  {
+    term: 'business-trip-charge',
+    topic: 'charge',
+    summary: 'BUSINESS_TRIP / BusinessTripCharge — any charge linked to a business trip.',
+    detail:
+      'The link to a trip is what sets the type; it wins over every other classification. Trip expenses are categorized (accommodation, flight, travel and subsistence, car rental, other) and measured against statutory per-diem ceilings — spend above the ceiling becomes non-deductible excess expenditure. Ledger balancing is relaxed here: every trip attendee is allowed to carry a non-zero balance.',
+    aliases: ['BUSINESS_TRIP', 'BusinessTripCharge'],
+    seeAlso: ['charge-type', 'ledger-balance'],
+  },
+  {
+    term: 'vat-charge',
+    topic: 'charge',
+    summary:
+      'VAT / MonthlyVatCharge — the periodic VAT settlement paid to or refunded by the tax authority.',
+    detail:
+      'Not the VAT amount on an ordinary charge — this is the standalone monthly settlement: output VAT collected minus input VAT reclaimed, reconciled against the actual bank transaction to the tax authority. The reported month is encoded in the charge user description rather than in a dedicated field.',
+    aliases: ['MonthlyVatCharge', 'monthly vat'],
+    seeAlso: ['charge-type', 'charge-vat', 'ledger-vat-split'],
+  },
+  {
+    term: 'bank-deposit-charge',
+    topic: 'charge',
+    summary:
+      'BANK_DEPOSIT / BankDepositCharge — deposits into, withdrawals from, and interest on a bank deposit.',
+    detail:
+      'Identified by the deposit counterparty business configured for the owner. Groups the movement of principal and the interest it earns.',
+    aliases: ['BANK_DEPOSIT', 'BankDepositCharge'],
+    seeAlso: ['charge-type'],
+  },
+  {
+    term: 'foreign-securities-charge',
+    topic: 'charge',
+    summary:
+      'FOREIGN_SECURITIES / ForeignSecuritiesCharge — activity in a securities portfolio held at the bank.',
+    detail:
+      'Buys, sells, dividends and fees on a foreign securities portfolio, identified by the securities counterparty business configured for the owner.',
+    aliases: ['FOREIGN_SECURITIES', 'ForeignSecuritiesCharge'],
+    seeAlso: ['charge-type'],
+  },
+  {
+    term: 'creditcard-bank-charge',
+    topic: 'charge',
+    summary:
+      'CREDITCARD_BANK / CreditcardBankCharge — the single bank debit for a whole credit-card statement.',
+    detail:
+      'The aggregate line where the bank debits the card statement, linked to the individual card transactions it settles. Beware of double-counting: the card statement debit and the individual card purchases describe the same money at two levels. Shares its ledger generator with COMMON.',
+    aliases: ['CREDITCARD_BANK', 'CreditcardBankCharge', 'credit card bank'],
+    seeAlso: ['charge-type', 'common-charge', 'transaction'],
+  },
+  {
+    term: 'financial-charge',
+    topic: 'charge',
+    summary:
+      'FINANCIAL / FinancialCharge — system-generated period-end accounting entries, not real-world events.',
+    detail:
+      'Created by the system rather than by a bank feed or an invoice: FX revaluation, tax expense, depreciation, vacation and recovery reserves, opening balances. They are auto-tagged "financial". Treat them as bookkeeping adjustments — they have no transaction or document behind them, and including them in "what did we spend" answers mixes accruals with cash activity.',
+    aliases: ['FINANCIAL', 'FinancialCharge'],
+    seeAlso: ['charge-type', 'ledger-record'],
+  },
+  {
+    term: 'charge-main-date',
+    topic: 'charge',
+    summary:
+      'A charge has one "main" date used for containment filters, and a wider any-date span used for overlap filters.',
+    detail:
+      'The main date is the earliest document date, falling back to the earliest transaction event date. `fromDate`/`toDate` filter on containment against that single date. The any-date filters (`fromAnyDate`/`toAnyDate`) are broader: they match if ANY document, transaction or ledger date falls in the window — the "was this charge active during the period" question. Choose deliberately: a charge invoiced in December and paid in January is inside a December main-date window but overlaps both months.',
+    aliases: ['fromDate', 'toDate', 'fromAnyDate', 'toAnyDate', 'main date'],
+    seeAlso: ['charge', 'event-date', 'value-date'],
+    tools: ['accounter_search_charges', 'accounter_get_charges'],
+  },
+  {
+    term: 'accountant-status',
+    topic: 'charge',
+    summary:
+      'APPROVED / PENDING / UNAPPROVED review state — PENDING specifically means "was approved, then the data changed".',
+    detail:
+      'UNAPPROVED means never reviewed. APPROVED means an accountant signed off. PENDING is the non-obvious one: it is a DOWNGRADE from APPROVED, applied automatically whenever a mutation changes what the charge is composed of. So PENDING is not "awaiting first review" — it is "was reviewed, then something moved underneath it". Tag-only edits and explicit approval edits deliberately do not trigger the downgrade.',
+    aliases: ['accountantApproval', 'AccountantStatus', 'APPROVED', 'PENDING', 'UNAPPROVED'],
+    seeAlso: ['charge', 'charge-validation'],
+    tools: ['accounter_search_charges', 'accounter_get_charges'],
+  },
+  {
+    term: 'tag',
+    topic: 'charge',
+    summary:
+      'A hierarchical label for grouping charges; a charge can carry several, each with a fractional part.',
+    detail:
+      'Tags form a tree, so a tag has both a name and a name path from its root. The charge-to-tag link is many-to-many and can carry a `part` fraction, splitting one charge across several tags rather than assigning it wholly to one — so summing charge totals by tag without weighting by `part` can overstate. An untagged charge is flagged as missing information.',
+    aliases: ['tags', 'byTags', 'namePath'],
+    seeAlso: ['charge', 'charge-validation'],
+    tools: ['accounter_list_tags', 'accounter_search_charges'],
+  },
+  {
+    term: 'charge-validation',
+    topic: 'charge',
+    summary:
+      'Per-charge completeness check listing what is missing: counterparty, description, documents, tags, transactions, VAT or tax category.',
+    detail:
+      'The rules are conditional, not uniform. Documents are NOT required for salary, internal-transfer, dividend, conversion, monthly-VAT, credit-card-bank, financial, business-trip, bank-deposit or foreign-securities charges, nor for businesses marked as not requiring invoices. VAT is skipped for foreign counterparties, VAT-exempt dealers, and charges flagged as optional-VAT. So "missing documents" appearing on a COMMON charge is meaningful, while its absence on a payroll charge says nothing.',
+    aliases: ['validationData', 'missingInfo', 'MissingChargeInfo'],
+    seeAlso: ['charge', 'accountant-status', 'charge-vat'],
+    tools: ['accounter_search_charges', 'accounter_get_charges'],
+  },
+  {
+    term: 'years-of-relevance',
+    topic: 'charge',
+    summary:
+      'The tax year(s) a charge belongs to, which can differ from its dates — a charge can be spread across years.',
+    detail:
+      'A charge can be assigned one or more tax years of relevance, splitting its expense or income across them independently of when the invoice or payment is dated. This is the cross-year / charge-spread mechanism: prepaid or accrued amounts are recognised in the year they relate to, not the year the money moved. When reporting by year, the years of relevance are the accounting truth, not the transaction dates.',
+    aliases: ['yearsOfRelevance', 'charge spread', 'cross year'],
+    seeAlso: ['charge', 'invoice-date', 'value-date'],
+  },
+  {
+    term: 'charge-vat',
+    topic: 'charge',
+    summary:
+      'The VAT amount on a charge, computed from its documents (invoice VAT preferred over receipt VAT), not stored.',
+    detail:
+      'Derived rather than entered, and only present when the charge has documents carrying VAT — many legitimately have none. The VAT rate is date-versioned in the database and has changed over time, so never assume a fixed percentage when reconciling: use the amounts as given.',
+    aliases: ['vat', 'vatAmount'],
+    seeAlso: ['charge', 'property-charge', 'ledger-vat-split', 'document'],
+  },
+  {
+    term: 'property-charge',
+    topic: 'charge',
+    summary:
+      'A charge covering equipment or property (pahat/tziyud), where only two thirds of the VAT is reclaimable.',
+    detail:
+      'Charges flagged as property represent capital equipment rather than consumables. Two consequences: the reclaimable input VAT is reduced to two thirds, and the charge feeds the depreciation schedule instead of being expensed in full. A charge is reported as property when it has at least one depreciation record attached.',
+    aliases: ['property', 'decreasedVAT', 'is_property'],
+    seeAlso: ['charge', 'charge-vat'],
+  },
+];
+
+const TRANSACTION_ENTRIES: readonly GlossaryEntry[] = [
+  {
+    term: 'transaction',
+    topic: 'transaction',
+    summary:
+      'A single movement on a bank account or credit card, scraped from the institution and attached to a charge.',
+    detail:
+      'The raw money movement, as the bank or card issuer reported it — never hand-entered. Each belongs to exactly one charge and one financial account. Only a few fields are user-editable (counterparty, charge link, effective date, fee flag); everything else mirrors the source. A charge can have zero transactions (an invoice not yet paid) or many (a payroll month).',
+    aliases: ['transactions', 'Transaction', 'CommonTransaction'],
+    seeAlso: ['charge', 'event-date', 'effective-date', 'amount-sign', 'is-fee'],
+    tools: ['accounter_get_transactions'],
+  },
+  {
+    term: 'event-date',
+    topic: 'transaction',
+    summary: 'When the purchase or event actually happened — as opposed to when the money moved.',
+    detail:
+      'The date of the underlying event: the day you bought the thing, or the day the card was swiped. For a credit-card purchase this can be weeks before the money leaves the bank. Pair it with the effective date rather than treating either as "the" transaction date.',
+    aliases: ['eventDate'],
+    seeAlso: ['effective-date', 'transaction', 'charge-main-date'],
+    tools: ['accounter_get_transactions'],
+  },
+  {
+    term: 'effective-date',
+    topic: 'transaction',
+    summary:
+      'The debit date — when money actually moved. Resolved through a fallback chain, and it can be missing.',
+    detail:
+      'Resolved in order: a user override, then the precise debit timestamp, then the debit date, then — for local-currency transactions only — the event date. Two cautions. It is nullable, and a meaningful number of historical rows have no value. And there is a separate source effective date that exposes the raw bank value only when it differs from the resolved one, which is how you tell an overridden date from an original.',
+    aliases: ['effectiveDate', 'debitDate', 'sourceEffectiveDate', 'exactEffectiveDate'],
+    seeAlso: ['event-date', 'value-date', 'transaction'],
+    tools: ['accounter_get_transactions'],
+  },
+  {
+    term: 'amount-sign',
+    topic: 'transaction',
+    summary:
+      'Transaction amounts are signed: POSITIVE means money in (credit), NEGATIVE means money out (debit).',
+    detail:
+      'The single most common source of sign errors. A supplier payment is negative; a customer receipt is positive. When summing spend, either filter to negatives and negate, or sort by absolute amount — the ABS_AMOUNT sort key exists precisely so "largest movements" does not mean "largest incomes". Charge-level totals follow the same convention.',
+    aliases: ['amount', 'ABS_AMOUNT', 'sign'],
+    seeAlso: ['transaction', 'charge'],
+    tools: ['accounter_get_transactions', 'accounter_search_charges'],
+  },
+  {
+    term: 'is-fee',
+    topic: 'transaction',
+    summary:
+      'Marks a bank or card fee line, which is excluded from the charge total and from counterparty derivation.',
+    detail:
+      'Fee rows are deliberately held apart. When a charge mixes fee and non-fee transactions, only the non-fee ones count toward the charge total and toward working out who the counterparty is — otherwise every foreign transfer would look like it had two counterparties. The exception: if EVERY transaction on the charge is a fee, they are summed normally. Fees post to their own fee tax category in the ledger.',
+    aliases: ['isFee', 'fee'],
+    seeAlso: ['transaction', 'counterparty', 'charge'],
+    tools: ['accounter_get_transactions'],
+  },
+  {
+    term: 'reference-key',
+    topic: 'transaction',
+    summary:
+      'The bank or card external identifier for the movement — the asmachta / reference number.',
+    detail:
+      'The identifier the institution itself uses, which is what a human reconciling against a bank statement will quote. Useful for matching a transaction to an external record; not unique across institutions.',
+    aliases: ['referenceKey', 'asmachta', 'אסמכתא', 'source reference'],
+    seeAlso: ['transaction', 'source-description'],
+    tools: ['accounter_get_transactions'],
+  },
+  {
+    term: 'source-description',
+    topic: 'transaction',
+    summary:
+      'The free-text description as the bank or card wrote it — the basis for guessing the counterparty.',
+    detail:
+      'Verbatim institution text, often abbreviated or in Hebrew. Businesses carry matching phrases that are tested against it to suggest a counterparty for an unassigned transaction, which is why a transaction can have a confident counterparty guess without anyone having set one.',
+    aliases: ['sourceDescription'],
+    seeAlso: ['transaction', 'counterparty', 'reference-key'],
+    tools: ['accounter_get_transactions'],
+  },
+  {
+    term: 'transaction-balance',
+    topic: 'transaction',
+    summary:
+      'The account balance immediately AFTER this transaction, as reported by the institution.',
+    detail:
+      'A running balance snapshot carried on the row, not a computed field. It reflects the institution view at that point, so it is the right thing to reconcile a statement against and the wrong thing to sum.',
+    aliases: ['balance', 'currentBalance'],
+    seeAlso: ['transaction'],
+  },
+  {
+    term: 'conversion-transaction',
+    topic: 'transaction',
+    summary:
+      'One leg of a currency exchange, typed QUOTE (buy) or BASE (sell), carrying both the bank rate and the official rate.',
+    detail:
+      'Conversion charges hold two of these — the currency going out and the currency coming in. QUOTE is the buy side, BASE is the sell side. Each carries the rate the bank actually applied alongside the official Bank of Israel rate for the day; the difference between them is the cost of the conversion and is posted to an exchange-rate account.',
+    aliases: ['ConversionTransaction', 'QUOTE', 'BASE'],
+    seeAlso: ['conversion-charge', 'transaction'],
+  },
+];
+
+const DOCUMENT_ENTRIES: readonly GlossaryEntry[] = [
+  {
+    term: 'document',
+    topic: 'document',
+    summary:
+      'A financial paper attached to a charge — invoice, receipt, credit note, proforma — with amount, VAT and two parties.',
+    detail:
+      'Documents arrive by email ingestion, scraping or upload, are OCR-classified, and are matched to a charge. Every accounting document names a creditor and a debtor; which of the two is you determines whether the charge is income or expense. A document that has not yet been classified is typed as unprocessed and is always considered invalid until it is.',
+    aliases: ['documents', 'Document'],
+    seeAlso: ['document-type', 'creditor', 'debtor', 'charge'],
+    tools: ['accounter_get_documents'],
+  },
+  {
+    term: 'document-type',
+    topic: 'document',
+    summary:
+      'INVOICE, RECEIPT, INVOICE_RECEIPT, CREDIT_INVOICE, PROFORMA, UNPROCESSED or OTHER — and the categories overlap.',
+    detail:
+      'The critical trap: these are not disjoint buckets. INVOICE_RECEIPT counts as BOTH an invoice and a receipt in every aggregate and filter. "Has no invoice" therefore means no INVOICE, no CREDIT_INVOICE and no INVOICE_RECEIPT. Likewise "is an invoice" spans three types. PROFORMA is an accounting document but not a tax invoice; UNPROCESSED means not yet classified; OTHER means classified as non-financial.',
+    aliases: ['documentType', 'DocumentType'],
+    seeAlso: ['invoice', 'receipt', 'invoice-receipt', 'credit-invoice', 'proforma'],
+    tools: ['accounter_get_documents', 'accounter_search_charges'],
+  },
+  {
+    term: 'invoice',
+    topic: 'document',
+    summary:
+      'A tax invoice (heshbonit mas) — the document that creates the obligation, independent of payment.',
+    detail:
+      'Establishes what is owed and carries the VAT. Note that for counting purposes an invoice is any of INVOICE, CREDIT_INVOICE or INVOICE_RECEIPT, so the `withoutInvoice` charge filter means none of those three is present.',
+    aliases: ['INVOICE', 'tax invoice', 'חשבונית מס'],
+    seeAlso: ['document-type', 'receipt', 'invoice-receipt'],
+    tools: ['accounter_get_documents'],
+  },
+  {
+    term: 'receipt',
+    topic: 'document',
+    summary:
+      'Proof of payment (kabala) — evidence money changed hands, as opposed to an invoice creating the obligation.',
+    detail:
+      'A receipt settles rather than creates. For counting purposes a receipt is either RECEIPT or INVOICE_RECEIPT. Some businesses are configured as settleable with a receipt alone, in which case no separate invoice is expected.',
+    aliases: ['RECEIPT', 'קבלה'],
+    seeAlso: ['document-type', 'invoice', 'invoice-receipt'],
+    tools: ['accounter_get_documents'],
+  },
+  {
+    term: 'invoice-receipt',
+    topic: 'document',
+    summary:
+      'A combined tax invoice and receipt (heshbonit mas kabala) — counts as BOTH types everywhere.',
+    detail:
+      'The Israeli combined document, issued when invoicing and payment happen together. It satisfies both the invoice requirement and the receipt requirement simultaneously, which is why a charge holding only an INVOICE_RECEIPT is correctly reported as having neither a missing invoice nor a missing receipt.',
+    aliases: ['INVOICE_RECEIPT', 'חשבונית מס קבלה'],
+    seeAlso: ['document-type', 'invoice', 'receipt'],
+  },
+  {
+    term: 'credit-invoice',
+    topic: 'document',
+    summary:
+      'A credit note (heshbonit zikui) reversing or reducing a prior invoice — it flips the VAT side.',
+    detail:
+      'Reverses part or all of an earlier invoice. It counts as an invoice for presence checks, but its accounting direction is inverted: a credit invoice swaps which side of the VAT accounts the amount lands on relative to an ordinary invoice between the same two parties. Expect negative-looking effects on totals.',
+    aliases: ['CREDIT_INVOICE', 'credit note', 'חשבונית זיכוי'],
+    seeAlso: ['document-type', 'invoice', 'ledger-vat-split'],
+  },
+  {
+    term: 'proforma',
+    topic: 'document',
+    summary: 'A proforma invoice — a quote or pre-invoice that carries no tax effect.',
+    detail:
+      'Counted as an accounting document but not as a tax invoice: it does not satisfy the invoice requirement on a charge and does not drive VAT.',
+    aliases: ['PROFORMA'],
+    seeAlso: ['document-type', 'invoice'],
+  },
+  {
+    term: 'creditor',
+    topic: 'document',
+    summary: 'The party being paid — the one issuing the invoice and recognising income.',
+    detail:
+      'On a document, creditor and debtor name the two sides. If YOU are the creditor, the document is income; if you are the debtor, it is an expense. Direction is decided by comparing the debtor to the charge owner, which is why a document with both parties missing cannot be classified at all and shows up as missing counterparty information.',
+    seeAlso: ['debtor', 'document', 'owner', 'counterparty'],
+    tools: ['accounter_get_documents'],
+  },
+  {
+    term: 'debtor',
+    topic: 'document',
+    summary: 'The party who owes — the one receiving the invoice and recognising an expense.',
+    detail:
+      'The mirror of creditor. When the debtor is your own business the charge is an expense and the counterparty is the creditor. Credit invoices invert this test, so do not read the debtor field alone as "this is an expense".',
+    seeAlso: ['creditor', 'document', 'credit-invoice', 'owner'],
+    tools: ['accounter_get_documents'],
+  },
+  {
+    term: 'open-document',
+    topic: 'document',
+    summary:
+      'An ISSUED document still unsettled in the external invoicing system — not the same as "unmatched".',
+    detail:
+      'Applies only to documents Accounter issued through the external invoicing provider, which mirrors back a status of open, closed, manually closed or cancelled. Open means the provider still considers it outstanding — typically an unpaid customer invoice. This is a receivables signal. It says nothing about whether the document has been matched to a bank transaction, which is a different question entirely.',
+    aliases: ['openDocuments', 'withOpenDocuments', 'OPEN'],
+    seeAlso: ['unmatched-document', 'document', 'charge'],
+    tools: ['accounter_search_charges', 'accounter_get_charges'],
+  },
+  {
+    term: 'unmatched-document',
+    topic: 'document',
+    summary:
+      'A document with no corresponding transaction — a bookkeeping gap, not an external payment status.',
+    detail:
+      'Means Accounter has the paper but not the money movement: an invoice with nothing paying it, or one whose payment has not been linked yet. Contrast with an open document, which is the external provider view of settlement. A charge can be unmatched but closed, or matched but open.',
+    aliases: ['unmatched'],
+    seeAlso: ['open-document', 'document', 'transaction'],
+    tools: ['accounter_get_documents'],
+  },
+  {
+    term: 'allocation-number',
+    topic: 'document',
+    summary:
+      'The Israeli invoice allocation number (mispar haktzaa), required above amount thresholds that tighten each year.',
+    detail:
+      'A number obtained from the tax authority that must appear on qualifying invoices for the input VAT to be reclaimable. The requirement is phased in by date and pre-VAT amount, with the threshold falling over successive years, so whether a given document needs one depends on both its date and its size. A missing required allocation number invalidates the document and blocks ledger generation for its charge.',
+    aliases: ['allocationNumber', 'מספר הקצאה', 'israel invoice'],
+    seeAlso: ['document', 'charge-validation'],
+  },
+];
+
+const LEDGER_ENTRIES: readonly GlossaryEntry[] = [
+  {
+    term: 'ledger-record',
+    topic: 'ledger',
+    summary:
+      'A double-entry bookkeeping line — "an atomic movement of funds" — GENERATED from a charge, never hand-entered.',
+    detail:
+      'The accounting layer beneath a charge. Records are derived by regenerating them from the charge contents, with a different generator per charge type, so they are a projection of the charge rather than an independent source of truth: fixing a ledger means fixing the charge and regenerating. Each record holds up to four account slots and both an invoice date and a value date.',
+    aliases: ['ledgerRecords', 'LedgerRecord', 'ledger'],
+    seeAlso: ['debit-account', 'credit-account', 'invoice-date', 'value-date', 'ledger-validation'],
+    tools: ['accounter_get_ledger_records'],
+  },
+  {
+    term: 'debit-account',
+    topic: 'ledger',
+    summary:
+      'Slots DEBIT_ACCOUNT_1 and DEBIT_ACCOUNT_2 — where value goes to: an expense category, or you as the receivable.',
+    detail:
+      'Slot 1 is the primary debit and is always present. Slot 2 is optional and carries the split-out portion — most often input VAT on a purchase. Each slot points at a financial entity, which may be a business OR a tax category, and carries both an original-currency amount and a local-currency amount.',
+    aliases: ['DEBIT_ACCOUNT_1', 'DEBIT_ACCOUNT_2', 'debitAccount1', 'debitAccount2'],
+    seeAlso: ['credit-account', 'ledger-vat-split', 'financial-entity', 'ledger-record'],
+    tools: ['accounter_get_ledger_records'],
+  },
+  {
+    term: 'credit-account',
+    topic: 'ledger',
+    summary:
+      'Slots CREDIT_ACCOUNT_1 and CREDIT_ACCOUNT_2 — where value comes from: the supplier, or revenue.',
+    detail:
+      'Mirror of the debit slots. Slot 1 is primary and always present; slot 2 carries the split-out portion, typically output VAT on a sale or withheld tax on a dividend. Filtering ledger records by a financial entity searches all four slots unless you narrow to specific ones.',
+    aliases: ['CREDIT_ACCOUNT_1', 'CREDIT_ACCOUNT_2', 'creditAccount1', 'creditAccount2'],
+    seeAlso: ['debit-account', 'ledger-vat-split', 'financial-entity', 'ledger-record'],
+    tools: ['accounter_get_ledger_records'],
+  },
+  {
+    term: 'ledger-vat-split',
+    topic: 'ledger',
+    summary:
+      'Why there are TWO debit and TWO credit slots: slot 2 holds the VAT (or withholding) portion of the same entry.',
+    detail:
+      'One invoice becomes ONE ledger record, not two. On a purchase: credit slot 1 is the supplier for the gross amount, debit slot 1 is the expense category for the net amount, and debit slot 2 is the input VAT account for the VAT. On a sale the shape mirrors: debit slot 1 is the customer for the gross, credit slot 1 is revenue for the net, credit slot 2 is output VAT. Credit invoices swap which VAT account is used, and dividend withholding tax uses credit slot 2 the same way. If you sum slot 1 alone you will be missing the VAT leg.',
+    aliases: ['vat split', 'second slot'],
+    seeAlso: ['debit-account', 'credit-account', 'charge-vat', 'credit-invoice'],
+  },
+  {
+    term: 'invoice-date',
+    topic: 'ledger',
+    summary: 'The accrual / recognition date of a ledger record — when the obligation arose.',
+    detail:
+      'For a record derived from a document it is the document date; for one derived from a transaction it is the event date. This is the date accounting periods are cut on. It is one of three ways to filter ledger records — invoice date, value date, or either.',
+    aliases: ['invoiceDate', 'fromInvoiceDate', 'toInvoiceDate'],
+    seeAlso: ['value-date', 'ledger-record', 'event-date'],
+    tools: ['accounter_get_ledger_records'],
+  },
+  {
+    term: 'value-date',
+    topic: 'ledger',
+    summary: 'The cash / settlement date of a ledger record — when the money actually moved.',
+    detail:
+      'For a document-derived record it equals the document date; for a transaction-derived record it is the resolved debit timestamp. The gap between invoice date and value date is exactly what creates an outstanding receivable or payable: the charge posts the obligation on one date and clears it on another, and until both exist the counterparty carries a non-zero balance.',
+    aliases: ['valueDate', 'fromValueDate', 'toValueDate'],
+    seeAlso: ['invoice-date', 'ledger-balance', 'effective-date'],
+    tools: ['accounter_get_ledger_records'],
+  },
+  {
+    term: 'local-currency-amount',
+    topic: 'ledger',
+    summary:
+      'Every ledger slot carries both the original-currency amount and its local-currency (ILS) equivalent.',
+    detail:
+      'The original amount preserves what was actually invoiced or paid; the local-currency amount is the converted value the books are kept in. Always aggregate on the local-currency amounts — summing original amounts across currencies is meaningless. FX movement between the two is itself posted to exchange-rate accounts by system-generated financial charges.',
+    aliases: ['localCurrencyDebitAmount1', 'localCurrencyCreditAmount1', 'local amount'],
+    seeAlso: ['ledger-record', 'financial-charge', 'debit-account'],
+    tools: ['accounter_get_ledger_records'],
+  },
+  {
+    term: 'ledger-balance',
+    topic: 'ledger',
+    summary:
+      'A charge balances when every BUSINESS nets to zero across its records — tax categories are expected NOT to.',
+    detail:
+      'The most misread rule in the ledger. Balancing is checked per financial entity, but only entities of type business are required to net to zero: an invoice creates a payable to a supplier and the payment clears it. Tax categories are SUPPOSED to carry a non-zero balance — that residue is the profit and loss. So "unbalanced" never means "the debits do not equal the credits"; it means a counterparty still has an open balance on this charge. Small residues below a tolerance are ignored, some businesses sit on an explicit allow-list, and business-trip attendees are always permitted a balance.',
+    aliases: ['isBalanced', 'unbalanced', 'unbalancedEntities', 'LedgerBalanceInfo'],
+    seeAlso: ['ledger-record', 'tax-category', 'business', 'value-date'],
+  },
+  {
+    term: 'ledger-lock',
+    topic: 'ledger',
+    summary:
+      'Charges before the lock date are frozen — and a locked charge always reports itself as balanced with no errors.',
+    detail:
+      'Once a period is closed, charges dated before the lock date stop regenerating their ledger and serve the stored records instead. The trap: a locked charge reports balanced and error-free regardless of its actual state, so ledger validity signals are only meaningful after the lock date. Check the lock date before concluding that historical data is clean.',
+    aliases: ['ledgerLock', 'isLedgerLocked', 'locked'],
+    seeAlso: ['ledger-balance', 'ledger-validation', 'admin-context'],
+  },
+  {
+    term: 'ledger-validation',
+    topic: 'ledger',
+    summary:
+      'VALID, INVALID or DIFF — the stored ledger compared against a fresh regeneration from the charge.',
+    detail:
+      'Because records are generated, they can drift from what the charge now implies. VALID means a regeneration matches what is stored. INVALID means regeneration fails or produces errors. DIFF means it succeeds but disagrees with the stored records — the signal that a charge changed after its ledger was written and needs regenerating.',
+    aliases: ['invalidLedger', 'VALID', 'INVALID', 'DIFF'],
+    seeAlso: ['ledger-record', 'ledger-lock', 'ledger-balance'],
+    tools: ['accounter_get_charges'],
+  },
+];
+
+const ENTITY_ENTRIES: readonly GlossaryEntry[] = [
+  {
+    term: 'financial-entity',
+    topic: 'entity',
+    summary:
+      'The supertype that lets BOTH businesses and tax categories sit in a ledger account slot.',
+    detail:
+      'Ledger slots do not hold "accounts" in a single sense — they hold financial entities, which come in two families discriminated by type: businesses (real counterparties) and tax categories (bookkeeping accounts). This is why one filter over financial entity ids can match a supplier and a revenue account alike, and why the balancing rule has to distinguish them.',
+    aliases: ['FinancialEntity', 'financialEntityIds'],
+    seeAlso: ['business', 'tax-category', 'ledger-balance', 'debit-account'],
+    tools: ['accounter_get_ledger_records'],
+  },
+  {
+    term: 'business',
+    topic: 'entity',
+    summary:
+      'A real party: a company, sole trader or individual — your own businesses and every counterparty alike.',
+    detail:
+      'One table holds them all, which is why the full business directory is much larger than the handful you are a member of. Carries the tax identifiers and behaviour flags that drive validation: government/VAT id, country (compared against your locality to decide whether VAT applies at all), VAT-exempt-dealer status, whether a receipt alone suffices, whether documents are required. Businesses also carry matching phrases used to guess a counterparty from a bank description.',
+    aliases: ['businesses', 'Business', 'LtdFinancialEntity'],
+    seeAlso: ['financial-entity', 'owner', 'counterparty', 'member-business-id'],
+    tools: ['accounter_list_businesses', 'accounter_list_business_memberships'],
+  },
+  {
+    term: 'tax-category',
+    topic: 'entity',
+    summary:
+      'A bookkeeping account — revenue, expense, VAT, reserves — used in ledger slots, never a real-world party.',
+    detail:
+      'The profit-and-loss and balance-sheet accounts. Unlike businesses, tax categories are EXPECTED to carry non-zero balances; that residue is the result. Businesses can be mapped to a default tax category so a supplier automatically posts to the right expense line, and financial accounts get a tax category per currency.',
+    aliases: ['taxCategories', 'TaxCategory'],
+    seeAlso: ['financial-entity', 'business', 'ledger-balance', 'sort-code'],
+    tools: ['accounter_list_tax_categories'],
+  },
+  {
+    term: 'sort-code',
+    topic: 'entity',
+    summary:
+      'The numeric chart-of-accounts grouping (kod miyun) that every financial report buckets by.',
+    detail:
+      'Attached to financial entities — both businesses and tax categories. Reports do not group by individual account but by sort-code range: revenue, cost of sales, research and development, marketing, management and general, financial expenses. If you want a profit-and-loss shaped answer, the sort code is the grouping key, not the entity name.',
+    aliases: ['sortCode', 'SortCode', 'קוד מיון'],
+    seeAlso: ['financial-entity', 'tax-category', 'irs-code'],
+    tools: ['accounter_list_tax_categories'],
+  },
+  {
+    term: 'irs-code',
+    topic: 'entity',
+    summary:
+      'The tax-authority reporting code a financial entity rolls up into for statutory annual filings.',
+    detail:
+      'A second, coarser classification alongside the sort code, used to aggregate entities into the line items of the statutory annual financial-statement filing. Sort codes supply a default IRS code, which individual entities can override.',
+    aliases: ['irsCode'],
+    seeAlso: ['sort-code', 'financial-entity', 'tax-category'],
+    tools: ['accounter_list_tax_categories'],
+  },
+  {
+    term: 'financial-account',
+    topic: 'entity',
+    summary:
+      'A scraped source of transactions — a specific bank account or credit card, belonging to one owner.',
+    detail:
+      'Represents the external thing being scraped, as distinct from the business that owns it: one business can hold several accounts, and a charge touching more than one of them is what makes it an internal transfer. Accounts carry a tax category per currency so ledger generation knows where to post.',
+    aliases: ['financialAccounts', 'account'],
+    seeAlso: ['transaction', 'internal-transfer-charge', 'business'],
+  },
+  {
+    term: 'admin-context',
+    topic: 'entity',
+    summary:
+      'The per-owner registry mapping well-known accounting roles to concrete entity ids — the ledger engine depends on it.',
+    detail:
+      'Each owning business configures which specific entity plays each role: input and output VAT categories, the tax authority business, social security, exchange-rate and fee categories, salary and reserve categories, the per-institution businesses, the local currency, and the ledger lock date. Nothing generates without it, and it is why the same conceptual account has different ids for different owners — never assume an id is shared across businesses.',
+    aliases: ['adminContext', 'AdminContextInfo'],
+    seeAlso: ['tax-category', 'ledger-record', 'ledger-lock', 'owner'],
+  },
+];
+
+const SCOPE_ENTRIES: readonly GlossaryEntry[] = [
+  {
+    term: 'owner',
+    topic: 'scope',
+    summary:
+      'YOUR business — the entity whose books a charge belongs to. This is the access-control axis.',
+    detail:
+      'Every charge, transaction, document and ledger record has exactly one owner: the business doing the bookkeeping. It is the row-level security key, so you only ever see rows owned by businesses you are a member of, and every row returned carries its ownerId so results spanning several of your businesses can be grouped. The owner is NEVER the other party to the deal.',
+    aliases: ['ownerId', 'owning business'],
+    seeAlso: ['counterparty', 'member-business-id', 'owner-vs-counterparty-filter', 'business'],
+    tools: ['accounter_list_business_memberships', 'accounter_search_charges'],
+  },
+  {
+    term: 'counterparty',
+    topic: 'scope',
+    summary:
+      'The OTHER party — vendor or customer. Derived, not stored, and null whenever it is ambiguous.',
+    detail:
+      'Computed by collecting every business referenced across the charge transactions, documents, ledger records and misc expenses, removing the owner, and ignoring fee-only rows. It resolves to a value ONLY when exactly one candidate remains. So a null counterparty does not mean "unknown vendor" — it usually means the charge touches two or more distinct parties, or none at all. Filtering for charges with a missing counterparty is how you find both cases.',
+    aliases: ['counterParty', 'withMissingCounterparty', 'mainBusiness'],
+    seeAlso: ['owner', 'owner-vs-counterparty-filter', 'is-fee', 'creditor', 'debtor'],
+    tools: ['accounter_search_charges', 'accounter_get_charges'],
+  },
+  {
+    term: 'member-business-id',
+    topic: 'scope',
+    summary:
+      'An id of a business you are a MEMBER of — the scoping input every business-scoped tool takes.',
+    detail:
+      'Your memberships are the businesses you may read at all. Passing `memberBusinessIds` narrows a call to a subset of them; omitting it covers all of them. It can only ever narrow — an id outside your memberships is rejected rather than silently dropped — and the resolved scope is echoed back on every response. Discover the ids first; do not guess them.',
+    aliases: ['memberBusinessIds', 'memberBusinessId', 'membership', 'scope'],
+    seeAlso: ['owner', 'owner-vs-counterparty-filter', 'business'],
+    tools: ['accounter_list_business_memberships'],
+  },
+  {
+    term: 'owner-vs-counterparty-filter',
+    topic: 'scope',
+    summary:
+      'THE filter trap: byOwners selects YOUR businesses, byBusinesses selects the COUNTERPARTY. They are not interchangeable.',
+    detail:
+      'Two similarly named charge filters ask opposite questions. `byOwners` (and the `memberBusinessIds` scope input) narrows by the business whose books the charge is in — your side. `byBusinesses` narrows by the other party, and the underlying data has the owner deliberately REMOVED from the list it matches against, so passing your own business id there returns almost nothing rather than everything. Symptom to watch for: a filter that should match thousands of rows returns zero. Same distinction on documents: business ids filter the counterparty; owner ids filter your side.',
+    aliases: ['byBusinesses', 'byOwners', 'businessIds'],
+    seeAlso: ['owner', 'counterparty', 'member-business-id'],
+    tools: ['accounter_search_charges', 'accounter_get_charges', 'accounter_get_documents'],
+  },
+];
+
+/** The full glossary, ordered by topic so index mode reads coherently. */
+export const GLOSSARY: readonly GlossaryEntry[] = [
+  ...CHARGE_ENTRIES,
+  ...TRANSACTION_ENTRIES,
+  ...DOCUMENT_ENTRIES,
+  ...LEDGER_ENTRIES,
+  ...ENTITY_ENTRIES,
+  ...SCOPE_ENTRIES,
+];

--- a/packages/mcp-server/src/tools/terminology.ts
+++ b/packages/mcp-server/src/tools/terminology.ts
@@ -1,0 +1,271 @@
+import { z } from 'zod';
+import { shapeListResult } from './output.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import {
+  GLOSSARY,
+  GLOSSARY_TOPICS,
+  type GlossaryEntry,
+  type GlossaryTopic,
+} from './terminology-data.js';
+
+/**
+ * Domain-terminology lookup (the connector's glossary).
+ *
+ * The other tools all return *data*; none of them explain what the data means.
+ * That gap is load-bearing here — "charge" is not a bank charge, `byOwners` and
+ * `byBusinesses` ask opposite questions, and ledger slot 2 is the VAT split —
+ * and it cannot live in per-tool `description` strings, which every caller pays
+ * for on every `tools/list` and which cannot carry concepts spanning tools.
+ *
+ * Two properties make this tool unlike the other eleven:
+ *
+ * 1. It is **pure**. The handler never touches `context.client`, so there is no
+ *    upstream call and no `x-business-scope` header. `scope-forwarding.test.ts`
+ *    knows about this via its `PURE_TOOLS` set.
+ * 2. It is **unscoped** (`requiresBusinessScope: false`). A caller with zero
+ *    memberships must still be able to read the glossary — same reasoning as
+ *    `businesses.ts`, and the reason the content carries no customer data and is
+ *    classified `public`.
+ */
+
+export const EXPLAIN_TERMINOLOGY_TOOL_NAME = 'accounter_explain_terminology';
+
+/** Upper bound on terms per call. Generous — each match is a few hundred bytes. */
+export const MAX_REQUESTED_TERMS = 20;
+
+/** Shortest shared prefix that makes a term worth suggesting for a typo. */
+const MIN_SUGGESTION_PREFIX = 3;
+
+/** Suggestions returned alongside an unmatched term. */
+const MAX_SUGGESTIONS = 3;
+
+/**
+ * Shortest spelling allowed to match as a substring *of the request*.
+ *
+ * That direction is what tolerates trailing noise (`ledgerrr` -> `ledger-record`),
+ * but applied to short aliases it fires on unrelated words — `fee` inside
+ * `feedback`, `vat` inside a longer token. Long spellings only.
+ */
+const MIN_LOOSE_MATCH_LENGTH = 5;
+
+const explainTerminologyInput = z.object({
+  terms: z
+    .array(z.string().min(2).max(60))
+    .min(1)
+    .max(MAX_REQUESTED_TERMS)
+    .optional()
+    .describe(
+      'Look up specific terms. Matches the canonical name, any alias (enum tokens like `INTERNAL`, ' +
+        'GraphQL type names like `InternalTransferCharge`, field names like `effectiveDate`), then ' +
+        'falls back to a substring search. Case, hyphens, underscores and spaces are ignored. ' +
+        'A term that matches nothing is reported under `unmatched` with suggestions — it does not fail the call.',
+    ),
+  topics: z
+    .array(z.enum(GLOSSARY_TOPICS))
+    .min(1)
+    .optional()
+    .describe(
+      'Return every term in these topics, in full. Topics are `charge`, `transaction`, `document`, ' +
+        '`ledger`, `entity` (businesses, tax categories, sort codes) and `scope` (owner vs counterparty, memberships).',
+    ),
+});
+
+type ExplainTerminologyInput = z.infer<typeof explainTerminologyInput>;
+
+/**
+ * Fold a term to its comparison form: lowercase, non-alphanumerics stripped.
+ *
+ * This is what lets one alias cover several spellings — `value-date`,
+ * `valueDate` and `value date` all fold to `valuedate`, and
+ * `InternalTransferCharge` folds onto the `internal-transfer-charge` term
+ * itself. Unicode-aware so Hebrew aliases survive.
+ */
+function fold(value: string): string {
+  return value.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, '');
+}
+
+/** Every folded spelling that should resolve to an entry. */
+function spellingsOf(entry: GlossaryEntry): string[] {
+  return [entry.term, ...(entry.aliases ?? [])].map(fold);
+}
+
+/** Folded spelling -> entry. Built once; the glossary is static. */
+const ENTRY_BY_SPELLING = new Map<string, GlossaryEntry>();
+for (const entry of GLOSSARY) {
+  for (const spelling of spellingsOf(entry)) {
+    // First writer wins; `terminology-contract.test.ts` proves there are no
+    // collisions, so this is a guard against silent overwrite, not a policy.
+    if (!ENTRY_BY_SPELLING.has(spelling)) {
+      ENTRY_BY_SPELLING.set(spelling, entry);
+    }
+  }
+}
+
+/**
+ * Resolve one requested term. Tried in order so an exact hit always beats a
+ * coincidental substring: exact spelling, then substring of a spelling, then
+ * substring of the summary text.
+ */
+function lookup(requested: string): GlossaryEntry | undefined {
+  const needle = fold(requested);
+  if (needle.length === 0) {
+    return undefined;
+  }
+
+  const exact = ENTRY_BY_SPELLING.get(needle);
+  if (exact) {
+    return exact;
+  }
+
+  const bySpelling = GLOSSARY.find(entry =>
+    spellingsOf(entry).some(
+      spelling =>
+        spelling.includes(needle) ||
+        (spelling.length >= MIN_LOOSE_MATCH_LENGTH && needle.includes(spelling)),
+    ),
+  );
+  if (bySpelling) {
+    return bySpelling;
+  }
+
+  return GLOSSARY.find(entry => fold(entry.summary).includes(needle));
+}
+
+/** Terms sharing a leading prefix with an unmatched request, for a "did you mean". */
+function suggestionsFor(requested: string): string[] {
+  const needle = fold(requested);
+  const prefix = needle.slice(0, MIN_SUGGESTION_PREFIX);
+  if (prefix.length < MIN_SUGGESTION_PREFIX) {
+    return [];
+  }
+  return GLOSSARY.filter(entry => spellingsOf(entry).some(spelling => spelling.startsWith(prefix)))
+    .slice(0, MAX_SUGGESTIONS)
+    .map(entry => entry.term);
+}
+
+interface IndexItem {
+  term: string;
+  topic: GlossaryTopic;
+  summary: string;
+}
+
+interface FullItem extends IndexItem {
+  detail: string;
+  aliases?: readonly string[];
+  seeAlso?: readonly string[];
+  tools?: readonly string[];
+}
+
+function toIndexItem(entry: GlossaryEntry): IndexItem {
+  return { term: entry.term, topic: entry.topic, summary: entry.summary };
+}
+
+function toFullItem(entry: GlossaryEntry): FullItem {
+  const item: FullItem = { ...toIndexItem(entry), detail: entry.detail };
+  if (entry.aliases) item.aliases = entry.aliases;
+  if (entry.seeAlso) item.seeAlso = entry.seeAlso;
+  if (entry.tools) item.tools = entry.tools;
+  return item;
+}
+
+interface UnmatchedTerm {
+  term: string;
+  suggestions: string[];
+}
+
+/**
+ * Select the entries to return, preserving glossary (topic) order regardless of
+ * the order the caller asked in, and de-duplicating when `terms` and `topics`
+ * both name the same entry.
+ */
+function selectEntries(input: ExplainTerminologyInput): {
+  entries: GlossaryEntry[];
+  unmatched: UnmatchedTerm[];
+} {
+  const selected = new Set<GlossaryEntry>();
+  const unmatched: UnmatchedTerm[] = [];
+
+  for (const requested of input.terms ?? []) {
+    const entry = lookup(requested);
+    if (entry) {
+      selected.add(entry);
+    } else {
+      unmatched.push({ term: requested, suggestions: suggestionsFor(requested) });
+    }
+  }
+
+  if (input.topics) {
+    const wanted = new Set<GlossaryTopic>(input.topics);
+    for (const entry of GLOSSARY) {
+      if (wanted.has(entry.topic)) {
+        selected.add(entry);
+      }
+    }
+  }
+
+  return { entries: GLOSSARY.filter(entry => selected.has(entry)), unmatched };
+}
+
+function handler(input: ExplainTerminologyInput, _context: ToolExecutionContext): ToolResult {
+  // Mode is derived rather than a flag: asking for nothing in particular means
+  // "show me what exists" (cheap), asking for something means "explain it".
+  const isIndexMode = input.terms === undefined && input.topics === undefined;
+
+  if (isIndexMode) {
+    return shapeListResult({
+      items: GLOSSARY.map(toIndexItem),
+      itemsKey: 'terms',
+      extra: { mode: 'index', topics: GLOSSARY_TOPICS },
+      summarize: (shown, total, truncated) =>
+        `Accounter glossary index: ${shown} of ${total} term(s)${truncated ? ' (truncated)' : ''}. ` +
+        'Call again with `terms` or `topics` for full definitions.',
+    });
+  }
+
+  const { entries, unmatched } = selectEntries(input);
+
+  return shapeListResult({
+    items: entries.map(toFullItem),
+    itemsKey: 'terms',
+    extra: { mode: 'full', unmatched },
+    summarize: (shown, total, truncated) => {
+      const found =
+        total === 0
+          ? 'No matching glossary terms.'
+          : `Returning ${shown} of ${total} glossary term(s)${truncated ? ' (truncated)' : ''}.`;
+      if (unmatched.length === 0) {
+        return found;
+      }
+      const detail = unmatched
+        .map(item =>
+          item.suggestions.length > 0
+            ? `${item.term} (did you mean: ${item.suggestions.join(', ')})`
+            : item.term,
+        )
+        .join('; ');
+      return `${found} Not found: ${detail}.`;
+    },
+  });
+}
+
+export const explainTerminologyTool: ToolDefinition<typeof explainTerminologyInput> = {
+  name: EXPLAIN_TERMINOLOGY_TOOL_NAME,
+  description:
+    'Explain Accounter domain terminology — what charges, transactions, documents, ledger records, ' +
+    'businesses and tax categories actually mean in this system, including the distinctions that are ' +
+    'not inferable from the schema (a "charge" is an aggregate grouping transactions + documents + ' +
+    'ledger records, not a bank charge; `byOwners` selects your business while `byBusinesses` selects ' +
+    'the counterparty; `INTERNAL`/`CONVERSION` charges are money moving between your own accounts and ' +
+    'double-count in spend totals). Call it with no arguments for a one-line index of every term, then ' +
+    'pass `terms` to define specific ones or `topics` to read a whole area. Reference content only: ' +
+    'static, read-only, no business data, and callable before you know which businesses you can access.',
+  inputSchema: explainTerminologyInput,
+  policy: {
+    // Deliberately unscoped and `public`: the content is static reference text
+    // with no customer data, and a caller with zero memberships must still be
+    // able to read it (cf. `listBusinessMembershipsTool`).
+    requiresBusinessScope: false,
+    dataClassification: 'public',
+  },
+  handler,
+};


### PR DESCRIPTION
Adds a new read-only MCP tool `accounter_explain_terminology` that provides a curated glossary of Accounter domain concepts. This is the twelfth tool in the registry.

## Summary

The glossary addresses a critical gap: while other tools return data, none explain what that data means. Concepts like "charge" (not a bank charge, but an aggregate grouping transactions, documents, and ledger records), the distinction between `byOwners` and `byBusinesses` filters, and ledger slot 2 being the VAT split are non-obvious and cannot live in per-tool descriptions without bloating every `tools/list` response.

## Key Changes

- **`terminology-data.ts`** (742 lines): Static glossary content organized into six topics (charge, transaction, document, ledger, entity, scope) with 62 entries. Each entry includes:
  - Canonical term (lowercase kebab-case)
  - Single-line summary (for index mode)
  - Detailed explanation covering what the term means and what it is *not*
  - Aliases (enum tokens like `INTERNAL`, GraphQL type names like `InternalTransferCharge`, field names like `effectiveDate`, Hebrew terms)
  - Cross-references (`seeAlso` links to related terms, `tools` that surface the concept)

- **`terminology.ts`** (271 lines): Tool handler with two modes:
  - **Index mode** (no arguments): Returns all 62 terms as one-liners for orientation (~10 KB)
  - **Full mode** (with `terms` or `topics` arguments): Returns selected entries with full detail
  - Flexible lookup: exact spelling match → substring match → summary text search
  - Typo tolerance: suggests near matches by shared prefix
  - Case/hyphen/underscore/space normalization so `value-date`, `valueDate`, `value date` all resolve identically

- **`terminology.test.ts`** (264 lines): Behavioral test suite covering:
  - Index and full modes
  - Alias resolution (enum tokens, GraphQL types, field names)
  - Substring matching and typo suggestions
  - Topic filtering
  - Input validation and contract enforcement
  - Verification that the tool is pure (makes no upstream calls)

- **`terminology-contract.test.ts`** (137 lines): Drift guards ensuring:
  - All charge types, accountant statuses, and ledger slots are defined
  - No colliding spellings across entries
  - All cross-references (`seeAlso`, `tools`) point to existing entries/tools
  - Every topic has entries and every entry has a non-empty detail
  - The entire glossary fits in one response (enforced against `MAX_TOOL_RESULT_BYTES`)

- **Tool registration**: Added to `registry-instance.ts` as the second tool (right after discovery), marked as unscoped (`requiresBusinessScope: false`) and pure so it works for users with zero memberships.

- **Documentation**: Updated README to reflect twelve tools instead of eleven.

## Notable Implementation Details

- **Pure tool**: Unlike the other eleven tools, this handler never calls `context.client`, so there is no upstream GraphQL call and no `x-business-scope` header. The `scope-forwarding.test.ts` suite knows about this via a `PURE_TOOLS` set.
- **Unscoped**: Callable by any authenticated user regardless of business memberships, same reasoning as the `businesses` tool — the glossary is public domain knowledge.
- **Folding strategy**: Spellings are normalized to lowercase alphanumerics only, allowing one alias to cover `value-date`, `valueDate`, and `value date` without duplication.
- **Substring matching**: Tolerates trailing noise (`ledgerrr` → `ledger-record`) by checking if the request is a substring of a long spelling, but prevents false positives like `fee` matching `feedback` by requiring the spelling to be at least 5 characters.
- **Budget**: At 62 entries the glossary is ~40 KB against the 60 KB `MAX_TOOL_RESULT_BYTES` guard, leaving room for ~30 more entries before truncation becomes a concern.

https://claude.ai/code/session_01YEQV9HZei9dq3TP2iTQ5bu