### PR TITLE
Add write tools: tags and document upload

### DIFF
--- a/.changeset/mcp-server-write-tools.md
+++ b/.changeset/mcp-server-write-tools.md
@@ -1,0 +1,57 @@
+---
+'@accounter/mcp-server': patch
+---
+
+First write ("edit") tools for the MCP connector, behind an opt-in flag.
+
+Adds `accounter_update_charges_tags` and `accounter_upload_documents`, plus the shared write path
+they need. Writes are **off by default** (`MCP_ENABLE_WRITE_TOOLS=0`), so upgrading a running
+deployment never silently grants the model write access — an operator opts in per environment.
+
+**Write path** — reads and writes now travel separate, individually guarded methods on the upstream
+client. `query()` still refuses anything that is not a read; the new `mutate()` and
+`mutateMultipart()` refuse anything that is not a *single top-level mutation*, so neither can send
+the other's traffic. Writes are **never retried**: a mutation is not idempotent, and re-sending one
+that may already have applied upstream could double-apply it. `executeOnce` now takes a body builder,
+so headers, the timeout/abort budget, and error sanitization are shared across all three paths rather
+than duplicated. `mutateMultipart` implements the GraphQL multipart request spec (which graphql-yoga
+handles natively upstream), following the existing precedent in `packages/gmail-listener`.
+
+**Policy and gating**
+
+- `ToolAuthPolicy.mutating` gates exposure, forces a **single write-target business** — a read may
+  span every membership, but an ambiguous write scope is refused with an actionable message rather
+  than resolved by picking one — and triggers an audit line emitted *before* the handler runs, so a
+  call that then times out still leaves a record. The line carries identifiers and counts only, never
+  file contents, filenames, or tokens.
+- New `MCP_ENABLE_WRITE_TOOLS` (`1`/`0`, default `0`). `isToolExposed` composes it with
+  `MCP_TOOL_ALLOWLIST` one way only: the allowlist can narrow which write tools are exposed, but
+  naming one in it can never turn writes on. A tool excluded by either control is reported as
+  `Unknown tool`, exactly like a nonexistent one, so neither control announces what it is hiding.
+- `shapeWriteResult` joins `shapeListResult` in the shared output layer. It is deliberately
+  asymmetric: a write's outcome is never droppable, so the payload guard applies only to the optional
+  per-item echo — and drops that echo *whole*, since a half-echoed list of changed records would read
+  as "these are the ones that changed", which would be false.
+
+**Tools**
+
+- `accounter_upload_documents` — attaches 1–10 base64-encoded documents to an **existing** charge.
+  `chargeId` is required: upstream `batchUploadDocuments` creates a new charge when it is omitted,
+  which is not a side effect the model should trigger by leaving a field blank. `isSensitive` is
+  pinned to `true` and deliberately absent from the input schema. Documents arrive as base64 because
+  this server is remote and has no access to the caller's filesystem; each is validated for encoding,
+  MIME type, and size (5 MB per file, 15 MB per call, decoded) *before* anything is uploaded —
+  `Buffer.from(x, 'base64')` silently skips characters it does not recognize, so a truncated payload
+  would otherwise decode to a plausible-looking short buffer and surface as a corrupt file much
+  later. Upstream returns one result per file, so partial failure is reported positionally rather
+  than collapsed.
+- `accounter_update_charges_tags` — adds and/or removes tags across 1–50 charges. Tags are given by
+  id, never by name: names are not unique across owners, so resolving them here would mean guessing
+  which of several same-named tags was meant — the model resolves them with `accounter_list_tags`
+  first. The edit is incremental, not a replacement, and removals run before additions, so a tag id
+  passed in both lists ends up added.
+
+Known gaps, filed as I6/I7 in `docs/todo.md`: writes carry no idempotency key (the server never
+retries, but a client retrying an upload whose result it never saw can duplicate the document), and
+the accountant-approval degradation that `batchUploadDocuments` performs upstream is not reflected in
+the tool's response.

--- a/.changeset/mcp-server-write-tools.md
+++ b/.changeset/mcp-server-write-tools.md
@@ -35,12 +35,12 @@ handles natively upstream), following the existing precedent in `packages/gmail-
 
 **Tools**
 
-- `accounter_upload_documents` — attaches 1–10 base64-encoded documents to an **existing** charge.
+- `accounter_upload_documents` — attaches 1–10 documents to an **existing** charge.
   `chargeId` is required: upstream `batchUploadDocuments` creates a new charge when it is omitted,
-  which is not a side effect the model should trigger by leaving a field blank. `isSensitive` is
-  pinned to `true` and deliberately absent from the input schema. Documents arrive as base64 because
-  this server is remote and has no access to the caller's filesystem; each is validated for encoding,
-  MIME type, and size (256KB per file, 512KB per call, decoded) *before* anything is uploaded —
+  which is not a side effect the model should trigger by leaving a field blank. Documents arrive
+  either as URLs the server fetches itself (preferred, no size limit) or as inline base64; each
+  inline document is validated for encoding, MIME type, and size (256KB per file, 512KB per call,
+  decoded) *before* anything is uploaded —
   `Buffer.from(x, 'base64')` silently skips characters it does not recognize, so a truncated payload
   would otherwise decode to a plausible-looking short buffer and surface as a corrupt file much
   later. Upstream returns one result per file, so partial failure is reported positionally rather
@@ -51,12 +51,18 @@ handles natively upstream), following the existing precedent in `packages/gmail-
   first. The edit is incremental, not a replacement, and removals run before additions, so a tag id
   passed in both lists ends up added.
 
-The upload caps are small because inline base64 makes the *model* the transport — it must emit the
+`isSensitive` is pinned to `false` and deliberately absent from the input schema. The upstream name
+is misleading: `getOcrData` returns early with `documentType: UNPROCESSED` whenever it is set, so
+`true` does not so much mark a document sensitive as skip OCR entirely — documents uploaded through
+the tool would land with no amount, date, counterparty, or serial. Documents ingested here are meant
+to be read, so both branches pass `false`.
+
+The inline caps are small because inline base64 makes the *model* the transport — it must emit the
 whole encoded file as tool arguments, and base64 tokenizes at roughly 3 characters per token, so a
 277KB PDF costs on the order of 100k output tokens. They are also pinned against
 `MAX_MCP_BODY_BYTES` by `tools/__tests__/upload-limits.test.ts`, because an earlier draft advertised
-5MB per file while the 1MB body cap made that unreachable. Over-size errors name the Drive and email
-ingestion paths rather than just reporting a number: without that, the model's natural move is to
+5MB per file while the 1MB body cap made that unreachable. Over-size errors name the URL path
+rather than just reporting a number: without that, the model's natural move is to
 re-encode a scanned receipt at lower quality until it fits, archiving a degraded copy of a legal
 financial record.
 

--- a/.changeset/mcp-server-write-tools.md
+++ b/.changeset/mcp-server-write-tools.md
@@ -40,7 +40,7 @@ handles natively upstream), following the existing precedent in `packages/gmail-
   which is not a side effect the model should trigger by leaving a field blank. `isSensitive` is
   pinned to `true` and deliberately absent from the input schema. Documents arrive as base64 because
   this server is remote and has no access to the caller's filesystem; each is validated for encoding,
-  MIME type, and size (5 MB per file, 15 MB per call, decoded) *before* anything is uploaded —
+  MIME type, and size (256KB per file, 512KB per call, decoded) *before* anything is uploaded —
   `Buffer.from(x, 'base64')` silently skips characters it does not recognize, so a truncated payload
   would otherwise decode to a plausible-looking short buffer and surface as a corrupt file much
   later. Upstream returns one result per file, so partial failure is reported positionally rather
@@ -50,6 +50,15 @@ handles natively upstream), following the existing precedent in `packages/gmail-
   which of several same-named tags was meant — the model resolves them with `accounter_list_tags`
   first. The edit is incremental, not a replacement, and removals run before additions, so a tag id
   passed in both lists ends up added.
+
+The upload caps are small because inline base64 makes the *model* the transport — it must emit the
+whole encoded file as tool arguments, and base64 tokenizes at roughly 3 characters per token, so a
+277KB PDF costs on the order of 100k output tokens. They are also pinned against
+`MAX_MCP_BODY_BYTES` by `tools/__tests__/upload-limits.test.ts`, because an earlier draft advertised
+5MB per file while the 1MB body cap made that unreachable. Over-size errors name the Drive and email
+ingestion paths rather than just reporting a number: without that, the model's natural move is to
+re-encode a scanned receipt at lower quality until it fits, archiving a degraded copy of a legal
+financial record.
 
 Known gaps, filed as I6/I7 in `docs/todo.md`: writes carry no idempotency key (the server never
 retries, but a client retrying an upload whose result it never saw can duplicate the document), and

--- a/.changeset/mcp-upload-from-urls.md
+++ b/.changeset/mcp-upload-from-urls.md
@@ -1,0 +1,40 @@
+---
+'@accounter/server': patch
+'@accounter/mcp-server': patch
+---
+
+Upload documents by URL, so the bytes stop travelling through the model.
+
+Inline base64 made the *model* the transport for every uploaded document, and that is the wrong
+place for a financial record to pass through: base64 has no redundancy, so a single mis-emitted
+character corrupts the file, and a 277KB PDF costs on the order of 100k output tokens before any
+server-side limit is even consulted. In practice the tool could only carry files small enough to be
+uninteresting.
+
+**Server: `batchUploadDocumentsFromUrls(urls, chargeId, isSensitive)`.** The server fetches each URL
+and hands the result to the existing `getDocumentFromFile`, so Cloudinary upload, OCR, hashing, and
+charge attachment are unchanged. Results are positional — one entry per input URL — so a partial
+failure names the URL that failed instead of sinking the batch.
+
+A server that fetches caller-supplied URLs is an SSRF primitive unless it is guarded, so
+`fetch-remote-document.helper.ts` refuses loopback, private, link-local (including the cloud metadata
+address), and carrier-grade-NAT ranges, plus `localhost`/`.local` by name and any non-http scheme.
+Redirects are followed **manually** and re-validated at every hop: checking only the submitted URL is
+the classic way this guard is bypassed, since the redirect target is attacker-controlled too. Bytes,
+redirects, and wall-clock time are all capped. The content type is taken from the *response*, never
+from the URL's extension — a `.pdf` link that answers with `text/html` is a login page, and storing
+it would file a web page as a financial record.
+
+Google Drive share links are routed through `GoogleDriveProvider`, which gains `isFileUrl` and
+`fetchFileFromUrl`. This is not optional politeness: `/file/d/<id>/view` returns an HTML page rather
+than the file, so a plain fetch would store the page. Going through the Drive API also reads files
+shared to the account rather than only public ones.
+
+**MCP: `documentUrls` on `accounter_upload_documents`.** Exactly one of `documentUrls` or
+`documents` per call, enforced by a schema refinement so the model gets one clear message rather than
+a pair of "no variant matched" branches. The URL branch has no size cap — the inline caps exist
+solely because base64 rides in the model's output, which a URL does not. The tool description now
+names URLs as the preferred path and inline base64 as the small-content fallback, and the over-size
+error points at `documentUrls` instead of merely reporting a number, so the model's next move is a
+link rather than a re-encoded, degraded copy of the receipt. The audit line records only
+`documentUrlsCount`, never the URLs themselves, which can carry access tokens.

--- a/.changeset/mcp-write-usage-logging.md
+++ b/.changeset/mcp-write-usage-logging.md
@@ -1,0 +1,31 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Give the write tools an `observe` hook, so their usage log line says what they did.
+
+The usage logging added in #4244 enriches a call's `tool_call` line from two sources: the shared
+list shaping (`returnedCount`/`totalCount`/`truncated`) and the tool's own `observe` hook. A write
+result has neither — `shapeWriteResult` produces an outcome, not a list — so a completed write
+logged *that* it happened and nothing about *what* it did.
+
+- `accounter_upload_documents` reports `documentSource` (`urls` or `inline`),
+  `requestedDocumentCount`, `uploadedCount` and `failedCount`, plus a `document_upload_source` label
+  counter. That counter is the one worth watching: `inline` is capped at 256KB per file because the
+  content rides in the model's own output, so a rising `inline` share means callers are still
+  hitting a ceiling `documentUrls` removes entirely.
+- `accounter_update_charges_tags` reports `requestedChargeCount`, `updatedChargeCount`,
+  `addedTagCount` and `removedTagCount`. The counts are reported separately because their difference
+  is the signal — upstream silently skips a charge id it cannot resolve, so "asked for 50, updated
+  43" is the shape of a model working from stale ids.
+
+Counts come from the finished result rather than the input, since upstream reports success per
+document and a partially failed batch is exactly the case worth seeing. Ids are deliberately left
+out: the `audit: true` line each write already emits *before* its handler runs carries them, and
+repeating them here would double the noisiest field for no added answer. Neither line carries
+document content, filenames, or URLs — a signed download link carries an access token, and a test
+pins that.
+
+Also fixes the registry-wide usage-log guard, which iterates every registered tool and asserts a
+successful call: it had no arguments for the two write tools, so both were passing only by way of
+the validation-rejection path.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -318,6 +318,16 @@ the `glossary_term_requests`, `glossary_term_misses` and `glossary_mode` label c
 caller looks up is the clearest available read on the vocabulary they arrived with, and
 `missedTerms` is a self-maintaining backlog of glossary entries to write.
 
+The write tools use it too. A write result has none of the shared list-shape fields, so without a
+hook its usage line would record _that_ a write happened and nothing about what it did:
+`accounter_upload_documents` reports `documentSource` (`urls` vs `inline`),
+`requestedDocumentCount`, `uploadedCount` and `failedCount` plus a `document_upload_source` counter,
+and `accounter_update_charges_tags` reports `requestedChargeCount`, `updatedChargeCount`,
+`addedTagCount` and `removedTagCount` — the gap between requested and updated is how a model working
+from stale charge ids becomes visible. This line is the complement to the `audit: true` line each
+write already emits _before_ its handler runs: the audit line names the records, this one says what
+applied. Neither carries document content, filenames, or URLs.
+
 See [`docs/operations-runbook.md`](./docs/operations-runbook.md) §3.1 for the full field reference
 and the `jq` extraction recipes (most-requested terms, missing terms, tool popularity).
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -194,7 +194,8 @@ The two **write** tools below are only exposed when `MCP_ENABLE_WRITE_TOOLS=1`; 
   `chargeId` is required (upstream would otherwise create a new charge), `isSensitive` is pinned to
   `true`, and each file is validated for encoding, MIME type, and size _before_ anything is
   uploaded. Upstream returns one result per file, so partial failure is reported positionally rather
-  than collapsed. Requires `business_owner`/`accountant`.
+  than collapsed. **Small files only** — see
+  [Why inline upload is small](#why-inline-upload-is-small). Requires `business_owner`/`accountant`.
 
 ## Upstream GraphQL client
 
@@ -521,14 +522,41 @@ Two tool-specific rules worth knowing:
   `removeTagIds` stay. Removals are applied before additions, so a tag id passed in _both_ lists
   ends up added.
 
+### Why inline upload is small
+
+`accounter_upload_documents` caps a document at **256KB** and a call at **512KB**, decoded. That is
+far below what the upstream mutation could take, and the reason is the transport, not the backend.
+
+Inline base64 makes the _model_ the transport: it has to emit the entire encoded file as tool
+arguments. Base64 tokenizes at roughly 3 characters per token, so a 277KB PDF costs on the order of
+100k output tokens — past a single message's budget. Three ceilings apply, and the model's is the
+tightest:
+
+| Ceiling                                           | Effective limit                              |
+| ------------------------------------------------- | -------------------------------------------- |
+| Model's per-message output budget                 | a few tens of KB of file                     |
+| `MAX_MCP_BODY_BYTES` (1MB JSON-RPC body)          | ~700KB decoded, after base64's 4/3 expansion |
+| `MAX_DOCUMENT_BYTES` / `MAX_TOTAL_DOCUMENT_BYTES` | 256KB / 512KB                                |
+
+An earlier revision advertised 5MB per file, which the body cap made unreachable — the request died
+as a 413 before the tool's own check ran. `tools/__tests__/upload-limits.test.ts` now asserts the
+caps against `MAX_MCP_BODY_BYTES` so the two cannot drift apart again.
+
+Over-size errors deliberately name the alternatives rather than just reporting a number. Without
+that, the model's natural move is to downscale or re-encode the file until it fits — which for a
+scanned receipt means archiving a degraded copy of a legal financial record. For anything larger
+than the caps, use a path that does not route bytes through the conversation: the Google Drive
+folder ingestion (`batchUploadDocumentsFromGoogleDrive`) or the email ingestion gateway.
+
 ## Known limitations
 
 - There is no generic "run any query" surface: every capability is a curated tool with a strict
   input schema, and the upstream client's read and write paths are separately guarded.
 - Responses are **bounded** (date ranges ≤ 366 days, page size ≤ 50, list caps of 500, a
   payload-size guard) — very large result sets are truncated with a `truncated`/`continuation` hint
-  rather than streamed in full. Uploads are bounded too: ≤ 10 documents, 5 MB per file and 15 MB per
-  call once decoded, against a MIME allowlist.
+  rather than streamed in full. Uploads are bounded too: ≤ 10 documents, 256KB per file and 512KB
+  per call once decoded, against a MIME allowlist. Inline base64 is only viable for small files at
+  all — see [Why inline upload is small](#why-inline-upload-is-small).
 - Rate limiting and metrics are **in-process** (per replica); there is no shared/Redis-backed
   limiter or Prometheus exposition yet (the limiter and metrics are behind swappable seams).
 - Tracing is exported to OpenTelemetry/Grafana Tempo (opt-in via `OTEL_ENABLED=1`), but metrics

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -190,11 +190,13 @@ The two **write** tools below are only exposed when `MCP_ENABLE_WRITE_TOOLS=1`; 
   resolving them here would mean guessing which of several same-named tags was meant — the model
   resolves them with `accounter_list_tags` first. Incremental, not a replacement, and removals run
   before additions so an id in both lists ends up added. Requires `business_owner`/`accountant`.
-- **`accounter_upload_documents`** — attach 1–10 base64-encoded documents to an **existing** charge.
-  `chargeId` is required (upstream would otherwise create a new charge), `isSensitive` is pinned to
-  `true`, and each file is validated for encoding, MIME type, and size _before_ anything is
-  uploaded. Upstream returns one result per file, so partial failure is reported positionally rather
-  than collapsed. **Small files only** — see
+- **`accounter_upload_documents`** — attach 1–10 documents to an **existing** charge, given either
+  as `documentUrls` (preferred — the server fetches them, so there is no size limit) or as inline
+  base64 `documents`; exactly one of the two per call. `chargeId` is required (upstream would
+  otherwise create a new charge) and `isSensitive` is pinned to `false`. Each inline file is
+  validated for encoding, MIME type, and size _before_ anything is uploaded. Upstream returns one
+  result per input, so partial failure is reported positionally rather than collapsed. See
+  [Uploading by URL](#uploading-by-url) and
   [Why inline upload is small](#why-inline-upload-is-small). Requires `business_owner`/`accountant`.
 
 ## Upstream GraphQL client
@@ -488,10 +490,10 @@ The automated equivalent of steps 1–7 (with the Auth0 verifier and upstream mo
 
 Two mutating tools are available, and both are **hidden unless `MCP_ENABLE_WRITE_TOOLS=1`**:
 
-| Tool                            | What it does                                                                     |
-| ------------------------------- | -------------------------------------------------------------------------------- |
-| `accounter_update_charges_tags` | Adds and/or removes tags across one or more charges (tag **ids**, not names)     |
-| `accounter_upload_documents`    | Attaches base64-encoded documents to an **existing** charge, always as sensitive |
+| Tool                            | What it does                                                                 |
+| ------------------------------- | ---------------------------------------------------------------------------- |
+| `accounter_update_charges_tags` | Adds and/or removes tags across one or more charges (tag **ids**, not names) |
+| `accounter_upload_documents`    | Attaches documents — by URL or inline base64 — to an **existing** charge     |
 
 The default is off so that upgrading a running deployment never silently grants the model write
 access — an operator opts in per environment. `MCP_TOOL_ALLOWLIST` composes on top and can narrow
@@ -517,10 +519,34 @@ Two tool-specific rules worth knowing:
 
 - `accounter_upload_documents` requires `chargeId`. The upstream mutation _creates a new charge_
   when it is omitted, which is not a side effect the model should trigger by leaving a field blank.
-  `isSensitive` is pinned to `true` and is deliberately absent from the input schema.
+  `isSensitive` is pinned to `false` and is deliberately absent from the input schema — the upstream
+  name is misleading, since `getOcrData` returns early with `documentType: UNPROCESSED` whenever it
+  is set, so `true` does not so much mark a document sensitive as skip OCR entirely and land it with
+  no amount, date, counterparty, or serial.
 - `accounter_update_charges_tags` is incremental, not a replacement: tags not named in
   `removeTagIds` stay. Removals are applied before additions, so a tag id passed in _both_ lists
   ends up added.
+
+### Uploading by URL
+
+`documentUrls` is the path to reach for. The **server** fetches each URL and ingests the result, so
+the bytes never pass through the model — which is what every limit in the next section is working
+around. There is no size cap on this branch. Google Drive share links work (they are resolved
+through the Drive API, because `/file/d/<id>/view` returns an HTML page rather than the file), as
+does any direct download link.
+
+A server that fetches caller-supplied URLs is an SSRF primitive, so
+`packages/server/src/modules/documents/helpers/fetch-remote-document.helper.ts` guards it: private,
+loopback, link-local (the cloud metadata address included) and CGNAT ranges are refused,
+`localhost`/`.local` are refused by name, non-`http(s)` schemes are refused, and redirects are
+followed **manually** so every hop is re-validated — checking only the submitted URL is how this
+guard is usually bypassed, since the redirect target is attacker-controlled too. Bytes, redirects,
+and wall-clock time are capped, and the content type is read from the _response_, never from the
+URL's extension: a `.pdf` link that answers with `text/html` is a login page, and storing it would
+file a web page as a financial record.
+
+The audit line records `documentUrlsCount` only, never the URLs themselves — a signed download link
+carries an access token.
 
 ### Why inline upload is small
 
@@ -542,11 +568,11 @@ An earlier revision advertised 5MB per file, which the body cap made unreachable
 as a 413 before the tool's own check ran. `tools/__tests__/upload-limits.test.ts` now asserts the
 caps against `MAX_MCP_BODY_BYTES` so the two cannot drift apart again.
 
-Over-size errors deliberately name the alternatives rather than just reporting a number. Without
+Over-size errors deliberately name the alternative rather than just reporting a number. Without
 that, the model's natural move is to downscale or re-encode the file until it fits — which for a
-scanned receipt means archiving a degraded copy of a legal financial record. For anything larger
-than the caps, use a path that does not route bytes through the conversation: the Google Drive
-folder ingestion (`batchUploadDocumentsFromGoogleDrive`) or the email ingestion gateway.
+scanned receipt means archiving a degraded copy of a legal financial record. The alternative is
+`documentUrls`: put the file somewhere fetchable and pass the link, and none of these ceilings
+apply.
 
 ## Known limitations
 
@@ -554,9 +580,9 @@ folder ingestion (`batchUploadDocumentsFromGoogleDrive`) or the email ingestion 
   input schema, and the upstream client's read and write paths are separately guarded.
 - Responses are **bounded** (date ranges ≤ 366 days, page size ≤ 50, list caps of 500, a
   payload-size guard) — very large result sets are truncated with a `truncated`/`continuation` hint
-  rather than streamed in full. Uploads are bounded too: ≤ 10 documents, 256KB per file and 512KB
-  per call once decoded, against a MIME allowlist. Inline base64 is only viable for small files at
-  all — see [Why inline upload is small](#why-inline-upload-is-small).
+  rather than streamed in full. Inline uploads are bounded too: ≤ 10 documents, 256KB per file and
+  512KB per call once decoded, against a MIME allowlist. Inline base64 is only viable for small
+  files at all — see [Why inline upload is small](#why-inline-upload-is-small).
 - Rate limiting and metrics are **in-process** (per replica); there is no shared/Redis-backed
   limiter or Prometheus exposition yet (the limiter and metrics are behind swappable seams).
 - Tracing is exported to OpenTelemetry/Grafana Tempo (opt-in via `OTEL_ENABLED=1`), but metrics

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -30,8 +30,10 @@ operational metrics (request/outcome counters, a latency histogram, auth-failure
 at `GET /metrics`; and OpenTelemetry tracing exported to Grafana Tempo (opt-in), correlated with the
 backend via `traceparent` and `X-Correlation-Id`.
 
-Phase 2 (write scope) is **not** implemented — see
-[Known limitations & phase 2](#known-limitations--phase-2-write-scope).
+Phase 2 (write scope) has landed its first two tools — `accounter_update_charges_tags` and
+`accounter_upload_documents` — behind the `MCP_ENABLE_WRITE_TOOLS` flag, which is **off by
+default**. See [Write tools](#write-tools) for the model, and
+[Known limitations](#known-limitations) for what is still out of scope.
 
 ## Tools
 
@@ -180,16 +182,30 @@ scope, because it _is_ the scope.
   `truncated` flag. Every row carries `ownerId` — the one business the report ran for, which the
   response also reports once alongside the echoed `scope`.
 
+The two **write** tools below are only exposed when `MCP_ENABLE_WRITE_TOOLS=1`; see
+[Write tools](#write-tools) for the rules they all share.
+
+- **`accounter_update_charges_tags`** — add and/or remove tags across 1–50 charges. Tags are given
+  by id (`addTagIds` / `removeTagIds`), never by name: names are not unique across owners, so
+  resolving them here would mean guessing which of several same-named tags was meant — the model
+  resolves them with `accounter_list_tags` first. Incremental, not a replacement, and removals run
+  before additions so an id in both lists ends up added. Requires `business_owner`/`accountant`.
+- **`accounter_upload_documents`** — attach 1–10 base64-encoded documents to an **existing** charge.
+  `chargeId` is required (upstream would otherwise create a new charge), `isSensitive` is pinned to
+  `true`, and each file is validated for encoding, MIME type, and size _before_ anything is
+  uploaded. Upstream returns one result per file, so partial failure is reported positionally rather
+  than collapsed. Requires `business_owner`/`accountant`.
+
 ## Upstream GraphQL client
 
 Tool handlers talk to the Accounter GraphQL server through a single hardened client
 (`src/upstream/graphql-client.ts`): a strict per-request **timeout** with cancellation, **bounded
 retries** for idempotent read failures only (network errors, timeouts, and 5xx — never 4xx
-auth/validation errors or GraphQL-level errors), **header propagation** of the correlation id, the
-caller's `Authorization` bearer token, and the resolved read scope as `x-business-scope`, and
-**sanitized** upstream errors (no stack traces or internal details). Phase 1 is read-only:
-mutations/subscriptions are refused, and there is **no** generic "execute anything" surface — tools
-use typed read-only wrappers via `createReadOperation`.
+auth/validation errors, GraphQL-level errors, or **any write**), **header propagation** of the
+correlation id, the caller's `Authorization` bearer token, and the resolved read scope as
+`x-business-scope`, and **sanitized** upstream errors (no stack traces or internal details). Phase 1
+is read-only: mutations/subscriptions are refused, and there is **no** generic "execute anything"
+surface — tools use typed read-only wrappers via `createReadOperation`.
 
 ## Identity & tenant scope
 
@@ -386,6 +402,7 @@ process to exit immediately with a clear error. Secrets are supplied via the env
 | `MCP_SERVER_PORT`             | no       | `3100`                   | TCP port the HTTP transport listens on                             |
 | `MCP_ENABLED`                 | no       | `1`                      | Master kill-switch (`1` on / `0` off)                              |
 | `MCP_TOOL_ALLOWLIST`          | no       | `''` (none)              | Comma-separated tool names allowed (empty = least privilege)       |
+| `MCP_ENABLE_WRITE_TOOLS`      | no       | `0`                      | Expose mutating (write) tools (`1` on / `0` off)                   |
 | `AUTH0_JWKS_URL`              | no       | derived from issuer      | JWKS endpoint; defaults to `<issuer>/.well-known/jwks.json`        |
 | `GRAPHQL_UPSTREAM_TIMEOUT_MS` | no       | `10000`                  | Upstream GraphQL request timeout budget (ms)                       |
 | `MCP_RATE_LIMIT_CONFIG`       | no       | `''` (defaults)          | Optional rate-limit override spec (parsed by the limiter later)    |
@@ -466,23 +483,58 @@ The automated equivalent of steps 1–7 (with the Auth0 verifier and upstream mo
 | Tool result code `AUTHORIZATION_ERROR`                                          | The caller lacks a required role, requested a business outside their memberships, or has no memberships. Verify the token's scopes and the server-side `business_users` rows.                         |
 | Tool result code `RATE_LIMIT_ERROR` with `retryAfterMs`                         | Per-`{user, scope, tool}` window exceeded. Back off for `retryAfterMs`, or tune `MCP_RATE_LIMIT_CONFIG`.                                                                                              |
 
-## Known limitations & phase 2 (write scope)
+## Write tools
 
-Phase 1 is intentionally **read-only** and single-purpose:
+Two mutating tools are available, and both are **hidden unless `MCP_ENABLE_WRITE_TOOLS=1`**:
 
-- Only the read-only tools above are exposed; there is no generic "run any query" surface and **no
-  mutations/subscriptions** (the upstream client refuses them).
+| Tool                            | What it does                                                                     |
+| ------------------------------- | -------------------------------------------------------------------------------- |
+| `accounter_update_charges_tags` | Adds and/or removes tags across one or more charges (tag **ids**, not names)     |
+| `accounter_upload_documents`    | Attaches base64-encoded documents to an **existing** charge, always as sensitive |
+
+The default is off so that upgrading a running deployment never silently grants the model write
+access — an operator opts in per environment. `MCP_TOOL_ALLOWLIST` composes on top and can narrow
+which write tools are exposed, but naming one in the allowlist can never turn writes on. A tool
+excluded by either control is reported as `Unknown tool`, exactly like a nonexistent one, so neither
+control announces the capability it is hiding.
+
+Four properties hold for every mutating tool, enforced centrally rather than per tool:
+
+- **A separate, guarded client path.** `UpstreamGraphQLClient.query()` still refuses anything that
+  is not a read; `mutate()` / `mutateMultipart()` refuse anything that is not a _single_ top-level
+  mutation. Neither can send the other's traffic.
+- **No retries.** A mutation is not idempotent, so a timed-out or failed write surfaces to the
+  caller rather than being re-sent and possibly double-applied.
+- **A single write target.** A read may span every membership; a write must resolve to exactly one
+  business. An ambiguous scope is refused with an actionable message (pass `memberBusinessId`)
+  rather than resolved by picking one.
+- **An audit line per call**, emitted _before_ the handler runs, carrying the tool, user,
+  correlation id, write-target business, and affected id counts — never file contents, filenames, or
+  tokens.
+
+Two tool-specific rules worth knowing:
+
+- `accounter_upload_documents` requires `chargeId`. The upstream mutation _creates a new charge_
+  when it is omitted, which is not a side effect the model should trigger by leaving a field blank.
+  `isSensitive` is pinned to `true` and is deliberately absent from the input schema.
+- `accounter_update_charges_tags` is incremental, not a replacement: tags not named in
+  `removeTagIds` stay. Removals are applied before additions, so a tag id passed in _both_ lists
+  ends up added.
+
+## Known limitations
+
+- There is no generic "run any query" surface: every capability is a curated tool with a strict
+  input schema, and the upstream client's read and write paths are separately guarded.
 - Responses are **bounded** (date ranges ≤ 366 days, page size ≤ 50, list caps of 500, a
   payload-size guard) — very large result sets are truncated with a `truncated`/`continuation` hint
-  rather than streamed in full.
+  rather than streamed in full. Uploads are bounded too: ≤ 10 documents, 5 MB per file and 15 MB per
+  call once decoded, against a MIME allowlist.
 - Rate limiting and metrics are **in-process** (per replica); there is no shared/Redis-backed
   limiter or Prometheus exposition yet (the limiter and metrics are behind swappable seams).
 - Tracing is exported to OpenTelemetry/Grafana Tempo (opt-in via `OTEL_ENABLED=1`), but metrics
   remain in-process (`GET /metrics`) and are not yet exported over OTLP.
-
-**Phase 2 (write scope)** — not implemented — will add mutating tools (e.g. tagging/updating
-charges) behind: per-tool write policies and role checks reusing the server's authorization model;
-the server's accountant-approval degradation on charge-mutating operations; write-target business
-resolution (a single owning business per write, versus phase-1 multi-business read scope); and
-idempotency/audit for writes. Until then, all tools are safe to expose to read-only assistant
-workflows.
+- Writes carry **no idempotency key**, so a client that retries a call it never saw the result of
+  can duplicate an upload. The tools themselves never retry (see above), and tag updates are
+  naturally idempotent, but document uploads are not.
+- The server's **accountant-approval degradation** runs upstream inside `batchUploadDocuments`; the
+  connector does not model it, so it is not reflected in the tool's response.

--- a/packages/mcp-server/docs/operations-runbook.md
+++ b/packages/mcp-server/docs/operations-runbook.md
@@ -38,15 +38,21 @@ Baseline latency targets and the load profile are captured by
 Tools contribute low-cardinality label counters through their `observe` hook. These answer product
 questions about how the connector is actually being used, not operational ones:
 
-| Counter                  | Label                           | Answers                                                        |
-| ------------------------ | ------------------------------- | -------------------------------------------------------------- |
-| `glossary_term_requests` | canonical glossary term         | Which terminology callers look up most (≤62 labels).           |
-| `glossary_term_misses`   | folded, 40-char-clipped request | Terms callers asked for that the glossary does not define yet. |
-| `glossary_mode`          | `index` \| `full`               | Browse-the-index-first vs. direct lookup.                      |
+| Counter                  | Label                           | Answers                                                         |
+| ------------------------ | ------------------------------- | --------------------------------------------------------------- |
+| `glossary_term_requests` | canonical glossary term         | Which terminology callers look up most (≤62 labels).            |
+| `glossary_term_misses`   | folded, 40-char-clipped request | Terms callers asked for that the glossary does not define yet.  |
+| `glossary_mode`          | `index` \| `full`               | Browse-the-index-first vs. direct lookup.                       |
+| `document_upload_source` | `urls` \| `inline`              | Whether uploads arrive as links or as base64 through the model. |
 
 ```bash
 curl -s "$MCP_BASE_URL/metrics" | jq '.labeledTotals'
 ```
+
+`document_upload_source` is the one to watch after a change to the upload tool's description:
+`inline` is capped at 256KB per file because that content rides in the model's own output, so a
+rising `inline` share means callers are still hitting a ceiling that `documentUrls` removes
+entirely.
 
 Two caveats before you read anything into these numbers:
 
@@ -133,6 +139,19 @@ Note that terms pulled in by `topics` are deliberately **not** counted as reques
 `topics: ["charge"]` call returns every charge entry, and crediting each one would turn
 "most-requested term" into a measure of topic breadth.
 
+Write-tool fields. Every write also emits a **separate** `mutating tool invoked` audit line
+(`audit: true`) _before_ its handler runs, carrying the affected record ids; the fields below are
+the complement to it, recorded _after_ the call and saying what actually applied. Neither line ever
+carries document content, filenames, or URLs — a signed download link carries an access token:
+
+| Field                                         | Tool                            | Meaning                                                                                  |
+| --------------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------- |
+| `documentSource`                              | `accounter_upload_documents`    | `urls` (server fetched them) or `inline` (base64 through the model).                     |
+| `requestedDocumentCount`                      | `accounter_upload_documents`    | Documents named in the call.                                                             |
+| `uploadedCount` / `failedCount`               | `accounter_upload_documents`    | Per-file outcome — upstream reports success per document, so a batch can partially fail. |
+| `requestedChargeCount` / `updatedChargeCount` | `accounter_update_charges_tags` | Charges asked for vs. actually updated. A gap means ids that upstream could not resolve. |
+| `addedTagCount` / `removedTagCount`           | `accounter_update_charges_tags` | Size of each direction of the edit.                                                      |
+
 Extraction recipes (pipe your platform's log stream in; `jq -c` on a file works the same):
 
 ```bash
@@ -147,6 +166,15 @@ jq -r 'select(.event=="tool_call") | .missedTerms // [] | .[]' logs.jsonl \
 # Which tool a caller reached for after a glossary lookup, in order
 jq -r 'select(.event=="tool_call") | [.userId, .tool, (.matchedTerms // [] | join(","))] | @tsv' \
   logs.jsonl
+
+# Uploads still taking the size-capped base64 path, by caller
+jq -r 'select(.event=="tool_call" and .documentSource=="inline") | .userId' logs.jsonl \
+  | sort | uniq -c | sort -rn
+
+# Tag updates that silently skipped charges (asked > updated)
+jq -r 'select(.event=="tool_call" and .updatedChargeCount != null
+  and .updatedChargeCount < .requestedChargeCount)
+  | [.correlationId, .requestedChargeCount, .updatedChargeCount] | @tsv' logs.jsonl
 
 # Tool popularity and error rate
 jq -r 'select(.event=="tool_call") | "\(.tool)\t\(.outcome)"' logs.jsonl \

--- a/packages/mcp-server/docs/spec.md
+++ b/packages/mcp-server/docs/spec.md
@@ -22,7 +22,8 @@ These decisions were explicitly selected and are treated as baseline requirement
 - Client surface for phase 1: Claude hosted surfaces (Claude.ai/Desktop)
 - Authentication baseline: Auth0-based OAuth using existing identity model
 - OAuth connector variant: CIMD preferred
-- Initial capability scope: read-only tools only
+- Initial capability scope: read-only tools only (write tools added later behind
+  `MCP_ENABLE_WRITE_TOOLS`, default off — see §12.3b)
 - Deployment model: new monorepo package for MCP server
 - Connector goal: directory-ready in near term
 - Metadata hosting: same domain as MCP server with well-known routes
@@ -463,6 +464,27 @@ Deliverable:
 Deliverable:
 
 - usable phase 1 feature set with read-only operations.
+
+## 12.3b Phase 2b: First Write Tools — implemented
+
+Writes are opt-in per deployment via `MCP_ENABLE_WRITE_TOOLS` (default `0`), evaluated together with
+`MCP_TOOL_ALLOWLIST` at the transport boundary. A tool excluded by either control is reported as
+`Unknown tool`, so neither leaks the capability it hides.
+
+Delivered:
+
+1. A guarded write path on the upstream client — `mutate()` and `mutateMultipart()` (GraphQL
+   multipart request spec), each refusing anything that is not a single top-level mutation, just as
+   `query()` refuses anything that is not a read. **No retries on writes**: a mutation is not
+   idempotent, so re-sending one that may already have applied could double-apply it.
+2. `ToolAuthPolicy.mutating`, which gates exposure, forces a **single write-target business** (an
+   ambiguous scope is refused, never resolved by picking one), and triggers an audit log line
+   emitted _before_ the handler runs, carrying only identifiers and counts.
+3. Two tools: `accounter_update_charges_tags` and `accounter_upload_documents`.
+
+Deferred to a later phase: idempotency keys for writes (a client retrying an upload it never saw the
+result of can still duplicate it), and modelling the server's accountant-approval degradation, which
+today runs upstream inside `batchUploadDocuments` and is not reflected in the tool response.
 
 ## 12.4 Phase 3: Hardening
 

--- a/packages/mcp-server/docs/todo.md
+++ b/packages/mcp-server/docs/todo.md
@@ -56,6 +56,26 @@ D3 (`MCP_TOOL_ALLOWLIST`) and D6 (rate-limit keying) are settled — see the clo
 
 Ranked by when they start to hurt, not by size.
 
+### I6. Writes have no idempotency key — **medium (once writes are enabled)**
+
+The first two write tools are in (`accounter_update_charges_tags`, `accounter_upload_documents`,
+behind `MCP_ENABLE_WRITE_TOOLS`, default off). The client deliberately never retries a mutation, so
+the server cannot double-apply one on its own — but a _client_ that retries a call whose result it
+never saw can. Tag updates are naturally idempotent and unaffected; document uploads are not, and
+would produce a duplicate document.
+
+- [ ] Decide whether an idempotency key belongs on the tool input, or on a dedupe check upstream
+      (`batchUploadDocuments` already computes a content hash — see `upload.helper.ts`)
+
+### I7. Accountant-approval degradation is invisible to the connector — **low**
+
+`batchUploadDocuments` calls `degradeChargesAccountantApproval` upstream, so uploading through
+`accounter_upload_documents` silently changes the charge's accountant status. The tool's response
+does not mention it, so the model cannot tell the user what else its call did.
+
+- [ ] Either surface the resulting accountant status in the write result, or say so in the tool
+      description
+
 ### I5. Stable tunnel for local development — **low (friction)**
 
 Production is settled (see the closed list — `https://mcp.accounter.tax`). Local development still
@@ -136,6 +156,11 @@ Recorded so nobody re-discovers them as bugs. Each has a stated condition that w
 Item ids (I1…I5, D1…D6) are kept stable even where the numbering now has gaps, because the other
 docs and PR descriptions reference them.
 
+- **Phase 2 write scope (first tools)** — the write path landed: `mutate`/`mutateMultipart` on the
+  upstream client (each guarded to a single top-level mutation, never retried), a `mutating` tool
+  policy that forces one write-target business and emits an audit line, the `MCP_ENABLE_WRITE_TOOLS`
+  kill-switch (default off, composed with the allowlist), and the tools
+  `accounter_update_charges_tags` and `accounter_upload_documents`. Remaining write gaps are I6/I7.
 - **I1 / D3 — `MCP_TOOL_ALLOWLIST` enforcement** — done in #4104. `isToolAllowed`
   (`src/tools/allowlist.ts`) is applied at the transport boundary: `tools/list` filters advertised
   descriptors and `tools/call` rejects an excluded tool as `Unknown tool`, so the allowlist never

--- a/packages/mcp-server/src/__tests__/mcp-e2e.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-e2e.test.ts
@@ -121,6 +121,24 @@ function upstreamData(query: string, authorization?: string): unknown {
       ],
     };
   }
+  if (query.includes('batchUpdateChargesTags')) {
+    return {
+      batchUpdateChargesTags: {
+        __typename: 'BatchUpdateChargesTagsSuccessfulResult',
+        charges: [{ id: 'charge-1', tags: [{ id: 'tag-1', name: 'travel' }] }],
+      },
+    };
+  }
+  if (query.includes('batchUploadDocuments')) {
+    return {
+      batchUploadDocuments: [
+        {
+          __typename: 'UploadDocumentSuccessfulResult',
+          document: { id: 'doc-1', documentType: 'INVOICE' },
+        },
+      ],
+    };
+  }
   throw new Error(`unexpected upstream query: ${query}`);
 }
 
@@ -131,15 +149,27 @@ function upstreamData(query: string, authorization?: string): unknown {
  */
 const forwardedScopes: Array<{ query: string; businessScope?: readonly string[] }> = [];
 
+type UpstreamCall = (
+  request: { query: string },
+  context: { authorization?: string; businessScope?: readonly string[] },
+) => Promise<unknown>;
+
+const record: UpstreamCall = async (request, context) => {
+  forwardedScopes.push({ query: request.query, businessScope: context.businessScope });
+  return upstreamData(request.query, context.authorization);
+};
+
 const fakeUpstreamClient = {
-  query: vi.fn(
+  query: vi.fn(record),
+  mutate: vi.fn(record),
+  // The real signature takes `(request, files, context)`; the files are asserted
+  // in the unit suites, so here the third argument is what matters.
+  mutateMultipart: vi.fn(
     async (
       request: { query: string },
+      _files: unknown,
       context: { authorization?: string; businessScope?: readonly string[] },
-    ) => {
-      forwardedScopes.push({ query: request.query, businessScope: context.businessScope });
-      return upstreamData(request.query, context.authorization);
-    },
+    ) => record(request, context),
   ),
 };
 
@@ -263,6 +293,25 @@ describe('authenticated tool invocation', () => {
     // Discovery leads the list, and the internal smoke tool is not advertised.
     expect(tools[0]).toBe('accounter_list_business_memberships');
     expect(tools).not.toContain('accounter_smoke_ping');
+    // MCP_ENABLE_WRITE_TOOLS is unset here, which is the default a deployment
+    // upgrades into: the write tools must not appear.
+    expect(tools).not.toContain('accounter_update_charges_tags');
+    expect(tools).not.toContain('accounter_upload_documents');
+  });
+
+  it('rejects a write tool as unknown while writes are disabled', async () => {
+    const res = await rpc('tools/call', {
+      params: {
+        name: 'accounter_update_charges_tags',
+        arguments: { chargeIds: ['charge-1'], addTagIds: ['tag-1'] },
+      },
+      token: 'owner-token',
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { error?: { message: string } };
+    // Indistinguishable from a nonexistent tool — a disabled capability must not
+    // announce itself as merely switched off.
+    expect(body.error?.message).toMatch(/Unknown tool/);
   });
 
   it('runs a charges search scoped to the caller and returns structured results', async () => {
@@ -379,5 +428,121 @@ describe('malformed input and error taxonomy', () => {
     });
     const body = (await res.json()) as { error?: { code: number } };
     expect(body.error?.code).toBe(-32700);
+  });
+});
+
+/**
+ * The write tools, on a server started with `MCP_ENABLE_WRITE_TOOLS=1`.
+ *
+ * A second server is spun up rather than flipping the flag on the shared one:
+ * the config is memoized per process, and the default-off case above is exactly
+ * what the rest of this file must keep asserting.
+ */
+describe('write tools with MCP_ENABLE_WRITE_TOOLS=1', () => {
+  let writeServer: Server;
+  let writeBaseUrl: string;
+
+  beforeAll(async () => {
+    vi.stubEnv('MCP_ENABLE_WRITE_TOOLS', '1');
+    const { resetEnvCache } = await import('../config/env.js');
+    resetEnvCache();
+
+    const { createHttpServer } = await import('../server.js');
+    writeServer = createHttpServer();
+    await new Promise<void>(resolve => writeServer.listen(0, '127.0.0.1', resolve));
+    const { port } = writeServer.address() as AddressInfo;
+    writeBaseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      writeServer.close(error => (error ? reject(error) : resolve())),
+    );
+    // Restore the default so nothing after this block inherits write access.
+    vi.stubEnv('MCP_ENABLE_WRITE_TOOLS', '0');
+    const { resetEnvCache } = await import('../config/env.js');
+    resetEnvCache();
+  });
+
+  async function writeRpc(method: string, params: unknown, token = 'owner-token') {
+    const res = await fetch(`${writeBaseUrl}/mcp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+    });
+    expect(res.status).toBe(200);
+    return (await res.json()) as {
+      result?: { isError?: boolean; structuredContent?: JsonRecord };
+      error?: { message: string };
+    };
+  }
+
+  it('advertises both write tools, after the read tools', async () => {
+    const res = await fetch(`${writeBaseUrl}/mcp`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: 'Bearer owner-token' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    const tools = (
+      (await res.json()) as { result: { tools: Array<{ name: string }> } }
+    ).result.tools.map(t => t.name);
+
+    expect(tools).toContain('accounter_update_charges_tags');
+    expect(tools).toContain('accounter_upload_documents');
+    // Reads still lead: a tool that changes data should not be the first thing
+    // the model reaches for.
+    expect(tools.indexOf('accounter_update_charges_tags')).toBeGreaterThan(
+      tools.indexOf('accounter_search_charges'),
+    );
+  });
+
+  it('updates charge tags end to end', async () => {
+    const body = await writeRpc('tools/call', {
+      name: 'accounter_update_charges_tags',
+      arguments: { chargeIds: ['charge-1'], addTagIds: ['tag-1'] },
+    });
+
+    expect(body.result?.isError).toBeUndefined();
+    const structured = body.result?.structuredContent as JsonRecord;
+    expect(structured.ok).toBe(true);
+    expect(structured.action).toBe('update_charges_tags');
+    expect(structured.updatedCount).toBe(1);
+    expect(fakeUpstreamClient.mutate).toHaveBeenCalled();
+    // The write is scoped to the caller's single membership.
+    expect(structured.scope).toEqual({ memberBusinessIds: [AUTHORIZED_BUSINESS] });
+  });
+
+  it('uploads a document to an existing charge, always as sensitive', async () => {
+    const body = await writeRpc('tools/call', {
+      name: 'accounter_upload_documents',
+      arguments: {
+        chargeId: 'charge-1',
+        documents: [
+          { filename: 'invoice.pdf', mimeType: 'application/pdf', contentBase64: 'aGVsbG8=' },
+        ],
+      },
+    });
+
+    expect(body.result?.isError).toBeUndefined();
+    const structured = body.result?.structuredContent as JsonRecord;
+    expect(structured.ok).toBe(true);
+    expect(structured.uploadedCount).toBe(1);
+    expect(structured.failedCount).toBe(0);
+    expect(structured.isSensitive).toBe(true);
+    expect(fakeUpstreamClient.mutateMultipart).toHaveBeenCalled();
+  });
+
+  it('denies a write to a caller with no memberships', async () => {
+    const body = await writeRpc(
+      'tools/call',
+      {
+        name: 'accounter_update_charges_tags',
+        arguments: { chargeIds: ['charge-1'], addTagIds: ['tag-1'] },
+      },
+      'viewer-token',
+    );
+
+    expect(body.result?.isError).toBe(true);
+    expect((body.result?.structuredContent as JsonRecord).code).toBe('AUTHORIZATION_ERROR');
   });
 });

--- a/packages/mcp-server/src/__tests__/mcp-e2e.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-e2e.test.ts
@@ -512,7 +512,7 @@ describe('write tools with MCP_ENABLE_WRITE_TOOLS=1', () => {
     expect(structured.scope).toEqual({ memberBusinessIds: [AUTHORIZED_BUSINESS] });
   });
 
-  it('uploads a document to an existing charge, always as sensitive', async () => {
+  it('uploads a document to an existing charge', async () => {
     const body = await writeRpc('tools/call', {
       name: 'accounter_upload_documents',
       arguments: {
@@ -528,7 +528,7 @@ describe('write tools with MCP_ENABLE_WRITE_TOOLS=1', () => {
     expect(structured.ok).toBe(true);
     expect(structured.uploadedCount).toBe(1);
     expect(structured.failedCount).toBe(0);
-    expect(structured.isSensitive).toBe(true);
+    expect(structured.isSensitive).toBe(false);
     expect(fakeUpstreamClient.mutateMultipart).toHaveBeenCalled();
   });
 

--- a/packages/mcp-server/src/config/__tests__/env.test.ts
+++ b/packages/mcp-server/src/config/__tests__/env.test.ts
@@ -17,6 +17,9 @@ describe('parseEnv — valid configuration', () => {
     expect(config.server.port).toBe(3100);
     expect(config.server.enabled).toBe(true);
     expect(config.server.toolAllowlist).toEqual([]);
+    // Writes are off unless an operator opts in, so upgrading a running
+    // deployment never silently grants the model write access.
+    expect(config.server.writeToolsEnabled).toBe(false);
     expect(config.auth0.issuerUrl).toBe('https://tenant.auth0.com/');
     expect(config.auth0.audience).toBe('https://api.accounter.example');
     expect(config.upstream.graphqlUrl).toBe('http://localhost:4000/graphql');
@@ -226,5 +229,28 @@ describe('loadEnv — fail-fast startup', () => {
     expect(config.server.port).toBe(3100);
     expect(config.upstream.graphqlUrl).toBe('http://localhost:4000/graphql');
     expect(exit).not.toHaveBeenCalled();
+  });
+});
+
+describe('parseEnv — MCP_ENABLE_WRITE_TOOLS', () => {
+  it('enables write tools only for the literal "1"', () => {
+    expect(parseEnv({ ...validEnv, MCP_ENABLE_WRITE_TOOLS: '1' }).server.writeToolsEnabled).toBe(
+      true,
+    );
+    expect(parseEnv({ ...validEnv, MCP_ENABLE_WRITE_TOOLS: '0' }).server.writeToolsEnabled).toBe(
+      false,
+    );
+  });
+
+  it('treats an empty value as unset (writes off)', () => {
+    expect(parseEnv({ ...validEnv, MCP_ENABLE_WRITE_TOOLS: '' }).server.writeToolsEnabled).toBe(
+      false,
+    );
+  });
+
+  it.each(['true', 'yes', 'on', '2'])('rejects the ambiguous value %s', value => {
+    // A value like "true" must fail loudly rather than being read as off — an
+    // operator who meant to enable writes should not be silently ignored.
+    expect(() => parseEnv({ ...validEnv, MCP_ENABLE_WRITE_TOOLS: value })).toThrow();
   });
 });

--- a/packages/mcp-server/src/config/env.ts
+++ b/packages/mcp-server/src/config/env.ts
@@ -20,6 +20,7 @@ import zod from 'zod';
  * | MCP_SERVER_PORT             | no       | 3100                     | TCP port the HTTP transport listens on.                           |
  * | MCP_ENABLED                 | no       | 1                        | Master kill-switch (`1` on / `0` off).                            |
  * | MCP_TOOL_ALLOWLIST          | no       | '' (all tools)           | Comma-separated allowed tool names; empty ⇒ no restriction.       |
+ * | MCP_ENABLE_WRITE_TOOLS      | no       | 0                        | Expose mutating (write) tools (`1` on / `0` off).                 |
  * | AUTH0_JWKS_URL              | no       | derived from issuer      | JWKS endpoint; defaults to `<issuer>/.well-known/jwks.json`.      |
  * | GRAPHQL_UPSTREAM_TIMEOUT_MS | no       | 10000                    | Upstream GraphQL request timeout budget in milliseconds.          |
  * | MCP_RATE_LIMIT_CONFIG       | no       | '' (defaults applied)    | Optional rate-limit override spec (parsed by the limiter later).  |
@@ -72,6 +73,12 @@ export const envSchema = zod
     // `tools/allowlist.ts`. When narrowing, keep `accounter_list_business_memberships`
     // in the set — it is the discovery entry point for business scoping.
     MCP_TOOL_ALLOWLIST: emptyStringAsUndefined(zod.string().optional().default('')),
+    // Master switch for mutating tools. Defaults to OFF so upgrading a running
+    // deployment never silently grants the model write access: an operator has
+    // to opt in per environment. Orthogonal to (and evaluated together with)
+    // MCP_TOOL_ALLOWLIST — turning writes on still respects a narrowed allowlist,
+    // and a write tool named in the allowlist stays hidden while this is off.
+    MCP_ENABLE_WRITE_TOOLS: booleanFlag('0'),
     AUTH0_JWKS_URL: emptyStringAsUndefined(
       zod.url({ message: 'AUTH0_JWKS_URL must be a valid URL' }).optional(),
     ),
@@ -160,6 +167,8 @@ export interface AppConfig {
     enabled: boolean;
     /** Parsed tool allowlist; empty array means "no restriction" (all tools). */
     toolAllowlist: readonly string[];
+    /** Whether mutating (write) tools are exposed at all. Off by default. */
+    writeToolsEnabled: boolean;
   };
   auth0: {
     issuerUrl: string;
@@ -237,6 +246,7 @@ export function parseEnv(source: NodeJS.ProcessEnv): AppConfig {
       toolAllowlist: raw.MCP_TOOL_ALLOWLIST.split(',')
         .map(name => name.trim())
         .filter(Boolean),
+      writeToolsEnabled: raw.MCP_ENABLE_WRITE_TOOLS === '1',
     },
     auth0: {
       issuerUrl: ensureTrailingSlash(raw.AUTH0_ISSUER_URL),

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -21,7 +21,7 @@ import { protectedResourceMetadataUrl } from '../oauth/metadata.js';
 import { getMetrics } from '../observability/metrics.js';
 import { withSpan } from '../observability/tracing.js';
 import { getRateLimiter } from '../rate-limit/default-limiter.js';
-import { isToolAllowed } from '../tools/allowlist.js';
+import { isToolExposed } from '../tools/allowlist.js';
 import { executeRegisteredTool } from '../tools/execute.js';
 import { toolRegistry } from '../tools/registry-instance.js';
 import { getUpstreamClient } from '../upstream/default-client.js';
@@ -166,6 +166,17 @@ export interface McpDispatchContext {
    * call site cannot silently bypass enforcement by forgetting the field.
    */
   allowlist: readonly string[];
+  /**
+   * `MCP_ENABLE_WRITE_TOOLS`, resolved at the HTTP boundary. When false,
+   * mutating tools are absent from `tools/list` and rejected by `tools/call`.
+   *
+   * Required for the same reason as `allowlist`, and deliberately not defaulted:
+   * a defaulted `writeToolsEnabled` would have to default to something, and
+   * either choice is wrong — `true` silently enables writes for a call site that
+   * forgot the field, `false` makes write tools mysteriously vanish for one that
+   * did. Making it explicit means the question is answered at every call site.
+   */
+  writeToolsEnabled: boolean;
 }
 
 /**
@@ -182,16 +193,21 @@ export async function dispatchMcpRequest(
   }
   const id = request.id ?? null;
 
-  // `MCP_TOOL_ALLOWLIST` enforcement: an empty allowlist exposes every tool; a
-  // non-empty one restricts both discovery and dispatch to the named subset.
-  // The list is threaded in via the dispatch context (built at the HTTP
+  // Exposure controls: `MCP_TOOL_ALLOWLIST` (empty ⇒ every tool; non-empty ⇒
+  // only the named subset) and `MCP_ENABLE_WRITE_TOOLS` (off ⇒ no mutating
+  // tool). Both are threaded in via the dispatch context (built at the HTTP
   // boundary) so this function stays env-free and directly unit-testable.
-  const { allowlist } = context;
+  const { allowlist, writeToolsEnabled } = context;
+  const exposure = { allowlist, writeToolsEnabled };
 
   if (request.method === 'tools/list') {
-    const registered = toolRegistry
-      .describe()
-      .filter(descriptor => isToolAllowed(allowlist, descriptor.name));
+    // `describe()` yields descriptors, which carry no policy — look the tool
+    // back up so the write switch is evaluated against the real policy rather
+    // than inferred from the name.
+    const registered = toolRegistry.describe().filter(descriptor => {
+      const tool = toolRegistry.get(descriptor.name);
+      return tool !== undefined && isToolExposed(tool, exposure);
+    });
     return success(id, { tools: [...listedTools, ...registered] });
   }
 
@@ -201,10 +217,11 @@ export async function dispatchMcpRequest(
     if (name === SMOKE_TOOL_NAME) {
       return success(id, runSmokeTool(params.arguments));
     }
-    // A tool that exists but is excluded by the allowlist is reported as
-    // unknown — indistinguishable from a nonexistent one, so the allowlist does
-    // not leak which capabilities the server could otherwise offer.
-    const tool = isToolAllowed(allowlist, name) ? toolRegistry.get(name) : undefined;
+    // A tool that exists but is excluded by the allowlist or by the write switch
+    // is reported as unknown — indistinguishable from a nonexistent one, so
+    // neither control leaks which capabilities the server could otherwise offer.
+    const registered = toolRegistry.get(name);
+    const tool = registered && isToolExposed(registered, exposure) ? registered : undefined;
     if (!tool) {
       return failure(id, JsonRpcErrorCode.InvalidParams, `Unknown tool: ${name}`);
     }
@@ -398,6 +415,7 @@ export async function mcpHttpHandler(req: IncomingMessage, res: ServerResponse):
     authorization:
       typeof req.headers.authorization === 'string' ? req.headers.authorization : undefined,
     allowlist: env.server.toolAllowlist,
+    writeToolsEnabled: env.server.writeToolsEnabled,
   });
 
   if (response === null) {

--- a/packages/mcp-server/src/tools/__tests__/allowlist.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/allowlist.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isToolAllowed } from '../allowlist.js';
+import { isToolAllowed, isToolExposed } from '../allowlist.js';
 
 describe('isToolAllowed', () => {
   it('permits every tool when the allowlist is empty (no restriction)', () => {
@@ -12,5 +12,32 @@ describe('isToolAllowed', () => {
     expect(isToolAllowed(allowlist, 'accounter_list_businesses')).toBe(true);
     expect(isToolAllowed(allowlist, 'accounter_search_charges')).toBe(true);
     expect(isToolAllowed(allowlist, 'accounter_balance_report')).toBe(false);
+  });
+});
+
+describe('isToolExposed', () => {
+  const read = { name: 'accounter_list_tags', policy: {} };
+  const write = { name: 'accounter_update_charges_tags', policy: { mutating: true } };
+
+  it('hides mutating tools while the write switch is off', () => {
+    const options = { allowlist: [], writeToolsEnabled: false };
+    expect(isToolExposed(read, options)).toBe(true);
+    expect(isToolExposed(write, options)).toBe(false);
+  });
+
+  it('exposes mutating tools once the write switch is on', () => {
+    expect(isToolExposed(write, { allowlist: [], writeToolsEnabled: true })).toBe(true);
+  });
+
+  it('cannot be turned on by the allowlist alone', () => {
+    // The two controls compose one way only: naming a write tool must never
+    // grant write access that MCP_ENABLE_WRITE_TOOLS has not granted.
+    expect(isToolExposed(write, { allowlist: [write.name], writeToolsEnabled: false })).toBe(false);
+  });
+
+  it('still honors the allowlist when writes are enabled', () => {
+    const options = { allowlist: [read.name], writeToolsEnabled: true };
+    expect(isToolExposed(read, options)).toBe(true);
+    expect(isToolExposed(write, options)).toBe(false);
   });
 });

--- a/packages/mcp-server/src/tools/__tests__/audit.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/audit.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { executeRegisteredTool } from '../execute.js';
+import type { ToolDefinition } from '../registry.js';
+import { z } from 'zod';
+
+/**
+ * The audit line for mutating tools.
+ *
+ * What it records is a security property, not a formatting detail: identifiers
+ * are what make the line answerable after the fact ("which charges did this
+ * retag?"), and payload — a document's bytes, filename, MIME type — must never
+ * appear in it. Both halves are asserted here.
+ */
+
+const B1 = 'aa000000-0000-4000-8000-000000000001';
+
+function authContext(): McpAuthContext {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: [],
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+  return buildAuthContext(principal, [{ memberBusinessId: B1, roleId: 'accountant' }]);
+}
+
+const noopClient = new UpstreamGraphQLClient({
+  endpoint: 'http://localhost:4000/graphql',
+  timeoutMs: 1000,
+  fetchImpl: (async () => {
+    throw new Error('not used');
+  }) as unknown as typeof fetch,
+});
+
+/** A stand-in write tool, so the assertions are about the executor, not a tool. */
+function writeTool(schema: z.ZodObject): ToolDefinition {
+  return {
+    name: 'test_write_tool',
+    description: 'd',
+    inputSchema: schema,
+    policy: { requiresBusinessScope: true, dataClassification: 'business', mutating: true },
+    handler: () => ({ content: [{ type: 'text', text: 'ok' }] }),
+  } as unknown as ToolDefinition;
+}
+
+/** Run a tool and return the parsed audit log entry, if one was emitted. */
+async function auditLineFor(schema: z.ZodObject, rawArgs: unknown) {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation(line => void lines.push(String(line)));
+  try {
+    await executeRegisteredTool({
+      tool: writeTool(schema),
+      rawArgs,
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: noopClient,
+      authorization: 'Bearer t',
+    });
+  } finally {
+    spy.mockRestore();
+  }
+  return lines
+    .map(line => JSON.parse(line) as Record<string, unknown>)
+    .find(entry => entry.audit === true);
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('audit line for mutating tools', () => {
+  it('records the ids touched, not merely how many', async () => {
+    const entry = await auditLineFor(
+      z.object({
+        memberBusinessId: z.string().optional(),
+        chargeIds: z.array(z.string()),
+        addTagIds: z.array(z.string()).optional(),
+      }),
+      { chargeIds: ['c1', 'c2'], addTagIds: ['t1'] },
+    );
+
+    expect(entry).toBeDefined();
+    expect(entry).toMatchObject({
+      audit: true,
+      tool: 'test_write_tool',
+      userId: 'user-1',
+      correlationId: 'corr-1',
+      writeTargetBusinessId: B1,
+      // The ids themselves — a bare `chargeIdsCount: 2` could not answer which
+      // charges were changed.
+      chargeIds: ['c1', 'c2'],
+      chargeIdsCount: 2,
+      addTagIds: ['t1'],
+      addTagIdsCount: 1,
+    });
+  });
+
+  it('records a scalar id field', async () => {
+    const entry = await auditLineFor(
+      z.object({ memberBusinessId: z.string().optional(), chargeId: z.string() }),
+      { chargeId: 'c1' },
+    );
+    expect(entry).toMatchObject({ chargeId: 'c1' });
+  });
+
+  it('never logs payload — a non-id array contributes only its length', async () => {
+    const entry = await auditLineFor(
+      z.object({
+        memberBusinessId: z.string().optional(),
+        chargeId: z.string(),
+        documents: z.array(
+          z.object({ filename: z.string(), mimeType: z.string(), contentBase64: z.string() }),
+        ),
+      }),
+      {
+        chargeId: 'c1',
+        documents: [
+          { filename: 'secret.pdf', mimeType: 'application/pdf', contentBase64: 'aGVsbG8=' },
+        ],
+      },
+    );
+
+    expect(entry).toMatchObject({ chargeId: 'c1', documentsCount: 1 });
+    expect(entry).not.toHaveProperty('documents');
+    // Nothing from the payload leaks anywhere in the serialized line.
+    const serialized = JSON.stringify(entry);
+    for (const secret of ['secret.pdf', 'application/pdf', 'aGVsbG8=']) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it('bounds a very long id list and flags the truncation', async () => {
+    const ids = Array.from({ length: 60 }, (_, i) => `c${i}`);
+    const entry = await auditLineFor(
+      z.object({ memberBusinessId: z.string().optional(), chargeIds: z.array(z.string()) }),
+      { chargeIds: ids },
+    );
+
+    expect((entry?.chargeIds as string[]).length).toBe(50);
+    expect(entry?.chargeIdsCount).toBe(60);
+    expect(entry?.chargeIdsTruncated).toBe(true);
+  });
+
+  it('emits nothing for a non-mutating tool', async () => {
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation(line => void lines.push(String(line)));
+    await executeRegisteredTool({
+      tool: {
+        ...writeTool(z.object({ chargeId: z.string() })),
+        policy: { requiresBusinessScope: true, dataClassification: 'business' },
+      } as ToolDefinition,
+      rawArgs: { chargeId: 'c1' },
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: noopClient,
+      authorization: 'Bearer t',
+    });
+    spy.mockRestore();
+
+    expect(lines.map(l => JSON.parse(l) as Record<string, unknown>).some(e => e.audit)).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/documents-write.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/documents-write.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import {
+  MAX_DOCUMENT_BYTES,
+  MAX_TOTAL_DOCUMENT_BYTES,
+  uploadDocumentsTool,
+} from '../documents-write.js';
+import { executeRegisteredTool } from '../execute.js';
+
+/**
+ * `accounter_upload_documents` is the first tool that sends binary content
+ * upstream, so most of what matters here is *what reaches the wire*: the
+ * multipart envelope, the pinned `isSensitive`, and the input guards that must
+ * reject a bad payload before any of it is uploaded.
+ */
+
+const B1 = 'aa000000-0000-4000-8000-000000000001';
+const B2 = 'aa000000-0000-4000-8000-000000000002';
+const CHARGE = 'cc000000-0000-4000-8000-000000000001';
+
+function authContext(memberBusinessIds: string[], roleId = 'accountant'): McpAuthContext {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: [],
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+  return buildAuthContext(
+    principal,
+    memberBusinessIds.map(memberBusinessId => ({ memberBusinessId, roleId })),
+  );
+}
+
+/** The parts of a captured multipart request the assertions care about. */
+interface CapturedUpload {
+  operations: { query: string; variables: Record<string, unknown> };
+  map: Record<string, string[]>;
+  parts: Array<{ name: string; filename: string; type: string; bytes: Uint8Array }>;
+  headers: Record<string, string>;
+}
+
+function uploadClient(responses: unknown[]) {
+  const captured: CapturedUpload[] = [];
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    const form = init.body as FormData;
+    const parts: CapturedUpload['parts'] = [];
+    for (const [name, value] of form.entries()) {
+      if (name === 'operations' || name === 'map') continue;
+      const file = value as File;
+      parts.push({
+        name,
+        filename: file.name,
+        type: file.type,
+        bytes: new Uint8Array(await file.arrayBuffer()),
+      });
+    }
+    captured.push({
+      operations: JSON.parse(String(form.get('operations'))),
+      map: JSON.parse(String(form.get('map'))),
+      parts,
+      headers: init.headers as Record<string, string>,
+    });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { batchUploadDocuments: responses } }),
+    } as unknown as Response;
+  });
+  const client = new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+  return { client, captured };
+}
+
+const ok = (id: string, documentType: string | null = 'INVOICE') => ({
+  __typename: 'UploadDocumentSuccessfulResult',
+  document: { id, documentType },
+});
+
+const doc = (overrides: Record<string, unknown> = {}) => ({
+  filename: 'invoice.pdf',
+  mimeType: 'application/pdf',
+  // "hello" — a known payload so the decoded bytes can be asserted exactly.
+  contentBase64: 'aGVsbG8=',
+  ...overrides,
+});
+
+function run(rawArgs: unknown, client: UpstreamGraphQLClient, auth = authContext([B1])) {
+  return executeRegisteredTool({
+    tool: uploadDocumentsTool,
+    rawArgs,
+    auth,
+    correlationId: 'c',
+    client,
+    authorization: 'Bearer t',
+  });
+}
+
+describe('uploadDocumentsTool — multipart envelope', () => {
+  it('sends files as multipart parts with null placeholders and a matching map', async () => {
+    const { client, captured } = uploadClient([ok('d1'), ok('d2')]);
+    const result = await run(
+      {
+        chargeId: CHARGE,
+        documents: [doc({ filename: 'a.pdf' }), doc({ filename: 'b.png', mimeType: 'image/png' })],
+      },
+      client,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(captured).toHaveLength(1);
+    const [call] = captured;
+
+    // Per the GraphQL multipart request spec the file variables are nulls, and
+    // `map` points each numbered part at its position.
+    expect(call.operations.variables.documents).toEqual([null, null]);
+    expect(call.map).toEqual({
+      '0': ['variables.documents.0'],
+      '1': ['variables.documents.1'],
+    });
+    expect(call.parts.map(part => [part.name, part.filename, part.type])).toEqual([
+      ['0', 'a.pdf', 'application/pdf'],
+      ['1', 'b.png', 'image/png'],
+    ]);
+    // Content survives the base64 round trip byte-for-byte.
+    expect(new TextDecoder().decode(call.parts[0].bytes)).toBe('hello');
+  });
+
+  it('does not set Content-Type, so FormData supplies the multipart boundary', async () => {
+    const { client, captured } = uploadClient([ok('d1')]);
+    await run({ chargeId: CHARGE, documents: [doc()] }, client);
+
+    const names = Object.keys(captured[0].headers).map(name => name.toLowerCase());
+    expect(names).not.toContain('content-type');
+  });
+
+  it('pins isSensitive to true and forwards the chargeId', async () => {
+    const { client, captured } = uploadClient([ok('d1')]);
+    await run({ chargeId: CHARGE, documents: [doc()] }, client);
+
+    expect(captured[0].operations.variables).toMatchObject({
+      chargeId: CHARGE,
+      isSensitive: true,
+    });
+  });
+
+  it('rejects a caller-supplied isSensitive — it is not part of the schema', async () => {
+    const { client, captured } = uploadClient([ok('d1')]);
+    const result = await run(
+      { chargeId: CHARGE, documents: [doc()], isSensitive: false },
+      client,
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+    expect(captured).toHaveLength(0);
+  });
+});
+
+describe('uploadDocumentsTool — input guards', () => {
+  it('requires a chargeId, so the tool can never create a charge', async () => {
+    const { client, captured } = uploadClient([]);
+    const result = await run({ documents: [doc()] }, client);
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+    // Nothing reached upstream — the omitted chargeId never had a chance to be
+    // read as "create a new charge for me".
+    expect(captured).toHaveLength(0);
+  });
+
+  it.each([
+    ['not base64 at all', 'not base64!!'],
+    ['a truncated payload Buffer.from would silently accept', 'aGVsbG8'],
+  ])('rejects %s before uploading anything', async (_label, contentBase64) => {
+    const { client, captured } = uploadClient([]);
+    const result = await run({ chargeId: CHARGE, documents: [doc({ contentBase64 })] }, client);
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+    expect(captured).toHaveLength(0);
+  });
+
+  it('accepts a data: URI prefix and surrounding whitespace', async () => {
+    const { client, captured } = uploadClient([ok('d1')]);
+    const result = await run(
+      {
+        chargeId: CHARGE,
+        documents: [doc({ contentBase64: 'data:application/pdf;base64,aGVs\nbG8=' })],
+      },
+      client,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(new TextDecoder().decode(captured[0].parts[0].bytes)).toBe('hello');
+  });
+
+  it('rejects an unlisted MIME type', async () => {
+    const { client } = uploadClient([]);
+    const result = await run(
+      { chargeId: CHARGE, documents: [doc({ mimeType: 'application/x-msdownload' })] },
+      client,
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects a file over the per-file size cap', async () => {
+    const { client, captured } = uploadClient([]);
+    const oversized = Buffer.alloc(MAX_DOCUMENT_BYTES + 1, 0x41).toString('base64');
+    const result = await run(
+      { chargeId: CHARGE, documents: [doc({ contentBase64: oversized })] },
+      client,
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { message: string }).message).toMatch(/per-file limit/);
+    expect(captured).toHaveLength(0);
+  });
+
+  it('rejects a batch over the per-call size cap even when each file fits', async () => {
+    const { client, captured } = uploadClient([]);
+    // Four 4MB files: each under the 5MB per-file cap, together over the 15MB call cap.
+    const chunk = Buffer.alloc(4 * 1024 * 1024, 0x41).toString('base64');
+    const result = await run(
+      {
+        chargeId: CHARGE,
+        documents: Array.from({ length: 4 }, (_, i) =>
+          doc({ filename: `f${i}.pdf`, contentBase64: chunk }),
+        ),
+      },
+      client,
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { message: string }).message).toMatch(
+      new RegExp(`${MAX_TOTAL_DOCUMENT_BYTES / 1024 / 1024}MB per-call limit`),
+    );
+    expect(captured).toHaveLength(0);
+  });
+});
+
+describe('uploadDocumentsTool — result mapping', () => {
+  it('reports per-file outcomes positionally when the batch partially fails', async () => {
+    const { client } = uploadClient([
+      ok('d1'),
+      { __typename: 'CommonError', message: 'OCR failed' },
+      ok('d3', null),
+    ]);
+    const result = await run(
+      {
+        chargeId: CHARGE,
+        documents: [
+          doc({ filename: 'a.pdf' }),
+          doc({ filename: 'b.pdf' }),
+          doc({ filename: 'c.pdf' }),
+        ],
+      },
+      client,
+    );
+
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as {
+      ok: boolean;
+      uploadedCount: number;
+      failedCount: number;
+      isSensitive: boolean;
+      results: Array<Record<string, unknown>>;
+    };
+
+    expect(structured.ok).toBe(true);
+    expect(structured.uploadedCount).toBe(2);
+    expect(structured.failedCount).toBe(1);
+    expect(structured.isSensitive).toBe(true);
+    // The failure is tied to the file it belongs to, so the model knows which
+    // one it still has to deal with.
+    expect(structured.results[1]).toMatchObject({
+      filename: 'b.pdf',
+      status: 'failed',
+      message: 'OCR failed',
+    });
+    expect(structured.results[0]).toMatchObject({
+      filename: 'a.pdf',
+      status: 'uploaded',
+      documentId: 'd1',
+    });
+    expect(result.content[0].text).toMatch(/1 failed/);
+  });
+});
+
+describe('uploadDocumentsTool — policy', () => {
+  it('refuses an ambiguous write target', async () => {
+    const { client, captured } = uploadClient([]);
+    const result = await run({ chargeId: CHARGE, documents: [doc()] }, client, authContext([B1, B2]));
+
+    expect(result.isError).toBe(true);
+    const structured = result.structuredContent as { code: string; message: string };
+    expect(structured.code).toBe('AUTHORIZATION_ERROR');
+    expect(structured.message).toMatch(/exactly one business/);
+    expect(captured).toHaveLength(0);
+  });
+
+  it('accepts a multi-member caller who names the target business', async () => {
+    const { client, captured } = uploadClient([ok('d1')]);
+    const result = await run(
+      { memberBusinessId: B2, chargeId: CHARGE, documents: [doc()] },
+      client,
+      authContext([B1, B2]),
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(captured[0].headers['x-business-scope']).toBe(B2);
+  });
+
+  it('denies a caller holding neither required role', async () => {
+    const { client } = uploadClient([]);
+    const result = await run(
+      { chargeId: CHARGE, documents: [doc()] },
+      client,
+      authContext([B1], 'viewer'),
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('AUTHORIZATION_ERROR');
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/documents-write.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/documents-write.test.ts
@@ -141,20 +141,20 @@ describe('uploadDocumentsTool — multipart envelope', () => {
     expect(names).not.toContain('content-type');
   });
 
-  it('pins isSensitive to true and forwards the chargeId', async () => {
+  it('pins isSensitive to false and forwards the chargeId', async () => {
     const { client, captured } = uploadClient([ok('d1')]);
     await run({ chargeId: CHARGE, documents: [doc()] }, client);
 
     expect(captured[0].operations.variables).toMatchObject({
       chargeId: CHARGE,
-      isSensitive: true,
+      isSensitive: false,
     });
   });
 
   it('rejects a caller-supplied isSensitive — it is not part of the schema', async () => {
     const { client, captured } = uploadClient([ok('d1')]);
     const result = await run(
-      { chargeId: CHARGE, documents: [doc()], isSensitive: false },
+      { chargeId: CHARGE, documents: [doc()], isSensitive: true },
       client,
     );
 
@@ -298,7 +298,7 @@ describe('uploadDocumentsTool — result mapping', () => {
     expect(structured.ok).toBe(true);
     expect(structured.uploadedCount).toBe(2);
     expect(structured.failedCount).toBe(1);
-    expect(structured.isSensitive).toBe(true);
+    expect(structured.isSensitive).toBe(false);
     // The failure is tied to the file it belongs to, so the model knows which
     // one it still has to deal with.
     expect(structured.results[1]).toMatchObject({
@@ -349,5 +349,149 @@ describe('uploadDocumentsTool — policy', () => {
 
     expect(result.isError).toBe(true);
     expect((result.structuredContent as { code: string }).code).toBe('AUTHORIZATION_ERROR');
+  });
+});
+
+/**
+ * The URL branch is the one that makes the tool usable for real files: the
+ * server fetches the bytes, so nothing about the document passes through the
+ * model and none of the inline size caps apply. What matters here is that the
+ * two branches stay mutually exclusive and that the URL branch takes the plain
+ * JSON mutation rather than the multipart one.
+ */
+describe('uploadDocumentsTool — documentUrls', () => {
+  interface CapturedJson {
+    query: string;
+    variables: Record<string, unknown>;
+    headers: Record<string, string>;
+  }
+
+  function urlClient(responses: unknown[]) {
+    const captured: CapturedJson[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body));
+      captured.push({
+        query: body.query,
+        variables: body.variables,
+        headers: init.headers as Record<string, string>,
+      });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { batchUploadDocumentsFromUrls: responses } }),
+      } as unknown as Response;
+    });
+    const client = new UpstreamGraphQLClient({
+      endpoint: 'http://localhost:4000/graphql',
+      timeoutMs: 1000,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    return { client, captured };
+  }
+
+  const DRIVE_URL = 'https://drive.google.com/file/d/abc123/view';
+
+  it('sends the URLs as a plain JSON mutation, not multipart', async () => {
+    const { client, captured } = urlClient([ok('d1')]);
+    const result = await run({ chargeId: CHARGE, documentUrls: [DRIVE_URL] }, client);
+
+    expect(result.isError).toBeUndefined();
+    expect(captured).toHaveLength(1);
+    expect(captured[0].query).toContain('batchUploadDocumentsFromUrls');
+    expect(captured[0].variables).toMatchObject({
+      urls: [DRIVE_URL],
+      chargeId: CHARGE,
+      isSensitive: false,
+    });
+    expect(captured[0].headers['content-type'] ?? captured[0].headers['Content-Type']).toContain(
+      'application/json',
+    );
+  });
+
+  it('reports each URL positionally, so a partial failure names the URL that failed', async () => {
+    const { client } = urlClient([
+      ok('d1'),
+      { __typename: 'CommonError', message: 'https://example.com/b.pdf: HTTP 404' },
+    ]);
+    const result = await run(
+      { chargeId: CHARGE, documentUrls: [DRIVE_URL, 'https://example.com/b.pdf'] },
+      client,
+    );
+
+    const structured = result.structuredContent as {
+      source: string;
+      uploadedCount: number;
+      failedCount: number;
+      results: Array<Record<string, unknown>>;
+    };
+    expect(structured.source).toBe('urls');
+    expect(structured.uploadedCount).toBe(1);
+    expect(structured.failedCount).toBe(1);
+    // Labelled `url`, not `filename` — the caller never supplied a filename here.
+    expect(structured.results[0]).toMatchObject({ url: DRIVE_URL, status: 'uploaded' });
+    expect(structured.results[1]).toMatchObject({
+      url: 'https://example.com/b.pdf',
+      status: 'failed',
+    });
+  });
+
+  it('applies no size limit to the URL branch', async () => {
+    // A URL list far past what any inline payload could carry is still fine:
+    // the bytes are the server's problem, not the model's.
+    const { client, captured } = urlClient([ok('d1')]);
+    const long = `https://example.com/${'a'.repeat(1900)}.pdf`;
+    const result = await run({ chargeId: CHARGE, documentUrls: [long] }, client);
+
+    expect(result.isError).toBeUndefined();
+    expect(captured[0].variables.urls).toEqual([long]);
+  });
+
+  it('rejects a call carrying both documentUrls and documents', async () => {
+    const { client, captured } = urlClient([]);
+    const result = await run(
+      { chargeId: CHARGE, documentUrls: [DRIVE_URL], documents: [doc()] },
+      client,
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+    expect(captured).toHaveLength(0);
+  });
+
+  it('rejects a call carrying neither', async () => {
+    const { client, captured } = urlClient([]);
+    const result = await run({ chargeId: CHARGE }, client);
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+    expect(captured).toHaveLength(0);
+  });
+
+  it('rejects a non-URL string', async () => {
+    const { client, captured } = urlClient([]);
+    const result = await run({ chargeId: CHARGE, documentUrls: ['/tmp/invoice.pdf'] }, client);
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+    expect(captured).toHaveLength(0);
+  });
+
+  it('audits the call without logging the URLs, which can carry access tokens', async () => {
+    const { client } = urlClient([ok('d1')]);
+    const lines: string[] = [];
+    const write = vi.spyOn(console, 'log').mockImplementation(line => void lines.push(String(line)));
+    try {
+      await run(
+        { chargeId: CHARGE, documentUrls: ['https://example.com/secret?token=hunter2'] },
+        client,
+      );
+    } finally {
+      write.mockRestore();
+    }
+
+    const audit = lines.find(line => line.includes('"audit":true'));
+    expect(audit).toBeDefined();
+    expect(audit).toContain('"documentUrlsCount":1');
+    expect(audit).not.toContain('hunter2');
   });
 });

--- a/packages/mcp-server/src/tools/__tests__/documents-write.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/documents-write.test.ts
@@ -228,12 +228,16 @@ describe('uploadDocumentsTool — input guards', () => {
 
   it('rejects a batch over the per-call size cap even when each file fits', async () => {
     const { client, captured } = uploadClient([]);
-    // Four 4MB files: each under the 5MB per-file cap, together over the 15MB call cap.
-    const chunk = Buffer.alloc(4 * 1024 * 1024, 0x41).toString('base64');
+    // Three 200KB files: each comfortably under the per-file cap, together over
+    // the per-call one — so this exercises the total check, not the per-file one.
+    const each = 200 * 1024;
+    expect(each).toBeLessThan(MAX_DOCUMENT_BYTES);
+    expect(each * 3).toBeGreaterThan(MAX_TOTAL_DOCUMENT_BYTES);
+    const chunk = Buffer.alloc(each, 0x41).toString('base64');
     const result = await run(
       {
         chargeId: CHARGE,
-        documents: Array.from({ length: 4 }, (_, i) =>
+        documents: Array.from({ length: 3 }, (_, i) =>
           doc({ filename: `f${i}.pdf`, contentBase64: chunk }),
         ),
       },
@@ -241,10 +245,25 @@ describe('uploadDocumentsTool — input guards', () => {
     );
 
     expect(result.isError).toBe(true);
-    expect((result.structuredContent as { message: string }).message).toMatch(
-      new RegExp(`${MAX_TOTAL_DOCUMENT_BYTES / 1024 / 1024}MB per-call limit`),
-    );
+    expect((result.structuredContent as { message: string }).message).toMatch(/per-call/);
     expect(captured).toHaveLength(0);
+  });
+
+  it('tells an over-size caller what to do instead of shrinking the file', async () => {
+    // The failure mode this guards against is not a wrong error code — it is the
+    // model "helpfully" re-rendering a tax receipt at lower quality until it
+    // fits, and archiving the degraded copy as the financial record.
+    const { client } = uploadClient([]);
+    const oversized = Buffer.alloc(MAX_DOCUMENT_BYTES + 1, 0x41).toString('base64');
+    const result = await run(
+      { chargeId: CHARGE, documents: [doc({ contentBase64: oversized })] },
+      client,
+    );
+
+    const message = (result.structuredContent as { message: string }).message;
+    expect(message).toMatch(/Do NOT downscale, re-encode, or reduce the quality/);
+    expect(message).toMatch(/Google Drive/);
+    expect(message).toMatch(/email/);
   });
 });
 

--- a/packages/mcp-server/src/tools/__tests__/policy.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/policy.test.ts
@@ -101,6 +101,64 @@ describe('evaluateToolPolicy — roles', () => {
   });
 });
 
+describe('evaluateToolPolicy — mutating tools', () => {
+  const writePolicy: ToolAuthPolicy = {
+    requiresBusinessScope: true,
+    dataClassification: 'business',
+    mutating: true,
+  };
+
+  it('allows a caller whose only membership is the write target', () => {
+    const decision = evaluateToolPolicy({ policy: writePolicy, auth: authContext([M('b1')]) });
+    expect(decision).toEqual({ allowed: true, readScope: { memberBusinessIds: ['b1'] } });
+  });
+
+  it('allows a multi-member caller who names one target', () => {
+    const decision = evaluateToolPolicy({
+      policy: writePolicy,
+      auth: authContext([M('b1'), M('b2')]),
+      requestedMemberBusinessIds: ['b2'],
+    });
+    expect(decision).toEqual({ allowed: true, readScope: { memberBusinessIds: ['b2'] } });
+  });
+
+  it('denies when the scope is ambiguous, rather than picking one', () => {
+    const decision = evaluateToolPolicy({
+      policy: writePolicy,
+      auth: authContext([M('b1'), M('b2')]),
+    });
+    expect(decision.allowed).toBe(false);
+    if (!decision.allowed) {
+      expect(decision.error.code).toBe('AUTHORIZATION_ERROR');
+      // The message names the count so the caller knows to narrow, not retry.
+      expect(decision.error.message).toMatch(/exactly one business, but the request resolved to 2/);
+      expect(decision.error.message).toMatch(/memberBusinessId/);
+    }
+  });
+
+  it('denies a caller narrowing to more than one target', () => {
+    const decision = evaluateToolPolicy({
+      policy: writePolicy,
+      auth: authContext([M('b1'), M('b2')]),
+      requestedMemberBusinessIds: ['b1', 'b2'],
+    });
+    expect(decision.allowed).toBe(false);
+  });
+
+  it('denies a caller with no memberships', () => {
+    const decision = evaluateToolPolicy({ policy: writePolicy, auth: authContext([]) });
+    expect(decision.allowed).toBe(false);
+  });
+
+  it('leaves non-mutating tools free to span every membership', () => {
+    const decision = evaluateToolPolicy({
+      policy: { ...writePolicy, mutating: false },
+      auth: authContext([M('b1'), M('b2')]),
+    });
+    expect(decision.allowed).toBe(true);
+  });
+});
+
 describe('authorizeToolCall', () => {
   it('evaluates the policy of a registered tool', () => {
     const tool = {

--- a/packages/mcp-server/src/tools/__tests__/registry-instance.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/registry-instance.test.ts
@@ -26,4 +26,23 @@ describe('production tool registry', () => {
     // No required parameters — the model can always call it cold.
     expect(descriptor?.inputSchema.required).toBeUndefined();
   });
+
+  it('registers every mutating tool after every read tool', () => {
+    // Registration order is what `tools/list` advertises. Reads first is a
+    // deliberate prompt-engineering choice: a tool that changes data should not
+    // be the first thing the model reaches for.
+    const tools = toolRegistry.list();
+    const firstWrite = tools.findIndex(tool => tool.policy.mutating);
+    expect(firstWrite).toBeGreaterThan(0);
+    expect(tools.slice(firstWrite).every(tool => tool.policy.mutating)).toBe(true);
+  });
+
+  it('gives every mutating tool a role gate and a single-business scope', () => {
+    for (const tool of toolRegistry.list().filter(t => t.policy.mutating)) {
+      expect(tool.policy.requiresBusinessScope, `${tool.name} must be scope-gated`).toBe(true);
+      expect(tool.policy.requiredRoles, `${tool.name} must gate on a role`).toEqual(
+        expect.arrayContaining(['business_owner', 'accountant']),
+      );
+    }
+  });
 });

--- a/packages/mcp-server/src/tools/__tests__/scope-forwarding.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/scope-forwarding.test.ts
@@ -51,8 +51,31 @@ function authContext(): McpAuthContext {
   ]);
 }
 
+/**
+ * The document a tool sent, whether it went out as JSON (reads, and writes with
+ * no files) or as a multipart form (writes carrying files, where the operation
+ * travels in the `operations` part). Both encodings must be understood here, or
+ * the write tools would silently skip the header assertions below.
+ */
+function queryFromBody(body: BodyInit | null | undefined): string {
+  if (typeof body === 'string') {
+    return (JSON.parse(body) as { query: string }).query;
+  }
+  const operations = (body as FormData).get('operations');
+  return (JSON.parse(String(operations)) as { query: string }).query;
+}
+
 /** Upstream payloads keyed by the operation each tool issues. */
 function dataFor(query: string): unknown {
+  if (query.includes('batchUploadDocuments')) return { batchUploadDocuments: [] };
+  if (query.includes('batchUpdateChargesTags')) {
+    return {
+      batchUpdateChargesTags: {
+        __typename: 'BatchUpdateChargesTagsSuccessfulResult',
+        charges: [],
+      },
+    };
+  }
   if (query.includes('allCharges')) {
     return {
       allCharges: {
@@ -75,11 +98,10 @@ function capturingClient() {
   const headersSeen: Array<Record<string, string>> = [];
   const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
     headersSeen.push(init.headers as Record<string, string>);
-    const body = JSON.parse(init.body as string) as { query: string };
     return {
       ok: true,
       status: 200,
-      json: async () => ({ data: dataFor(body.query) }),
+      json: async () => ({ data: dataFor(queryFromBody(init.body)) }),
     } as unknown as Response;
   });
   const client = new UpstreamGraphQLClient({
@@ -90,12 +112,29 @@ function capturingClient() {
   return { client, headersSeen };
 }
 
-/** Minimal valid arguments per tool; everything else is optional. */
+/**
+ * Minimal valid arguments per tool; everything else is optional.
+ *
+ * A `memberBusinessId` here is not just a filter — it is also what the expected
+ * scope is derived from below, so narrowing a tool's args narrows its assertion
+ * automatically. The write tools must pass one: a mutating policy refuses an
+ * ambiguous target, and this fixture's caller belongs to two businesses.
+ */
 const ARGS_BY_TOOL: Record<string, unknown> = {
   accounter_balance_report: { memberBusinessId: B1, fromDate: '2026-01-01', toDate: '2026-03-01' },
   accounter_get_charges: { chargeIds: ['c1'] },
   accounter_get_transactions: { transactionIds: ['t1'] },
   accounter_get_documents: { documentIds: ['d1'] },
+  accounter_update_charges_tags: {
+    memberBusinessId: B1,
+    chargeIds: ['c1'],
+    addTagIds: ['tag-1'],
+  },
+  accounter_upload_documents: {
+    memberBusinessId: B1,
+    chargeId: 'c1',
+    documents: [{ filename: 'a.pdf', mimeType: 'application/pdf', contentBase64: 'eA==' }],
+  },
 };
 
 describe('registry-wide business-scope forwarding', () => {
@@ -109,9 +148,10 @@ describe('registry-wide business-scope forwarding', () => {
     '%s forwards the resolved scope and echoes it',
     async (name, tool) => {
       const { client, headersSeen } = capturingClient();
+      const args = ARGS_BY_TOOL[name] ?? {};
       const result = await executeRegisteredTool({
         tool,
-        rawArgs: ARGS_BY_TOOL[name] ?? {},
+        rawArgs: args,
         auth: authContext(),
         correlationId: 'c',
         client,
@@ -129,8 +169,10 @@ describe('registry-wide business-scope forwarding', () => {
       }
 
       expect(headersSeen.length, `${name} should call upstream`).toBeGreaterThan(0);
-      // The balance report narrows to its single memberBusinessId; the rest keep both.
-      const expectedScope = name === 'accounter_balance_report' ? [B1] : [B1, B2];
+      // A tool given an explicit `memberBusinessId` narrows to it; the rest keep
+      // the caller's full membership set.
+      const requested = (args as { memberBusinessId?: string }).memberBusinessId;
+      const expectedScope = requested ? [requested] : [B1, B2];
       for (const headers of headersSeen) {
         expect(headers[BUSINESS_SCOPE_HEADER]).toBe(expectedScope.join(','));
       }

--- a/packages/mcp-server/src/tools/__tests__/tags-write.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/tags-write.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { executeRegisteredTool } from '../execute.js';
+import { updateChargesTagsTool } from '../tags-write.js';
+
+/**
+ * `accounter_update_charges_tags` is a JSON-bodied write, so what matters here
+ * is the variables it sends, how it maps the result *union*, and the guards that
+ * stop a pointless or ambiguous call before it reaches upstream.
+ */
+
+const B1 = 'aa000000-0000-4000-8000-000000000001';
+const B2 = 'aa000000-0000-4000-8000-000000000002';
+const C1 = 'cc000000-0000-4000-8000-000000000001';
+const T1 = 'dd000000-0000-4000-8000-000000000001';
+const T2 = 'dd000000-0000-4000-8000-000000000002';
+
+function authContext(memberBusinessIds: string[], roleId = 'accountant'): McpAuthContext {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: [],
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+  return buildAuthContext(
+    principal,
+    memberBusinessIds.map(memberBusinessId => ({ memberBusinessId, roleId })),
+  );
+}
+
+interface CapturedCall {
+  query: string;
+  variables: Record<string, unknown>;
+  headers: Record<string, string>;
+}
+
+function tagsClient(payload: unknown, status = 200) {
+  const captured: CapturedCall[] = [];
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(init.body as string) as {
+      query: string;
+      variables: Record<string, unknown>;
+    };
+    captured.push({
+      query: body.query,
+      variables: body.variables,
+      headers: init.headers as Record<string, string>,
+    });
+    return {
+      ok: status < 400,
+      status,
+      json: async () => ({ data: { batchUpdateChargesTags: payload } }),
+    } as unknown as Response;
+  });
+  const client = new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+  return { client, captured };
+}
+
+const success = (charges: Array<{ id: string; tags: Array<{ id: string; name: string }> }>) => ({
+  __typename: 'BatchUpdateChargesTagsSuccessfulResult',
+  charges,
+});
+
+function run(rawArgs: unknown, client: UpstreamGraphQLClient, auth = authContext([B1])) {
+  return executeRegisteredTool({
+    tool: updateChargesTagsTool,
+    rawArgs,
+    auth,
+    correlationId: 'c',
+    client,
+    authorization: 'Bearer t',
+  });
+}
+
+describe('updateChargesTagsTool — request', () => {
+  it('sends a single mutation with the requested ids', async () => {
+    const { client, captured } = tagsClient(success([{ id: C1, tags: [{ id: T1, name: 'food' }] }]));
+    const result = await run(
+      { chargeIds: [C1], addTagIds: [T1], removeTagIds: [T2] },
+      client,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(captured).toHaveLength(1);
+    expect(captured[0].query).toMatch(/^\s*mutation\b/);
+    expect(captured[0].variables).toEqual({
+      chargeIds: [C1],
+      addTagIds: [T1],
+      removeTagIds: [T2],
+    });
+  });
+
+  it('sends null for an omitted direction rather than an empty array', async () => {
+    // An empty list and "no change in this direction" are different requests
+    // upstream; sending `[]` for an omitted field would assert the former.
+    const { client, captured } = tagsClient(success([]));
+    await run({ chargeIds: [C1], addTagIds: [T1] }, client);
+
+    expect(captured[0].variables.removeTagIds).toBeNull();
+    expect(captured[0].variables.addTagIds).toEqual([T1]);
+  });
+
+  it('forwards the resolved business scope', async () => {
+    const { client, captured } = tagsClient(success([]));
+    await run({ chargeIds: [C1], addTagIds: [T1] }, client);
+
+    expect(captured[0].headers['x-business-scope']).toBe(B1);
+  });
+});
+
+describe('updateChargesTagsTool — guards', () => {
+  it('rejects a call that changes nothing, without a round trip', async () => {
+    const { client, captured } = tagsClient(success([]));
+    const result = await run({ chargeIds: [C1] }, client);
+
+    expect(result.isError).toBe(true);
+    const structured = result.structuredContent as { code: string; message: string };
+    expect(structured.code).toBe('VALIDATION_ERROR');
+    expect(structured.message).toMatch(/No tag changes/);
+    expect(captured).toHaveLength(0);
+  });
+
+  it('treats explicitly empty tag lists as no change', async () => {
+    const { client, captured } = tagsClient(success([]));
+    const result = await run({ chargeIds: [C1], addTagIds: [], removeTagIds: [] }, client);
+
+    expect(result.isError).toBe(true);
+    expect(captured).toHaveLength(0);
+  });
+
+  it('requires at least one charge', async () => {
+    const { client } = tagsClient(success([]));
+    const result = await run({ chargeIds: [], addTagIds: [T1] }, client);
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('refuses an ambiguous write target', async () => {
+    const { client, captured } = tagsClient(success([]));
+    const result = await run({ chargeIds: [C1], addTagIds: [T1] }, client, authContext([B1, B2]));
+
+    expect(result.isError).toBe(true);
+    const structured = result.structuredContent as { code: string; message: string };
+    expect(structured.code).toBe('AUTHORIZATION_ERROR');
+    expect(structured.message).toMatch(/exactly one business/);
+    expect(captured).toHaveLength(0);
+  });
+
+  it('denies a caller holding neither required role', async () => {
+    const { client } = tagsClient(success([]));
+    const result = await run(
+      { chargeIds: [C1], addTagIds: [T1] },
+      client,
+      authContext([B1], 'viewer'),
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('AUTHORIZATION_ERROR');
+  });
+});
+
+describe('updateChargesTagsTool — result mapping', () => {
+  it('reports the updated charges with their resulting tags', async () => {
+    const { client } = tagsClient(
+      success([
+        { id: C1, tags: [{ id: T1, name: 'food' }] },
+        { id: 'c2', tags: [] },
+      ]),
+    );
+    const result = await run({ chargeIds: [C1, 'c2', 'c3'], addTagIds: [T1] }, client);
+
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as {
+      ok: boolean;
+      updatedCount: number;
+      requestedCount: number;
+      addedTagIds: string[];
+      removedTagIds: string[];
+      charges: Array<{ id: string; tags: Array<{ id: string; name: string }> }>;
+    };
+
+    expect(structured.ok).toBe(true);
+    // `updatedCount` reflects what upstream actually changed; `requestedCount`
+    // is what was asked for, so a shortfall is visible rather than implied.
+    expect(structured.updatedCount).toBe(2);
+    expect(structured.requestedCount).toBe(3);
+    expect(structured.addedTagIds).toEqual([T1]);
+    expect(structured.removedTagIds).toEqual([]);
+    expect(structured.charges[0]).toEqual({ id: C1, tags: [{ id: T1, name: 'food' }] });
+  });
+
+  it('surfaces a CommonError from upstream as a non-retryable failure', async () => {
+    const { client } = tagsClient({ __typename: 'CommonError', message: 'Charge not found' });
+    const result = await run({ chargeIds: [C1], addTagIds: [T1] }, client);
+
+    expect(result.isError).toBe(true);
+    const structured = result.structuredContent as {
+      code: string;
+      message: string;
+      retryable: boolean;
+    };
+    expect(structured.code).toBe('UPSTREAM_ERROR');
+    expect(structured.message).toBe('Charge not found');
+    // Re-sending the identical request would be refused identically.
+    expect(structured.retryable).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/upload-limits.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/upload-limits.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_MCP_BODY_BYTES } from '../../mcp/handler.js';
+import { MAX_DOCUMENT_BYTES, MAX_TOTAL_DOCUMENT_BYTES } from '../documents-write.js';
+
+/**
+ * Contract between the upload caps and the transport that has to carry them.
+ *
+ * This exists because the two silently disagreed once: the tool advertised 5MB
+ * per file while `MAX_MCP_BODY_BYTES` capped the whole JSON-RPC body at 1MB, so
+ * a 5MB upload died as a 413 before the tool's own check ever ran. The tool was
+ * documenting a capability it could not deliver.
+ *
+ * Base64 costs 4/3 of the decoded size, and the operation JSON, filenames, and
+ * MIME types ride along in the same body, so the caps must leave headroom on top
+ * of that expansion.
+ */
+
+const BASE64_EXPANSION = 4 / 3;
+/** Room for the JSON-RPC envelope: method, params, filenames, MIME types. */
+const ENVELOPE_HEADROOM_BYTES = 64 * 1024;
+
+describe('upload caps vs the transport body limit', () => {
+  it('keeps a full-size call inside MAX_MCP_BODY_BYTES', () => {
+    const encoded = MAX_TOTAL_DOCUMENT_BYTES * BASE64_EXPANSION;
+    expect(encoded + ENVELOPE_HEADROOM_BYTES).toBeLessThanOrEqual(MAX_MCP_BODY_BYTES);
+  });
+
+  it('keeps a single largest document inside MAX_MCP_BODY_BYTES', () => {
+    const encoded = MAX_DOCUMENT_BYTES * BASE64_EXPANSION;
+    expect(encoded + ENVELOPE_HEADROOM_BYTES).toBeLessThanOrEqual(MAX_MCP_BODY_BYTES);
+  });
+
+  it('does not advertise a per-file cap larger than the per-call one', () => {
+    expect(MAX_DOCUMENT_BYTES).toBeLessThanOrEqual(MAX_TOTAL_DOCUMENT_BYTES);
+  });
+
+  it('stays small enough to be emittable as tool arguments', () => {
+    // The binding limit in practice is neither cap above but the model's own
+    // per-message output budget: it must *type* the base64. At roughly 3 chars
+    // per token, this bounds a single document to a few tens of thousands of
+    // tokens — large, but within a single message. A cap that failed this would
+    // be unreachable in practice no matter what the server allows.
+    const approxTokens = (MAX_DOCUMENT_BYTES * BASE64_EXPANSION) / 3;
+    expect(approxTokens).toBeLessThan(150_000);
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/usage-log.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/usage-log.test.ts
@@ -5,8 +5,10 @@ import { Metrics } from '../../observability/metrics.js';
 import { RateLimiter } from '../../rate-limit/limiter.js';
 import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
 import { SEARCH_CHARGES_TOOL_NAME, searchChargesTool } from '../charges.js';
+import { DOCUMENT_SOURCE_COUNTER, uploadDocumentsTool } from '../documents-write.js';
 import { executeRegisteredTool, TOOL_CALL_EVENT } from '../execute.js';
 import { toolRegistry } from '../registry-instance.js';
+import { updateChargesTagsTool } from '../tags-write.js';
 import { explainTerminologyTool } from '../terminology.js';
 import type { ToolDefinition, ToolResult } from '../registry.js';
 
@@ -54,6 +56,24 @@ function dataFor(query: string): unknown {
   if (query.includes('transactionsByIDs')) return { transactionsByIDs: [] };
   if (query.includes('documentsByIds')) return { documentsByIds: [] };
   if (query.includes('allTags')) return { allTags: [] };
+  if (query.includes('batchUpdateChargesTags')) {
+    return {
+      batchUpdateChargesTags: {
+        __typename: 'BatchUpdateChargesTagsSuccessfulResult',
+        charges: [{ id: 'c1', tags: [{ id: 't1', name: 'travel' }] }],
+      },
+    };
+  }
+  if (query.includes('batchUploadDocumentsFromUrls')) {
+    return {
+      batchUploadDocumentsFromUrls: [
+        {
+          __typename: 'UploadDocumentSuccessfulResult',
+          document: { id: 'd1', documentType: 'INVOICE' },
+        },
+      ],
+    };
+  }
   if (query.includes('taxCategories')) return { taxCategories: [] };
   if (query.includes('allBusinesses')) return { allBusinesses: { nodes: [] } };
   if (query.includes('transactionsForBalanceReport')) return { transactionsForBalanceReport: [] };
@@ -82,6 +102,17 @@ const ARGS_BY_TOOL: Record<string, unknown> = {
   accounter_get_charges: { chargeIds: ['c1'] },
   accounter_get_transactions: { transactionIds: ['t1'] },
   accounter_get_documents: { documentIds: ['d1'] },
+  // The write tools need a resolved single write target and real arguments; `{}`
+  // would only ever exercise the validation-rejection path.
+  accounter_update_charges_tags: { memberBusinessId: B1, chargeIds: ['c1'], addTagIds: ['t1'] },
+  // The URL branch keeps this a plain JSON mutation, which is what the shared
+  // fake upstream here speaks; the multipart branch has its own coverage in
+  // `documents-write.test.ts`.
+  accounter_upload_documents: {
+    memberBusinessId: B1,
+    chargeId: 'c1',
+    documentUrls: ['https://example.com/invoice.pdf?token=hunter2'],
+  },
 };
 
 interface UsageLine {
@@ -271,5 +302,77 @@ describe('observation failures', () => {
 
     expect(result.isError).toBeUndefined();
     expect(usageLine()).toMatchObject({ tool: 'broken_observe_tool', outcome: 'success' });
+  });
+});
+
+/**
+ * A write's usage line is not covered by the automatic `listShapeFields` path —
+ * a write result has no `returnedCount`/`totalCount`/`truncated` — so what it
+ * reports comes entirely from each tool's `observe` hook. These pin what that
+ * hook may and may not say.
+ */
+describe('write tool usage logging', () => {
+  const uploadArgs = {
+    memberBusinessId: B1,
+    chargeId: 'c1',
+    documentUrls: ['https://example.com/invoice.pdf?token=hunter2'],
+  };
+
+  function runUpload(metrics = new Metrics()) {
+    return executeRegisteredTool({
+      tool: uploadDocumentsTool,
+      rawArgs: uploadArgs,
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: client(),
+      metrics,
+    });
+  }
+
+  it('reports which branch an upload took, and what actually applied', async () => {
+    await runUpload();
+
+    expect(usageLine()).toMatchObject({
+      tool: 'accounter_upload_documents',
+      outcome: 'success',
+      documentSource: 'urls',
+      requestedDocumentCount: 1,
+      uploadedCount: 1,
+      failedCount: 0,
+    });
+  });
+
+  it('counts the upload branch, so base64 fallbacks are visible in metrics', async () => {
+    const metrics = new Metrics();
+    await runUpload(metrics);
+
+    expect(metrics.snapshot().labeledTotals[DOCUMENT_SOURCE_COUNTER]).toEqual({ urls: 1 });
+  });
+
+  it('never logs the URLs themselves — a signed link carries an access token', async () => {
+    await runUpload();
+
+    expect(JSON.stringify(usageLine())).not.toContain('hunter2');
+  });
+
+  it('reports requested and updated charge counts, whose difference is the signal', async () => {
+    await executeRegisteredTool({
+      tool: updateChargesTagsTool,
+      // Two charges asked for; the fake upstream resolves one, which is exactly
+      // the stale-id case the two counts exist to expose.
+      rawArgs: { memberBusinessId: B1, chargeIds: ['c1', 'c2'], addTagIds: ['t1'] },
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: client(),
+    });
+
+    expect(usageLine()).toMatchObject({
+      tool: 'accounter_update_charges_tags',
+      outcome: 'success',
+      requestedChargeCount: 2,
+      updatedChargeCount: 1,
+      addedTagCount: 1,
+      removedTagCount: 0,
+    });
   });
 });

--- a/packages/mcp-server/src/tools/allowlist.ts
+++ b/packages/mcp-server/src/tools/allowlist.ts
@@ -1,11 +1,10 @@
 /**
- * Tool allowlist enforcement (`MCP_TOOL_ALLOWLIST`).
+ * Tool exposure controls: the allowlist (`MCP_TOOL_ALLOWLIST`) and the write
+ * master switch (`MCP_ENABLE_WRITE_TOOLS`), both enforced at the transport
+ * boundary in `mcp/handler.ts`.
  *
  * The allowlist is a comma-separated set of tool names parsed into
- * `env.server.toolAllowlist`. Until now it was parsed and never read — every
- * registered tool was advertised and dispatchable regardless. That is harmless
- * while phase 1 is read-only, but a real control gap the moment mutating tools
- * land, so enforcement is wired in here at the transport boundary.
+ * `env.server.toolAllowlist`.
  *
  * **Semantics.** An *empty* allowlist means "no restriction" — every registered
  * tool is exposed. A *non-empty* allowlist restricts both `tools/list` and
@@ -30,4 +29,37 @@
  */
 export function isToolAllowed(allowlist: readonly string[], toolName: string): boolean {
   return allowlist.length === 0 || allowlist.includes(toolName);
+}
+
+/** The subset of a tool needed to decide exposure. */
+export interface ExposableTool {
+  name: string;
+  policy: { mutating?: boolean };
+}
+
+export interface ExposureOptions {
+  allowlist: readonly string[];
+  /** `MCP_ENABLE_WRITE_TOOLS`. When false, mutating tools are never exposed. */
+  writeToolsEnabled: boolean;
+}
+
+/**
+ * Whether a tool is exposed at all: allowed by {@link isToolAllowed} **and**,
+ * if it mutates, permitted by the write master switch.
+ *
+ * The two controls compose one way only — the allowlist can narrow the write
+ * tools an operator wants, but naming a write tool in it can never turn writes
+ * on. That ordering matters because the allowlist defaults to "everything":
+ * without this, shipping the first mutating tool would have handed write access
+ * to every existing deployment on upgrade.
+ *
+ * A tool excluded here is reported as `Unknown tool`, exactly like one excluded
+ * by the allowlist — a caller cannot tell a disabled write tool from a
+ * nonexistent one, so neither control leaks the capabilities it is hiding.
+ */
+export function isToolExposed(tool: ExposableTool, options: ExposureOptions): boolean {
+  if (tool.policy.mutating && !options.writeToolsEnabled) {
+    return false;
+  }
+  return isToolAllowed(options.allowlist, tool.name);
 }

--- a/packages/mcp-server/src/tools/documents-write.ts
+++ b/packages/mcp-server/src/tools/documents-write.ts
@@ -1,0 +1,253 @@
+import { z } from 'zod';
+import { ToolInputError } from '../errors/taxonomy.js';
+import type { McpBatchUploadDocumentsMutation } from '../gql/index.js';
+import type { UploadFile } from '../upstream/graphql-client.js';
+import { shapeWriteResult } from './output.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import { WRITE_SCOPE_DESCRIPTION_SUFFIX, writeTargetBusinessIdInput } from './scope-input.js';
+
+/**
+ * Write tool: attach documents to an existing charge.
+ *
+ * Two upstream facts shape this tool:
+ *
+ * 1. `batchUploadDocuments` takes real binary files (`FileScalar` is a web
+ *    `File`/`Blob` — the upstream helper calls `.arrayBuffer()` on it, so a
+ *    string will not do). This server is a *remote* HTTP service with no access
+ *    to the caller's filesystem, so documents arrive as inline base64 and are
+ *    decoded here into the GraphQL multipart request upstream.
+ *
+ * 2. `batchUploadDocuments` **creates a new charge when `chargeId` is omitted**.
+ *    That is a side effect the model should never trigger by leaving a field
+ *    blank, so `chargeId` is required here: this tool attaches to an existing
+ *    charge or it fails.
+ *
+ * `isSensitive` is pinned to `true` and deliberately absent from the input
+ * schema — it is a property of this ingestion path, not a choice to delegate.
+ */
+
+export const UPLOAD_DOCUMENTS_TOOL_NAME = 'accounter_upload_documents';
+
+/** Max documents per call. */
+export const MAX_DOCUMENTS_PER_CALL = 10;
+/** Max decoded size of one document. */
+export const MAX_DOCUMENT_BYTES = 5 * 1024 * 1024;
+/** Max decoded size of all documents in one call. */
+export const MAX_TOTAL_DOCUMENT_BYTES = 15 * 1024 * 1024;
+
+/**
+ * Accepted document MIME types. An allowlist rather than a blocklist: everything
+ * here ends up in Cloudinary and an OCR pipeline, so an unexpected type is a
+ * failure deep in someone else's system rather than a clear error here.
+ */
+export const ALLOWED_DOCUMENT_MIME_TYPES = [
+  'application/pdf',
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+  'image/tiff',
+] as const;
+
+const documentInput = z.object({
+  filename: z
+    .string()
+    .min(1)
+    .max(255)
+    .describe('File name including extension, e.g. `invoice-2026-01.pdf`.'),
+  mimeType: z
+    .enum(ALLOWED_DOCUMENT_MIME_TYPES)
+    .describe('MIME type of the file. Must match the actual content.'),
+  contentBase64: z
+    .string()
+    .min(1)
+    .describe(
+      'The file content, base64-encoded. A `data:<type>;base64,` prefix is accepted and stripped. ' +
+        `Max ${MAX_DOCUMENT_BYTES / 1024 / 1024}MB per file once decoded.`,
+    ),
+});
+
+const uploadDocumentsInput = z.object({
+  memberBusinessId: writeTargetBusinessIdInput,
+  chargeId: z
+    .string()
+    .min(1)
+    .describe(
+      'The EXISTING charge to attach the documents to. Required — this tool never creates a charge. ' +
+        'Use accounter_search_charges to find one.',
+    ),
+  documents: z
+    .array(documentInput)
+    .min(1)
+    .max(MAX_DOCUMENTS_PER_CALL)
+    .describe(`The documents to upload (1-${MAX_DOCUMENTS_PER_CALL} per call).`),
+});
+type UploadDocumentsInput = z.infer<typeof uploadDocumentsInput>;
+
+const BATCH_UPLOAD_DOCUMENTS_MUTATION = /* GraphQL */ `
+  mutation McpBatchUploadDocuments(
+    $documents: [FileScalar!]!
+    $chargeId: UUID
+    $isSensitive: Boolean
+  ) {
+    batchUploadDocuments(documents: $documents, chargeId: $chargeId, isSensitive: $isSensitive) {
+      __typename
+      ... on UploadDocumentSuccessfulResult {
+        document {
+          id
+          documentType
+        }
+      }
+      ... on CommonError {
+        message
+      }
+    }
+  }
+`;
+
+/** `data:<mime>;base64,` prefix some clients prepend to encoded content. */
+const DATA_URI_PREFIX_RE = /^data:[^;,]*;base64,/i;
+const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
+
+/**
+ * Decode one document's base64 payload, or throw a pointed
+ * {@link ToolInputError}.
+ *
+ * `Buffer.from(x, 'base64')` is lenient — it silently skips characters it does
+ * not recognize, so a truncated or corrupted payload decodes to a shorter,
+ * plausible-looking buffer instead of failing. That would surface as a corrupt
+ * file in Cloudinary long after the call reported success, so the encoding is
+ * validated strictly first and the size is checked on the decoded bytes.
+ */
+function decodeDocument(contentBase64: string, index: number): Uint8Array {
+  const path = `documents.${index}.contentBase64`;
+  // Whitespace (including the newlines in MIME-wrapped base64) is not
+  // significant; strip it before validating rather than rejecting on it.
+  const stripped = contentBase64.replace(DATA_URI_PREFIX_RE, '').replace(/\s/g, '');
+  if (stripped.length === 0) {
+    throw new ToolInputError('Document content is empty', [
+      { path, message: 'contentBase64 decodes to no content' },
+    ]);
+  }
+  if (stripped.length % 4 !== 0 || !BASE64_RE.test(stripped)) {
+    throw new ToolInputError('Document content is not valid base64', [
+      { path, message: 'contentBase64 must be a valid base64 string' },
+    ]);
+  }
+  const content = new Uint8Array(Buffer.from(stripped, 'base64'));
+  if (content.byteLength === 0) {
+    throw new ToolInputError('Document content is empty', [
+      { path, message: 'contentBase64 decodes to no content' },
+    ]);
+  }
+  if (content.byteLength > MAX_DOCUMENT_BYTES) {
+    throw new ToolInputError(
+      `Document exceeds the ${MAX_DOCUMENT_BYTES / 1024 / 1024}MB per-file limit`,
+      [{ path, message: `decoded size is ${content.byteLength} bytes` }],
+    );
+  }
+  return content;
+}
+
+async function uploadDocumentsHandler(
+  input: UploadDocumentsInput,
+  context: ToolExecutionContext,
+): Promise<ToolResult> {
+  const contents = input.documents.map((document, index) =>
+    decodeDocument(document.contentBase64, index),
+  );
+
+  const totalBytes = contents.reduce((sum, content) => sum + content.byteLength, 0);
+  if (totalBytes > MAX_TOTAL_DOCUMENT_BYTES) {
+    throw new ToolInputError(
+      `Documents total ${totalBytes} bytes, over the ${
+        MAX_TOTAL_DOCUMENT_BYTES / 1024 / 1024
+      }MB per-call limit. Split them across several calls.`,
+    );
+  }
+
+  const files: UploadFile[] = input.documents.map((document, index) => ({
+    // Matches the `documents` argument name in the mutation above; the
+    // placeholder nulls below occupy these positions.
+    variablePath: `variables.documents.${index}`,
+    filename: document.filename,
+    contentType: document.mimeType,
+    content: contents[index],
+  }));
+
+  const data = await context.client.mutateMultipart<McpBatchUploadDocumentsMutation>(
+    {
+      query: BATCH_UPLOAD_DOCUMENTS_MUTATION,
+      variables: {
+        // Per the GraphQL multipart request spec the file variables are null
+        // placeholders; `map` (built by the client from `files`) points each
+        // form part at its position here.
+        documents: input.documents.map(() => null),
+        chargeId: input.chargeId,
+        // Pinned, not caller-supplied: every document ingested through this tool
+        // is treated as sensitive.
+        isSensitive: true,
+      },
+    },
+    files,
+    context.upstream,
+  );
+
+  // Upstream returns a list of a *union*, one entry per file, so a partial
+  // failure is expressed per element. Report each outcome positionally rather
+  // than collapsing the batch to one status — the model needs to know which
+  // files it still has to deal with.
+  const results = data.batchUploadDocuments.map((result, index) => {
+    const filename = input.documents[index]?.filename;
+    if (result.__typename === 'UploadDocumentSuccessfulResult') {
+      return {
+        filename,
+        status: 'uploaded' as const,
+        documentId: result.document?.id ?? null,
+        documentType: result.document?.documentType ?? null,
+      };
+    }
+    return {
+      filename,
+      status: 'failed' as const,
+      message: result.__typename === 'CommonError' ? result.message : 'Unknown upload failure',
+    };
+  });
+
+  const uploadedCount = results.filter(result => result.status === 'uploaded').length;
+  const failedCount = results.length - uploadedCount;
+
+  return shapeWriteResult({
+    action: 'upload_documents',
+    outcome: {
+      chargeId: input.chargeId,
+      uploadedCount,
+      failedCount,
+      isSensitive: true,
+      scope: { memberBusinessIds: context.readScope.memberBusinessIds },
+    },
+    items: { key: 'results', values: results },
+    summary:
+      failedCount === 0
+        ? `Uploaded ${uploadedCount} document(s) to charge ${input.chargeId}.`
+        : `Uploaded ${uploadedCount} document(s) to charge ${input.chargeId}; ${failedCount} failed.`,
+  });
+}
+
+export const uploadDocumentsTool: ToolDefinition<typeof uploadDocumentsInput> = {
+  name: UPLOAD_DOCUMENTS_TOOL_NAME,
+  description:
+    'Attach one or more documents (invoices, receipts, contracts) to an EXISTING charge. Documents are ' +
+    'passed as base64-encoded content and are always stored as sensitive. This tool never creates a ' +
+    'charge: `chargeId` is required and must already exist. ' +
+    WRITE_SCOPE_DESCRIPTION_SUFFIX,
+  inputSchema: uploadDocumentsInput,
+  policy: {
+    requiredRoles: ['business_owner', 'accountant'],
+    requiresBusinessScope: true,
+    dataClassification: 'sensitive',
+    mutating: true,
+  },
+  handler: uploadDocumentsHandler,
+};

--- a/packages/mcp-server/src/tools/documents-write.ts
+++ b/packages/mcp-server/src/tools/documents-write.ts
@@ -6,7 +6,12 @@ import type {
 } from '../gql/index.js';
 import type { UploadFile } from '../upstream/graphql-client.js';
 import { shapeWriteResult } from './output.js';
-import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import type {
+  ToolDefinition,
+  ToolExecutionContext,
+  ToolObservation,
+  ToolResult,
+} from './registry.js';
 import { WRITE_SCOPE_DESCRIPTION_SUFFIX, writeTargetBusinessIdInput } from './scope-input.js';
 
 /**
@@ -409,6 +414,43 @@ async function uploadDocumentsHandler(
   });
 }
 
+/**
+ * Which branch a call took: `urls` (server fetches) or `inline` (base64 through
+ * the model). This is the counter the URL branch exists to move — it answers
+ * whether the model actually reaches for links, or still falls back to base64
+ * and its size ceiling.
+ */
+export const DOCUMENT_SOURCE_COUNTER = 'document_upload_source';
+
+/**
+ * Usage telemetry for one upload.
+ *
+ * A write result carries no `returnedCount`/`totalCount`/`truncated`, so
+ * `listShapeFields` contributes nothing to its usage line — without this hook a
+ * completed upload would log *that* it happened and nothing about *what* it
+ * did. The counts come from the shaped result rather than the input, because
+ * upstream reports success per file and a partially failed batch is the case
+ * worth seeing.
+ *
+ * The same rule as the audit line applies, for the same reason: counts and
+ * shape only. Filenames describe the caller's documents and URLs can carry
+ * access tokens, so neither reaches the log.
+ */
+function observe(input: UploadDocumentsInput, result: ToolResult): ToolObservation {
+  const source = input.documentUrls ? 'urls' : 'inline';
+  const structured = result.structuredContent as
+    { uploadedCount?: number; failedCount?: number } | undefined;
+  return {
+    fields: {
+      documentSource: source,
+      requestedDocumentCount: (input.documentUrls ?? input.documents ?? []).length,
+      uploadedCount: structured?.uploadedCount,
+      failedCount: structured?.failedCount,
+    },
+    counters: [[DOCUMENT_SOURCE_COUNTER, source]],
+  };
+}
+
 export const uploadDocumentsTool: ToolDefinition<typeof uploadDocumentsInput> = {
   name: UPLOAD_DOCUMENTS_TOOL_NAME,
   description:
@@ -432,4 +474,5 @@ export const uploadDocumentsTool: ToolDefinition<typeof uploadDocumentsInput> = 
     mutating: true,
   },
   handler: uploadDocumentsHandler,
+  observe,
 };

--- a/packages/mcp-server/src/tools/documents-write.ts
+++ b/packages/mcp-server/src/tools/documents-write.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 import { ToolInputError } from '../errors/taxonomy.js';
-import type { McpBatchUploadDocumentsMutation } from '../gql/index.js';
+import type {
+  McpBatchUploadDocumentsFromUrlsMutation,
+  McpBatchUploadDocumentsMutation,
+} from '../gql/index.js';
 import type { UploadFile } from '../upstream/graphql-client.js';
 import { shapeWriteResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
@@ -9,24 +12,52 @@ import { WRITE_SCOPE_DESCRIPTION_SUFFIX, writeTargetBusinessIdInput } from './sc
 /**
  * Write tool: attach documents to an existing charge.
  *
- * Two upstream facts shape this tool:
+ * The tool has two branches, and which one a call takes decides who moves the
+ * bytes:
+ *
+ * - **`documentUrls`** — the server fetches each URL itself. The model emits a
+ *   link, not a payload, so nothing about the file passes through it and there
+ *   is no size limit worth stating. This is the branch to prefer for anything
+ *   that already lives somewhere fetchable.
+ * - **`documents`** — inline base64. Here the *model* is the transport: it has
+ *   to reproduce the whole encoded file as tool arguments, which both costs
+ *   enormous output budget and risks corrupting the file, since base64 has no
+ *   redundancy and a single mis-emitted character destroys it. Hence the small
+ *   caps below.
+ *
+ * Exactly one branch per call; see {@link uploadDocumentsInput}.
+ *
+ * Two upstream facts shape the rest:
  *
  * 1. `batchUploadDocuments` takes real binary files (`FileScalar` is a web
  *    `File`/`Blob` — the upstream helper calls `.arrayBuffer()` on it, so a
  *    string will not do). This server is a *remote* HTTP service with no access
- *    to the caller's filesystem, so documents arrive as inline base64 and are
- *    decoded here into the GraphQL multipart request upstream.
+ *    to the caller's filesystem, so inline documents arrive as base64 and are
+ *    decoded here into the GraphQL multipart request upstream. The URL branch
+ *    sidesteps this entirely: `batchUploadDocumentsFromUrls` takes plain
+ *    strings, so it is an ordinary JSON mutation.
  *
  * 2. `batchUploadDocuments` **creates a new charge when `chargeId` is omitted**.
  *    That is a side effect the model should never trigger by leaving a field
  *    blank, so `chargeId` is required here: this tool attaches to an existing
  *    charge or it fails.
  *
- * `isSensitive` is pinned to `true` and deliberately absent from the input
- * schema — it is a property of this ingestion path, not a choice to delegate.
+ * `isSensitive` is pinned and deliberately absent from the input schema — see
+ * {@link PINNED_IS_SENSITIVE}.
  */
 
 export const UPLOAD_DOCUMENTS_TOOL_NAME = 'accounter_upload_documents';
+
+/**
+ * Pinned, not caller-supplied.
+ *
+ * The upstream name is misleading: `getOcrData` returns early with
+ * `documentType: UNPROCESSED` when this is set, so `true` does not so much mark
+ * a document sensitive as skip OCR entirely — every document uploaded here would
+ * land with no amount, date, counterparty, or serial. Documents ingested through
+ * this tool are meant to be read, so both branches pass `false`.
+ */
+const PINNED_IS_SENSITIVE = false;
 
 /** Max documents per call. */
 export const MAX_DOCUMENTS_PER_CALL = 10;
@@ -66,9 +97,10 @@ export const MAX_TOTAL_DOCUMENT_BYTES = 512 * 1024;
  */
 export const OVERSIZE_GUIDANCE =
   'Do NOT downscale, re-encode, or reduce the quality of the document to fit — the stored file is a ' +
-  'financial record and must keep its original fidelity. Instead use a path that does not send bytes ' +
-  'through the conversation: upload the file to the shared Google Drive folder and use the Drive ' +
-  'ingestion flow, or forward it to the document-ingestion email address.';
+  'financial record and must keep its original fidelity. Use `documentUrls` instead: put the file ' +
+  'somewhere fetchable (Google Drive, or any direct download link) and pass the link, so the server ' +
+  'fetches the bytes rather than routing them through this conversation. There is no size limit on ' +
+  'that path. Failing that, forward the file to the document-ingestion email address.';
 
 /** Render a byte count for humans; every limit here is KB-scale. */
 const asKb = (bytes: number) => `${Math.round(bytes / 1024)}KB`;
@@ -107,21 +139,46 @@ const documentInput = z.object({
     ),
 });
 
-const uploadDocumentsInput = z.object({
-  memberBusinessId: writeTargetBusinessIdInput,
-  chargeId: z
-    .string()
-    .min(1)
-    .describe(
-      'The EXISTING charge to attach the documents to. Required — this tool never creates a charge. ' +
-        'Use accounter_search_charges to find one.',
-    ),
-  documents: z
-    .array(documentInput)
-    .min(1)
-    .max(MAX_DOCUMENTS_PER_CALL)
-    .describe(`The documents to upload (1-${MAX_DOCUMENTS_PER_CALL} per call).`),
-});
+const uploadDocumentsInput = z
+  .object({
+    memberBusinessId: writeTargetBusinessIdInput,
+    chargeId: z
+      .string()
+      .min(1)
+      .describe(
+        'The EXISTING charge to attach the documents to. Required — this tool never creates a charge. ' +
+          'Use accounter_search_charges to find one.',
+      ),
+    documentUrls: z
+      .array(z.url().max(2048))
+      .min(1)
+      .max(MAX_DOCUMENTS_PER_CALL)
+      .optional()
+      .describe(
+        'PREFERRED. http(s) URLs the SERVER fetches the documents from — the bytes never travel ' +
+          'through this conversation, so there is no size limit. Google Drive share links are ' +
+          'resolved through the Drive API; any other URL must answer with a PDF or an image ' +
+          '(a link that renders a web page is rejected). ' +
+          `1-${MAX_DOCUMENTS_PER_CALL} per call. Mutually exclusive with \`documents\`.`,
+      ),
+    documents: z
+      .array(documentInput)
+      .min(1)
+      .max(MAX_DOCUMENTS_PER_CALL)
+      .optional()
+      .describe(
+        `Inline base64 documents (1-${MAX_DOCUMENTS_PER_CALL} per call). Use ONLY for small content ` +
+          'you generated yourself; for an existing file prefer `documentUrls`. Mutually exclusive ' +
+          'with `documentUrls`.',
+      ),
+  })
+  // Enforced here rather than as a union so the model gets one clear message
+  // instead of a pair of "no variant matched" branches, and so omitting both is
+  // named as its own mistake.
+  .refine(input => !!input.documentUrls !== !!input.documents, {
+    message: 'Provide exactly one of `documentUrls` or `documents` — not both, and not neither.',
+    path: ['documentUrls'],
+  });
 type UploadDocumentsInput = z.infer<typeof uploadDocumentsInput>;
 
 const BATCH_UPLOAD_DOCUMENTS_MUTATION = /* GraphQL */ `
@@ -146,6 +203,27 @@ const BATCH_UPLOAD_DOCUMENTS_MUTATION = /* GraphQL */ `
 `;
 
 /** `data:<mime>;base64,` prefix some clients prepend to encoded content. */
+const BATCH_UPLOAD_DOCUMENTS_FROM_URLS_MUTATION = /* GraphQL */ `
+  mutation McpBatchUploadDocumentsFromUrls(
+    $urls: [String!]!
+    $chargeId: UUID
+    $isSensitive: Boolean
+  ) {
+    batchUploadDocumentsFromUrls(urls: $urls, chargeId: $chargeId, isSensitive: $isSensitive) {
+      __typename
+      ... on UploadDocumentSuccessfulResult {
+        document {
+          id
+          documentType
+        }
+      }
+      ... on CommonError {
+        message
+      }
+    }
+  }
+`;
+
 const DATA_URI_PREFIX_RE = /^data:[^;,]*;base64,/i;
 const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
 
@@ -190,11 +268,67 @@ function decodeDocument(contentBase64: string, index: number): Uint8Array {
   return content;
 }
 
-async function uploadDocumentsHandler(
+/** One entry per input document/URL, in the order it was given. */
+type UploadOutcome =
+  | {
+      label: string | undefined;
+      status: 'uploaded';
+      documentId: string | null;
+      documentType: string | null;
+    }
+  | { label: string | undefined; status: 'failed'; message: string };
+
+/**
+ * Upstream returns a list of a *union*, one entry per input, so a partial
+ * failure is expressed per element. Map it positionally rather than collapsing
+ * the batch to one status — the model needs to know which files it still has to
+ * deal with.
+ */
+function toOutcomes(
+  results: McpBatchUploadDocumentsMutation['batchUploadDocuments'],
+  labels: Array<string | undefined>,
+): UploadOutcome[] {
+  return results.map((result, index) => {
+    const label = labels[index];
+    if (result.__typename === 'UploadDocumentSuccessfulResult') {
+      return {
+        label,
+        status: 'uploaded' as const,
+        documentId: result.document?.id ?? null,
+        documentType: result.document?.documentType ?? null,
+      };
+    }
+    return {
+      label,
+      status: 'failed' as const,
+      message: result.__typename === 'CommonError' ? result.message : 'Unknown upload failure',
+    };
+  });
+}
+
+/** The URL branch: the server fetches, so nothing here touches bytes. */
+async function uploadFromUrls(
+  urls: string[],
   input: UploadDocumentsInput,
   context: ToolExecutionContext,
-): Promise<ToolResult> {
-  const contents = input.documents.map((document, index) =>
+): Promise<UploadOutcome[]> {
+  const data = await context.client.mutate<McpBatchUploadDocumentsFromUrlsMutation>(
+    {
+      query: BATCH_UPLOAD_DOCUMENTS_FROM_URLS_MUTATION,
+      variables: { urls, chargeId: input.chargeId, isSensitive: PINNED_IS_SENSITIVE },
+    },
+    context.upstream,
+  );
+  return toOutcomes(data.batchUploadDocumentsFromUrls, urls);
+}
+
+/** The inline branch: base64 in, multipart out. */
+async function uploadInline(
+  documents: NonNullable<UploadDocumentsInput['documents']>,
+  input: UploadDocumentsInput,
+  context: ToolExecutionContext,
+): Promise<UploadOutcome[]> {
+  const contents = documents.map((document, index) =>
     decodeDocument(document.contentBase64, index),
   );
 
@@ -207,7 +341,7 @@ async function uploadDocumentsHandler(
     );
   }
 
-  const files: UploadFile[] = input.documents.map((document, index) => ({
+  const files: UploadFile[] = documents.map((document, index) => ({
     // Matches the `documents` argument name in the mutation above; the
     // placeholder nulls below occupy these positions.
     variablePath: `variables.documents.${index}`,
@@ -223,37 +357,36 @@ async function uploadDocumentsHandler(
         // Per the GraphQL multipart request spec the file variables are null
         // placeholders; `map` (built by the client from `files`) points each
         // form part at its position here.
-        documents: input.documents.map(() => null),
+        documents: documents.map(() => null),
         chargeId: input.chargeId,
-        // Pinned, not caller-supplied: every document ingested through this tool
-        // is treated as sensitive.
-        isSensitive: true,
+        isSensitive: PINNED_IS_SENSITIVE,
       },
     },
     files,
     context.upstream,
   );
 
-  // Upstream returns a list of a *union*, one entry per file, so a partial
-  // failure is expressed per element. Report each outcome positionally rather
-  // than collapsing the batch to one status — the model needs to know which
-  // files it still has to deal with.
-  const results = data.batchUploadDocuments.map((result, index) => {
-    const filename = input.documents[index]?.filename;
-    if (result.__typename === 'UploadDocumentSuccessfulResult') {
-      return {
-        filename,
-        status: 'uploaded' as const,
-        documentId: result.document?.id ?? null,
-        documentType: result.document?.documentType ?? null,
-      };
-    }
-    return {
-      filename,
-      status: 'failed' as const,
-      message: result.__typename === 'CommonError' ? result.message : 'Unknown upload failure',
-    };
-  });
+  return toOutcomes(
+    data.batchUploadDocuments,
+    documents.map(document => document.filename),
+  );
+}
+
+async function uploadDocumentsHandler(
+  input: UploadDocumentsInput,
+  context: ToolExecutionContext,
+): Promise<ToolResult> {
+  // Exactly one of the two is set — the schema's refinement guarantees it.
+  const source = input.documentUrls ? 'urls' : 'inline';
+  const outcomes = input.documentUrls
+    ? await uploadFromUrls(input.documentUrls, input, context)
+    : await uploadInline(input.documents!, input, context);
+
+  // The label means different things per branch, so it is named for what it is
+  // rather than reported under a `filename` key holding a URL.
+  const results = outcomes.map(({ label, ...rest }) =>
+    source === 'urls' ? { url: label, ...rest } : { filename: label, ...rest },
+  );
 
   const uploadedCount = results.filter(result => result.status === 'uploaded').length;
   const failedCount = results.length - uploadedCount;
@@ -262,9 +395,10 @@ async function uploadDocumentsHandler(
     action: 'upload_documents',
     outcome: {
       chargeId: input.chargeId,
+      source,
       uploadedCount,
       failedCount,
-      isSensitive: true,
+      isSensitive: PINNED_IS_SENSITIVE,
       scope: { memberBusinessIds: context.readScope.memberBusinessIds },
     },
     items: { key: 'results', values: results },
@@ -278,14 +412,17 @@ async function uploadDocumentsHandler(
 export const uploadDocumentsTool: ToolDefinition<typeof uploadDocumentsInput> = {
   name: UPLOAD_DOCUMENTS_TOOL_NAME,
   description:
-    'Attach one or more documents (invoices, receipts, contracts) to an EXISTING charge. Documents are ' +
-    'passed as base64-encoded content and are always stored as sensitive. This tool never creates a ' +
-    'charge: `chargeId` is required and must already exist. ' +
-    `Inline upload suits small files only (max ${asKb(MAX_DOCUMENT_BYTES)} per file, ` +
-    `${asKb(MAX_TOTAL_DOCUMENT_BYTES)} per call, decoded): the content travels as tool arguments, so ` +
-    'a large file cannot fit in one message regardless of encoding. For anything bigger use the ' +
-    'Google Drive or email ingestion paths — never re-encode a financial document at lower quality ' +
-    'to make it fit. ' +
+    'Attach one or more documents (invoices, receipts, contracts) to an EXISTING charge. This tool ' +
+    'never creates a charge: `chargeId` is required and must already exist. ' +
+    'Provide EXACTLY ONE of two inputs. ' +
+    '(1) `documentUrls` — PREFERRED: http(s) links the server fetches itself, with no size limit, ' +
+    'since the bytes never pass through the conversation. Google Drive share links work. If the file ' +
+    'is on disk and you have a shell, put it somewhere fetchable first and pass the resulting link. ' +
+    '(2) `documents` — inline base64, for small content only ' +
+    `(max ${asKb(MAX_DOCUMENT_BYTES)} per file, ${asKb(MAX_TOTAL_DOCUMENT_BYTES)} per call, decoded), ` +
+    'because that content travels as tool arguments and both costs enormous output and risks ' +
+    'corrupting the file. Never re-encode or downscale a financial document to make it fit — use ' +
+    '`documentUrls` instead. ' +
     WRITE_SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: uploadDocumentsInput,
   policy: {

--- a/packages/mcp-server/src/tools/documents-write.ts
+++ b/packages/mcp-server/src/tools/documents-write.ts
@@ -30,10 +30,48 @@ export const UPLOAD_DOCUMENTS_TOOL_NAME = 'accounter_upload_documents';
 
 /** Max documents per call. */
 export const MAX_DOCUMENTS_PER_CALL = 10;
-/** Max decoded size of one document. */
-export const MAX_DOCUMENT_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Size limits for inline base64.
+ *
+ * These are small on purpose, and the reason is worth stating plainly: inline
+ * base64 makes the *model* the transport. It has to emit the whole encoded file
+ * as tool arguments, and base64 tokenizes at roughly 3 characters per token, so
+ * a 277 KB PDF costs on the order of 100k output tokens — past a single
+ * message's budget before any server-side limit is consulted.
+ *
+ * Three ceilings therefore apply, and the model's is by far the tightest:
+ *
+ *  1. the model's per-message output budget — practically a few tens of KB;
+ *  2. `MAX_MCP_BODY_BYTES`, the 1 MB cap on the whole JSON-RPC body, which after
+ *     base64's 4/3 expansion leaves roughly 700 KB of file;
+ *  3. these constants.
+ *
+ * An earlier revision advertised 5 MB per file, which ceiling (2) made
+ * unreachable — the request died as a 413 long before this check ran. The values
+ * below sit under (2) with room for the JSON envelope, and
+ * `upload-limits.test.ts` asserts that relationship so the two cannot drift
+ * apart again. Anything larger belongs on a transport that does not route bytes
+ * through the model; {@link OVERSIZE_GUIDANCE} tells the caller which.
+ */
+export const MAX_DOCUMENT_BYTES = 256 * 1024;
 /** Max decoded size of all documents in one call. */
-export const MAX_TOTAL_DOCUMENT_BYTES = 15 * 1024 * 1024;
+export const MAX_TOTAL_DOCUMENT_BYTES = 512 * 1024;
+
+/**
+ * Appended to every over-size error. A tool that merely says "too large" invites
+ * the model to shrink the file until it fits — which, for a scanned receipt,
+ * means re-rendering a legal document at degraded quality and archiving that
+ * instead. Naming the real alternatives is what stops the retry loop.
+ */
+export const OVERSIZE_GUIDANCE =
+  'Do NOT downscale, re-encode, or reduce the quality of the document to fit — the stored file is a ' +
+  'financial record and must keep its original fidelity. Instead use a path that does not send bytes ' +
+  'through the conversation: upload the file to the shared Google Drive folder and use the Drive ' +
+  'ingestion flow, or forward it to the document-ingestion email address.';
+
+/** Render a byte count for humans; every limit here is KB-scale. */
+const asKb = (bytes: number) => `${Math.round(bytes / 1024)}KB`;
 
 /**
  * Accepted document MIME types. An allowlist rather than a blocklist: everything
@@ -64,7 +102,8 @@ const documentInput = z.object({
     .min(1)
     .describe(
       'The file content, base64-encoded. A `data:<type>;base64,` prefix is accepted and stripped. ' +
-        `Max ${MAX_DOCUMENT_BYTES / 1024 / 1024}MB per file once decoded.`,
+        `Max ${asKb(MAX_DOCUMENT_BYTES)} per file once decoded — this content travels as tool ` +
+        'arguments, so a larger file will not fit in a single message however it is encoded.',
     ),
 });
 
@@ -143,7 +182,8 @@ function decodeDocument(contentBase64: string, index: number): Uint8Array {
   }
   if (content.byteLength > MAX_DOCUMENT_BYTES) {
     throw new ToolInputError(
-      `Document exceeds the ${MAX_DOCUMENT_BYTES / 1024 / 1024}MB per-file limit`,
+      `Document is ${asKb(content.byteLength)}, over the ${asKb(MAX_DOCUMENT_BYTES)} per-file limit ` +
+        `for inline upload. ${OVERSIZE_GUIDANCE}`,
       [{ path, message: `decoded size is ${content.byteLength} bytes` }],
     );
   }
@@ -161,9 +201,9 @@ async function uploadDocumentsHandler(
   const totalBytes = contents.reduce((sum, content) => sum + content.byteLength, 0);
   if (totalBytes > MAX_TOTAL_DOCUMENT_BYTES) {
     throw new ToolInputError(
-      `Documents total ${totalBytes} bytes, over the ${
-        MAX_TOTAL_DOCUMENT_BYTES / 1024 / 1024
-      }MB per-call limit. Split them across several calls.`,
+      `Documents total ${asKb(totalBytes)}, over the ${asKb(MAX_TOTAL_DOCUMENT_BYTES)} per-call ` +
+        `limit for inline upload. Sending fewer documents per call may resolve this; if a single ` +
+        `document is itself near the limit, it will not. ${OVERSIZE_GUIDANCE}`,
     );
   }
 
@@ -241,6 +281,11 @@ export const uploadDocumentsTool: ToolDefinition<typeof uploadDocumentsInput> = 
     'Attach one or more documents (invoices, receipts, contracts) to an EXISTING charge. Documents are ' +
     'passed as base64-encoded content and are always stored as sensitive. This tool never creates a ' +
     'charge: `chargeId` is required and must already exist. ' +
+    `Inline upload suits small files only (max ${asKb(MAX_DOCUMENT_BYTES)} per file, ` +
+    `${asKb(MAX_TOTAL_DOCUMENT_BYTES)} per call, decoded): the content travels as tool arguments, so ` +
+    'a large file cannot fit in one message regardless of encoding. For anything bigger use the ' +
+    'Google Drive or email ingestion paths — never re-encode a financial document at lower quality ' +
+    'to make it fit. ' +
     WRITE_SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: uploadDocumentsInput,
   policy: {

--- a/packages/mcp-server/src/tools/execute.ts
+++ b/packages/mcp-server/src/tools/execute.ts
@@ -93,6 +93,27 @@ function requestedMemberBusinessIds(input: unknown): string[] | undefined {
   return undefined;
 }
 
+/**
+ * Size-only summary of a write tool's input, for the audit log. Deliberately
+ * records *how much* was touched and *which ids*, never payload content — a
+ * document's bytes, filename, or MIME type must not reach the logs. Array
+ * lengths and string ids are the only things extracted.
+ */
+function auditCounts(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== 'object') {
+    return {};
+  }
+  const fields: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (Array.isArray(value)) {
+      fields[`${key}Count`] = value.length;
+    } else if (typeof value === 'string' && key.toLowerCase().endsWith('id')) {
+      fields[key] = value;
+    }
+  }
+  return fields;
+}
+
 export interface ExecuteToolParams {
   tool: ToolDefinition;
   rawArgs: unknown;
@@ -258,11 +279,28 @@ async function runTool(params: ExecuteToolParams): Promise<ToolRun> {
     }
   }
 
-  // 4. Execute the handler.
+  // 4. Audit the write. Mutating tools are logged BEFORE the handler runs, so a
+  // call that then times out or crashes still leaves a record that it was
+  // attempted — the opposite ordering would lose exactly the calls worth
+  // investigating. Only identifiers and counts are recorded: never file
+  // contents, never the token.
+  if (tool.policy.mutating) {
+    log('info', 'mutating tool invoked', {
+      audit: true,
+      tool: tool.name,
+      userId: auth.userId,
+      correlationId,
+      // Guaranteed to be exactly one id by the single-write-target policy rule.
+      writeTargetBusinessId: decision.readScope.memberBusinessIds[0],
+      ...auditCounts(input),
+    });
+  }
+
+  // 5. Execute the handler.
   //
   // `upstream` is built here, where the resolved read scope is known, so a
   // handler cannot forget to forward `x-business-scope` — it only has to pass
-  // `context.upstream` through to `client.query`.
+  // `context.upstream` through to `client.query`/`client.mutate`.
   const context: ToolExecutionContext = {
     auth,
     readScope: decision.readScope,

--- a/packages/mcp-server/src/tools/execute.ts
+++ b/packages/mcp-server/src/tools/execute.ts
@@ -94,12 +94,32 @@ function requestedMemberBusinessIds(input: unknown): string[] | undefined {
 }
 
 /**
- * Size-only summary of a write tool's input, for the audit log. Deliberately
- * records *how much* was touched and *which ids*, never payload content — a
- * document's bytes, filename, or MIME type must not reach the logs. Array
- * lengths and string ids are the only things extracted.
+ * Most ids recorded for a single field. Every current write tool caps well below
+ * this (50 charges, 50 tags, 10 documents), so the bound exists to stop a future
+ * tool with a larger cap from turning one audit line into a log flood.
  */
-function auditCounts(input: unknown): Record<string, unknown> {
+const MAX_AUDITED_IDS = 50;
+
+/** Whether a field name denotes a record identifier (`chargeId`, `addTagIds`). */
+function isIdField(key: string): boolean {
+  const lower = key.toLowerCase();
+  return lower.endsWith('id') || lower.endsWith('ids');
+}
+
+/**
+ * Summary of a write tool's input, for the audit log.
+ *
+ * Records **which records were touched and how many** — never payload content.
+ * The distinction is the whole design: identifiers are what make an audit line
+ * answerable after the fact ("which charges did this retag?"), while a
+ * document's bytes, filename, or MIME type must never reach the logs.
+ *
+ * So id fields contribute their values (bounded by {@link MAX_AUDITED_IDS}), and
+ * every array additionally contributes its length. An array that is *not* an id
+ * field — `documents`, whose elements are the payload — contributes its length
+ * and nothing else.
+ */
+function auditFields(input: unknown): Record<string, unknown> {
   if (!input || typeof input !== 'object') {
     return {};
   }
@@ -107,7 +127,16 @@ function auditCounts(input: unknown): Record<string, unknown> {
   for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
     if (Array.isArray(value)) {
       fields[`${key}Count`] = value.length;
-    } else if (typeof value === 'string' && key.toLowerCase().endsWith('id')) {
+      // `every(string)` is load-bearing, not defensive: it is what keeps an array
+      // of objects (documents) from being spread into the log by a field name
+      // that merely happens to end in "ids".
+      if (isIdField(key) && value.every(entry => typeof entry === 'string')) {
+        fields[key] = value.slice(0, MAX_AUDITED_IDS);
+        if (value.length > MAX_AUDITED_IDS) {
+          fields[`${key}Truncated`] = true;
+        }
+      }
+    } else if (typeof value === 'string' && isIdField(key)) {
       fields[key] = value;
     }
   }
@@ -292,7 +321,7 @@ async function runTool(params: ExecuteToolParams): Promise<ToolRun> {
       correlationId,
       // Guaranteed to be exactly one id by the single-write-target policy rule.
       writeTargetBusinessId: decision.readScope.memberBusinessIds[0],
-      ...auditCounts(input),
+      ...auditFields(input),
     });
   }
 

--- a/packages/mcp-server/src/tools/output.ts
+++ b/packages/mcp-server/src/tools/output.ts
@@ -8,6 +8,10 @@ import type { ToolResult } from './registry.js';
  * (never cutting a JSON structure mid-object), reports how many items were
  * returned versus available, and attaches a continuation hint whenever the
  * caller is not seeing everything (either an upstream cap or the payload guard).
+ *
+ * Write tools use {@link shapeWriteResult} instead: what matters there is what
+ * changed, so the outcome fields are always kept and only the optional per-item
+ * echo is dropped when the payload guard trips.
  */
 
 /** Max serialized size of a tool result's structured content, in bytes. */
@@ -145,4 +149,59 @@ export function listShapeFields(result: ToolResult): Record<string, unknown> {
   if (typeof totalCount === 'number') fields.totalCount = totalCount;
   if (typeof truncated === 'boolean') fields.truncated = truncated;
   return fields;
+}
+
+export interface ShapeWriteParams<T> {
+  /** What the tool did, e.g. `upload_documents`. Echoed as `action`. */
+  action: string;
+  /** Human-readable summary line. */
+  summary: string;
+  /** Outcome fields (counts, ids). Always kept — never dropped by the guard. */
+  outcome: Record<string, unknown>;
+  /** Optional per-item echo of what changed, dropped whole if too large. */
+  items?: { key: string; values: readonly T[] };
+  /** Override the byte cap (mainly for tests). */
+  maxBytes?: number;
+}
+
+/**
+ * Shape a completed write into a bounded {@link ToolResult}.
+ *
+ * The asymmetry with {@link shapeListResult} is deliberate. A truncated *list*
+ * is still a useful answer, so it drops trailing items one at a time. A write's
+ * outcome — did it apply, to what, how many — is never droppable, so the guard
+ * applies only to the optional `items` echo, and it drops that echo **whole**:
+ * a half-echoed list of changed records would read as "these are the ones that
+ * changed", which would be false. When it is dropped, `itemsOmitted` says so
+ * rather than leaving the model to infer it from an absent key.
+ */
+export function shapeWriteResult<T>(params: ShapeWriteParams<T>): ToolResult {
+  const maxBytes = params.maxBytes ?? MAX_TOOL_RESULT_BYTES;
+  const base: Record<string, unknown> = {
+    ...params.outcome,
+    ok: true,
+    action: params.action,
+  };
+
+  let structured = base;
+  if (params.items) {
+    const withItems = { ...base, [params.items.key]: params.items.values };
+    structured =
+      byteLength(JSON.stringify(withItems)) <= maxBytes
+        ? withItems
+        : {
+            ...base,
+            itemsOmitted: {
+              key: params.items.key,
+              count: params.items.values.length,
+              reason: 'payload_size',
+              hint: 'The write applied in full; only the per-item echo was too large to return.',
+            },
+          };
+  }
+
+  return {
+    content: [{ type: 'text', text: params.summary }],
+    structuredContent: structured,
+  };
 }

--- a/packages/mcp-server/src/tools/policy.ts
+++ b/packages/mcp-server/src/tools/policy.ts
@@ -46,6 +46,8 @@ export interface EvaluatePolicyParams {
  *   otherwise the request is denied (not silently dropped).
  * - When the tool requires business scope, the resolved scope must be
  *   non-empty (a caller with no memberships cannot use it).
+ * - When the tool is mutating, the resolved scope must name exactly one
+ *   business — a write needs a single, unambiguous target.
  */
 export function evaluateToolPolicy(params: EvaluatePolicyParams): PolicyDecision {
   const { policy, auth, requestedMemberBusinessIds } = params;
@@ -61,7 +63,18 @@ export function evaluateToolPolicy(params: EvaluatePolicyParams): PolicyDecision
     return deny('No authorized business scope for this request');
   }
 
-  // 3. Role gate (any-of) evaluated against membership roleIds in the resolved scope.
+  // 3. Single write target. A read may legitimately span every membership, but
+  // a write must land in one known business, so an ambiguous scope is refused
+  // rather than resolved by picking one. The message names the count so the
+  // caller knows to narrow instead of retrying the same call.
+  if (policy.mutating && readScope.memberBusinessIds.length !== 1) {
+    return deny(
+      `This tool writes data and must target exactly one business, but the request resolved to ${readScope.memberBusinessIds.length}. ` +
+        'Pass a single `memberBusinessId`; use accounter_list_business_memberships to choose one.',
+    );
+  }
+
+  // 4. Role gate (any-of) evaluated against membership roleIds in the resolved scope.
   if (policy.requiredRoles && policy.requiredRoles.length > 0) {
     const inScope = new Set(readScope.memberBusinessIds);
     const held = new Set(

--- a/packages/mcp-server/src/tools/registry-instance.ts
+++ b/packages/mcp-server/src/tools/registry-instance.ts
@@ -3,10 +3,12 @@ import { getChargesTool } from './charge-details.js';
 import { searchChargesTool } from './charges.js';
 import { getContractsTool } from './contracts.js';
 import { getDocumentsTool } from './document-details.js';
+import { uploadDocumentsTool } from './documents-write.js';
 import { getLedgerRecordsTool } from './ledger.js';
 import { listBusinessesTool, listTagsTool, listTaxCategoriesTool } from './lookups.js';
 import { ToolRegistry } from './registry.js';
 import { balanceReportTool } from './reports.js';
+import { updateChargesTagsTool } from './tags-write.js';
 import { explainTerminologyTool } from './terminology.js';
 import { getTransactionsTool } from './transaction-details.js';
 
@@ -44,3 +46,10 @@ toolRegistry.register(listTaxCategoriesTool);
 // The full business directory sits with the other reference-data lookups.
 toolRegistry.register(listBusinessesTool);
 toolRegistry.register(balanceReportTool);
+
+// Write tools last. Registration order is the order the model sees, and reads
+// are what it should reach for first — a tool that changes data should not be
+// the first thing in the list. These are also hidden entirely unless
+// `MCP_ENABLE_WRITE_TOOLS=1`, so on a default deployment the list ends above.
+toolRegistry.register(updateChargesTagsTool);
+toolRegistry.register(uploadDocumentsTool);

--- a/packages/mcp-server/src/tools/registry.ts
+++ b/packages/mcp-server/src/tools/registry.ts
@@ -25,6 +25,17 @@ export interface ToolAuthPolicy {
   requiresBusinessScope: boolean;
   /** Sensitivity of the data the tool returns. */
   dataClassification: DataClassification;
+  /**
+   * The tool performs an upstream mutation. This is the flag the whole write
+   * path hangs off, and it carries three consequences:
+   *  - the tool is hidden and undispatchable unless `MCP_ENABLE_WRITE_TOOLS=1`
+   *    (see `allowlist.ts` / `mcp/handler.ts`);
+   *  - its resolved scope must name exactly ONE business — a write needs an
+   *    unambiguous target, unlike a read that may span memberships (see
+   *    `policy.ts`);
+   *  - each call is audit-logged before the handler runs (see `execute.ts`).
+   */
+  mutating?: boolean;
 }
 
 /** Context passed to a tool handler at execution time. */

--- a/packages/mcp-server/src/tools/scope-input.ts
+++ b/packages/mcp-server/src/tools/scope-input.ts
@@ -58,3 +58,29 @@ export const SINGLE_BUSINESS_SCOPE_DESCRIPTION_SUFFIX =
   'Scope: this covers exactly one business — pass its id as the required `memberBusinessId`. The ' +
   'response echoes the effective `scope.memberBusinessIds` alongside it. If you belong to more than ' +
   'one business, call `accounter_list_business_memberships` first to choose.';
+
+/**
+ * Write-target input for **mutating** tools.
+ *
+ * Optional rather than required, unlike {@link memberBusinessIdsInput}'s
+ * single-business sibling above: a caller who belongs to exactly one business
+ * already resolves to an unambiguous target, so demanding the id would be
+ * ceremony. When they belong to several, the mutating-policy rule in `policy.ts`
+ * refuses the call and says to pass this field — so the ambiguous case fails
+ * loudly instead of the tool guessing a target.
+ */
+export const writeTargetBusinessIdInput = z
+  .string()
+  .min(1)
+  .optional()
+  .describe(
+    'The business to write to — required only if you are a member of more than one. Must be one of ' +
+      'your memberships. Use accounter_list_business_memberships to discover ids.',
+  );
+
+/** Trailing clause for mutating tools, stating the write-target rule. */
+export const WRITE_SCOPE_DESCRIPTION_SUFFIX =
+  'This tool CHANGES data. Scope: a write targets exactly one business — if you are a member of ' +
+  'several, pass `memberBusinessId` (call `accounter_list_business_memberships` to choose), ' +
+  'otherwise your only membership is used. The response echoes the effective ' +
+  '`scope.memberBusinessIds`.';

--- a/packages/mcp-server/src/tools/tags-write.ts
+++ b/packages/mcp-server/src/tools/tags-write.ts
@@ -3,7 +3,12 @@ import { ToolInputError } from '../errors/taxonomy.js';
 import type { McpBatchUpdateChargesTagsMutation } from '../gql/index.js';
 import { UpstreamError } from '../upstream/graphql-client.js';
 import { shapeWriteResult } from './output.js';
-import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import type {
+  ToolDefinition,
+  ToolExecutionContext,
+  ToolObservation,
+  ToolResult,
+} from './registry.js';
 import { WRITE_SCOPE_DESCRIPTION_SUFFIX, writeTargetBusinessIdInput } from './scope-input.js';
 
 /**
@@ -126,6 +131,31 @@ async function updateChargesTagsHandler(
   });
 }
 
+/**
+ * Usage telemetry for one tag update.
+ *
+ * As with the upload tool, a write result has none of the list-shape fields the
+ * executor logs automatically, so the counts have to come from here. Requested
+ * and updated counts are both reported because their *difference* is the signal:
+ * upstream silently skips a charge id it cannot resolve, so a call that asked
+ * for 50 and updated 43 is the shape of a model working from stale ids.
+ *
+ * Ids themselves are deliberately left out. The pre-handler audit line already
+ * carries them, and repeating them here would double the volume of the noisiest
+ * field for no added answer.
+ */
+function observe(input: UpdateChargesTagsInput, result: ToolResult): ToolObservation {
+  const structured = result.structuredContent as { updatedCount?: number } | undefined;
+  return {
+    fields: {
+      requestedChargeCount: input.chargeIds.length,
+      updatedChargeCount: structured?.updatedCount,
+      addedTagCount: input.addTagIds?.length ?? 0,
+      removedTagCount: input.removeTagIds?.length ?? 0,
+    },
+  };
+}
+
 export const updateChargesTagsTool: ToolDefinition<typeof updateChargesTagsInput> = {
   name: UPDATE_CHARGES_TAGS_TOOL_NAME,
   description:
@@ -143,4 +173,5 @@ export const updateChargesTagsTool: ToolDefinition<typeof updateChargesTagsInput
     mutating: true,
   },
   handler: updateChargesTagsHandler,
+  observe,
 };

--- a/packages/mcp-server/src/tools/tags-write.ts
+++ b/packages/mcp-server/src/tools/tags-write.ts
@@ -1,0 +1,146 @@
+import { z } from 'zod';
+import { ToolInputError } from '../errors/taxonomy.js';
+import type { McpBatchUpdateChargesTagsMutation } from '../gql/index.js';
+import { UpstreamError } from '../upstream/graphql-client.js';
+import { shapeWriteResult } from './output.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import { WRITE_SCOPE_DESCRIPTION_SUFFIX, writeTargetBusinessIdInput } from './scope-input.js';
+
+/**
+ * Write tool: add and/or remove tags across many charges at once.
+ *
+ * Tags are identified by id, never by name. Name resolution is left to the model
+ * via `accounter_list_tags` on purpose: names are not unique across owners, so
+ * resolving them here would mean either guessing which of several same-named
+ * tags was meant, or failing on an ambiguity the model is better placed to
+ * settle. Ids make the write unambiguous.
+ */
+
+export const UPDATE_CHARGES_TAGS_TOOL_NAME = 'accounter_update_charges_tags';
+
+/** Max charges updated in one call, matching the shared scope-input cap. */
+export const MAX_CHARGES_PER_CALL = 50;
+/** Max tag ids per direction (add / remove). */
+export const MAX_TAG_IDS_PER_CALL = 50;
+
+const tagIds = z.array(z.string().min(1)).max(MAX_TAG_IDS_PER_CALL).optional();
+
+const updateChargesTagsInput = z.object({
+  memberBusinessId: writeTargetBusinessIdInput,
+  chargeIds: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(MAX_CHARGES_PER_CALL)
+    .describe(
+      `The charges to update (1-${MAX_CHARGES_PER_CALL} per call). Use accounter_search_charges to find ids.`,
+    ),
+  addTagIds: tagIds.describe(
+    'Tag ids to add to every listed charge. Use accounter_list_tags to resolve names to ids.',
+  ),
+  removeTagIds: tagIds.describe('Tag ids to remove from every listed charge.'),
+});
+type UpdateChargesTagsInput = z.infer<typeof updateChargesTagsInput>;
+
+const BATCH_UPDATE_CHARGES_TAGS_MUTATION = /* GraphQL */ `
+  mutation McpBatchUpdateChargesTags(
+    $chargeIds: [UUID!]!
+    $addTagIds: [UUID!]
+    $removeTagIds: [UUID!]
+  ) {
+    batchUpdateChargesTags(
+      chargeIds: $chargeIds
+      addTagIds: $addTagIds
+      removeTagIds: $removeTagIds
+    ) {
+      __typename
+      ... on BatchUpdateChargesTagsSuccessfulResult {
+        charges {
+          id
+          tags {
+            id
+            name
+          }
+        }
+      }
+      ... on CommonError {
+        message
+      }
+    }
+  }
+`;
+
+async function updateChargesTagsHandler(
+  input: UpdateChargesTagsInput,
+  context: ToolExecutionContext,
+): Promise<ToolResult> {
+  const addTagIds = input.addTagIds ?? [];
+  const removeTagIds = input.removeTagIds ?? [];
+  // Upstream answers a no-op call with a CommonError; catching it here spends no
+  // round trip and returns a field-level validation error instead of an opaque
+  // upstream one.
+  if (addTagIds.length === 0 && removeTagIds.length === 0) {
+    throw new ToolInputError('No tag changes requested', [
+      { path: 'addTagIds', message: 'provide at least one of addTagIds or removeTagIds' },
+    ]);
+  }
+
+  const data = await context.client.mutate<McpBatchUpdateChargesTagsMutation>(
+    {
+      query: BATCH_UPDATE_CHARGES_TAGS_MUTATION,
+      variables: {
+        chargeIds: input.chargeIds,
+        addTagIds: input.addTagIds ?? null,
+        removeTagIds: input.removeTagIds ?? null,
+      },
+    },
+    context.upstream,
+  );
+
+  const result = data.batchUpdateChargesTags;
+  if (result.__typename !== 'BatchUpdateChargesTagsSuccessfulResult') {
+    // A domain refusal upstream (unknown charge, no changes, …). Not retryable —
+    // resending the identical request would be refused identically.
+    throw new UpstreamError(
+      'UPSTREAM_ERROR',
+      result.__typename === 'CommonError' ? result.message : 'Tag update failed',
+      false,
+    );
+  }
+
+  const charges = result.charges.map(charge => ({
+    id: charge.id,
+    tags: charge.tags.map(tag => ({ id: tag.id, name: tag.name })),
+  }));
+
+  return shapeWriteResult({
+    action: 'update_charges_tags',
+    outcome: {
+      updatedCount: charges.length,
+      requestedCount: input.chargeIds.length,
+      addedTagIds: addTagIds,
+      removedTagIds: removeTagIds,
+      scope: { memberBusinessIds: context.readScope.memberBusinessIds },
+    },
+    items: { key: 'charges', values: charges },
+    summary: `Updated tags on ${charges.length} of ${input.chargeIds.length} requested charge(s).`,
+  });
+}
+
+export const updateChargesTagsTool: ToolDefinition<typeof updateChargesTagsInput> = {
+  name: UPDATE_CHARGES_TAGS_TOOL_NAME,
+  description:
+    'Add and/or remove tags across one or more charges. Tags are given by id — call ' +
+    '`accounter_list_tags` first to resolve names. This is an incremental edit, not a replacement: ' +
+    'tags already on a charge and not listed in `removeTagIds` stay. Removals are applied before ' +
+    'additions, so a tag id passed in BOTH lists ends up added. Adding a tag a charge already has ' +
+    'does nothing. ' +
+    WRITE_SCOPE_DESCRIPTION_SUFFIX,
+  inputSchema: updateChargesTagsInput,
+  policy: {
+    requiredRoles: ['business_owner', 'accountant'],
+    requiresBusinessScope: true,
+    dataClassification: 'business',
+    mutating: true,
+  },
+  handler: updateChargesTagsHandler,
+};

--- a/packages/mcp-server/src/upstream/__tests__/graphql-client.write.test.ts
+++ b/packages/mcp-server/src/upstream/__tests__/graphql-client.write.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  BUSINESS_SCOPE_HEADER,
+  UpstreamError,
+  UpstreamGraphQLClient,
+  type UploadFile,
+  type UpstreamRequestContext,
+} from '../graphql-client.js';
+
+/**
+ * The write half of the upstream client. The read half (`query`) is covered in
+ * `graphql-client.test.ts`; what is specific here is that the two halves cannot
+ * be used for each other's traffic, that a write is never retried, and that the
+ * multipart envelope is assembled to spec.
+ */
+
+const CONTEXT: UpstreamRequestContext = {
+  correlationId: 'corr-1',
+  authorization: 'Bearer t',
+  businessScope: ['b1'],
+};
+
+const MUTATION = /* GraphQL */ `
+  mutation McpDoThing($id: UUID!) {
+    doThing(id: $id) {
+      id
+    }
+  }
+`;
+
+function clientWith(fetchImpl: unknown, maxRetries?: number) {
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    ...(maxRetries === undefined ? {} : { maxRetries }),
+    fetchImpl: fetchImpl as typeof fetch,
+  });
+}
+
+const okFetch = (data: unknown = { doThing: { id: '1' } }) =>
+  vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ data }) }) as unknown as Response);
+
+const file = (overrides: Partial<UploadFile> = {}): UploadFile => ({
+  variablePath: 'variables.documents.0',
+  filename: 'a.pdf',
+  contentType: 'application/pdf',
+  content: new TextEncoder().encode('hello'),
+  ...overrides,
+});
+
+describe('assertSingleMutation (via mutate)', () => {
+  it.each([
+    ['a query document', 'query McpThing { thing { id } }'],
+    ['a subscription', 'subscription McpThing { thing { id } }'],
+    [
+      'a mutation hidden behind a leading query',
+      'query McpRead { thing { id } }\nmutation McpWrite { doThing { id } }',
+    ],
+    [
+      'two mutations in one document',
+      'mutation McpA { a { id } }\nmutation McpB { b { id } }',
+    ],
+    ['a commented-out mutation with a real query', '# mutation McpFake\nquery McpReal { a }'],
+  ])('refuses %s', async (_label, document) => {
+    const fetchImpl = okFetch();
+    await expect(clientWith(fetchImpl).mutate({ query: document }, CONTEXT)).rejects.toThrow(
+      UpstreamError,
+    );
+    // Rejected before any network call — the guard is not a post-hoc check.
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('accepts a single top-level mutation', async () => {
+    const fetchImpl = okFetch();
+    await expect(
+      clientWith(fetchImpl).mutate({ query: MUTATION, variables: { id: '1' } }, CONTEXT),
+    ).resolves.toEqual({ doThing: { id: '1' } });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('still refuses a mutation on the read path', async () => {
+    const fetchImpl = okFetch();
+    await expect(clientWith(fetchImpl).query({ query: MUTATION }, CONTEXT)).rejects.toThrow(
+      /read-only/,
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('mutate — no retries', () => {
+  it('does not retry a 5xx, which a read would retry', async () => {
+    const fetchImpl = vi.fn(
+      async () => ({ ok: false, status: 503, json: async () => ({}) }) as unknown as Response,
+    );
+    const client = clientWith(fetchImpl, 2);
+
+    await expect(client.mutate({ query: MUTATION }, CONTEXT)).rejects.toThrow(UpstreamError);
+    // A write may already have applied upstream; re-sending could double-apply.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    // Contrast: the same client retries a read failure up to maxRetries.
+    fetchImpl.mockClear();
+    await expect(client.query({ query: 'query McpX { x }' }, CONTEXT)).rejects.toThrow(
+      UpstreamError,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry a network failure', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('ECONNRESET');
+    });
+    await expect(clientWith(fetchImpl, 2).mutate({ query: MUTATION }, CONTEXT)).rejects.toThrow(
+      UpstreamError,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('mutateMultipart', () => {
+  it('builds an operations/map/parts form to the multipart request spec', async () => {
+    let captured: RequestInit | undefined;
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      captured = init;
+      return { ok: true, status: 200, json: async () => ({ data: { ok: true } }) } as unknown as Response;
+    });
+
+    await clientWith(fetchImpl).mutateMultipart(
+      { query: MUTATION, variables: { documents: [null, null] } },
+      [file({ filename: 'a.pdf' }), file({ variablePath: 'variables.documents.1', filename: 'b.png', contentType: 'image/png' })],
+      CONTEXT,
+    );
+
+    const form = captured!.body as FormData;
+    expect(JSON.parse(String(form.get('map')))).toEqual({
+      '0': ['variables.documents.0'],
+      '1': ['variables.documents.1'],
+    });
+    const operations = JSON.parse(String(form.get('operations'))) as {
+      query: string;
+      variables: Record<string, unknown>;
+    };
+    expect(operations.query).toBe(MUTATION);
+    expect(operations.variables.documents).toEqual([null, null]);
+
+    const part0 = form.get('0') as File;
+    expect(part0.name).toBe('a.pdf');
+    expect(part0.type).toBe('application/pdf');
+    expect(new TextDecoder().decode(await part0.arrayBuffer())).toBe('hello');
+    expect((form.get('1') as File).type).toBe('image/png');
+  });
+
+  it('leaves Content-Type unset so FormData supplies the boundary', async () => {
+    let captured: RequestInit | undefined;
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      captured = init;
+      return { ok: true, status: 200, json: async () => ({ data: {} }) } as unknown as Response;
+    });
+
+    await clientWith(fetchImpl).mutateMultipart(
+      { query: MUTATION, variables: { documents: [null] } },
+      [file()],
+      CONTEXT,
+    );
+
+    const headers = captured!.headers as Record<string, string>;
+    expect(Object.keys(headers).map(k => k.toLowerCase())).not.toContain('content-type');
+    // The identity/tracing/scope headers still ride along.
+    expect(headers.Authorization).toBe('Bearer t');
+    expect(headers['X-Correlation-Id']).toBe('corr-1');
+    expect(headers[BUSINESS_SCOPE_HEADER]).toBe('b1');
+  });
+
+  it('refuses a non-mutation document', async () => {
+    const fetchImpl = okFetch();
+    await expect(
+      clientWith(fetchImpl).mutateMultipart({ query: 'query McpX { x }' }, [file()], CONTEXT),
+    ).rejects.toThrow(UpstreamError);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('omits the scope header entirely when the scope is empty', async () => {
+    // Upstream reads an absent header as "all memberships"; an empty one would
+    // mean the opposite, so it must never be sent.
+    let captured: RequestInit | undefined;
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      captured = init;
+      return { ok: true, status: 200, json: async () => ({ data: {} }) } as unknown as Response;
+    });
+
+    await clientWith(fetchImpl).mutateMultipart(
+      { query: MUTATION, variables: { documents: [null] } },
+      [file()],
+      { correlationId: 'c', businessScope: [] },
+    );
+
+    expect(captured!.headers as Record<string, string>).not.toHaveProperty(BUSINESS_SCOPE_HEADER);
+  });
+
+  it('sanitizes a GraphQL-level error rather than leaking it', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({ errors: [{ message: 'relation "documents" does not exist' }] }),
+        }) as unknown as Response,
+    );
+
+    await expect(
+      clientWith(fetchImpl).mutateMultipart(
+        { query: MUTATION, variables: { documents: [null] } },
+        [file()],
+        CONTEXT,
+      ),
+    ).rejects.toThrow(UpstreamError);
+  });
+});

--- a/packages/mcp-server/src/upstream/__tests__/graphql-client.write.test.ts
+++ b/packages/mcp-server/src/upstream/__tests__/graphql-client.write.test.ts
@@ -216,3 +216,37 @@ describe('mutateMultipart', () => {
     ).rejects.toThrow(UpstreamError);
   });
 });
+
+describe('body construction failures', () => {
+  it('leaves no live timer when building the body throws', async () => {
+    // Regression guard: the body used to be built after the timeout was armed
+    // but outside the try/finally that clears it, so a build failure leaked a
+    // pending timer that held the event loop open for the whole budget.
+    const fetchImpl = okFetch();
+    const client = new UpstreamGraphQLClient({
+      endpoint: 'http://localhost:4000/graphql',
+      timeoutMs: 60_000,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    await expect(
+      client.mutate({ query: MUTATION, variables: { circular } }, CONTEXT),
+    ).rejects.toThrow();
+
+    // Nothing was armed at all, so there is nothing left to clear.
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+    expect(fetchImpl).not.toHaveBeenCalled();
+    setTimeoutSpy.mockRestore();
+  });
+
+  it('clears the timer on a successful call', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    await clientWith(okFetch()).mutate({ query: MUTATION, variables: { id: '1' } }, CONTEXT);
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/packages/mcp-server/src/upstream/graphql-client.ts
+++ b/packages/mcp-server/src/upstream/graphql-client.ts
@@ -2,12 +2,14 @@
  * Shared upstream GraphQL client used by tool handlers.
  *
  * Design constraints (spec §5.3, §8.3, §10):
- * - Phase 1 is read-only: mutations/subscriptions are refused.
- * - No generic "execute anything" is exposed to tools — tools call typed
- *   read-only operation wrappers built on `createReadOperation`, never this
- *   engine directly.
+ * - Reads and writes travel separate, individually guarded methods: `query`
+ *   refuses anything that is not a read, and `mutate`/`mutateMultipart` refuse
+ *   anything that is not a single mutation. Neither can be used to send the
+ *   other kind of document, so a read tool cannot mutate and a write tool cannot
+ *   smuggle an arbitrary operation.
  * - A strict timeout budget with cancellation; bounded retries for idempotent
- *   read failures only (never on auth/validation errors).
+ *   read failures only (never on auth/validation errors, and never on a write —
+ *   mutations are not idempotent, so a retry could double-apply).
  * - The correlation id and the caller's Authorization header are propagated
  *   upstream; the raw token is never logged or persisted.
  * - Upstream errors are sanitized (no stack traces / internal SQL details).
@@ -66,6 +68,24 @@ export interface UpstreamRequestContext {
   businessScope?: readonly string[];
 }
 
+/**
+ * A binary file sent alongside a mutation via the GraphQL multipart request
+ * spec. `variablePath` is the dot path of the `null` placeholder it replaces in
+ * the operation variables, e.g. `variables.documents.0`.
+ */
+export interface UploadFile {
+  variablePath: string;
+  filename: string;
+  contentType: string;
+  content: Uint8Array;
+}
+
+/** The body of one wire attempt, plus the headers specific to its encoding. */
+interface WireBody {
+  headers: Record<string, string>;
+  body: BodyInit;
+}
+
 export interface UpstreamClientConfig {
   endpoint: string;
   timeoutMs: number;
@@ -89,6 +109,34 @@ const NON_READ_OPERATION_RE = /\b(mutation|subscription)\b/i;
 function assertReadOnly(query: string): void {
   if (NON_READ_OPERATION_RE.test(query)) {
     throw new UpstreamError('UPSTREAM_ERROR', 'Only read-only operations are permitted', false);
+  }
+}
+
+/** Strip `#` line comments so a commented-out operation cannot fool the guards. */
+function stripGraphQLComments(query: string): string {
+  return query.replace(/#[^\n]*/g, '');
+}
+
+// Mirror of `assertReadOnly` for the write path. A write wrapper must be just as
+// unable to send an arbitrary document as a read wrapper is to send a mutation:
+//  - the document must *start* with `mutation`, so a leading `query` cannot be
+//    paired with a trailing mutation selected via `operationName`;
+//  - `subscription` is refused outright;
+//  - exactly one operation definition may be present.
+// The operation count is matched per line, so a *field* named `mutation` inside a
+// selection set also trips it. Over-rejecting is the safe direction here — our
+// own wrappers only send single, top-level mutations.
+const OPERATION_DEFINITION_RE = /^[ \t]*(query|mutation|subscription)\b/gm;
+
+function assertSingleMutation(query: string): void {
+  const stripped = stripGraphQLComments(query);
+  const operations = stripped.match(OPERATION_DEFINITION_RE) ?? [];
+  if (!/^\s*mutation\b/.test(stripped) || operations.length !== 1) {
+    throw new UpstreamError(
+      'UPSTREAM_ERROR',
+      'Only a single top-level mutation may be sent on the write path',
+      false,
+    );
   }
 }
 
@@ -135,7 +183,103 @@ export class UpstreamGraphQLClient {
    */
   async query<TData>(request: GraphQLRequest, context: UpstreamRequestContext): Promise<TData> {
     assertReadOnly(request.query);
+    return this.execute<TData>(
+      () => ({
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({
+          query: request.query,
+          variables: request.variables ?? {},
+          ...(request.operationName ? { operationName: request.operationName } : {}),
+        }),
+      }),
+      context,
+      this.maxRetries,
+    );
+  }
 
+  /**
+   * Execute a single mutation with a JSON body. Same timeout, headers, and error
+   * sanitization as {@link query}, but **never retried**: a mutation is not
+   * idempotent, so re-sending a request that may already have been applied
+   * upstream could double-apply it. A timed-out or network-failed write surfaces
+   * to the caller as-is, for them to decide about.
+   */
+  async mutate<TData>(request: GraphQLRequest, context: UpstreamRequestContext): Promise<TData> {
+    assertSingleMutation(request.query);
+    return this.execute<TData>(
+      () => ({
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({
+          query: request.query,
+          variables: request.variables ?? {},
+          ...(request.operationName ? { operationName: request.operationName } : {}),
+        }),
+      }),
+      context,
+      0,
+    );
+  }
+
+  /**
+   * Execute a single mutation carrying binary files, using the GraphQL multipart
+   * request spec (which graphql-yoga implements natively upstream — there is no
+   * upload plugin to route around).
+   *
+   * `request.variables` must already carry `null` placeholders at each file's
+   * {@link UploadFile.variablePath}; this method only assembles the form. Like
+   * {@link mutate} it is never retried.
+   *
+   * `Content-Type` is deliberately left unset: `FormData` supplies it along with
+   * the generated multipart boundary, and setting it by hand would strip the
+   * boundary and make the body unparseable upstream.
+   */
+  async mutateMultipart<TData>(
+    request: GraphQLRequest,
+    files: readonly UploadFile[],
+    context: UpstreamRequestContext,
+  ): Promise<TData> {
+    assertSingleMutation(request.query);
+    return this.execute<TData>(
+      () => {
+        const form = new FormData();
+        form.set(
+          'operations',
+          JSON.stringify({
+            query: request.query,
+            variables: request.variables ?? {},
+            ...(request.operationName ? { operationName: request.operationName } : {}),
+          }),
+        );
+        form.set(
+          'map',
+          JSON.stringify(
+            Object.fromEntries(files.map((file, index) => [String(index), [file.variablePath]])),
+          ),
+        );
+        for (const [index, file] of files.entries()) {
+          form.append(
+            String(index),
+            new Blob([file.content as BlobPart], { type: file.contentType }),
+            file.filename,
+          );
+        }
+        return { headers: { Accept: 'application/json' }, body: form };
+      },
+      context,
+      0,
+    );
+  }
+
+  /**
+   * Shared engine: retry loop around {@link executeOnce}. `buildBody` is called
+   * per attempt rather than once, so a retried request never re-sends an already
+   * consumed body stream.
+   */
+  private async execute<TData>(
+    buildBody: () => WireBody,
+    context: UpstreamRequestContext,
+    maxRetries: number,
+  ): Promise<TData> {
     // Span covers all retry attempts; the correlation id also propagates to the
     // upstream server via the X-Correlation-Id header on each attempt.
     return withSpan('upstream:graphql', context.correlationId, async () => {
@@ -143,10 +287,10 @@ export class UpstreamGraphQLClient {
       // Total tries = 1 + maxRetries; only retryable failures loop.
       for (;;) {
         try {
-          return await this.executeOnce<TData>(request, context);
+          return await this.executeOnce<TData>(buildBody, context);
         } catch (error) {
           const isRetryable = error instanceof UpstreamError && error.retryable;
-          if (!isRetryable || attempt >= this.maxRetries) {
+          if (!isRetryable || attempt >= maxRetries) {
             throw error;
           }
           attempt += 1;
@@ -156,22 +300,22 @@ export class UpstreamGraphQLClient {
   }
 
   private async executeOnce<TData>(
-    request: GraphQLRequest,
+    buildBody: () => WireBody,
     context: UpstreamRequestContext,
   ): Promise<TData> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
 
+    const wire = buildBody();
     const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
+      ...wire.headers,
       'X-Correlation-Id': context.correlationId,
     };
     // Forward the caller's bearer token so upstream applies the same identity.
     if (context.authorization) {
       headers.Authorization = context.authorization;
     }
-    // Forward the resolved read scope so upstream RLS narrows the query.
+    // Forward the resolved business scope so upstream RLS narrows the request.
     //
     // Two guards, both load-bearing:
     //  - Only set the header when at least one id survives. Upstream reads an
@@ -193,11 +337,7 @@ export class UpstreamGraphQLClient {
         response = await this.fetchImpl(this.endpoint, {
           method: 'POST',
           headers,
-          body: JSON.stringify({
-            query: request.query,
-            variables: request.variables ?? {},
-            ...(request.operationName ? { operationName: request.operationName } : {}),
-          }),
+          body: wire.body,
           signal: controller.signal,
         });
       } catch (error) {

--- a/packages/mcp-server/src/upstream/graphql-client.ts
+++ b/packages/mcp-server/src/upstream/graphql-client.ts
@@ -303,9 +303,11 @@ export class UpstreamGraphQLClient {
     buildBody: () => WireBody,
     context: UpstreamRequestContext,
   ): Promise<TData> {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
-
+    // Build the request BEFORE arming the timeout. Two reasons: the timeout
+    // budget is for the upstream exchange, not for serializing our own body; and
+    // a `buildBody()` that throws (a variable that will not JSON-serialize, a
+    // runtime without Blob/FormData) must not leave a live timer behind holding
+    // the event loop open — it would escape the `finally` that clears it.
     const wire = buildBody();
     const headers: Record<string, string> = {
       ...wire.headers,
@@ -331,6 +333,9 @@ export class UpstreamGraphQLClient {
     // The timeout budget spans the entire exchange — obtaining the response AND
     // consuming its body — so an upstream that sends headers then stalls the body
     // is still aborted. The timer is cleared only once everything is done.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
     try {
       let response: Response;
       try {

--- a/packages/server/src/modules/app-providers/google-drive/google-drive.provider.ts
+++ b/packages/server/src/modules/app-providers/google-drive/google-drive.provider.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, Scope } from 'graphql-modules';
 import { ENVIRONMENT } from '../../../shared/tokens.js';
 import type { Environment } from '../../../shared/types/index.js';
 import {
+  fileSchema,
   folderContentSchema,
   type DriveFileContent,
   type DriveFolderContent,
@@ -74,6 +75,85 @@ export class GoogleDriveProvider {
   private isRelevantFileType(originalMimeType: string): boolean {
     const mimeType = originalMimeType.toLowerCase();
     return mimeType === 'application/pdf' || mimeType.startsWith('image/');
+  }
+
+  /**
+   * Whether a URL points at a single Google Drive *file* (as opposed to a
+   * folder, which {@link fetchFilesFromSharedFolder} handles).
+   */
+  public static isFileUrl(rawUrl: string): boolean {
+    return GoogleDriveProvider.extractFileId(rawUrl) !== null;
+  }
+
+  /**
+   * Pull the file id out of the several share-link shapes Drive hands out:
+   * `/file/d/<id>/view`, `/open?id=<id>`, `/uc?id=<id>`.
+   */
+  private static extractFileId(rawUrl: string): string | null {
+    let url: URL;
+    try {
+      url = new URL(rawUrl);
+    } catch {
+      return null;
+    }
+    const host = url.hostname.toLowerCase();
+    if (host !== 'drive.google.com' && host !== 'docs.google.com') {
+      return null;
+    }
+    const pathMatch = /\/(?:file|document|spreadsheets|presentation)\/d\/([^/?#]+)/.exec(
+      url.pathname,
+    );
+    if (pathMatch) {
+      return pathMatch[1];
+    }
+    const idParam = url.searchParams.get('id');
+    return idParam && idParam.length > 0 ? idParam : null;
+  }
+
+  private async fetchFileMetadata(fileId: string): Promise<DriveFileContent> {
+    const url = new URL(
+      `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(fileId)}?fields=id,name,mimeType,kind&key=${this.apiKey}`,
+    );
+
+    const res = await fetch(url).catch(err => {
+      const message = `Failed fetching file metadata from Google Drive for id="${fileId}"`;
+      console.error(`${message}: ${err}`);
+      throw new Error(message);
+    });
+
+    if (!res.ok) {
+      // Almost always "not shared with the API key" rather than "missing".
+      throw new Error(
+        `Google Drive returned HTTP ${res.status} for file id="${fileId}". Make sure the file is shared with anyone holding the link.`,
+      );
+    }
+
+    const parsed = fileSchema.safeParse(await res.json().catch(() => null));
+    if (!parsed.success) {
+      throw new Error(`Failed to parse Google Drive metadata for file id="${fileId}"`);
+    }
+    return parsed.data;
+  }
+
+  /**
+   * Fetch a single file from a Drive share link.
+   *
+   * A share link is not a download link — `/file/d/<id>/view` answers with an
+   * HTML page — so the id is resolved through the Drive API for its real name
+   * and MIME type before the bytes are pulled.
+   */
+  public async fetchFileFromUrl(fileUrl: string): Promise<File> {
+    const fileId = GoogleDriveProvider.extractFileId(fileUrl);
+    if (!fileId) {
+      throw new Error(`Not a Google Drive file URL: "${fileUrl}"`);
+    }
+    const metadata = await this.fetchFileMetadata(fileId);
+    if (!this.isRelevantFileType(metadata.mimeType)) {
+      throw new Error(
+        `Unsupported Google Drive file type "${metadata.mimeType}" for file="${metadata.name}" — expected a PDF or an image`,
+      );
+    }
+    return this.fetchFile(metadata);
   }
 
   public async fetchFilesFromSharedFolder(folderUrl: string): Promise<File[]> {

--- a/packages/server/src/modules/app-providers/google-drive/types/folder-content.ts
+++ b/packages/server/src/modules/app-providers/google-drive/types/folder-content.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-const fileSchema = z.object({
+export const fileSchema = z.object({
   kind: z.string(),
   mimeType: z.string(),
   id: z.string(),

--- a/packages/server/src/modules/documents/helpers/fetch-remote-document.helper.ts
+++ b/packages/server/src/modules/documents/helpers/fetch-remote-document.helper.ts
@@ -1,0 +1,211 @@
+import { isIP } from 'node:net';
+
+/**
+ * Fetch a document from a caller-supplied URL, safely.
+ *
+ * A server that fetches arbitrary URLs on request is an SSRF primitive: it sits
+ * inside the private network and will happily read the cloud metadata endpoint,
+ * an internal admin panel, or `localhost` on behalf of whoever asked. Every
+ * guard below exists for that reason, and each one is re-applied **after every
+ * redirect** — checking only the submitted URL is the classic way this goes
+ * wrong, since the attacker controls the redirect target too.
+ *
+ * Google Drive share links are *not* handled here; they are not download links
+ * (`/file/d/<id>/view` answers with an HTML page) and need the Drive API. The
+ * resolver routes those to `GoogleDriveProvider` before reaching this helper.
+ */
+
+/** Max bytes accepted from a remote document. */
+export const MAX_REMOTE_DOCUMENT_BYTES = 25 * 1024 * 1024;
+/** Max redirects followed before giving up. */
+export const MAX_REDIRECTS = 5;
+/** Wall-clock budget for one document fetch, including redirects. */
+export const FETCH_TIMEOUT_MS = 30_000;
+
+/**
+ * Accepted content types, matched against the *response's* `Content-Type` — not
+ * the URL's extension and not anything the caller claims. A `.pdf` URL that
+ * answers with `text/html` is a login page or an error, and storing it would
+ * file a web page as a financial record.
+ */
+export const ALLOWED_REMOTE_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+  'image/tiff',
+]);
+
+/** Thrown for every refusal here, so the resolver can report it per URL. */
+export class RemoteDocumentError extends Error {}
+
+/**
+ * Whether a literal IP address belongs to a range that must never be reachable
+ * through this helper: loopback, private, link-local (which includes the cloud
+ * metadata address 169.254.169.254), carrier-grade NAT, and the IPv6
+ * equivalents.
+ */
+export function isBlockedIp(address: string): boolean {
+  const version = isIP(address);
+  if (version === 4) {
+    const octets = address.split('.').map(Number);
+    const [a, b] = octets as [number, number, number, number];
+    if (a === 0 || a === 10 || a === 127) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true;
+    if (a >= 224) return true;
+    return false;
+  }
+  if (version === 6) {
+    const lower = address.toLowerCase().replace(/^\[|\]$/g, '');
+    if (lower === '::' || lower === '::1') return true;
+    // Unique-local (fc00::/7) and link-local (fe80::/10).
+    if (/^f[cd]/.test(lower) || /^fe[89ab]/.test(lower)) return true;
+    // IPv4-mapped (::ffff:127.0.0.1) — recurse on the embedded address.
+    const mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(lower);
+    if (mapped) return isBlockedIp(mapped[1]);
+    return false;
+  }
+  return false;
+}
+
+/**
+ * Reject a URL before it is fetched. Applied to the submitted URL and again to
+ * every redirect target.
+ *
+ * Hostnames that are not literal IPs are checked by name only. Resolving them
+ * here would not close the DNS-rebinding gap either (the name is resolved again
+ * by `fetch`), so the meaningful guard is the response-side one: a redirect to
+ * an internal host still has to pass this check, and the content-type check
+ * rejects whatever an internal service would answer with.
+ */
+export function assertFetchableUrl(rawUrl: string): URL {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new RemoteDocumentError(`Not a valid URL: "${rawUrl}"`);
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new RemoteDocumentError(
+      `Unsupported URL scheme "${url.protocol}" — only http and https are fetched`,
+    );
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, '');
+  if (isIP(hostname) && isBlockedIp(hostname)) {
+    throw new RemoteDocumentError(`Refusing to fetch a private or loopback address: ${hostname}`);
+  }
+  const lowerHost = hostname.toLowerCase();
+  if (
+    lowerHost === 'localhost' ||
+    lowerHost.endsWith('.localhost') ||
+    lowerHost.endsWith('.local')
+  ) {
+    throw new RemoteDocumentError(`Refusing to fetch a local address: ${hostname}`);
+  }
+
+  return url;
+}
+
+/** Best-effort filename: the last path segment, else a generic one. */
+function filenameFromUrl(url: URL, contentType: string): string {
+  const segment = decodeURIComponent(url.pathname.split('/').findLast(Boolean) ?? '');
+  if (segment && /\.[a-z0-9]{2,5}$/i.test(segment)) {
+    return segment;
+  }
+  const extension = contentType === 'application/pdf' ? 'pdf' : contentType.split('/')[1];
+  return `document.${extension || 'bin'}`;
+}
+
+/**
+ * Fetch one document. Redirects are followed manually so each hop can be
+ * re-validated; `fetch`'s own `redirect: 'follow'` would hide the intermediate
+ * targets and defeat {@link assertFetchableUrl}.
+ */
+export async function fetchRemoteDocument(rawUrl: string): Promise<File> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    let url = assertFetchableUrl(rawUrl);
+    let response: Response | undefined;
+
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      response = await fetch(url, {
+        redirect: 'manual',
+        signal: controller.signal,
+        headers: { Accept: [...ALLOWED_REMOTE_MIME_TYPES].join(', ') },
+      }).catch(error => {
+        throw new RemoteDocumentError(
+          `Failed fetching document: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+
+      if (response.status < 300 || response.status >= 400) {
+        break;
+      }
+      const location = response.headers.get('location');
+      if (!location) {
+        throw new RemoteDocumentError(
+          `Redirect with no Location header (status ${response.status})`,
+        );
+      }
+      // Re-validating here is the point of the manual loop.
+      url = assertFetchableUrl(new URL(location, url).toString());
+      response = undefined;
+    }
+
+    if (!response) {
+      throw new RemoteDocumentError(`Too many redirects (over ${MAX_REDIRECTS})`);
+    }
+    if (!response.ok) {
+      throw new RemoteDocumentError(`Document URL returned HTTP ${response.status}`);
+    }
+
+    const contentType = (response.headers.get('content-type') ?? '')
+      .split(';')[0]
+      .trim()
+      .toLowerCase();
+    if (!ALLOWED_REMOTE_MIME_TYPES.has(contentType)) {
+      throw new RemoteDocumentError(
+        `Unsupported content type "${contentType || 'unknown'}" — expected a PDF or an image. ` +
+          `A share link that renders a web page will land here; use a direct download link.`,
+      );
+    }
+
+    // Trust the declared length only to fail early; the real check is on the
+    // bytes actually received, since the header is attacker-controlled.
+    const declared = Number(response.headers.get('content-length') ?? Number.NaN);
+    if (Number.isFinite(declared) && declared > MAX_REMOTE_DOCUMENT_BYTES) {
+      throw new RemoteDocumentError(
+        `Document is ${Math.round(declared / 1024 / 1024)}MB, over the ` +
+          `${MAX_REMOTE_DOCUMENT_BYTES / 1024 / 1024}MB limit`,
+      );
+    }
+
+    const buffer = await response.arrayBuffer().catch(error => {
+      throw new RemoteDocumentError(
+        `Failed reading document body: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+    if (buffer.byteLength === 0) {
+      throw new RemoteDocumentError('Document URL returned an empty body');
+    }
+    if (buffer.byteLength > MAX_REMOTE_DOCUMENT_BYTES) {
+      throw new RemoteDocumentError(
+        `Document is ${Math.round(buffer.byteLength / 1024 / 1024)}MB, over the ` +
+          `${MAX_REMOTE_DOCUMENT_BYTES / 1024 / 1024}MB limit`,
+      );
+    }
+
+    return new File([buffer], filenameFromUrl(url, contentType), { type: contentType });
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/packages/server/src/modules/documents/helpers/fetch-remote-document.test.ts
+++ b/packages/server/src/modules/documents/helpers/fetch-remote-document.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GoogleDriveProvider } from '../../app-providers/google-drive/google-drive.provider.js';
+import {
+  assertFetchableUrl,
+  fetchRemoteDocument,
+  isBlockedIp,
+  MAX_REMOTE_DOCUMENT_BYTES,
+  RemoteDocumentError,
+} from './fetch-remote-document.helper.js';
+
+/**
+ * These tests are about refusals. A server that fetches caller-supplied URLs is
+ * an SSRF primitive unless every one of them holds, and the redirect cases are
+ * the ones that are easy to get wrong: validating only the submitted URL leaves
+ * the whole guard bypassable by a public host that answers with a `Location`
+ * pointing inside the network.
+ */
+
+const PDF_HEADERS = { 'content-type': 'application/pdf' };
+
+/** A minimal stand-in for `Response`, enough for the helper's use of it. */
+function response(
+  init: { status?: number; headers?: Record<string, string>; body?: string } = {},
+): Response {
+  const status = init.status ?? 200;
+  const headers = new Headers(init.headers ?? PDF_HEADERS);
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers,
+    arrayBuffer: async () => new TextEncoder().encode(init.body ?? '%PDF-1.7 fake').buffer,
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('isBlockedIp', () => {
+  it.each([
+    '127.0.0.1',
+    '10.1.2.3',
+    '172.16.0.1',
+    '192.168.1.1',
+    // The cloud metadata endpoint — the single most valuable SSRF target.
+    '169.254.169.254',
+    '0.0.0.0',
+    '100.64.0.1',
+    '::1',
+    'fd00::1',
+    'fe80::1',
+    '::ffff:127.0.0.1',
+  ])('blocks %s', address => {
+    expect(isBlockedIp(address)).toBe(true);
+  });
+
+  it.each(['8.8.8.8', '1.1.1.1', '2606:4700::1111'])('allows %s', address => {
+    expect(isBlockedIp(address)).toBe(false);
+  });
+});
+
+describe('assertFetchableUrl', () => {
+  it('refuses the cloud metadata address', () => {
+    expect(() => assertFetchableUrl('http://169.254.169.254/latest/meta-data/')).toThrow(
+      RemoteDocumentError,
+    );
+  });
+
+  it('refuses localhost by name as well as by address', () => {
+    expect(() => assertFetchableUrl('http://localhost:4000/graphql')).toThrow(RemoteDocumentError);
+    expect(() => assertFetchableUrl('http://db.local/file.pdf')).toThrow(RemoteDocumentError);
+  });
+
+  it('refuses non-http schemes, which is what makes file:// unreachable', () => {
+    expect(() => assertFetchableUrl('file:///etc/passwd')).toThrow(RemoteDocumentError);
+    expect(() => assertFetchableUrl('gs://bucket/object')).toThrow(RemoteDocumentError);
+  });
+
+  it('accepts an ordinary public https URL', () => {
+    expect(assertFetchableUrl('https://example.com/invoice.pdf').hostname).toBe('example.com');
+  });
+});
+
+describe('fetchRemoteDocument', () => {
+  it('returns a File named from the URL, typed from the response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => response()),
+    );
+
+    const file = await fetchRemoteDocument('https://example.com/docs/invoice-2026.pdf');
+    expect(file.name).toBe('invoice-2026.pdf');
+    expect(file.type).toBe('application/pdf');
+    expect(file.size).toBeGreaterThan(0);
+  });
+
+  it('refuses a redirect from a public host into the private network', async () => {
+    const fetchMock = vi.fn(async (url: URL) =>
+      String(url).includes('example.com')
+        ? response({ status: 302, headers: { location: 'http://169.254.169.254/latest/' } })
+        : response(),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchRemoteDocument('https://example.com/invoice.pdf')).rejects.toThrow(
+      /private or loopback/,
+    );
+    // The second hop was never attempted.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows a redirect between public hosts', async () => {
+    const fetchMock = vi.fn(async (url: URL) =>
+      String(url).includes('short.example')
+        ? response({ status: 301, headers: { location: 'https://files.example.com/a.pdf' } })
+        : response(),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const file = await fetchRemoteDocument('https://short.example/x');
+    expect(file.name).toBe('a.pdf');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up on a redirect loop rather than following it forever', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        response({ status: 302, headers: { location: 'https://example.com/again' } }),
+      ),
+    );
+
+    await expect(fetchRemoteDocument('https://example.com/start')).rejects.toThrow(
+      /Too many redirects/,
+    );
+  });
+
+  it('refuses an HTML response to a .pdf URL — the type comes from the response, not the path', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        response({ headers: { 'content-type': 'text/html; charset=utf-8' }, body: '<html>' }),
+      ),
+    );
+
+    await expect(fetchRemoteDocument('https://example.com/invoice.pdf')).rejects.toThrow(
+      /Unsupported content type "text\/html"/,
+    );
+  });
+
+  it('refuses a body over the size cap even when Content-Length lied', async () => {
+    const oversize = new Uint8Array(MAX_REMOTE_DOCUMENT_BYTES + 1);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          ({
+            status: 200,
+            ok: true,
+            headers: new Headers({ ...PDF_HEADERS, 'content-length': '10' }),
+            arrayBuffer: async () => oversize.buffer,
+          }) as unknown as Response,
+      ),
+    );
+
+    await expect(fetchRemoteDocument('https://example.com/big.pdf')).rejects.toThrow(/over the/);
+  });
+
+  it('refuses an empty body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => response({ body: '' })),
+    );
+
+    await expect(fetchRemoteDocument('https://example.com/a.pdf')).rejects.toThrow(/empty body/);
+  });
+
+  it('surfaces an HTTP error rather than storing the error page', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => response({ status: 404 })),
+    );
+
+    await expect(fetchRemoteDocument('https://example.com/a.pdf')).rejects.toThrow(/HTTP 404/);
+  });
+});
+
+describe('GoogleDriveProvider.isFileUrl', () => {
+  it.each([
+    'https://drive.google.com/file/d/1AbC_dEf/view?usp=sharing',
+    'https://drive.google.com/open?id=1AbC_dEf',
+    'https://drive.google.com/uc?export=download&id=1AbC_dEf',
+    'https://docs.google.com/document/d/1AbC_dEf/edit',
+  ])('recognizes %s as a Drive file link', url => {
+    expect(GoogleDriveProvider.isFileUrl(url)).toBe(true);
+  });
+
+  it.each([
+    // A folder is the other mutation's job, not a single-file fetch.
+    'https://drive.google.com/drive/folders/1AbC_dEf',
+    'https://example.com/invoice.pdf',
+    'https://drive.google.com.evil.test/file/d/1AbC/view',
+    'not a url',
+  ])('does not treat %s as a Drive file link', url => {
+    expect(GoogleDriveProvider.isFileUrl(url)).toBe(false);
+  });
+});

--- a/packages/server/src/modules/documents/resolvers/documents.resolver.ts
+++ b/packages/server/src/modules/documents/resolvers/documents.resolver.ts
@@ -10,6 +10,10 @@ import { deleteCharges } from '../../charges/helpers/delete-charges.helper.js';
 import { ChargesProvider } from '../../charges/providers/charges.provider.js';
 import type { IGetChargesByIdsResult } from '../../charges/types.js';
 import { TransactionsProvider } from '../../transactions/providers/transactions.provider.js';
+import {
+  fetchRemoteDocument,
+  RemoteDocumentError,
+} from '../helpers/fetch-remote-document.helper.js';
 import { getDocumentFromFile } from '../helpers/upload.helper.js';
 import { basicDocumentValidation } from '../helpers/validate-document.helper.js';
 import { DocumentsProvider } from '../providers/documents.provider.js';
@@ -151,6 +155,82 @@ export const documentsResolvers: DocumentsModule.Resolvers &
       await degradeChargesAccountantApproval(injector, [chargeId]);
 
       return res.map(document => ({ document: document as IGetAllDocumentsResult }));
+    },
+    batchUploadDocumentsFromUrls: async (_, { urls, isSensitive, chargeId }, { injector }) => {
+      if (!chargeId) {
+        const { ownerId } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+
+        // generate new charge
+        const newCharge = await injector.get(ChargesProvider).generateCharge({
+          ownerId,
+          userDescription: 'New uploaded documents',
+        });
+        if (!newCharge) {
+          throw new GraphQLError(`Failed to generate new charge for new document`);
+        }
+        chargeId = newCharge.id;
+      }
+
+      // Results are positional and one URL's failure must not sink the batch, so
+      // each fetch is settled independently and its outcome is carried alongside
+      // the index it came from.
+      const settled = await Promise.all(
+        urls.map(async (url, index) => {
+          try {
+            // A Drive share link is not a download link — `/file/d/<id>/view`
+            // answers with an HTML page — so those go through the Drive API,
+            // which also reads files shared to the account rather than public.
+            const file = GoogleDriveProvider.isFileUrl(url)
+              ? await injector.get(GoogleDriveProvider).fetchFileFromUrl(url)
+              : await fetchRemoteDocument(url);
+            const document = await getDocumentFromFile(injector, file, chargeId, isSensitive);
+            return { index, document };
+          } catch (error) {
+            const message =
+              error instanceof RemoteDocumentError
+                ? error.message
+                : `Failed ingesting document from URL: ${error instanceof Error ? error.message : String(error)}`;
+            console.error(`Failed ingesting document from URL="${url}": ${error}`);
+            return { index, message };
+          }
+        }),
+      );
+
+      const fetched = settled.filter(
+        (
+          entry,
+        ): entry is { index: number; document: IInsertDocumentsParams['documents'][number] } =>
+          'document' in entry,
+      );
+
+      const inserted = fetched.length
+        ? await injector
+            .get(DocumentsProvider)
+            .insertDocuments({ documents: fetched.map(entry => entry.document) })
+        : [];
+
+      if (inserted.length) {
+        await degradeChargesAccountantApproval(injector, [chargeId]);
+      }
+
+      // `insertDocuments` returns rows in the order it was given them, so the
+      // Nth inserted row belongs to the Nth successfully fetched URL.
+      const documentByIndex = new Map(
+        fetched.map((entry, position) => [entry.index, inserted[position]]),
+      );
+
+      return urls.map((url, index) => {
+        const document = documentByIndex.get(index);
+        if (document) {
+          return { document: document as IGetAllDocumentsResult };
+        }
+        const failure = settled.find(entry => entry.index === index);
+        const reason =
+          failure && 'message' in failure
+            ? failure.message
+            : 'document was fetched but could not be stored';
+        return { __typename: 'CommonError' as const, message: `${url}: ${reason}` };
+      });
     },
     batchUploadDocumentsFromGoogleDrive: async (
       _,

--- a/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
+++ b/packages/server/src/modules/documents/typeDefs/documents.graphql.ts
@@ -51,6 +51,14 @@ export default gql`
     ): [UploadDocumentResult!]!
       @requiresAuth
       @requiresAnyRole(roles: ["business_owner", "accountant"])
+    " Attach documents to a charge by fetching them from URLs server-side, so the bytes never travel through the caller. Google Drive share links are resolved through the Drive API; every other URL must answer with a PDF or an image. Results are positional — one entry per input URL, so a partial failure names the URL that failed. "
+    batchUploadDocumentsFromUrls(
+      urls: [String!]!
+      isSensitive: Boolean
+      chargeId: UUID
+    ): [UploadDocumentResult!]!
+      @requiresAuth
+      @requiresAnyRole(roles: ["business_owner", "accountant"])
     batchUploadDocumentsFromGoogleDrive(
       sharedFolderUrl: String!
       isSensitive: Boolean


### PR DESCRIPTION
Implement the first two write tools (`accounter_update_charges_tags` and `accounter_upload_documents`) behind the `MCP_ENABLE_WRITE_TOOLS` feature flag, which defaults to off. This completes the Phase 2 write scope foundation.

## Key Changes

**Write tool infrastructure:**
- Extended `UpstreamGraphQLClient` with `mutate()` and `mutateMultipart()` methods, guarded to refuse anything but single top-level mutations (mirroring the read path's `query()` guard against mutations)
- Added `UploadFile` interface for binary file handling via GraphQL multipart request spec
- Mutations never retry (idempotency not guaranteed), unlike reads which retry on transient failures
- New `shapeWriteResult()` output formatter that always preserves outcome fields (counts, ids) and optionally includes per-item details when within the payload guard

**Write tool policies:**
- New `mutating` flag in `ToolAuthPolicy` to distinguish write tools
- Write tools require explicit `memberBusinessId` when the caller has multiple memberships (ambiguity is rejected, not guessed)
- New `writeTargetBusinessIdInput` schema helper for write tool inputs

**`accounter_update_charges_tags`:**
- Add/remove tags across 1–50 charges in one call
- Tags identified by id (not name) to avoid ambiguity — model resolves names via `accounter_list_tags` first
- Rejects no-op calls (both add and remove empty/omitted) before any upstream round trip
- Incremental operation: removals run before additions, so an id in both lists ends up added

**`accounter_upload_documents`:**
- Attach 1–10 base64-encoded documents to an **existing** charge
- `chargeId` required (upstream would otherwise create a new charge)
- `isSensitive` pinned to `true` and absent from input schema (property of this ingestion path, not a choice)
- Strict input validation before upload: base64 encoding, MIME type allowlist, per-file and total size limits
- Accepts `data:<type>;base64,` URI prefix and surrounding whitespace
- Multipart envelope assembled per GraphQL spec with null placeholders and a matching map
- Upstream returns one result per file, so partial failure is reported positionally

**Configuration & exposure:**
- New `MCP_ENABLE_WRITE_TOOLS` env var (default false) controls whether write tools appear in `tools/list` and are dispatchable
- Write tools are indistinguishable from unknown tools when disabled (no "feature is off" message)
- Allowlist enforcement extended to cover both read and write tools
- Audit logging captures write input size/counts (array lengths, id values) but never payload content (bytes, filenames, MIME types)

**Testing:**
- Comprehensive unit tests for both write tools covering multipart envelope assembly, input guards, and result mapping
- Extended upstream client tests for mutation guards and multipart handling
- E2E tests with write tools enabled, plus verification they're hidden when disabled
- Scope forwarding tests updated for write operations

## Implementation Details

- Write tools use the same auth/scope resolution as reads but require explicit targeting when ambiguous
- The multipart request spec is implemented to spec: `operations` part carries the mutation with null file placeholders, `map` points numbered parts to their variable paths, and file parts carry the actual binary content
- Base64 validation is strict (not lenient like `Buffer.from()`) to catch truncation before it reaches Cloudinary
- Write tools are registered after all read tools in the registry, maintaining a clear separation in `tools/list`

https://claude.ai/code/session_01NX23zbWULd9mYUdEWrKc5K