### PR TITLE
Add connection-leak detection and recovery for Postgres pool

### DIFF
--- a/.changeset/tame-pugs-shave.md
+++ b/.changeset/tame-pugs-shave.md
@@ -1,0 +1,24 @@
+---
+'@accounter/server': patch
+---
+
+Fix Postgres connection leak that wedged the server on cancelled requests
+
+A request cancelled mid-execution never fired `onExecuteDone`, so its pooled connection was never
+released and its transaction never closed — Postgres kept the session `idle in transaction`
+indefinitely. Since urql aborts the in-flight query on every keystroke, each cancelled search leaked
+one connection permanently; once the leaks reached `POSTGRES_MAX_CLIENTS`, every request hung in
+`pool.connect()` until the process was restarted.
+
+Clients are now disposed on the request's `AbortSignal`, with three independent backstops: a
+watchdog that reclaims connections idle beyond a ceiling, pool-level timeouts
+(`connectionTimeoutMillis`, `statement_timeout`, `idle_in_transaction_session_timeout`, TCP
+keepalive) so exhaustion errors loudly instead of hanging, and an `'error'` listener on checked-out
+clients that returns a broken connection to the pool instead of losing the slot.
+
+Adds a `db-pool-heartbeat` log line reporting pool saturation, connection holders, and event-loop
+delay, plus `application_name` on connections so app sessions are identifiable in
+`pg_stat_activity`. New optional env vars: `POSTGRES_CONNECTION_TIMEOUT_MS`,
+`POSTGRES_STATEMENT_TIMEOUT_MS`, `POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS`,
+`POSTGRES_CLIENT_MAX_IDLE_MS`, `POSTGRES_WATCHDOG_INTERVAL_MS`, `POSTGRES_MONITOR_INTERVAL_MS` — all
+defaulted, see `docs/operations/db-connection-pool.md`.

--- a/docs/operations/db-connection-pool.md
+++ b/docs/operations/db-connection-pool.md
@@ -71,14 +71,15 @@ does not run", so no single mechanism is trusted:
 
 ## Configuration
 
-| Variable                                  | Default  | Notes                                                       |
-| ----------------------------------------- | -------- | ----------------------------------------------------------- |
-| `POSTGRES_MAX_CLIENTS`                    | `20`     | Pool size. Keep well under the server's `max_connections`.  |
-| `POSTGRES_CONNECTION_TIMEOUT_MS`          | `10000`  | Never set to `0` in production — that means "wait forever". |
-| `POSTGRES_STATEMENT_TIMEOUT_MS`           | `120000` | Bounds a pathological query. Raise if bulk jobs need it.    |
-| `POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS` | `300000` | See the warning below before lowering.                      |
-| `POSTGRES_CLIENT_MAX_IDLE_MS`             | `300000` | Client-side counterpart of the above.                       |
-| `POSTGRES_MONITOR_INTERVAL_MS`            | `30000`  | `0` disables the heartbeat.                                 |
+| Variable                                  | Default  | Notes                                                      |
+| ----------------------------------------- | -------- | ---------------------------------------------------------- |
+| `POSTGRES_MAX_CLIENTS`                    | `20`     | Pool size. Keep well under the server's `max_connections`. |
+| `POSTGRES_CONNECTION_TIMEOUT_MS`          | `10000`  | Rejects `0`, so "wait forever" is unreachable.             |
+| `POSTGRES_STATEMENT_TIMEOUT_MS`           | `120000` | Bounds a pathological query. Raise if bulk jobs need it.   |
+| `POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS` | `300000` | See the warning below before lowering.                     |
+| `POSTGRES_CLIENT_MAX_IDLE_MS`             | `300000` | Client-side counterpart of the above.                      |
+| `POSTGRES_WATCHDOG_INTERVAL_MS`           | derived  | Sweep interval; defaults to `min(30s, client max idle)`.   |
+| `POSTGRES_MONITOR_INTERVAL_MS`            | `30000`  | `0` disables the heartbeat.                                |
 
 ### Why the idle timeouts are 5 minutes and not 60 seconds
 

--- a/docs/operations/db-connection-pool.md
+++ b/docs/operations/db-connection-pool.md
@@ -1,0 +1,99 @@
+# Database Connection Pool — Runbook
+
+## The failure this guards against
+
+The server holds one pooled Postgres connection per in-flight GraphQL request, inside an open
+transaction (see `TenantAwareDBClient`). If a request ends without disposing its client, that
+connection is never returned to the pool and its transaction is never closed. Postgres shows the
+session as `idle in transaction` with `wait_event = ClientRead`, forever.
+
+Leak enough of them and the pool (`POSTGRES_MAX_CLIENTS`, default 20) is exhausted. From that moment
+every request hangs in `pool.connect()`:
+
+- CPU near zero, memory flat — the process is waiting, not working
+- the database looks perfectly healthy: low CPU, zero failed connections, no errors anywhere
+- Yoga logs `Processing GraphQL Parameters` with no matching `done.`
+- new requests may stop appearing in the logs entirely, because the browser's ~6 sockets per origin
+  are all consumed by hung requests and the rest queue client-side
+- only a process restart recovers it
+
+The original cause was request cancellation: `dbCleanupPlugin` disposed clients in `onExecuteDone`,
+which never fires when a client aborts mid-execution (urql cancels the in-flight query on every
+keystroke of a search box). Each cancelled search leaked one connection permanently.
+
+## Diagnosing
+
+Run against the app database — `application_name` is set to `accounter-server`, so app connections
+are identifiable:
+
+```sql
+select pid, application_name, state, wait_event,
+       now()-xact_start as xact_age, left(query,120) as query
+from pg_stat_activity
+where backend_type = 'client backend'
+order by xact_start nulls last;
+```
+
+Any `idle in transaction` row with an `xact_age` beyond a few minutes is a leak. The `query` column
+names the code path it leaked from (it is the _last_ statement that ran on the session, not
+necessarily the culprit).
+
+From the app side, the heartbeat log (`msg: "db-pool-heartbeat"`, every
+`POSTGRES_MONITOR_INTERVAL_MS`) reports the same thing from inside the process:
+
+```json
+{
+  "msg": "db-pool-heartbeat",
+  "pool": { "total": 20, "idle": 0, "waiting": 7, "max": 20 },
+  "sessions": { "holdingConnection": 20, "maxIdleMs": 431000 },
+  "eventLoopDelayP99Ms": 3
+}
+```
+
+`waiting > 0` with `idle: 0` **is** the wedge. It is logged at error level with `saturated: true`. A
+high `sessions.maxIdleMs` means something is holding a connection without querying — a leak in
+progress. The heartbeat still printing at all proves the event loop is alive, which rules out a
+whole class of unrelated theories in one line.
+
+## Layers of defence
+
+Four independent mechanisms, deliberately overlapping — the bug class here is "a cleanup path that
+does not run", so no single mechanism is trusted:
+
+1. **Disposal on abort** (`dbCleanupPlugin`) — fixes the root cause: the request's `AbortSignal`
+   disposes the client when the caller goes away.
+2. **Watchdog** (`startTenantDbClientWatchdog`) — sweeps every connection holder and force-disposes
+   any that has not issued a query in `POSTGRES_CLIENT_MAX_IDLE_MS`. The predicate is _idle_ time,
+   not age, so a slow-but-active request is untouched while a leaked one is reclaimed.
+3. **`connectionTimeoutMillis`** — an exhausted pool now produces fast, loud errors naming the
+   operation instead of silently hanging forever.
+4. **`idle_in_transaction_session_timeout`** — Postgres itself terminates an abandoned session.
+
+## Configuration
+
+| Variable                                  | Default  | Notes                                                       |
+| ----------------------------------------- | -------- | ----------------------------------------------------------- |
+| `POSTGRES_MAX_CLIENTS`                    | `20`     | Pool size. Keep well under the server's `max_connections`.  |
+| `POSTGRES_CONNECTION_TIMEOUT_MS`          | `10000`  | Never set to `0` in production — that means "wait forever". |
+| `POSTGRES_STATEMENT_TIMEOUT_MS`           | `120000` | Bounds a pathological query. Raise if bulk jobs need it.    |
+| `POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS` | `300000` | See the warning below before lowering.                      |
+| `POSTGRES_CLIENT_MAX_IDLE_MS`             | `300000` | Client-side counterpart of the above.                       |
+| `POSTGRES_MONITOR_INTERVAL_MS`            | `30000`  | `0` disables the heartbeat.                                 |
+
+### Why the idle timeouts are 5 minutes and not 60 seconds
+
+The request-scoped session model keeps a transaction open for the whole request, **including across
+external I/O** — document OCR via Anthropic, Green Invoice, Cloudinary. A legitimate upload can sit
+idle-in-transaction for a minute or more while waiting on an upstream API. An aggressive timeout
+would kill live requests. Five minutes bounds a leak to something survivable without touching real
+traffic.
+
+The right long-term fix is to stop holding a connection across external calls at all, which would
+let these timeouts drop by an order of magnitude.
+
+### Terminating leaked sessions by hand
+
+`pg_terminate_backend` on a leaked session is safe **only** because the client now attaches an
+`'error'` listener to checked-out connections. pg removes its own idle-client error handler while a
+client is checked out, so without that listener a terminated backend raises an unhandled `'error'`
+event, which becomes an `uncaughtException` and takes the process down. Do not remove that listener.

--- a/packages/server/.env.template
+++ b/packages/server/.env.template
@@ -12,6 +12,15 @@ POSTGRES_DB=accounter
 POSTGRES_SSL='0'
 POSTGRES_MAX_CLIENTS=10
 
+# Connection-pool safety valves — all optional, sensible defaults applied.
+# See docs/operations/db-connection-pool.md for the rationale behind each.
+# POSTGRES_CONNECTION_TIMEOUT_MS=10000
+# POSTGRES_STATEMENT_TIMEOUT_MS=120000
+# POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS=300000
+# POSTGRES_CLIENT_MAX_IDLE_MS=300000
+# POSTGRES_WATCHDOG_INTERVAL_MS=30000
+# POSTGRES_MONITOR_INTERVAL_MS=30000
+
 ; Auth0 Configuration (JWT Verification)
 AUTH0_DOMAIN=your-tenant.us.auth0.com
 AUTH0_AUDIENCE=https://api.accounter.com

--- a/packages/server/src/environment.test.ts
+++ b/packages/server/src/environment.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `environment.ts` reads `process.env` at import time, so each case needs a
+ * fresh module registry. dotenv does not override variables already present in
+ * `process.env`, so the values set here win over any local `.env`.
+ */
+async function loadEnv(overrides: Record<string, string>) {
+  vi.resetModules();
+  for (const [key, value] of Object.entries(overrides)) {
+    process.env[key] = value;
+  }
+  const { env } = await import('./environment.js');
+  return env;
+}
+
+const REQUIRED = {
+  POSTGRES_HOST: 'localhost',
+  POSTGRES_PORT: '5432',
+  POSTGRES_DB: 'test',
+  POSTGRES_USER: 'test',
+  POSTGRES_PASSWORD: 'test',
+  CREDENTIALS_ENCRYPTION_KEY: 'a'.repeat(64),
+};
+
+const MANAGED_KEYS = [
+  'POSTGRES_WATCHDOG_INTERVAL_MS',
+  'POSTGRES_CLIENT_MAX_IDLE_MS',
+  'POSTGRES_MONITOR_INTERVAL_MS',
+  'POSTGRES_CONNECTION_TIMEOUT_MS',
+];
+
+describe('postgres pool configuration', () => {
+  let original: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    original = Object.fromEntries(
+      [...MANAGED_KEYS, ...Object.keys(REQUIRED)].map(key => [key, process.env[key]]),
+    );
+    for (const key of MANAGED_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    vi.resetModules();
+  });
+
+  it('derives the watchdog interval when not configured', async () => {
+    const env = await loadEnv(REQUIRED);
+
+    expect(env.postgres.clientMaxIdleMs).toBe(300_000);
+    expect(env.postgres.watchdogIntervalMs).toBe(30_000);
+  });
+
+  it('honours an explicit watchdog interval', async () => {
+    const env = await loadEnv({ ...REQUIRED, POSTGRES_WATCHDOG_INTERVAL_MS: '5000' });
+
+    expect(env.postgres.watchdogIntervalMs).toBe(5000);
+  });
+
+  it('keeps the derived sweep interval in step with a tightened idle ceiling', async () => {
+    const env = await loadEnv({ ...REQUIRED, POSTGRES_CLIENT_MAX_IDLE_MS: '9000' });
+
+    // Sweeping every 30s would let a leak sit for far longer than the ceiling.
+    expect(env.postgres.watchdogIntervalMs).toBe(9000);
+  });
+
+  it('accepts 0 for the monitor interval, which disables the heartbeat', async () => {
+    const env = await loadEnv({ ...REQUIRED, POSTGRES_MONITOR_INTERVAL_MS: '0' });
+
+    expect(env.postgres.monitorIntervalMs).toBe(0);
+  });
+
+  it('rejects 0 for the connection timeout, keeping "wait forever" unreachable', async () => {
+    // pg treats 0 as "queue indefinitely" — the behaviour that turns an
+    // exhausted pool into a silent, permanent wedge.
+    await expect(
+      loadEnv({ ...REQUIRED, POSTGRES_CONNECTION_TIMEOUT_MS: '0' }),
+    ).rejects.toBeDefined();
+  });
+});

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -20,6 +20,12 @@ const numberFromNumberOrNumberString = (input: unknown): number | undefined => {
 
 const NumberFromString = zod.preprocess(numberFromNumberOrNumberString, zod.number().min(1));
 
+/** Same as `NumberFromString`, but `0` is a meaningful value (e.g. "disabled"). */
+const NonNegativeNumberFromString = zod.preprocess(
+  numberFromNumberOrNumberString,
+  zod.number().min(0),
+);
+
 // treat an empty string (`''`) as undefined
 const emptyString = <T extends zod.ZodType>(input: T) => {
   return zod.preprocess((value: unknown) => {
@@ -38,8 +44,9 @@ const PostgresModel = zod.object({
   POSTGRES_MAX_CLIENTS: emptyString(NumberFromString).optional().default(20),
   /**
    * How long `pool.connect()` may wait for a free connection before failing.
-   * `0` restores pg's default of waiting forever — never do that in production:
-   * an exhausted pool then wedges every request with no error and no recovery.
+   * pg's own default is to wait forever, which turns an exhausted pool into a
+   * silent, permanent wedge — so this is always set, and the schema rejects
+   * `0` to keep "wait forever" unreachable through configuration.
    */
   POSTGRES_CONNECTION_TIMEOUT_MS: emptyString(NumberFromString).optional().default(10_000),
   /**
@@ -66,8 +73,14 @@ const PostgresModel = zod.object({
    * its connection to the pool. Same reasoning for the default.
    */
   POSTGRES_CLIENT_MAX_IDLE_MS: emptyString(NumberFromString).optional().default(300_000),
+  /**
+   * How often the watchdog sweeps for leaked connections. Defaults to the
+   * smaller of 30s and the idle ceiling, so a tightened ceiling is still
+   * enforced promptly.
+   */
+  POSTGRES_WATCHDOG_INTERVAL_MS: emptyString(NumberFromString).optional(),
   /** Interval for the pool/session health heartbeat log. `0` disables it. */
-  POSTGRES_MONITOR_INTERVAL_MS: emptyString(NumberFromString).optional().default(30_000),
+  POSTGRES_MONITOR_INTERVAL_MS: emptyString(NonNegativeNumberFromString).optional().default(30_000),
 });
 
 const CloudinaryModel = zod.union([
@@ -285,6 +298,9 @@ export const env = {
     statementTimeoutMs: postgres.POSTGRES_STATEMENT_TIMEOUT_MS,
     idleInTransactionTimeoutMs: postgres.POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS,
     clientMaxIdleMs: postgres.POSTGRES_CLIENT_MAX_IDLE_MS,
+    watchdogIntervalMs:
+      postgres.POSTGRES_WATCHDOG_INTERVAL_MS ??
+      Math.min(postgres.POSTGRES_CLIENT_MAX_IDLE_MS, 30_000),
     monitorIntervalMs: postgres.POSTGRES_MONITOR_INTERVAL_MS,
   },
   cloudinary: cloudinary?.CLOUDINARY_API_KEY

--- a/packages/server/src/environment.ts
+++ b/packages/server/src/environment.ts
@@ -36,6 +36,38 @@ const PostgresModel = zod.object({
   POSTGRES_USER: zod.string(),
   POSTGRES_PASSWORD: zod.string(),
   POSTGRES_MAX_CLIENTS: emptyString(NumberFromString).optional().default(20),
+  /**
+   * How long `pool.connect()` may wait for a free connection before failing.
+   * `0` restores pg's default of waiting forever — never do that in production:
+   * an exhausted pool then wedges every request with no error and no recovery.
+   */
+  POSTGRES_CONNECTION_TIMEOUT_MS: emptyString(NumberFromString).optional().default(10_000),
+  /**
+   * Server-side cap on a single statement. Generous by default so bulk
+   * mutations (merges, ledger regeneration, imports) are unaffected; it exists
+   * to bound a pathological query, not to police normal ones.
+   */
+  POSTGRES_STATEMENT_TIMEOUT_MS: emptyString(NumberFromString).optional().default(120_000),
+  /**
+   * Postgres-side backstop against leaked sessions: a connection left `idle in
+   * transaction` this long is terminated by the server.
+   *
+   * Must stay comfortably above the longest legitimate in-request pause. The
+   * request-scoped session model keeps a transaction open across external I/O
+   * (document OCR, Green Invoice, Cloudinary), so a too-aggressive value would
+   * kill live requests. 5 minutes bounds a leak without touching real traffic.
+   */
+  POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS: emptyString(NumberFromString)
+    .optional()
+    .default(300_000),
+  /**
+   * Client-side counterpart to the above: a TenantAwareDBClient whose last
+   * query finished this long ago is force-disposed by the watchdog, returning
+   * its connection to the pool. Same reasoning for the default.
+   */
+  POSTGRES_CLIENT_MAX_IDLE_MS: emptyString(NumberFromString).optional().default(300_000),
+  /** Interval for the pool/session health heartbeat log. `0` disables it. */
+  POSTGRES_MONITOR_INTERVAL_MS: emptyString(NumberFromString).optional().default(30_000),
 });
 
 const CloudinaryModel = zod.union([
@@ -249,6 +281,11 @@ export const env = {
     password: postgres.POSTGRES_PASSWORD,
     ssl: postgres.POSTGRES_SSL === '1',
     max: postgres.POSTGRES_MAX_CLIENTS,
+    connectionTimeoutMs: postgres.POSTGRES_CONNECTION_TIMEOUT_MS,
+    statementTimeoutMs: postgres.POSTGRES_STATEMENT_TIMEOUT_MS,
+    idleInTransactionTimeoutMs: postgres.POSTGRES_IDLE_IN_TRANSACTION_TIMEOUT_MS,
+    clientMaxIdleMs: postgres.POSTGRES_CLIENT_MAX_IDLE_MS,
+    monitorIntervalMs: postgres.POSTGRES_MONITOR_INTERVAL_MS,
   },
   cloudinary: cloudinary?.CLOUDINARY_API_KEY
     ? {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -66,7 +66,7 @@ async function main() {
   // sweep deliberately trusts none of them.
   const dbClientWatchdog = startTenantDbClientWatchdog({
     maxIdleMs: env.postgres.clientMaxIdleMs,
-    intervalMs: Math.min(env.postgres.clientMaxIdleMs, 30_000),
+    intervalMs: env.postgres.watchdogIntervalMs,
     onLeak: ({ idleMs, lastQuery }) => {
       process.stderr.write(
         `[db] Reclaiming leaked connection after ${Math.round(idleMs / 1000)}s idle. Last query: ${lastQuery ?? 'unknown'}\n`,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -12,7 +12,9 @@ import { cleanupExpiredInvitations, type Logger } from './jobs/cleanup-expired-i
 import { scheduleDailyAtUtc } from './jobs/utils.js';
 import { createGraphQLApp } from './modules-app.js';
 import { DBProvider } from './modules/app-providers/db.provider.js';
+import { startTenantDbClientWatchdog } from './modules/app-providers/tenant-db-client.js';
 import { Auth0ManagementProvider } from './modules/auth/providers/auth0-management.provider.js';
+import { startPoolMonitor } from './observability/pool-monitor.js';
 import { authPlugin } from './plugins/auth-plugin.js';
 import { correlationIdPlugin } from './plugins/correlation-id-plugin.js';
 import { dbCleanupPlugin } from './plugins/db-cleanup-plugin.js';
@@ -35,6 +37,19 @@ async function main() {
     database: env.postgres.db,
     ssl: env.postgres.ssl ? { rejectUnauthorized: false } : false,
     max: env.postgres.max, // maximum number of clients in the pool
+    // Names this app's connections in pg_stat_activity, so a session can be
+    // attributed without guessing from client_addr.
+    application_name: 'accounter-server',
+    // Never queue for a connection indefinitely: without this, an exhausted
+    // pool makes every request hang silently and forever.
+    connectionTimeoutMillis: env.postgres.connectionTimeoutMs,
+    statement_timeout: env.postgres.statementTimeoutMs,
+    // Server-side backstop: Postgres reclaims a session abandoned mid-transaction.
+    idle_in_transaction_session_timeout: env.postgres.idleInTransactionTimeoutMs,
+    // Detect connections silently dropped by an intermediary rather than
+    // discovering it on the next query.
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10_000,
   });
 
   if (env.auth0) {
@@ -44,6 +59,29 @@ async function main() {
   }
 
   const dbProvider = new DBProvider(pool);
+
+  // Reclaim any request-scoped connection whose owner disappeared without
+  // disposing it. Disposal is driven by request lifecycle hooks, and the bug
+  // class this guards against is precisely a hook that never fires — so this
+  // sweep deliberately trusts none of them.
+  const dbClientWatchdog = startTenantDbClientWatchdog({
+    maxIdleMs: env.postgres.clientMaxIdleMs,
+    intervalMs: Math.min(env.postgres.clientMaxIdleMs, 30_000),
+    onLeak: ({ idleMs, lastQuery }) => {
+      process.stderr.write(
+        `[db] Reclaiming leaked connection after ${Math.round(idleMs / 1000)}s idle. Last query: ${lastQuery ?? 'unknown'}\n`,
+      );
+    },
+  });
+
+  const poolMonitor =
+    env.postgres.monitorIntervalMs > 0
+      ? startPoolMonitor({
+          pool,
+          intervalMs: env.postgres.monitorIntervalMs,
+          max: env.postgres.max,
+        })
+      : null;
   const auth0Provider = new Auth0ManagementProvider(env);
   const logger: Logger = {
     info: (message, meta) => {
@@ -143,6 +181,8 @@ async function main() {
     });
 
     cleanupSchedule?.cancel();
+    dbClientWatchdog.stop();
+    poolMonitor?.stop();
 
     // Allow in-flight requests some time to complete, then close the pool
     const FORCE_EXIT_TIMEOUT_MS = 10_000;

--- a/packages/server/src/modules/app-providers/__tests__/tenant-db-client-leak.test.ts
+++ b/packages/server/src/modules/app-providers/__tests__/tenant-db-client-leak.test.ts
@@ -1,0 +1,126 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Pool, PoolClient } from 'pg';
+import type { AuthContext } from '../../../shared/types/auth.js';
+import { AuthContextProvider } from '../../auth/providers/auth-context.provider.js';
+import { DBProvider } from '../db.provider.js';
+import {
+  getTenantDbClientStats,
+  startTenantDbClientWatchdog,
+  TenantAwareDBClient,
+} from '../tenant-db-client.js';
+
+/**
+ * A PoolClient that behaves like the real thing in the ways that matter here:
+ * it is an EventEmitter, and an 'error' with no listener throws.
+ */
+class FakePoolClient extends EventEmitter {
+  query = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+  release = vi.fn();
+}
+
+const authContext: AuthContext = {
+  authType: 'jwt',
+  token: 'token',
+  user: {
+    userId: 'user-123',
+    roleId: 'admin',
+    email: 'test@test.com',
+    permissions: [],
+    emailVerified: true,
+    permissionsVersion: 1,
+  },
+  tenant: { businessId: 'business-456', roleId: 'admin' },
+  activeReadScope: { businessIds: ['business-456'] },
+} as unknown as AuthContext;
+
+function buildClient(poolClient: FakePoolClient) {
+  const dbProvider = {
+    pool: { connect: vi.fn().mockResolvedValue(poolClient as unknown as PoolClient) } as unknown as
+      | Pool
+      | undefined,
+  } as unknown as DBProvider;
+
+  const authContextProvider = {
+    getAuthContext: () => Promise.resolve(authContext),
+  } as AuthContextProvider;
+
+  // A GraphQL context puts the client in request-scoped mode: the connection is
+  // held until dispose(), which is exactly the lifecycle that can leak.
+  return new TenantAwareDBClient(dbProvider, authContextProvider, {} as GraphQLModules.GlobalContext);
+}
+
+describe('TenantAwareDBClient connection-leak safeguards', () => {
+  let poolClient: FakePoolClient;
+
+  beforeEach(() => {
+    poolClient = new FakePoolClient();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('absorbs errors on a checked-out client instead of crashing the process', async () => {
+    const client = buildClient(poolClient);
+    await client.query('SELECT 1');
+
+    // pg drops its own idle error handler while a client is checked out, so an
+    // unhandled 'error' here would surface as an uncaughtException and take
+    // down the server — which is exactly what Postgres terminating an
+    // abandoned session (idle_in_transaction_session_timeout) would trigger.
+    expect(() => poolClient.emit('error', new Error('connection terminated'))).not.toThrow();
+
+    await client.dispose();
+  });
+
+  it('reports a held connection in the stats, and stops once released', async () => {
+    expect(getTenantDbClientStats().holdingConnection).toBe(0);
+
+    const client = buildClient(poolClient);
+    await client.query('SELECT 1');
+
+    expect(getTenantDbClientStats().holdingConnection).toBe(1);
+
+    await client.dispose();
+    expect(getTenantDbClientStats().holdingConnection).toBe(0);
+  });
+
+  it('reclaims a connection whose owner vanished without disposing it', async () => {
+    vi.useFakeTimers();
+    const client = buildClient(poolClient);
+    await client.query('SELECT 1');
+
+    const onLeak = vi.fn();
+    const watchdog = startTenantDbClientWatchdog({ maxIdleMs: 1000, intervalMs: 100, onLeak });
+
+    // Nothing disposes the client — the leak this whole change exists to stop.
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(onLeak).toHaveBeenCalledTimes(1);
+    expect(onLeak.mock.calls[0]![0].lastQuery).toBe('SELECT 1');
+    await vi.waitFor(() => expect(poolClient.release).toHaveBeenCalled());
+
+    watchdog.stop();
+  });
+
+  it('leaves a slow but active client alone', async () => {
+    vi.useFakeTimers();
+    const client = buildClient(poolClient);
+    await client.query('SELECT 1');
+
+    const onLeak = vi.fn();
+    const watchdog = startTenantDbClientWatchdog({ maxIdleMs: 1000, intervalMs: 100, onLeak });
+
+    // A healthy long request keeps issuing queries; only silence indicates a leak.
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(500);
+      await client.query('SELECT 2');
+    }
+
+    expect(onLeak).not.toHaveBeenCalled();
+
+    watchdog.stop();
+    await client.dispose();
+  });
+});

--- a/packages/server/src/modules/app-providers/__tests__/tenant-db-client-leak.test.ts
+++ b/packages/server/src/modules/app-providers/__tests__/tenant-db-client-leak.test.ts
@@ -74,6 +74,19 @@ describe('TenantAwareDBClient connection-leak safeguards', () => {
     await client.dispose();
   });
 
+  it('returns a broken connection to the pool as destroyed', async () => {
+    const client = buildClient(poolClient);
+    await client.query('SELECT 1');
+    expect(getTenantDbClientStats().holdingConnection).toBe(1);
+
+    poolClient.emit('error', new Error('connection terminated'));
+
+    // Dropping the reference without releasing would leave the pool counting
+    // the connection as checked out forever — a permanently lost slot.
+    expect(poolClient.release).toHaveBeenCalledWith(true);
+    expect(getTenantDbClientStats().holdingConnection).toBe(0);
+  });
+
   it('reports a held connection in the stats, and stops once released', async () => {
     expect(getTenantDbClientStats().holdingConnection).toBe(0);
 

--- a/packages/server/src/modules/app-providers/__tests__/tenant-db-client.test.ts
+++ b/packages/server/src/modules/app-providers/__tests__/tenant-db-client.test.ts
@@ -15,9 +15,13 @@ describe('TenantAwareDBClient', () => {
 
   beforeEach(() => {
     // Mock PoolClient
+    // A real PoolClient is an EventEmitter; the client attaches an 'error'
+    // listener while the connection is checked out.
     mockPoolClient = {
       query: vi.fn(),
       release: vi.fn(),
+      on: vi.fn(),
+      removeListener: vi.fn(),
     } as unknown as PoolClient;
 
     // Mock Pool

--- a/packages/server/src/modules/app-providers/tenant-db-client.ts
+++ b/packages/server/src/modules/app-providers/tenant-db-client.ts
@@ -337,9 +337,11 @@ export class TenantAwareDBClient {
       const onClientError = (error: Error) => {
         console.error('[db] Error on checked-out client, discarding connection:', error);
         this.sessionOpen = false;
-        this.activeClient = null;
-        this.clientErrorListener = null;
-        connectionHolders.delete(this);
+        // Hand the connection back to the pool as destroyed. Merely dropping
+        // our own reference would leave the pool counting it as checked out
+        // forever — losing the slot permanently, which is precisely the leak
+        // this class exists to prevent.
+        this.releaseClient(true);
       };
       client.on('error', onClientError);
       this.clientErrorListener = onClientError;

--- a/packages/server/src/modules/app-providers/tenant-db-client.ts
+++ b/packages/server/src/modules/app-providers/tenant-db-client.ts
@@ -23,6 +23,80 @@ export function isDataModifyingQuery(text: string): boolean {
 }
 
 /**
+ * Clients currently holding a checked-out pooled connection, so a leaked one
+ * can be found and reclaimed. A client that is never disposed holds that
+ * connection *and* an open transaction forever: Postgres reports it as `idle
+ * in transaction` with `wait_event = ClientRead`, and the pool loses the slot
+ * permanently. Once the leak count reaches the pool's `max`, every request
+ * hangs in `pool.connect()`.
+ *
+ * Membership is tied to holding a connection rather than to the client's
+ * lifetime, so the set stays bounded by the pool size no matter how many
+ * clients are constructed or whether anything disposes them.
+ */
+const connectionHolders = new Set<TenantAwareDBClient>();
+
+export interface TenantDbClientStats {
+  /** Clients holding a checked-out connection right now. */
+  holdingConnection: number;
+  /** Longest any holder has gone without issuing a query. */
+  maxIdleMs: number;
+}
+
+export function getTenantDbClientStats(): TenantDbClientStats {
+  const now = Date.now();
+  let maxIdleMs = 0;
+
+  for (const client of connectionHolders) {
+    maxIdleMs = Math.max(maxIdleMs, now - client.lastActivityAt);
+  }
+
+  return { holdingConnection: connectionHolders.size, maxIdleMs };
+}
+
+export interface WatchdogOptions {
+  /** Force-dispose a client idle for longer than this. */
+  maxIdleMs: number;
+  /** How often to sweep. */
+  intervalMs: number;
+  onLeak?: (info: { idleMs: number; lastQuery: string | null }) => void;
+}
+
+/**
+ * Last line of defence against a connection leak.
+ *
+ * Disposal is driven by request lifecycle hooks, and the whole class of bug
+ * this guards against is a hook that does not fire. So the watchdog trusts no
+ * hook: it sweeps every live client and reclaims any that has gone quiet for
+ * longer than a request could plausibly stay quiet.
+ *
+ * The predicate is *idle* time (since the last query), not total age — a slow
+ * but healthy request keeps querying, while a leaked client never issues
+ * another statement, so its idle time grows without bound.
+ */
+export function startTenantDbClientWatchdog(options: WatchdogOptions): { stop: () => void } {
+  const timer = setInterval(() => {
+    const now = Date.now();
+    for (const client of connectionHolders) {
+      if (now - client.lastActivityAt < options.maxIdleMs) {
+        continue;
+      }
+
+      const info = { idleMs: now - client.lastActivityAt, lastQuery: client.lastQuery };
+      options.onLeak?.(info);
+      void client.dispose().catch(error => {
+        console.error('Watchdog failed to dispose leaked TenantAwareDBClient:', error);
+      });
+    }
+  }, options.intervalMs);
+
+  // Never hold the event loop open just to sweep.
+  timer.unref();
+
+  return { stop: () => clearInterval(timer) };
+}
+
+/**
  * TenantAwareDBClient enforces Row-Level Security (RLS) by setting PostgreSQL
  * session variables on a request-scoped transaction.
  *
@@ -79,6 +153,16 @@ export class TenantAwareDBClient {
   private isDisposed = false;
   private authContext: AuthContext | null = null;
   private authContextInitialized = false;
+  private clientErrorListener: ((error: Error) => void) | null = null;
+
+  /** Timestamp of the last query issued, for leak detection. See the watchdog. */
+  public lastActivityAt = Date.now();
+  /** First line of the last statement issued, to identify a leak's origin. */
+  public lastQuery: string | null = null;
+
+  public get holdsConnection(): boolean {
+    return this.activeClient !== null;
+  }
 
   /**
    * Per-operation mode: commit and release the connection after every
@@ -108,6 +192,12 @@ export class TenantAwareDBClient {
     }
   }
 
+  /** Records query activity so the watchdog can tell a busy client from a leaked one. */
+  private markActivity(text: string): void {
+    this.lastActivityAt = Date.now();
+    this.lastQuery = text.trim().split('\n')[0]?.slice(0, 120) ?? null;
+  }
+
   /**
    * Execute a query with RLS enforcement on the request-scoped session.
    * Data-modifying statements are committed immediately.
@@ -128,7 +218,9 @@ export class TenantAwareDBClient {
 
     // Inside an explicit transaction() scope — run on its client directly.
     if (this.storage.getStore() && this.activeClient) {
+      this.markActivity(text);
       const result = await this.activeClient.query<T>(text, params);
+      this.markActivity(text);
       return { ...result, rowCount: result.rowCount ?? 0 };
     }
 
@@ -136,7 +228,9 @@ export class TenantAwareDBClient {
       this.ensureNotDisposed();
       const client = await this.ensureSession();
       try {
+        this.markActivity(text);
         const result = await client.query<T>(text, params);
+        this.markActivity(text);
         if (this.autoRelease || isDataModifyingQuery(text)) {
           await this.endSession('COMMIT');
         }
@@ -231,7 +325,27 @@ export class TenantAwareDBClient {
    * Always called while holding the mutex.
    */
   private async ensureSession(): Promise<PoolClient> {
-    this.activeClient ||= await this.dbProvider.pool.connect();
+    if (!this.activeClient) {
+      const client = await this.dbProvider.pool.connect();
+
+      // pg removes its own idle-client error handler while a client is checked
+      // out, leaving the borrower responsible for it. Without a listener here,
+      // a connection reset — including Postgres terminating the session via
+      // `idle_in_transaction_session_timeout` — emits an unhandled 'error'
+      // event, which surfaces as an uncaughtException and takes down the whole
+      // process. Absorb it and let the pool discard the connection instead.
+      const onClientError = (error: Error) => {
+        console.error('[db] Error on checked-out client, discarding connection:', error);
+        this.sessionOpen = false;
+        this.activeClient = null;
+        this.clientErrorListener = null;
+        connectionHolders.delete(this);
+      };
+      client.on('error', onClientError);
+      this.clientErrorListener = onClientError;
+      this.activeClient = client;
+      connectionHolders.add(this);
+    }
 
     if (!this.sessionOpen) {
       const client = this.activeClient;
@@ -247,12 +361,7 @@ export class TenantAwareDBClient {
         } catch {
           // Ignore rollback errors (e.g. if connection closed)
         }
-        try {
-          client.release(true);
-        } catch {
-          // Ignore release errors
-        }
-        this.activeClient = null;
+        this.releaseClient(true);
         throw error;
       }
     }
@@ -274,19 +383,19 @@ export class TenantAwareDBClient {
       await this.activeClient.query(mode);
     } catch (error) {
       console.error(`Failed to ${mode} transaction:`, error);
-      try {
-        this.activeClient.release(true);
-      } catch {
-        // Ignore release errors
-      }
-      this.activeClient = null;
+      this.releaseClient(true);
     }
   }
 
-  private releaseClient(): void {
+  private releaseClient(destroy = false): void {
+    connectionHolders.delete(this);
     if (this.activeClient) {
+      if (this.clientErrorListener) {
+        this.activeClient.removeListener('error', this.clientErrorListener);
+        this.clientErrorListener = null;
+      }
       try {
-        this.activeClient.release();
+        this.activeClient.release(destroy);
       } catch (e) {
         console.error('Error releasing client:', e);
       }
@@ -355,7 +464,7 @@ export class TenantAwareDBClient {
     if (this.isDisposed) return;
 
     if (!this.activeClient) {
-      this.isDisposed = true;
+      this.markDisposed();
       return;
     }
 
@@ -379,7 +488,7 @@ export class TenantAwareDBClient {
       // Mark disposed to prevent further usage, and schedule cleanup for when
       // the in-flight operation finishes — otherwise the held connection would
       // leak from the pool.
-      this.isDisposed = true;
+      this.markDisposed();
       void this.mutex
         .runExclusive(async () => {
           await this.endSession('ROLLBACK');
@@ -398,10 +507,15 @@ export class TenantAwareDBClient {
       // COMMIT keeps a missed write-classification durable as a safety net.
       await this.endSession('COMMIT');
       this.releaseClient();
-      this.isDisposed = true;
+      this.markDisposed();
     } finally {
       release();
     }
+  }
+
+  private markDisposed(): void {
+    this.isDisposed = true;
+    connectionHolders.delete(this);
   }
 
   private ensureNotDisposed() {

--- a/packages/server/src/observability/pool-monitor.ts
+++ b/packages/server/src/observability/pool-monitor.ts
@@ -1,0 +1,68 @@
+import { monitorEventLoopDelay } from 'node:perf_hooks';
+import type { Pool } from 'pg';
+import { getTenantDbClientStats } from '../modules/app-providers/tenant-db-client.js';
+
+const NS_PER_MS = 1e6;
+
+export interface PoolMonitorOptions {
+  pool: Pool;
+  /** Emit a heartbeat this often. */
+  intervalMs: number;
+  /** Pool size, for saturation reporting. */
+  max: number;
+}
+
+/**
+ * Periodic health heartbeat for the Postgres pool.
+ *
+ * The failure this exists for is silent by construction: an exhausted pool
+ * produces no error, no CPU, and no log line — requests simply queue in
+ * `pool.connect()` forever. `waiting > 0` alongside `idle === 0` is that state,
+ * visible in a single line, and the heartbeat continuing to print at all is
+ * proof the event loop is still turning.
+ */
+export function startPoolMonitor({ pool, intervalMs, max }: PoolMonitorOptions): {
+  stop: () => void;
+} {
+  const loopDelay = monitorEventLoopDelay({ resolution: 20 });
+  loopDelay.enable();
+
+  const timer = setInterval(() => {
+    const clients = getTenantDbClientStats();
+    const saturated = pool.waitingCount > 0 || pool.totalCount - pool.idleCount >= max;
+
+    const snapshot = {
+      msg: 'db-pool-heartbeat',
+      pool: {
+        total: pool.totalCount,
+        idle: pool.idleCount,
+        waiting: pool.waitingCount,
+        max,
+      },
+      sessions: {
+        holdingConnection: clients.holdingConnection,
+        maxIdleMs: clients.maxIdleMs,
+      },
+      eventLoopDelayP99Ms: Math.round(loopDelay.percentile(99) / NS_PER_MS),
+    };
+
+    // A saturated pool is one step from wedging every request — say so loudly.
+    if (saturated) {
+      console.error(JSON.stringify({ ...snapshot, level: 'error', saturated: true }));
+    } else {
+      console.log(JSON.stringify(snapshot));
+    }
+
+    loopDelay.reset();
+  }, intervalMs);
+
+  // The heartbeat must never be the reason the process stays alive.
+  timer.unref();
+
+  return {
+    stop: () => {
+      clearInterval(timer);
+      loopDelay.disable();
+    },
+  };
+}

--- a/packages/server/src/plugins/__tests__/db-cleanup-plugin.test.ts
+++ b/packages/server/src/plugins/__tests__/db-cleanup-plugin.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import { dbCleanupPlugin } from '../db-cleanup-plugin.js';
+import type { AccounterContext } from '../../shared/types/index.js';
+
+type ContextBuildingArg = Parameters<
+  NonNullable<ReturnType<typeof dbCleanupPlugin>['onContextBuilding']>
+>[0];
+
+/** Context carrying a real AbortController, as Yoga supplies per request. */
+function buildContext(controller: AbortController) {
+  return { request: { signal: controller.signal } } as unknown as AccounterContext;
+}
+
+function onContextBuilding(context: AccounterContext) {
+  dbCleanupPlugin().onContextBuilding?.({ context } as unknown as ContextBuildingArg);
+}
+
+describe('dbCleanupPlugin', () => {
+  it('initializes the disposal list', () => {
+    const context = buildContext(new AbortController());
+
+    onContextBuilding(context);
+
+    expect(context.dbClientsToDispose).toEqual([]);
+  });
+
+  it('disposes clients when the client cancels the request mid-execution', async () => {
+    // The leak this guards against: urql aborts the in-flight query on every
+    // keystroke, so execution never completes and `onExecuteDone` never fires.
+    const controller = new AbortController();
+    const context = buildContext(controller);
+    onContextBuilding(context);
+
+    const dispose = vi.fn().mockResolvedValue(undefined);
+    context.dbClientsToDispose!.push({ dispose });
+
+    controller.abort();
+
+    await vi.waitFor(() => {
+      expect(dispose).toHaveBeenCalledTimes(1);
+      // Cleared so a later disposal pass cannot double-dispose.
+      expect(context.dbClientsToDispose).toEqual([]);
+    });
+  });
+
+  it('disposes clients registered after the abort listener was attached', async () => {
+    // Clients are constructed during execution, well after context building.
+    const controller = new AbortController();
+    const context = buildContext(controller);
+    onContextBuilding(context);
+
+    const first = vi.fn().mockResolvedValue(undefined);
+    const second = vi.fn().mockResolvedValue(undefined);
+    context.dbClientsToDispose!.push({ dispose: first }, { dispose: second });
+
+    controller.abort();
+
+    await vi.waitFor(() => {
+      expect(first).toHaveBeenCalledTimes(1);
+      expect(second).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('handles a request that was already aborted before context building', () => {
+    const controller = new AbortController();
+    controller.abort();
+    const context = buildContext(controller);
+
+    // `addEventListener('abort')` never fires on an already-aborted signal, so
+    // the plugin must handle this case explicitly rather than silently
+    // attaching a listener that will never run.
+    expect(() => onContextBuilding(context)).not.toThrow();
+    expect(context.dbClientsToDispose).toEqual([]);
+  });
+
+  it('does not throw when the context carries no request signal', () => {
+    const context = {} as AccounterContext;
+
+    expect(() => onContextBuilding(context)).not.toThrow();
+    expect(context.dbClientsToDispose).toEqual([]);
+  });
+});

--- a/packages/server/src/plugins/db-cleanup-plugin.ts
+++ b/packages/server/src/plugins/db-cleanup-plugin.ts
@@ -7,7 +7,29 @@ export function dbCleanupPlugin(): Plugin<AccounterContext> {
       // Initialize the cleanup list
       // Cast to AccounterContext to avoid potential readonly issues or type mismatches
       // during initial context building phase.
-      (context as AccounterContext).dbClientsToDispose = [];
+      const accounterContext = context as AccounterContext;
+      accounterContext.dbClientsToDispose = [];
+
+      // Dispose when the client goes away.
+      //
+      // `onExecuteDone` below only runs when execution *completes*. A request
+      // the client cancels mid-flight (urql aborts the previous query on every
+      // keystroke of a search box) rejects with an AbortError instead, so the
+      // hook never fires and the request-scoped connection is never released:
+      // it stays checked out of the pool, holding an open transaction, until
+      // the process restarts. Postgres reports these as `idle in transaction`
+      // with `wait_event = ClientRead`. Enough of them and the pool is gone and
+      // every subsequent request hangs forever in `pool.connect()`.
+      const signal = accounterContext.request?.signal;
+      if (signal) {
+        if (signal.aborted) {
+          void disposeClients(accounterContext);
+          return;
+        }
+        signal.addEventListener('abort', () => void disposeClients(accounterContext), {
+          once: true,
+        });
+      }
     },
     onExecute({ args }) {
       return {


### PR DESCRIPTION
## Summary

Adds a multi-layered defense system against Postgres connection leaks in the request-scoped database client. The original failure mode: when a GraphQL request is cancelled mid-execution (e.g., urql aborting on every keystroke), the `onExecuteDone` hook never fires, leaving the connection checked out indefinitely. Enough leaks exhaust the pool and wedge every subsequent request in `pool.connect()` with no error, no CPU, and no recovery path except a restart.

## Key Changes

- **Connection leak watchdog** (`startTenantDbClientWatchdog`): Sweeps all active clients periodically and force-disposes any that haven't issued a query in `POSTGRES_CLIENT_MAX_IDLE_MS` (default 5 min). Uses idle time, not age, so slow-but-active requests are untouched while leaked ones are reclaimed.

- **Connection holder tracking**: New `connectionHolders` Set tracks clients with checked-out connections. Bounded by pool size regardless of how many clients are constructed.

- **Error listener on checked-out clients**: pg removes its own idle-client error handler while a connection is checked out. Without a listener, a connection reset (including Postgres terminating via `idle_in_transaction_session_timeout`) emits an unhandled `'error'` event, crashing the process. Now absorbed and logged.

- **Request abort handler** (`dbCleanupPlugin`): Disposes clients when the client cancels the request mid-flight via `AbortSignal`, fixing the root cause of the leak.

- **Pool monitor heartbeat** (`startPoolMonitor`): Periodic log line reporting pool saturation, held connections, and event loop delay. Proves the event loop is alive and makes silent pool exhaustion visible.

- **Pool configuration**: Added `connectionTimeoutMillis`, `statement_timeout`, `idle_in_transaction_session_timeout`, `keepAlive`, and `application_name` to pool config for better observability and timeout enforcement.

- **Environment variables**: New config for timeouts, watchdog interval, and monitor interval with sensible defaults and detailed documentation.

- **Runbook** (`docs/operations/db-connection-pool.md`): Diagnostic guide, failure mode explanation, and configuration rationale.

- **Tests**: Comprehensive test coverage for leak detection, watchdog behavior, and abort handling.

## Implementation Details

- The watchdog is deliberately independent of request lifecycle hooks (which can fail to fire) — it sweeps every holder and reclaims based on idle time.
- Four overlapping defense layers: abort handler, watchdog, connection timeout, and server-side `idle_in_transaction_session_timeout`.
- Idle timeouts default to 5 minutes to avoid killing legitimate slow requests that hold connections across external I/O (OCR, API calls).
- The heartbeat continues printing even when the pool is exhausted, proving the event loop is responsive and ruling out a whole class of unrelated theories.

https://claude.ai/code/session_01TbVUKNr6YdsPsEaDh2F3ZK