### PR TITLE
fix(tooling): scope the root TypeScript project and repair type-aware ESLint

### DIFF
--- a/.changeset/scope-root-typescript-project.md
+++ b/.changeset/scope-root-typescript-project.md
@@ -1,0 +1,43 @@
+---
+'@accounter/server': patch
+---
+
+Fix the IDE TypeScript server restart loop and the `yarn lint` out-of-memory crash, both caused by
+the root `tsconfig.json` having no `include`.
+
+Without `include`, and with `allowJs: true`, the root config globbed the entire monorepo into a
+single program — 9854 files, ~4.3 GB peak heap, 79s to check. VS Code launches `tsserver` with
+`--max-old-space-size=3072`, so the root project could never fit: it OOM'd and was respawned
+continuously, which is what left the editor stuck on `Initializing 'tsconfig.json'` and
+`Loading IntelliSense status`. The same whole-repo program made `yarn lint` die at 4.08 GB.
+
+- **Root `tsconfig.json`** now sets `include` to the root-level scripts and config files it is
+  actually responsible for. It remains the `extends` base for every package. The root project drops
+  to 2238 files, 0.56 GB, 2.6s.
+- **`green-invoice-graphql`, `hashavshevet-mesh`, `israeli-vat-scraper`, `payper-mesh` and
+  `pcn874-generator`** gain an explicit `"include": ["src"]`. They had none and would otherwise
+  inherit the root's, which is scoped to root paths. No emit change — these packages have no `.ts`
+  outside `src/`, and each already pinned `rootDir: ./src`.
+- **`@accounter/server`**: the `declare global { namespace GraphQLModules }` augmentation moves out
+  of `modules-app.ts` into `src/shared/types/graphql-modules.d.ts`. A global augmentation buried in a
+  heavyweight entry file only applies when that file is in the program, so anything importing server
+  sources without pulling in the whole module graph lost `GlobalContext` and failed on
+  `dbClientsToDispose`. As a `.d.ts` it is cheap for other projects to include. Identical type
+  surface; the now-unused `RawAuth` import is dropped.
+- **`.vscode/settings.json`** raises the `tsserver` memory ceiling (the client project alone needs
+  ~1.9 GB), pins the workspace TypeScript version, and uses fsevents-based watching. Uses the current
+  `js/ts.*` setting IDs, since the `typescript.*`-prefixed ones are deprecated.
+
+**Type-aware ESLint was broken independently** and is fixed here too, because scoping the root
+project exposed it. `parserOptions.project` listed `'*/tsconfig.json'`, which resolves to
+`packages/tsconfig.json` — a file that does not exist. No package tsconfig was ever in the project
+list; every file under `packages/` was typed solely via the root glob-everything project. Replaced
+with `projectService: true`, which resolves the nearest `tsconfig.json` per file and cannot silently
+miss a package. Files that no tsconfig includes (`**/tests/`, `**/.storybook/`, `vite.config.ts`,
+`vitest.config.ts`, `packages/*/scripts/`, `packages/*/tools/`) are added to `ignores`, matching the
+existing `**/__tests__/` and `**/tsup.config.ts` entries. The root `lint` script raises the Node heap
+to 8 GB — the client and server programs coexist in one process and exceed the ~4 GB default.
+
+`yarn lint` now exits 0 (852 pre-existing warnings, 837 of them the intentionally-`warn` `no-console`
+rule). Type resolution is verified working, not merely quiet: a floating-promise probe under
+`@typescript-eslint/no-floating-promises` errors as it should.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,14 @@
       "tooltip": "Start dev environment"
     }
   ],
+  // TS server: this monorepo's largest project (client) needs ~1.9GB; default cap is 3GB.
+  "js/ts.tsserver.maxMemory": 6144,
+  // Use the repo's TypeScript (6.0.3), not VS Code's bundled version.
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsserver.watchOptions": {
+    "watchFile": "useFsEventsOnParentDirectory",
+    "watchDirectory": "useFsEvents"
+  },
   "editor.formatOnSave": true,
   "cSpell.words": ["Hashavshevet", "mantine"],
   "prettier.configPath": "./prettier.config.mjs",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,6 +56,12 @@ export default [
       '**/__generated__/',
       '**/schema.graphql',
       '**/__tests__/',
+      '**/tests/',
+      '**/.storybook/',
+      '**/vite.config.ts',
+      '**/vitest.config.ts',
+      'packages/*/scripts/',
+      'packages/*/tools/',
       '**/.eslintrc.cjs',
       '**/.*rc.*js',
       '**/.bob/',
@@ -75,7 +81,11 @@ export default [
       sourceType: 'script',
 
       parserOptions: {
-        project: ['tsconfig.json', '*/tsconfig.json', 'packages/*/tsconfig.scripts.json'],
+        // Resolve the nearest tsconfig.json per file. Replaces a `project` glob list that
+        // silently matched nothing under packages/ and fell back to the (whole-repo) root
+        // project, which OOM'd ESLint.
+        projectService: true,
+        tsconfigRootDir: __dirname,
       },
     },
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "generate:watch": "concurrently -c blue,green -n GraphQL,SQL \"yarn generate:graphql --watch\" \"yarn generate:sql:watch\"",
     "graphql:coverage": "yarn graphql-inspector coverage './packages/client/src/**/*.{ts,tsx}' './schema.graphql'",
     "graphql:validate": "yarn graphql-inspector validate './packages/client/src/**/*.{ts,tsx}' './schema.graphql'",
-    "lint": "eslint --cache --cache-location node_modules/.cache/.eslintcache .",
+    "lint": "NODE_OPTIONS=--max-old-space-size=8192 eslint --cache --cache-location node_modules/.cache/.eslintcache .",
     "local:setup": "docker-compose -f ./docker/docker-compose.dev.yml up -d --wait && yarn setup",
     "mesh:artifacts-rename": "yarn node ./scripts/mesh-artifacts-rename.mjs",
     "migration:check-conflicts": "node --import ./scripts/register-esm.js ./scripts/check-migration-conflicts.ts",

--- a/packages/green-invoice-graphql/tsconfig.json
+++ b/packages/green-invoice-graphql/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "./src"
   },
+  "include": ["src"],
   "exclude": ["**/node_modules", "**/dist"]
 }

--- a/packages/hashavshevet-mesh/tsconfig.json
+++ b/packages/hashavshevet-mesh/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "./src"
   },
+  "include": ["src"],
   "exclude": ["**/node_modules", "**/dist"]
 }

--- a/packages/israeli-vat-scraper/tsconfig.json
+++ b/packages/israeli-vat-scraper/tsconfig.json
@@ -5,5 +5,6 @@
     "outDir": "dist",
     "rootDir": "./src"
   },
+  "include": ["src"],
   "exclude": ["**/node_modules", "**/dist"]
 }

--- a/packages/migrations/src/__tests__/rls-all-tables.test.ts
+++ b/packages/migrations/src/__tests__/rls-all-tables.test.ts
@@ -3,6 +3,7 @@ import { createConnectionString } from '../connection-string.js';
 import { env } from '../environment.js';
 import { runPGMigrations } from '../run-pg-migrations.js';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import z from 'zod';
 
 const TEST_DB_NAME = `accounter_migration_test_rls_${Date.now()}`;
 const TEST_ROLE_NAME = `rls_test_user_${Date.now()}`;
@@ -200,11 +201,11 @@ describe('RLS All Tables Migration', () => {
             `);
 
             // 3. Verify Visibility for A
-            const resultA = await connection.query(sql.unsafe`
-                SELECT * FROM accounter_schema.charges
+            const resultA = await connection.query(sql.type(z.object({ id: z.string() }))`
+                SELECT id FROM accounter_schema.charges
                 WHERE id = ${chargeIdA}
             `);
-            
+
             expect(resultA.rows).toHaveLength(1);
             expect(resultA.rows[0].id).toBe(chargeIdA);
           } finally {

--- a/packages/payper-mesh/tsconfig.json
+++ b/packages/payper-mesh/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "./src"
   },
+  "include": ["src"],
   "exclude": ["**/node_modules", "**/dist"]
 }

--- a/packages/pcn874-generator/tsconfig.json
+++ b/packages/pcn874-generator/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "./src"
   },
+  "include": ["src"],
   "exclude": ["**/node_modules", "**/dist"]
 }

--- a/packages/server/src/modules-app.ts
+++ b/packages/server/src/modules-app.ts
@@ -46,22 +46,10 @@ import { sortCodesModule } from './modules/sort-codes/index.js';
 import { tagsModule } from './modules/tags/index.js';
 import { transactionsModule } from './modules/transactions/index.js';
 import { vatModule } from './modules/vat/index.js';
-import type { RawAuth } from './plugins/auth-plugin.js';
 import { ENVIRONMENT, RAW_AUTH } from './shared/tokens.js';
 import type { Environment } from './shared/types/index.js';
 
 const { Pool } = pg;
-
-declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
-  namespace GraphQLModules {
-    interface GlobalContext {
-      env: Environment;
-      rawAuth: RawAuth;
-      dbClientsToDispose?: { dispose: () => Promise<void> }[];
-    }
-  }
-}
 
 export async function createGraphQLApp(env: Environment, pool: pg.Pool) {
   const application = createApplication({

--- a/packages/server/src/shared/types/graphql-modules.d.ts
+++ b/packages/server/src/shared/types/graphql-modules.d.ts
@@ -1,0 +1,12 @@
+import type { RawAuth } from '../../plugins/auth-plugin.js';
+import type { Environment } from './index.js';
+
+declare global {
+  namespace GraphQLModules {
+    interface GlobalContext {
+      env: Environment;
+      rawAuth: RawAuth;
+      dbClientsToDispose?: { dispose: () => Promise<void> }[];
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,6 +47,16 @@
       "graphql-modules": ["./node_modules/graphql-modules/index"]
     }
   },
+  "include": [
+    "scripts",
+    "codegen.ts",
+    "vitest.config.ts",
+    "*.mjs",
+    "graphql.config.js",
+    // Global GraphQLModules.GlobalContext augmentation, needed by any server
+    // source the root scripts pull in transitively.
+    "packages/server/src/shared/types/graphql-modules.d.ts"
+  ],
   "exclude": [
     "**/node_modules",
     "**/dist",


### PR DESCRIPTION
## Problem

The IDE's TypeScript server was stuck in a restart loop — `Initializing 'tsconfig.json'` and `Loading IntelliSense status` never completing. Root cause: the root `tsconfig.json` had **no `include`**, so with `allowJs: true` it globbed the entire monorepo into one program.

```
Files:      9854   (client + server + every scraper + all generated gql)
Total time:   79s
Max RSS:    4.32 GB
```

VS Code launches `tsserver` with `--max-old-space-size=3072`. The root project needed **4.3 GB against a 3 GB ceiling**, so it OOM'd and was respawned forever. Caught in the act: the same tsserver kept reappearing under new PIDs with a few seconds' uptime and RSS climbing toward the cap.

The per-package projects were never the problem (client 1.87 GB, server 0.98 GB — both fit). Only the root one, which any file outside a package opens: `scripts/*.ts`, `codegen.ts`, `vitest.config.ts`.

The same whole-repo program made `yarn lint` die at 4.08 GB.

## Changes

**Root `tsconfig.json`** — `include` now scopes it to the root-level scripts and configs it is actually responsible for. It stays the `extends` base for every package.

| | before | after |
|---|---|---|
| Files | 9854 | 2238 |
| Time | 79s | 2.6s |
| Max RSS | 4.32 GB | 0.56 GB |

**Five package tsconfigs** (`green-invoice-graphql`, `hashavshevet-mesh`, `israeli-vat-scraper`, `payper-mesh`, `pcn874-generator`) — added `"include": ["src"]`. They had none and would otherwise inherit the root's, which is now root-relative. No emit change: verified none has a `.ts` outside `src/`, and each already set `rootDir: ./src`.

**`@accounter/server`** — moved the `declare global { namespace GraphQLModules }` augmentation out of `modules-app.ts` into `src/shared/types/graphql-modules.d.ts`. Scoping the root project surfaced a latent fragility: a global augmentation buried in a heavyweight entry file only applies when that file is in the program, so anything importing server sources without pulling in the whole module graph lost `GlobalContext` and failed on `dbClientsToDispose`. As a `.d.ts` it is cheap for other projects to include. Identical type surface; dropped the now-unused `RawAuth` import.

**`.vscode/settings.json`** — raised the tsserver memory ceiling, pinned the workspace TypeScript version, fsevents watching. Uses the current `js/ts.*` setting IDs (the `typescript.*` ones are deprecated).

### Type-aware ESLint was separately broken

`parserOptions.project` listed `'*/tsconfig.json'`, which resolves to `packages/tsconfig.json` — **a file that does not exist**. No package tsconfig was ever in the project list; everything under `packages/` was typed solely via the root glob-everything project. That is why scoping the root project turned a lint OOM into 1193 `Parsing error` reports.

Replaced with `projectService: true` (resolves the nearest tsconfig per file, cannot silently miss a package). Files no tsconfig includes — `**/tests/`, `**/.storybook/`, `vite.config.ts`, `vitest.config.ts`, `packages/*/scripts/`, `packages/*/tools/` — go into `ignores`, matching the existing `**/__tests__/` and `**/tsup.config.ts` entries. The root `lint` script raises the Node heap to 8 GB, since the client and server programs coexist in one process and exceed the ~4 GB default.

### Drive-by

`packages/migrations/src/__tests__/rls-all-tables.test.ts` had a pre-existing `TS2571: Object is of type 'unknown'` — it indexed into a `sql.unsafe` result, whose rows are `unknown`. Now declares the row shape with a zod schema via slonik's `sql.type`, so the row is typed *and* validated at runtime rather than asserted with an unchecked cast, and the projection is narrowed to the one column asserted on.

## Verification

- `yarn lint` → **exit 0** (852 warnings, all pre-existing; 837 are the intentionally-`warn` `no-console` rule).
- Lint coverage is real, not silenced: findings across 151 client files, 116 server files, 5 root `scripts/` files.
- Type information genuinely resolves — a floating-promise probe correctly errors under `@typescript-eslint/no-floating-promises`, and a `console.log` probe fires `no-console`. Both probes deleted.
- `tsc --noEmit` clean on the root project and all 17 active packages.
- Lint measurements taken with `--no-cache` on both trees; a stale `.eslintcache` otherwise makes a crashed run look like a completed one.

## Not addressed

- `yarn prettier --check` flags `packages/mcp-server/bench/summary.md` and `packages/scraper-app/history.json`. Both fail identically on `main` and are outside this diff.
- The `**/tests/` and config/script `ignores` reduce nominal lint coverage. Those files were never successfully linted before, so nothing regressed — but the more thorough option is adding them to the relevant package tsconfig `include`s so they get typechecked *and* linted. That risks surfacing new errors in never-checked code, so it belongs in its own pass.
- The migrations test's zod validation path is typechecked but not executed here. It needs a live Postgres, and it does `CREATE DATABASE` / `CREATE ROLE` / `DROP DATABASE`, so it must be pointed at a local DB rather than whatever `.env` resolves to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)