### PR TITLE
feat(mcp-server): log every tool call, with glossary lookups enriched

### DIFF
--- a/.changeset/mcp-tool-usage-logging.md
+++ b/.changeset/mcp-tool-usage-logging.md
@@ -1,0 +1,51 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Log every tool call as one structured `event: "tool_call"` line, with glossary lookups enriched.
+
+`accounter_explain_terminology` is a read of caller *intent*: what someone asks the glossary is the
+clearest available signal of the vocabulary they arrived with and what they were trying to do before
+they knew how to ask for data. None of it was being recorded. Nor was anything else about a tool
+call — `executeRegisteredTool` fed the in-memory metrics registry and returned, so a successful
+`tools/call` produced no log line at all, and the per-request logs in `server.ts` cannot fill the gap
+because every MCP call is the same `POST /mcp`. This also closes a documented gap: `docs/spec.md`
+§11.1 asks for per-request logs carrying `user_id`, `business_scope`, `tool_name`, outcome and
+`latency_ms`, none of which were logged.
+
+Every completed call now emits exactly one line tagged `event: "tool_call"` — on every path,
+including the validation, authorization and rate-limit rejections that never reach a handler —
+carrying `tool`, `outcome` (the same label set as the `requestsTotal` metric), `latencyMs`, `userId`,
+`correlationId`, `businessScopeSize`, and, for anything built with the shared list shaping,
+`returnedCount`/`totalCount`/`truncated`. `event` is a stable discriminator so the stream can be
+selected on without matching free-text messages.
+
+A tool enriches its own line through a new optional `observe(input, result)` hook on
+`ToolDefinition`. It is deliberately not a field on `ToolResult`: `tools/call` returns that object
+verbatim as the JSON-RPC payload, so telemetry attached there would be sent to every caller. The
+hook is pure, guarded against throwing (a broken hook must not turn a successful call into an error),
+and its fields are merged *beneath* the canonical ones — a tool cannot misreport its own name,
+outcome, or caller.
+
+The glossary implements it with `glossaryMode`, `requestedTerms` (verbatim, so an alias the caller
+reached for stays visible), `matchedTerms` (canonical), `missedTerms` and `requestedTopics`, plus
+three label counters — `glossary_term_requests`, `glossary_term_misses` and `glossary_mode` — exposed
+under a new `labeledTotals` key on `GET /metrics`, so "most-requested term" and "terms we do not
+define yet" are one `curl` away and do not require parsing logs. Two decisions there are load-bearing:
+
+- **Matches are resolved from the input, not read back off the result.** A call carrying
+  `topics: ["charge"]` returns every charge entry, and none of those was individually asked for;
+  counting them would turn "most-requested term" into a measure of topic breadth. Index mode, which
+  returns all 62 entries, credits no individual term at all for the same reason.
+- **Label cardinality is capped.** Miss labels derive from caller input, so they are folded (one
+  concept, one label, regardless of spelling), clipped to 40 characters, and bounded at
+  `MAX_COUNTER_LABELS` distinct labels per counter with further new labels folded into `__other__`.
+  Labels already tracked keep counting, so the top-N stays accurate once the cap is reached. Worth
+  knowing: `/metrics` is unauthenticated while calling a tool requires a valid token, so miss labels
+  are authenticated-write and publicly readable — bounded to junk vocabulary by the folding and the
+  caps, and the glossary tool is classified `public` with no customer data, but a reason to gate
+  `/metrics` eventually.
+
+Guarded by a registry-wide test in the style of `scope-forwarding.test.ts`: it iterates the
+production registry and asserts every registered tool emits exactly one canonical `tool_call` line,
+so a tool added later cannot silently ship without usage logging.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -269,12 +269,38 @@ process (labels never carry PII — only tool names, outcome classes, and error 
   from "tokens are misconfigured/abused".
 - **`upstreamErrorsTotal`** — upstream failure counter keyed by category.
 - **`rateLimitedTotal`** — total rate-limited requests.
+- **`labeledTotals`** — tool-contributed usage counters, keyed by counter name then label (see
+  [Usage logging](#usage-logging)). Distinct labels per counter are capped, with new labels beyond
+  the cap folded into `__other__`, because some labels derive from caller input.
 
 A snapshot is exposed at `GET /metrics`:
 
 ```bash
 curl http://localhost:3100/metrics
 ```
+
+### Usage logging
+
+Operational telemetry answers "is it healthy"; usage telemetry answers "what are callers trying to
+do". Every completed tool call emits exactly one structured log line tagged `event: "tool_call"` —
+including calls rejected by validation, policy, or the rate limiter — carrying `tool`, `outcome`,
+`latencyMs`, `userId`, `correlationId`, `businessScopeSize`, and result-size fields. The
+request-level logs cannot carry this: every MCP call is the same `POST /mcp`.
+
+A tool can enrich its own line through the optional `observe` hook on its `ToolDefinition`
+(`src/tools/registry.ts`). The hook is pure, guarded against throwing, and deliberately separate
+from `ToolResult` — `tools/call` returns the result object verbatim as the JSON-RPC payload, so
+anything attached there would be sent to the caller. Tool-supplied fields are merged _beneath_ the
+canonical ones, so a tool cannot misreport its own name, outcome, or caller.
+
+`accounter_explain_terminology` uses it to record what callers ask the glossary — `requestedTerms`
+(verbatim), `matchedTerms` (canonical), `missedTerms`, `requestedTopics` and `glossaryMode` — plus
+the `glossary_term_requests`, `glossary_term_misses` and `glossary_mode` label counters. What a
+caller looks up is the clearest available read on the vocabulary they arrived with, and
+`missedTerms` is a self-maintaining backlog of glossary entries to write.
+
+See [`docs/operations-runbook.md`](./docs/operations-runbook.md) §3.1 for the full field reference
+and the `jq` extraction recipes (most-requested terms, missing terms, tool popularity).
 
 ### Tracing (OpenTelemetry → Grafana Tempo)
 

--- a/packages/mcp-server/docs/operations-runbook.md
+++ b/packages/mcp-server/docs/operations-runbook.md
@@ -28,9 +28,37 @@ Labels never carry PII — only tool names, outcome classes, and error categorie
 | `authFailuresTotal`   | counter by reason (`missing_token`, `expired_token`, `invalid_token`) | `expired_token` = live tokens aging out (clients should refresh); `invalid_token` = bad signature/issuer/audience → misconfig or abuse; a burst of `missing_token` = clients reconnecting (tokenless probes). |
 | `upstreamErrorsTotal` | counter by category                                                   | Sustained `TIMEOUT_ERROR`/`UPSTREAM_ERROR` → upstream health issue.                                                                                                                                           |
 | `rateLimitedTotal`    | counter                                                               | Sustained growth → limits too tight or a hot client.                                                                                                                                                          |
+| `labeledTotals`       | counter keyed `<counter> -> <label>`                                  | Tool-contributed usage counters (see below). `__other__` growing means a counter hit its label cap.                                                                                                           |
 
 Baseline latency targets and the load profile are captured by
 `packages/mcp-server/src/__tests__/perf.test.ts` (`yarn workspace @accounter/mcp-server benchmark`).
+
+### 2.1 Usage counters (`labeledTotals`)
+
+Tools contribute low-cardinality label counters through their `observe` hook. These answer product
+questions about how the connector is actually being used, not operational ones:
+
+| Counter                  | Label                           | Answers                                                        |
+| ------------------------ | ------------------------------- | -------------------------------------------------------------- |
+| `glossary_term_requests` | canonical glossary term         | Which terminology callers look up most (≤62 labels).           |
+| `glossary_term_misses`   | folded, 40-char-clipped request | Terms callers asked for that the glossary does not define yet. |
+| `glossary_mode`          | `index` \| `full`               | Browse-the-index-first vs. direct lookup.                      |
+
+```bash
+curl -s "$MCP_BASE_URL/metrics" | jq '.labeledTotals'
+```
+
+Two caveats before you read anything into these numbers:
+
+- **Per process, and reset on restart.** These are in-memory counters, so a redeploy or a spin-down
+  zeroes them and a multi-instance deployment splits them. Treat them as a live sample; the log
+  stream is the durable record.
+- **`/metrics` is unauthenticated, while calling a tool requires a valid token.**
+  `glossary_term_misses` labels are therefore caller-supplied text that is publicly readable. They
+  are folded, clipped to 40 characters, and capped at `MAX_COUNTER_LABELS` distinct labels per
+  counter (further new labels land in `__other__`), which bounds this to junk vocabulary rather than
+  data — the glossary tool is classified `public` and touches no customer data. Worth closing when
+  `/metrics` gets gated.
 
 ## 3. Logs
 
@@ -67,6 +95,63 @@ Useful queries (adapt to your log backend):
 - **Slow requests**: completion logs where `latencyMs` exceeds your target.
 - **Unexpected tool errors**: `message == "unexpected error during tool execution"` (carries `tool`,
   `correlationId`, and the sanitized error) — these map to `INTERNAL_ERROR` for callers.
+
+### 3.1 Tool-call usage logs (`event: "tool_call"`)
+
+Every completed tool call emits exactly one line with `event: "tool_call"` — including calls
+rejected by validation, policy, or the rate limiter, which never reach a handler. This is the only
+per-tool record: every MCP call is the same `POST /mcp`, so the
+`request started`/`request completed` pair cannot tell one tool from another.
+
+`event` is the stable discriminator to select on; prefer it over matching the free-text `message`.
+
+Common fields:
+
+| Field                                        | Meaning                                                                          |
+| -------------------------------------------- | -------------------------------------------------------------------------------- |
+| `tool`                                       | Registered tool name.                                                            |
+| `outcome`                                    | Same label set as the `requestsTotal` metric (`success`, `validation_error`, …). |
+| `latencyMs`                                  | End-to-end time inside the executor.                                             |
+| `userId`                                     | Auth0 subject of the caller.                                                     |
+| `correlationId`                              | Ties the call to its request and to the upstream GraphQL hop.                    |
+| `businessScopeSize`                          | Number of businesses in the resolved read scope; absent when no handler ran.     |
+| `returnedCount` / `totalCount` / `truncated` | Result size, for any tool using the shared list shaping.                         |
+
+Glossary-specific fields (`accounter_explain_terminology`), which are the readable signal of what a
+caller was trying to do before they knew how to ask for data:
+
+| Field                | Meaning                                                                         |
+| -------------------- | ------------------------------------------------------------------------------- |
+| `glossaryMode`       | `index` (asked what exists) or `full` (asked what something means).             |
+| `requestedTerms`     | Verbatim spellings the caller used, e.g. `valueDate`.                           |
+| `matchedTerms`       | Canonical terms those resolved to, e.g. `value-date`.                           |
+| `missedTerms`        | Requested terms the glossary does not define — the backlog of entries to write. |
+| `requestedTopics`    | Topics asked for in full.                                                       |
+| `requestedTermCount` | Number of terms explicitly named (`0` in index mode and for topic-only calls).  |
+
+Note that terms pulled in by `topics` are deliberately **not** counted as requested — a
+`topics: ["charge"]` call returns every charge entry, and crediting each one would turn
+"most-requested term" into a measure of topic breadth.
+
+Extraction recipes (pipe your platform's log stream in; `jq -c` on a file works the same):
+
+```bash
+# Most-requested glossary terms
+jq -r 'select(.event=="tool_call") | .matchedTerms // [] | .[]' logs.jsonl \
+  | sort | uniq -c | sort -rn
+
+# Terms callers asked for that the glossary is missing — the content backlog
+jq -r 'select(.event=="tool_call") | .missedTerms // [] | .[]' logs.jsonl \
+  | sort | uniq -c | sort -rn
+
+# Which tool a caller reached for after a glossary lookup, in order
+jq -r 'select(.event=="tool_call") | [.userId, .tool, (.matchedTerms // [] | join(","))] | @tsv' \
+  logs.jsonl
+
+# Tool popularity and error rate
+jq -r 'select(.event=="tool_call") | "\(.tool)\t\(.outcome)"' logs.jsonl \
+  | sort | uniq -c | sort -rn
+```
 
 ## 4. Incident playbooks
 

--- a/packages/mcp-server/docs/operations-runbook.md
+++ b/packages/mcp-server/docs/operations-runbook.md
@@ -107,15 +107,15 @@ per-tool record: every MCP call is the same `POST /mcp`, so the
 
 Common fields:
 
-| Field                                        | Meaning                                                                          |
-| -------------------------------------------- | -------------------------------------------------------------------------------- |
-| `tool`                                       | Registered tool name.                                                            |
-| `outcome`                                    | Same label set as the `requestsTotal` metric (`success`, `validation_error`, …). |
-| `latencyMs`                                  | End-to-end time inside the executor.                                             |
-| `userId`                                     | Auth0 subject of the caller.                                                     |
-| `correlationId`                              | Ties the call to its request and to the upstream GraphQL hop.                    |
-| `businessScopeSize`                          | Number of businesses in the resolved read scope; absent when no handler ran.     |
-| `returnedCount` / `totalCount` / `truncated` | Result size, for any tool using the shared list shaping.                         |
+| Field                                        | Meaning                                                                                                                                                                                                                  |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `tool`                                       | Registered tool name.                                                                                                                                                                                                    |
+| `outcome`                                    | Same label set as the `requestsTotal` metric (`success`, `validation_error`, …).                                                                                                                                         |
+| `latencyMs`                                  | End-to-end time inside the executor.                                                                                                                                                                                     |
+| `userId`                                     | Auth0 subject of the caller.                                                                                                                                                                                             |
+| `correlationId`                              | Ties the call to its request and to the upstream GraphQL hop.                                                                                                                                                            |
+| `businessScopeSize`                          | Businesses in the resolved read scope. Present once the policy resolved a scope, **including a rate-limited call** (scope is resolved before the limiter runs); absent only for a validation or authorization rejection. |
+| `returnedCount` / `totalCount` / `truncated` | Result size, for any tool using the shared list shaping.                                                                                                                                                                 |
 
 Glossary-specific fields (`accounter_explain_terminology`), which are the readable signal of what a
 caller was trying to do before they knew how to ask for data:

--- a/packages/mcp-server/src/observability/__tests__/metrics.test.ts
+++ b/packages/mcp-server/src/observability/__tests__/metrics.test.ts
@@ -3,8 +3,10 @@ import type { McpErrorCode } from '../../errors/taxonomy.js';
 import {
   getMetrics,
   LATENCY_BUCKETS_MS,
+  MAX_COUNTER_LABELS,
   Metrics,
   outcomeForCode,
+  OVERFLOW_LABEL,
   resetMetrics,
   type RequestOutcome,
 } from '../metrics.js';
@@ -103,6 +105,61 @@ describe('Metrics', () => {
     expect(snapshot.latencyMs.count).toBe(0);
     expect(snapshot.latencyMs.sum).toBe(0);
     expect(snapshot.latencyMs.buckets['+Inf']).toBe(0);
+    expect(snapshot.labeledTotals).toEqual({});
+  });
+});
+
+describe('Metrics.recordLabeled', () => {
+  it('counts labels per counter, keeping counters independent', () => {
+    const metrics = new Metrics();
+    metrics.recordLabeled('glossary_term_requests', 'charge');
+    metrics.recordLabeled('glossary_term_requests', 'charge');
+    metrics.recordLabeled('glossary_term_requests', 'ledger-record');
+    metrics.recordLabeled('glossary_mode', 'full');
+
+    expect(metrics.snapshot().labeledTotals).toEqual({
+      glossary_term_requests: { charge: 2, 'ledger-record': 1 },
+      glossary_mode: { full: 1 },
+    });
+  });
+
+  it('omits counters that were never touched', () => {
+    expect(new Metrics().snapshot().labeledTotals).toEqual({});
+  });
+
+  it('folds new labels into the overflow bucket once the cap is reached', () => {
+    const metrics = new Metrics();
+    for (let i = 0; i < MAX_COUNTER_LABELS; i += 1) {
+      metrics.recordLabeled('misses', `term-${i}`);
+    }
+    metrics.recordLabeled('misses', 'one-too-many');
+    metrics.recordLabeled('misses', 'another-one');
+
+    const labels = metrics.snapshot().labeledTotals.misses;
+    // Labels are caller-derived, so the map must not grow past the cap (+ the
+    // overflow bucket itself) no matter what a caller sends.
+    expect(Object.keys(labels)).toHaveLength(MAX_COUNTER_LABELS + 1);
+    expect(labels[OVERFLOW_LABEL]).toBe(2);
+    expect(labels['one-too-many']).toBeUndefined();
+  });
+
+  it('keeps counting labels it already tracks after the cap is reached', () => {
+    const metrics = new Metrics();
+    for (let i = 0; i < MAX_COUNTER_LABELS; i += 1) {
+      metrics.recordLabeled('misses', `term-${i}`);
+    }
+    metrics.recordLabeled('misses', 'overflowing');
+    metrics.recordLabeled('misses', 'term-0');
+
+    // The top-N that matters stays accurate; only unseen labels are collapsed.
+    expect(metrics.snapshot().labeledTotals.misses['term-0']).toBe(2);
+  });
+
+  it('is cleared by reset', () => {
+    const metrics = new Metrics();
+    metrics.recordLabeled('misses', 'frobnicator');
+    metrics.reset();
+    expect(metrics.snapshot().labeledTotals).toEqual({});
   });
 });
 

--- a/packages/mcp-server/src/observability/metrics.ts
+++ b/packages/mcp-server/src/observability/metrics.ts
@@ -42,6 +42,19 @@ export function outcomeForCode(code: McpErrorCode): RequestOutcome {
 /** Upper bounds (ms) for the latency histogram buckets. */
 export const LATENCY_BUCKETS_MS = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000] as const;
 
+/**
+ * Maximum distinct labels retained per labeled counter.
+ *
+ * Labeled counters carry values derived from tool input (e.g. a glossary term a
+ * caller asked for that does not exist), so their cardinality is bounded by the
+ * caller, not by us. Past this many labels, further *new* labels are folded into
+ * {@link OVERFLOW_LABEL} — labels already being tracked keep counting normally.
+ */
+export const MAX_COUNTER_LABELS = 200;
+
+/** Bucket that absorbs new labels once a counter reaches {@link MAX_COUNTER_LABELS}. */
+export const OVERFLOW_LABEL = '__other__';
+
 interface Histogram {
   /**
    * Per-bucket counts (non-cumulative): each entry counts observations that
@@ -64,6 +77,8 @@ export interface MetricsSnapshot {
   rateLimitedTotal: number;
   /** `mcp_request_latency_ms` histogram. */
   latencyMs: { count: number; sum: number; buckets: Record<string, number> };
+  /** Tool-contributed label counters, keyed by counter name then label. */
+  labeledTotals: Record<string, Record<string, number>>;
 }
 
 function inc(map: Map<string, number>, key: string): void {
@@ -74,6 +89,7 @@ export class Metrics {
   private readonly requests = new Map<string, number>();
   private readonly authFailures = new Map<string, number>();
   private readonly upstreamErrors = new Map<string, number>();
+  private readonly labeled = new Map<string, Map<string, number>>();
   private rateLimited = 0;
   private readonly latency: Histogram = {
     buckets: new Array(LATENCY_BUCKETS_MS.length + 1).fill(0),
@@ -115,18 +131,42 @@ export class Metrics {
     this.rateLimited += 1;
   }
 
+  /**
+   * Increment a labeled counter contributed by a tool's `observe` hook.
+   *
+   * Bounded on purpose: an unknown label arriving at a counter that already
+   * holds {@link MAX_COUNTER_LABELS} labels is counted under
+   * {@link OVERFLOW_LABEL} instead of adding a new key, so caller-derived labels
+   * cannot grow this map without limit. Known labels always increment, so the
+   * top-N that matters stays accurate once the cap is reached.
+   */
+  recordLabeled(counter: string, label: string): void {
+    let labels = this.labeled.get(counter);
+    if (!labels) {
+      labels = new Map<string, number>();
+      this.labeled.set(counter, labels);
+    }
+    const key = labels.has(label) || labels.size < MAX_COUNTER_LABELS ? label : OVERFLOW_LABEL;
+    inc(labels, key);
+  }
+
   snapshot(): MetricsSnapshot {
     const bucketLabels: Record<string, number> = {};
     for (const [i, bound] of LATENCY_BUCKETS_MS.entries()) {
       bucketLabels[String(bound)] = this.latency.buckets[i];
     }
     bucketLabels['+Inf'] = this.latency.buckets[LATENCY_BUCKETS_MS.length];
+    const labeledTotals: Record<string, Record<string, number>> = {};
+    for (const [counter, labels] of this.labeled) {
+      labeledTotals[counter] = Object.fromEntries(labels);
+    }
     return {
       requestsTotal: Object.fromEntries(this.requests),
       authFailuresTotal: Object.fromEntries(this.authFailures),
       upstreamErrorsTotal: Object.fromEntries(this.upstreamErrors),
       rateLimitedTotal: this.rateLimited,
       latencyMs: { count: this.latency.count, sum: this.latency.sum, buckets: bucketLabels },
+      labeledTotals,
     };
   }
 
@@ -134,6 +174,7 @@ export class Metrics {
     this.requests.clear();
     this.authFailures.clear();
     this.upstreamErrors.clear();
+    this.labeled.clear();
     this.rateLimited = 0;
     this.latency.buckets.fill(0);
     this.latency.count = 0;

--- a/packages/mcp-server/src/tools/__tests__/terminology-usage.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/terminology-usage.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { Metrics } from '../../observability/metrics.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { executeRegisteredTool, TOOL_CALL_EVENT } from '../execute.js';
+import {
+  EXPLAIN_TERMINOLOGY_TOOL_NAME,
+  explainTerminologyTool,
+  GLOSSARY_MODE_COUNTER,
+  GLOSSARY_TERM_MISSES_COUNTER,
+  GLOSSARY_TERM_REQUESTS_COUNTER,
+} from '../terminology.js';
+import { GLOSSARY } from '../terminology-data.js';
+
+/**
+ * Usage-telemetry suite for the glossary tool: what a caller asks the glossary
+ * is the readable signal of what they were trying to do, so these assertions
+ * pin the fields and counters that answer "most-requested term" and "which
+ * requested terms are missing".
+ *
+ * Driven through `executeRegisteredTool` (not the `observe` hook directly) so
+ * the log line and the counter recording are covered together with it.
+ */
+
+const PRINCIPAL: AuthPrincipal = {
+  subject: 'user-1',
+  issuer: 'https://tenant.auth0.com/',
+  audience: 'aud',
+  scopes: [],
+  email: null,
+  expiresAt: undefined,
+  claims: { sub: 'user-1' },
+};
+
+function authContext(memberBusinessIds: string[] = ['b1']): McpAuthContext {
+  return buildAuthContext(
+    PRINCIPAL,
+    memberBusinessIds.map(memberBusinessId => ({ memberBusinessId, roleId: 'accountant' })),
+  );
+}
+
+function client() {
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: vi.fn() as unknown as typeof fetch,
+  });
+}
+
+interface UsageLine {
+  event?: string;
+  tool?: string;
+  outcome?: string;
+  userId?: string;
+  latencyMs?: number;
+  glossaryMode?: string;
+  requestedTerms?: string[];
+  matchedTerms?: string[];
+  missedTerms?: string[];
+  requestedTopics?: string[];
+  requestedTermCount?: number;
+  returnedCount?: number;
+  [key: string]: unknown;
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** The single `tool_call` line emitted by the run. */
+function usageLine(): UsageLine {
+  const lines = logSpy.mock.calls
+    .map(call => JSON.parse(String(call[0])) as UsageLine)
+    .filter(entry => entry.event === TOOL_CALL_EVENT);
+  expect(lines).toHaveLength(1);
+  return lines[0];
+}
+
+async function run(rawArgs: unknown) {
+  const metrics = new Metrics();
+  const result = await executeRegisteredTool({
+    tool: explainTerminologyTool,
+    rawArgs,
+    auth: authContext(),
+    correlationId: 'corr-1',
+    client: client(),
+    metrics,
+  });
+  return { result, metrics, line: usageLine() };
+}
+
+describe('terminology usage logging', () => {
+  it('logs the canonical fields for a term lookup', async () => {
+    const { line } = await run({ terms: ['charge'] });
+
+    expect(line).toMatchObject({
+      event: TOOL_CALL_EVENT,
+      tool: EXPLAIN_TERMINOLOGY_TOOL_NAME,
+      outcome: 'success',
+      userId: 'user-1',
+      glossaryMode: 'full',
+      matchedTerms: ['charge'],
+      missedTerms: [],
+      requestedTermCount: 1,
+    });
+    expect(typeof line.latencyMs).toBe('number');
+  });
+
+  it('keeps the verbatim spelling alongside the canonical term it resolved to', async () => {
+    const { line } = await run({ terms: ['valueDate'] });
+
+    expect(line.requestedTerms).toEqual(['valueDate']);
+    expect(line.matchedTerms).toEqual(['value-date']);
+  });
+
+  it('reports an unmatched term as a miss without failing the call', async () => {
+    const { result, line, metrics } = await run({ terms: ['frobnicator'] });
+
+    expect(result.isError).toBeUndefined();
+    expect(line.missedTerms).toEqual(['frobnicator']);
+    expect(line.matchedTerms).toEqual([]);
+    expect(metrics.snapshot().labeledTotals[GLOSSARY_TERM_MISSES_COUNTER]).toEqual({
+      frobnicator: 1,
+    });
+  });
+
+  it('folds a miss label so one missing concept is one label', async () => {
+    const { metrics } = await run({ terms: ['Frob Nicator', 'frob-nicator'] });
+
+    expect(metrics.snapshot().labeledTotals[GLOSSARY_TERM_MISSES_COUNTER]).toEqual({
+      frobnicator: 2,
+    });
+  });
+
+  it('counts each requested term under its canonical name', async () => {
+    const { metrics } = await run({ terms: ['charge', 'valueDate', 'value-date'] });
+
+    expect(metrics.snapshot().labeledTotals[GLOSSARY_TERM_REQUESTS_COUNTER]).toEqual({
+      charge: 1,
+      'value-date': 2,
+    });
+  });
+
+  describe('index mode', () => {
+    it('is logged as its own mode with no requested terms', async () => {
+      const { line } = await run({});
+
+      expect(line).toMatchObject({ glossaryMode: 'index', requestedTermCount: 0 });
+      expect(line.matchedTerms).toBeUndefined();
+    });
+
+    it('credits no individual term', async () => {
+      const { metrics } = await run({});
+      const snapshot = metrics.snapshot();
+
+      // Index mode returns the whole glossary; counting every entry as
+      // "requested" would drown the signal from real lookups.
+      expect(snapshot.labeledTotals[GLOSSARY_TERM_REQUESTS_COUNTER]).toBeUndefined();
+      expect(snapshot.labeledTotals[GLOSSARY_MODE_COUNTER]).toEqual({ index: 1 });
+    });
+  });
+
+  describe('topics', () => {
+    it('does not credit the terms a topic pulled in', async () => {
+      const { line, metrics } = await run({ topics: ['charge'] });
+
+      // Every charge entry is returned, but none of them was asked for by name.
+      expect(line.requestedTopics).toEqual(['charge']);
+      expect(line.matchedTerms).toEqual([]);
+      expect(line.requestedTermCount).toBe(0);
+      expect(metrics.snapshot().labeledTotals[GLOSSARY_TERM_REQUESTS_COUNTER]).toBeUndefined();
+
+      const chargeTerms = GLOSSARY.filter(entry => entry.topic === 'charge');
+      expect(chargeTerms.length).toBeGreaterThan(1);
+      expect(line.returnedCount).toBe(chargeTerms.length);
+    });
+
+    it('still credits a term named explicitly alongside a topic', async () => {
+      const { metrics } = await run({ terms: ['charge'], topics: ['ledger'] });
+
+      expect(metrics.snapshot().labeledTotals[GLOSSARY_TERM_REQUESTS_COUNTER]).toEqual({
+        charge: 1,
+      });
+    });
+  });
+
+  it('emits no usage fields onto the wire payload', async () => {
+    const { result } = await run({ terms: ['charge'] });
+
+    // `tools/call` returns this object verbatim as the JSON-RPC result, so
+    // telemetry leaking onto it would be sent to every caller.
+    expect(Object.keys(result).sort()).toEqual(['content', 'structuredContent']);
+    expect(JSON.stringify(result)).not.toContain('matchedTerms');
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/usage-log.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/usage-log.test.ts
@@ -7,6 +7,7 @@ import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
 import { SEARCH_CHARGES_TOOL_NAME, searchChargesTool } from '../charges.js';
 import { executeRegisteredTool, TOOL_CALL_EVENT } from '../execute.js';
 import { toolRegistry } from '../registry-instance.js';
+import { explainTerminologyTool } from '../terminology.js';
 import type { ToolDefinition, ToolResult } from '../registry.js';
 
 /**
@@ -199,6 +200,41 @@ describe('usage logging across outcomes', () => {
 
     const outcomes = usageLines().map(line => line.outcome);
     expect(outcomes).toEqual(['success', 'rate_limited']);
+  });
+
+  it('keeps the resolved scope on a rate-limited call, which ran no handler', async () => {
+    // The scope is resolved before the limiter, so it is real and worth logging
+    // even though nothing executed — unlike a rejection that never got that far.
+    const limiter = new RateLimiter({ windowMs: 1000, max: 1 }, () => 0);
+    const params = {
+      tool: explainTerminologyTool,
+      rawArgs: { terms: ['charge'] },
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: client(),
+      limiter,
+    };
+    await executeRegisteredTool(params);
+    await executeRegisteredTool(params);
+
+    const [, limited] = usageLines();
+    expect(limited).toMatchObject({ outcome: 'rate_limited', businessScopeSize: 2 });
+    // `observe` must not run for a call whose handler never did, or the glossary
+    // would report a lookup that never happened.
+    expect(limited.glossaryMode).toBeUndefined();
+    expect(limited.matchedTerms).toBeUndefined();
+  });
+
+  it('omits the scope for rejections that never resolved one', async () => {
+    await executeRegisteredTool({
+      tool: searchChargesTool,
+      rawArgs: { notAField: 1 },
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: client(),
+    });
+
+    expect(usageLine().businessScopeSize).toBeUndefined();
   });
 
   it('records the resolved scope size so a narrowed call is distinguishable', async () => {

--- a/packages/mcp-server/src/tools/__tests__/usage-log.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/usage-log.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { Metrics } from '../../observability/metrics.js';
+import { RateLimiter } from '../../rate-limit/limiter.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { SEARCH_CHARGES_TOOL_NAME, searchChargesTool } from '../charges.js';
+import { executeRegisteredTool, TOOL_CALL_EVENT } from '../execute.js';
+import { toolRegistry } from '../registry-instance.js';
+import type { ToolDefinition, ToolResult } from '../registry.js';
+
+/**
+ * The cross-cutting guard for usage logging: iterate the *production registry*
+ * rather than a hand-listed set, so a tool added later cannot silently ship
+ * without a usage log line.
+ *
+ * This is the only record of which tool a caller reached for — every MCP call is
+ * the same `POST /mcp`, so the per-request logs in `server.ts` cannot tell one
+ * tool from another.
+ */
+
+const B1 = 'aa000000-0000-4000-8000-000000000001';
+const B2 = 'aa000000-0000-4000-8000-000000000002';
+
+const PRINCIPAL: AuthPrincipal = {
+  subject: 'user-1',
+  issuer: 'https://tenant.auth0.com/',
+  audience: 'aud',
+  scopes: [],
+  email: null,
+  expiresAt: undefined,
+  claims: { sub: 'user-1' },
+};
+
+function authContext(): McpAuthContext {
+  return buildAuthContext(PRINCIPAL, [
+    { memberBusinessId: B1, roleId: 'business_owner' },
+    { memberBusinessId: B2, roleId: 'business_owner' },
+  ]);
+}
+
+/** Upstream payloads keyed by the operation each tool issues. */
+function dataFor(query: string): unknown {
+  if (query.includes('allCharges')) {
+    return {
+      allCharges: {
+        nodes: [],
+        pageInfo: { totalPages: 1, totalRecords: 0, currentPage: 1, pageSize: 25 },
+      },
+    };
+  }
+  if (query.includes('chargesByIDs')) return { chargesByIDs: [] };
+  if (query.includes('transactionsByIDs')) return { transactionsByIDs: [] };
+  if (query.includes('documentsByIds')) return { documentsByIds: [] };
+  if (query.includes('allTags')) return { allTags: [] };
+  if (query.includes('taxCategories')) return { taxCategories: [] };
+  if (query.includes('allBusinesses')) return { allBusinesses: { nodes: [] } };
+  if (query.includes('transactionsForBalanceReport')) return { transactionsForBalanceReport: [] };
+  return {};
+}
+
+function client() {
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(init.body as string) as { query: string };
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: dataFor(body.query) }),
+    } as unknown as Response;
+  });
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+/** Minimal valid arguments per tool; everything else is optional. */
+const ARGS_BY_TOOL: Record<string, unknown> = {
+  accounter_balance_report: { memberBusinessId: B1, fromDate: '2026-01-01', toDate: '2026-03-01' },
+  accounter_get_charges: { chargeIds: ['c1'] },
+  accounter_get_transactions: { transactionIds: ['t1'] },
+  accounter_get_documents: { documentIds: ['d1'] },
+};
+
+interface UsageLine {
+  event?: string;
+  tool?: string;
+  outcome?: string;
+  userId?: string;
+  correlationId?: string;
+  latencyMs?: number;
+  isError?: boolean;
+  businessScopeSize?: number;
+  [key: string]: unknown;
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function usageLines(): UsageLine[] {
+  return logSpy.mock.calls
+    .map(call => JSON.parse(String(call[0])) as UsageLine)
+    .filter(entry => entry.event === TOOL_CALL_EVENT);
+}
+
+function usageLine(): UsageLine {
+  const lines = usageLines();
+  expect(lines).toHaveLength(1);
+  return lines[0];
+}
+
+describe('registry-wide usage logging', () => {
+  const tools = toolRegistry.list();
+
+  it('has tools registered (guards against an empty-registry false pass)', () => {
+    expect(tools.length).toBeGreaterThan(0);
+  });
+
+  it.each(tools.map(tool => [tool.name, tool] as const))(
+    '%s emits exactly one usage log line with the canonical fields',
+    async (name, tool) => {
+      await executeRegisteredTool({
+        tool,
+        rawArgs: ARGS_BY_TOOL[name] ?? {},
+        auth: authContext(),
+        correlationId: 'corr-1',
+        client: client(),
+        authorization: 'Bearer t',
+        metrics: new Metrics(),
+      });
+
+      const line = usageLine();
+      expect(line).toMatchObject({
+        tool: name,
+        outcome: 'success',
+        userId: 'user-1',
+        correlationId: 'corr-1',
+        isError: false,
+      });
+      expect(typeof line.latencyMs).toBe('number');
+    },
+  );
+});
+
+describe('usage logging across outcomes', () => {
+  it('logs a validation_error for rejected input', async () => {
+    await executeRegisteredTool({
+      tool: searchChargesTool,
+      rawArgs: { notAField: 1 },
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: client(),
+    });
+
+    expect(usageLine()).toMatchObject({
+      tool: SEARCH_CHARGES_TOOL_NAME,
+      outcome: 'validation_error',
+      isError: true,
+    });
+  });
+
+  it('logs an authorization_error for a caller with no memberships', async () => {
+    await executeRegisteredTool({
+      tool: searchChargesTool,
+      rawArgs: {},
+      auth: buildAuthContext(PRINCIPAL, []),
+      correlationId: 'corr-1',
+      client: client(),
+    });
+
+    expect(usageLine()).toMatchObject({
+      tool: SEARCH_CHARGES_TOOL_NAME,
+      outcome: 'authorization_error',
+      isError: true,
+    });
+  });
+
+  it('logs a rate_limited outcome once the limiter trips', async () => {
+    const limiter = new RateLimiter({ windowMs: 1000, max: 1 }, () => 0);
+    const params = {
+      tool: searchChargesTool,
+      rawArgs: {},
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: client(),
+      limiter,
+    };
+    await executeRegisteredTool(params);
+    await executeRegisteredTool(params);
+
+    const outcomes = usageLines().map(line => line.outcome);
+    expect(outcomes).toEqual(['success', 'rate_limited']);
+  });
+
+  it('records the resolved scope size so a narrowed call is distinguishable', async () => {
+    await executeRegisteredTool({
+      tool: searchChargesTool,
+      rawArgs: { memberBusinessIds: [B1] },
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: client(),
+    });
+
+    expect(usageLine().businessScopeSize).toBe(1);
+  });
+});
+
+describe('observation failures', () => {
+  /** A tool whose `observe` throws — telemetry must not break the call. */
+  const brokenObserveTool: ToolDefinition = {
+    ...searchChargesTool,
+    name: 'broken_observe_tool',
+    observe: (): never => {
+      throw new Error('boom');
+    },
+  } as ToolDefinition;
+
+  it('still returns the result and logs the call', async () => {
+    const result: ToolResult = await executeRegisteredTool({
+      tool: brokenObserveTool,
+      rawArgs: {},
+      auth: authContext(),
+      correlationId: 'corr-1',
+      client: client(),
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(usageLine()).toMatchObject({ tool: 'broken_observe_tool', outcome: 'success' });
+  });
+});

--- a/packages/mcp-server/src/tools/execute.ts
+++ b/packages/mcp-server/src/tools/execute.ts
@@ -1,4 +1,4 @@
-import type { McpAuthContext } from '../auth/identity.js';
+import type { AuthorizedReadScope, McpAuthContext } from '../auth/identity.js';
 import {
   errorPayload,
   isInternalError,
@@ -11,11 +11,13 @@ import { outcomeForCode, type Metrics, type RequestOutcome } from '../observabil
 import { withSpan } from '../observability/tracing.js';
 import { rateLimitKey, type RateLimiterLike } from '../rate-limit/limiter.js';
 import type { UpstreamGraphQLClient } from '../upstream/graphql-client.js';
+import { listShapeFields } from './output.js';
 import { evaluateToolPolicy } from './policy.js';
 import {
   validateToolInput,
   type ToolDefinition,
   type ToolExecutionContext,
+  type ToolObservation,
   type ToolResult,
 } from './registry.js';
 
@@ -26,11 +28,49 @@ import {
  * ({@link toErrorPayload}) and returned as an MCP tool result with `isError`
  * and a structured `{ code, message, correlationId, retryable }` payload rather
  * than as a protocol-level JSON-RPC error, so the model can read it.
+ *
+ * Every completed call also emits exactly one `tool call` usage log line (see
+ * {@link TOOL_CALL_EVENT}) — on every path, including the validation,
+ * authorization and rate-limit rejections that never reach a handler. The
+ * per-request logs in `server.ts` cannot carry this: every MCP call is the same
+ * `POST /mcp`, so the tool name, its outcome and its inputs are only knowable
+ * here.
  */
 
 // Re-exported so tool handlers can import the domain-validation error alongside
 // the executor; the canonical definition lives in the error taxonomy.
 export { ToolInputError } from '../errors/taxonomy.js';
+
+/**
+ * `event` discriminator on the usage log line, so tool calls can be selected out
+ * of the log stream without matching on free-text messages.
+ */
+export const TOOL_CALL_EVENT = 'tool_call';
+
+/**
+ * Run a tool's `observe` hook without letting it affect the call.
+ *
+ * Telemetry is strictly secondary to serving the request: a buggy hook must not
+ * turn a successful tool call into an error, so a throw is logged and dropped.
+ */
+function safeObserve(
+  tool: ToolDefinition,
+  input: Record<string, unknown>,
+  result: ToolResult,
+): ToolObservation | undefined {
+  if (!tool.observe) {
+    return undefined;
+  }
+  try {
+    return tool.observe(input, result);
+  } catch (error) {
+    log('warn', 'tool observation failed', {
+      tool: tool.name,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
 
 /**
  * Optional per-tool convention: input fields carrying scope narrowing. Either a
@@ -97,13 +137,14 @@ function outcomeOf(result: ToolResult): RequestOutcome {
  * provided.
  */
 export async function executeRegisteredTool(params: ExecuteToolParams): Promise<ToolResult> {
-  const { metrics } = params;
+  const { metrics, tool } = params;
   const start = performance.now();
-  const result = await runTool(params);
+  const { result, input, readScope } = await runTool(params);
+  const latencyMs = Math.round(performance.now() - start);
+  const outcome = outcomeOf(result);
 
   if (metrics) {
-    const outcome = outcomeOf(result);
-    metrics.recordRequest(params.tool.name, outcome, Math.round(performance.now() - start));
+    metrics.recordRequest(tool.name, outcome, latencyMs);
     if (outcome === 'rate_limited') {
       metrics.recordRateLimited();
     } else if (outcome === 'upstream_error' || outcome === 'timeout_error') {
@@ -111,20 +152,59 @@ export async function executeRegisteredTool(params: ExecuteToolParams): Promise<
     }
   }
 
+  // Only observe a call that actually ran a handler: `input` is undefined when
+  // validation, policy or the rate limiter rejected it, and a hook reading an
+  // input that was never parsed would be reporting fiction.
+  const observation = input === undefined ? undefined : safeObserve(tool, input, result);
+
+  // Tool-contributed fields are spread first so the canonical fields below
+  // always win a name collision — cf. `completionFields` and `shapeListResult`.
+  // A tool cannot misreport its own name, outcome, or caller.
+  log('info', 'tool call', {
+    ...observation?.fields,
+    ...listShapeFields(result),
+    event: TOOL_CALL_EVENT,
+    tool: tool.name,
+    outcome,
+    latencyMs,
+    userId: params.auth.userId,
+    correlationId: params.correlationId,
+    businessScopeSize: readScope?.memberBusinessIds.length,
+    isError: result.isError === true,
+  });
+
+  for (const [counter, label] of observation?.counters ?? []) {
+    metrics?.recordLabeled(counter, label);
+  }
+
   return result;
 }
 
-async function runTool(params: ExecuteToolParams): Promise<ToolResult> {
+/**
+ * A finished run plus the context the usage log needs.
+ *
+ * `input` and `readScope` are only present once the call has cleared validation
+ * and policy — their absence is exactly what tells the caller no handler ran.
+ */
+interface ToolRun {
+  result: ToolResult;
+  input?: Record<string, unknown>;
+  readScope?: AuthorizedReadScope;
+}
+
+async function runTool(params: ExecuteToolParams): Promise<ToolRun> {
   const { tool, rawArgs, auth, correlationId, client, authorization, limiter } = params;
 
   // 1. Strict input validation (unknown fields rejected).
   const validation = validateToolInput(tool, rawArgs);
   if (!validation.ok) {
-    return toToolErrorResult(
-      errorPayload('VALIDATION_ERROR', validation.error.message, correlationId, {
-        issues: validation.error.issues,
-      }),
-    );
+    return {
+      result: toToolErrorResult(
+        errorPayload('VALIDATION_ERROR', validation.error.message, correlationId, {
+          issues: validation.error.issues,
+        }),
+      ),
+    };
   }
   const input = validation.data;
 
@@ -135,9 +215,11 @@ async function runTool(params: ExecuteToolParams): Promise<ToolResult> {
     requestedMemberBusinessIds: requestedMemberBusinessIds(input),
   });
   if (!decision.allowed) {
-    return toToolErrorResult(
-      errorPayload('AUTHORIZATION_ERROR', decision.error.message, correlationId),
-    );
+    return {
+      result: toToolErrorResult(
+        errorPayload('AUTHORIZATION_ERROR', decision.error.message, correlationId),
+      ),
+    };
   }
 
   // 3. Rate limit (before any expensive upstream call), keyed by identity +
@@ -153,14 +235,17 @@ async function runTool(params: ExecuteToolParams): Promise<ToolResult> {
     );
     if (!outcome.allowed) {
       const retryAfterSeconds = Math.ceil(outcome.retryAfterMs / 1000);
-      return toToolErrorResult(
-        errorPayload(
-          'RATE_LIMIT_ERROR',
-          `Rate limit exceeded. Retry in ${retryAfterSeconds}s.`,
-          correlationId,
-          { retryAfterMs: outcome.retryAfterMs },
+      return {
+        result: toToolErrorResult(
+          errorPayload(
+            'RATE_LIMIT_ERROR',
+            `Rate limit exceeded. Retry in ${retryAfterSeconds}s.`,
+            correlationId,
+            { retryAfterMs: outcome.retryAfterMs },
+          ),
         ),
-      );
+        readScope: decision.readScope,
+      };
     }
   }
 
@@ -183,9 +268,10 @@ async function runTool(params: ExecuteToolParams): Promise<ToolResult> {
   };
   try {
     // Span covers the handler + its upstream calls for tracing.
-    return await withSpan(`tool:${tool.name}`, correlationId, async () =>
+    const result = await withSpan(`tool:${tool.name}`, correlationId, async () =>
       tool.handler(input, context),
     );
+    return { result, input, readScope: decision.readScope };
   } catch (error) {
     // Log unexpected (unmapped) failures so bugs aren't hidden; the caller only
     // ever sees the generic, sanitized INTERNAL_ERROR message.
@@ -197,6 +283,10 @@ async function runTool(params: ExecuteToolParams): Promise<ToolResult> {
         stack: error instanceof Error ? error.stack : undefined,
       });
     }
-    return toToolErrorResult(toErrorPayload(error, correlationId));
+    return {
+      result: toToolErrorResult(toErrorPayload(error, correlationId)),
+      input,
+      readScope: decision.readScope,
+    };
   }
 }

--- a/packages/mcp-server/src/tools/execute.ts
+++ b/packages/mcp-server/src/tools/execute.ts
@@ -183,8 +183,17 @@ export async function executeRegisteredTool(params: ExecuteToolParams): Promise<
 /**
  * A finished run plus the context the usage log needs.
  *
- * `input` and `readScope` are only present once the call has cleared validation
- * and policy — their absence is exactly what tells the caller no handler ran.
+ * The two optional fields are populated at different points on purpose, so they
+ * are not interchangeable signals:
+ *
+ * - `readScope` is present as soon as the policy resolved a scope — including on
+ *   a rate-limit rejection, where the scope is real and worth logging even
+ *   though nothing ran. It is absent only for a validation or authorization
+ *   rejection, where no scope was ever resolved.
+ * - `input` is present only when a handler actually executed, which is precisely
+ *   what gates `observe`: a hook reporting on a call that was rejected before
+ *   its handler would be describing work that never happened. A rate-limited
+ *   call therefore carries `readScope` but no `input`.
  */
 interface ToolRun {
   result: ToolResult;

--- a/packages/mcp-server/src/tools/output.ts
+++ b/packages/mcp-server/src/tools/output.ts
@@ -120,3 +120,29 @@ export function shapeListResult<T>(params: ShapeListParams<T>): ToolResult {
     structuredContent: structured,
   };
 }
+
+/**
+ * Result-size fields for the usage log, pulled off a shaped result.
+ *
+ * Every list-producing tool builds its payload with {@link shapeListResult}, so
+ * these three keys are a shared shape rather than a per-tool convention — the
+ * executor can log how much a call actually returned without any tool opting in.
+ * Returns an empty object for a result that is not list-shaped (an error result,
+ * or a tool that builds its own structured content).
+ */
+export function listShapeFields(result: ToolResult): Record<string, unknown> {
+  const structured = result.structuredContent;
+  if (!structured || typeof structured !== 'object') {
+    return {};
+  }
+  const { returnedCount, totalCount, truncated } = structured as {
+    returnedCount?: unknown;
+    totalCount?: unknown;
+    truncated?: unknown;
+  };
+  const fields: Record<string, unknown> = {};
+  if (typeof returnedCount === 'number') fields.returnedCount = returnedCount;
+  if (typeof totalCount === 'number') fields.totalCount = totalCount;
+  if (typeof truncated === 'boolean') fields.truncated = truncated;
+  return fields;
+}

--- a/packages/mcp-server/src/tools/registry.ts
+++ b/packages/mcp-server/src/tools/registry.ts
@@ -64,6 +64,29 @@ export interface ToolResult {
 /** A zod object schema describing a tool's input. */
 export type ToolInputSchema = z.ZodObject;
 
+/**
+ * A bounded label counter to increment: `[counter name, label]`.
+ *
+ * Labels must be low-cardinality and free of customer data — they are rendered
+ * into the `/metrics` snapshot. The metrics registry caps distinct labels per
+ * counter, so a caller-derived label cannot grow the process unboundedly.
+ */
+export type LabeledCounter = readonly [counter: string, label: string];
+
+/**
+ * A tool's contribution to usage telemetry: extra log fields and label counters.
+ *
+ * Deliberately separate from {@link ToolResult}: `tools/call` returns the result
+ * object verbatim as the JSON-RPC payload, so anything attached to it would be
+ * sent to the caller. Observation data must never reach the wire.
+ */
+export interface ToolObservation {
+  /** Extra structured fields merged into the `tool call` log line. */
+  fields?: Record<string, unknown>;
+  /** Bounded label counters to increment on the metrics registry. */
+  counters?: readonly LabeledCounter[];
+}
+
 /** A registered, curated tool. Handlers must be pure and testable. */
 export interface ToolDefinition<Schema extends ToolInputSchema = ToolInputSchema> {
   name: string;
@@ -74,6 +97,16 @@ export interface ToolDefinition<Schema extends ToolInputSchema = ToolInputSchema
     input: z.infer<Schema>,
     context: ToolExecutionContext,
   ) => Promise<ToolResult> | ToolResult;
+  /**
+   * Derive usage telemetry from the validated input and the finished result.
+   *
+   * Optional and pure: it must not throw, mutate, or perform I/O. The executor
+   * calls it once per completed handler run, guards it against throwing, and
+   * merges {@link ToolObservation.fields} into the usage log line beneath the
+   * canonical fields — so a tool can enrich its own telemetry but never spoof
+   * `tool`, `outcome`, or `userId`.
+   */
+  observe?: (input: z.infer<Schema>, result: ToolResult) => ToolObservation;
 }
 
 /** Tool descriptor advertised by `tools/list` (JSON Schema for the input). */

--- a/packages/mcp-server/src/tools/terminology.ts
+++ b/packages/mcp-server/src/tools/terminology.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 import { shapeListResult } from './output.js';
-import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import type {
+  LabeledCounter,
+  ToolDefinition,
+  ToolExecutionContext,
+  ToolObservation,
+  ToolResult,
+} from './registry.js';
 import {
   GLOSSARY,
   GLOSSARY_TOPICS,
@@ -32,6 +38,28 @@ export const EXPLAIN_TERMINOLOGY_TOOL_NAME = 'accounter_explain_terminology';
 
 /** Upper bound on terms per call. Generous — each match is a few hundred bytes. */
 export const MAX_REQUESTED_TERMS = 20;
+
+/**
+ * Labeled counters this tool contributes to `/metrics`.
+ *
+ * The glossary's value is a function of what callers actually ask it, so the two
+ * questions worth answering cheaply are which terms get looked up and which
+ * looked-up terms do not exist yet — the latter being the list of entries the
+ * glossary is missing.
+ */
+export const GLOSSARY_TERM_REQUESTS_COUNTER = 'glossary_term_requests';
+export const GLOSSARY_TERM_MISSES_COUNTER = 'glossary_term_misses';
+export const GLOSSARY_MODE_COUNTER = 'glossary_mode';
+
+/**
+ * Length cap on a miss label.
+ *
+ * A miss label is caller-supplied text reaching the unauthenticated `/metrics`
+ * snapshot, so it is folded (collapsing `Value Date`/`valueDate`/`value-date`
+ * into one label) and clipped. The input schema already caps a term at 60 chars;
+ * this keeps the label short enough to read in a snapshot.
+ */
+const MAX_MISS_LABEL_LENGTH = 40;
 
 /** Shortest shared prefix that makes a term worth suggesting for a typo. */
 const MIN_SUGGESTION_PREFIX = 3;
@@ -209,9 +237,7 @@ function selectEntries(input: ExplainTerminologyInput): {
 function handler(input: ExplainTerminologyInput, _context: ToolExecutionContext): ToolResult {
   // Mode is derived rather than a flag: asking for nothing in particular means
   // "show me what exists" (cheap), asking for something means "explain it".
-  const isIndexMode = input.terms === undefined && input.topics === undefined;
-
-  if (isIndexMode) {
+  if (isIndexMode(input)) {
     return shapeListResult({
       items: GLOSSARY.map(toIndexItem),
       itemsKey: 'terms',
@@ -248,6 +274,74 @@ function handler(input: ExplainTerminologyInput, _context: ToolExecutionContext)
   });
 }
 
+/** Index mode is "show me what exists"; full mode is "explain this". */
+function isIndexMode(input: ExplainTerminologyInput): boolean {
+  return input.terms === undefined && input.topics === undefined;
+}
+
+/**
+ * Usage telemetry for a finished lookup.
+ *
+ * Matches are resolved from `input.terms` rather than read back off the result,
+ * which looks like duplicated work but is the only correct source. A call
+ * carrying `topics` returns every entry in those topics, and none of those
+ * entries were individually asked for — counting them would make
+ * "most-requested term" a measure of topic breadth instead of caller interest.
+ * Re-resolving is a `Map` hit per term, at most {@link MAX_REQUESTED_TERMS} of
+ * them.
+ *
+ * Both spellings are reported: `requestedTerms` verbatim (so an alias the caller
+ * reached for, `valueDate`, stays visible) alongside the canonical `matchedTerms`
+ * it resolved to.
+ */
+function observe(input: ExplainTerminologyInput, _result: ToolResult): ToolObservation {
+  if (isIndexMode(input)) {
+    // No per-term counters here on purpose: index mode returns all of the
+    // glossary, and crediting every entry would bury the real signal.
+    return {
+      fields: { glossaryMode: 'index', requestedTermCount: 0 },
+      counters: [[GLOSSARY_MODE_COUNTER, 'index']],
+    };
+  }
+
+  const requestedTerms = input.terms ?? [];
+  const matchedTerms: string[] = [];
+  const missedTerms: string[] = [];
+  for (const requested of requestedTerms) {
+    const entry = lookup(requested);
+    if (entry) {
+      matchedTerms.push(entry.term);
+    } else {
+      missedTerms.push(requested);
+    }
+  }
+
+  const counters: LabeledCounter[] = [[GLOSSARY_MODE_COUNTER, 'full']];
+  for (const term of matchedTerms) {
+    counters.push([GLOSSARY_TERM_REQUESTS_COUNTER, term]);
+  }
+  for (const term of missedTerms) {
+    counters.push([GLOSSARY_TERM_MISSES_COUNTER, missLabel(term)]);
+  }
+
+  return {
+    fields: {
+      glossaryMode: 'full',
+      requestedTermCount: requestedTerms.length,
+      requestedTerms,
+      matchedTerms,
+      missedTerms,
+      requestedTopics: input.topics ?? [],
+    },
+    counters,
+  };
+}
+
+/** Fold and clip an unmatched term into a metrics-safe label. */
+function missLabel(term: string): string {
+  return fold(term).slice(0, MAX_MISS_LABEL_LENGTH);
+}
+
 export const explainTerminologyTool: ToolDefinition<typeof explainTerminologyInput> = {
   name: EXPLAIN_TERMINOLOGY_TOOL_NAME,
   description:
@@ -268,4 +362,5 @@ export const explainTerminologyTool: ToolDefinition<typeof explainTerminologyInp
     dataClassification: 'public',
   },
   handler,
+  observe,
 };


### PR DESCRIPTION
## Why

`accounter_explain_terminology` (added on the base branch) is a read of caller **intent**: what someone asks the glossary is the clearest available signal of the vocabulary they arrived with and what they were trying to do before they knew how to ask for data. None of that was being recorded.

Nor was anything else about a tool call. `executeRegisteredTool` fed the in-memory metrics registry and returned, so a *successful* `tools/call` produced **no log line at all** — the only tool-level log was the `isInternalError` branch. The per-request logs in `server.ts` can't fill the gap, because every MCP call is the same `POST /mcp`.

This also closes a documented gap: `docs/spec.md` §11.1 asks for per-request logs carrying `user_id`, `business_scope`, `tool_name`, outcome and `latency_ms`. None were logged.

## What

**One `event: "tool_call"` line per completed call**, on every path — including the validation, authorization and rate-limit rejections that never reach a handler. Carries `tool`, `outcome` (same label set as `requestsTotal`), `latencyMs`, `userId`, `correlationId`, `businessScopeSize`, and `returnedCount`/`totalCount`/`truncated` for anything built with the shared list shaping. `event` is a stable discriminator, so the stream can be selected on without matching free-text messages.

**A new optional `observe(input, result)` hook on `ToolDefinition`** lets a tool enrich its own line. Deliberately *not* a field on `ToolResult`: `tools/call` returns that object verbatim as the JSON-RPC payload, so telemetry attached there would be sent to every caller. The hook is pure, guarded against throwing (a broken hook must not turn a successful call into an error), and its fields merge *beneath* the canonical ones — a tool cannot misreport its own name, outcome or caller.

**The glossary implements it** with `glossaryMode`, `requestedTerms` (verbatim, so an alias the caller reached for stays visible), `matchedTerms` (canonical), `missedTerms` and `requestedTopics`, plus three label counters — `glossary_term_requests`, `glossary_term_misses`, `glossary_mode` — exposed under a new `labeledTotals` key on `GET /metrics`. So "most-requested term" and "terms we don't define yet" are one `curl` away, no log parsing needed.

Real output from a run against `{ terms: ["valueDate", "byOwners", "frobnicator"] }`:

```json
{"glossaryMode":"full","requestedTermCount":3,
 "requestedTerms":["valueDate","byOwners","frobnicator"],
 "matchedTerms":["value-date","owner-vs-counterparty-filter"],
 "missedTerms":["frobnicator"],"requestedTopics":[],
 "returnedCount":2,"totalCount":2,"truncated":false,
 "event":"tool_call","tool":"accounter_explain_terminology","outcome":"success",
 "latencyMs":1,"userId":"auth0|abc123","correlationId":"corr-verify",
 "businessScopeSize":1,"isError":false,"level":"info","message":"tool call"}
```

## Two decisions worth reviewing

- **Matches resolve from the input, not read back off the result.** A `topics: ["charge"]` call returns every charge entry and none of them was individually asked for; crediting them would turn "most-requested term" into a measure of topic breadth. Index mode, which returns all 62 entries, credits no individual term for the same reason. Costs one `Map` hit per requested term (≤20).
- **Label cardinality is capped.** Miss labels derive from caller input, so they're folded (one concept → one label regardless of spelling), clipped to 40 chars, and bounded at `MAX_COUNTER_LABELS` distinct labels per counter with further new labels folded into `__other__`. Labels already tracked keep counting, so the top-N stays accurate past the cap.

## One thing to flag

`/metrics` is **unauthenticated** (no auth on any `GET` route) while calling a tool requires a valid token — so `glossary_term_misses` labels are authenticated-write and publicly readable. The folding, the 40-char clip and the 200-label cap bound this to junk vocabulary rather than data, and the glossary tool is already classified `public` with no customer data. Called out in the runbook as a reason to gate `/metrics` eventually. Happy to drop that one counter from `/metrics` and keep misses in the logs only if you'd rather not widen it at all.

## Testing

`packages/mcp-server`: **578 tests / 45 files pass** (533 → 578; +45 new). Typecheck, ESLint and Prettier clean.

- `src/tools/__tests__/usage-log.test.ts` — registry-wide guard in the style of `scope-forwarding.test.ts`: iterates the **production registry** and asserts every tool emits exactly one canonical `tool_call` line, so a tool added later can't silently ship without usage logging. Plus each outcome class, scope size, and an `observe` that throws.
- `src/tools/__tests__/terminology-usage.test.ts` — alias → canonical resolution, misses, miss-label folding, index mode crediting no term, `topics` not inflating `matchedTerms`, and an assertion that no usage field reaches the wire payload.
- `src/observability/__tests__/metrics.test.ts` — extended for the cap, the overflow bucket, known-label counting past the cap, and `reset()`.

Also verified at runtime end-to-end (log lines above, `labeledTotals` snapshot, and a byte-identical `tools/call` response).

Based on `claude/accounter-terminology-mcp-wo1prq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)