### PR TITLE
fix(scraper-app): skip Max transactions not received by the credit card company

### DIFF
--- a/.changeset/wild-badgers-tickle.md
+++ b/.changeset/wild-badgers-tickle.md
@@ -1,0 +1,7 @@
+---
+'@accounter/scraper-app': patch
+---
+
+Skip Max transactions with `runtimeReference.type === 0` — these are declarations of transactions
+not received by the credit card company and are missing many required attributes, which previously
+failed payload validation and aborted the whole Max scrape.

--- a/packages/scraper-app/src/server/scrapers/__tests__/max.test.ts
+++ b/packages/scraper-app/src/server/scrapers/__tests__/max.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import { makeMaxTransaction } from '../../__tests__/fixtures/max.js';
 import { PayloadValidationError } from '../../validate-payload.js';
-import { scrapeMax } from '../max.js';
+import { filterUnreceivedMaxTransactions, scrapeMax } from '../max.js';
 
 const CREDS = { id: 'src-1', username: 'user', password: 'pass' };
 const DATE_FROM = new Date('2024-01-01');
@@ -81,6 +82,93 @@ describe('scrapeMax — happy path', () => {
 
     await scrapeMax(CREDS, DATE_FROM, DATE_TO, noop);
     expect(close).toHaveBeenCalledOnce();
+  });
+});
+
+describe('filterUnreceivedMaxTransactions', () => {
+  it('drops transactions whose runtimeReference.type is 0', () => {
+    const raw = [
+      {
+        accountNumber: '1234',
+        txns: [
+          { uid: 'kept', runtimeReference: { id: '1', type: 1 } },
+          { uid: 'dropped', runtimeReference: { id: '2', type: 0 } },
+        ],
+      },
+    ];
+
+    const result = filterUnreceivedMaxTransactions(raw) as typeof raw;
+    expect(result[0]!.txns.map(t => t.uid)).toEqual(['kept']);
+  });
+
+  it('keeps transactions with a missing or non-numeric runtimeReference', () => {
+    const raw = [
+      {
+        accountNumber: '1234',
+        txns: [{ uid: 'no-ref' }, { uid: 'null-ref', runtimeReference: null }],
+      },
+    ];
+
+    const result = filterUnreceivedMaxTransactions(raw) as typeof raw;
+    expect(result[0]!.txns).toHaveLength(2);
+  });
+
+  it('passes through payloads that are not shaped like a Max payload', () => {
+    expect(filterUnreceivedMaxTransactions('not-an-array')).toBe('not-an-array');
+    expect(filterUnreceivedMaxTransactions([{ accountNumber: '1' }])).toEqual([
+      { accountNumber: '1' },
+    ]);
+  });
+});
+
+describe('scrapeMax — unreceived transactions', () => {
+  it('skips type-0 transactions instead of failing validation on them', async () => {
+    const payload = [
+      {
+        accountNumber: '1234',
+        txns: [
+          makeMaxTransaction({ uid: 'settled' }),
+          // Declared but not received by the credit card company: partial record.
+          { uid: 'unreceived', runtimeReference: { id: '2', type: 0 } },
+        ],
+      },
+    ];
+    const initMock = await getInitMock();
+    initMock.mockResolvedValue({
+      max: vi.fn().mockResolvedValue({
+        getTransactions: vi.fn().mockResolvedValue(payload),
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await scrapeMax(CREDS, DATE_FROM, DATE_TO, noop);
+    expect(result[0]!.txns.map(t => t.uid)).toEqual(['settled']);
+  });
+
+  it('reports the post-filter transaction count', async () => {
+    const payload = [
+      {
+        accountNumber: '1234',
+        txns: [
+          makeMaxTransaction({ uid: 'settled' }),
+          { uid: 'unreceived', runtimeReference: { id: '2', type: 0 } },
+        ],
+      },
+    ];
+    const initMock = await getInitMock();
+    initMock.mockResolvedValue({
+      max: vi.fn().mockResolvedValue({
+        getTransactions: vi.fn().mockResolvedValue(payload),
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const emitted: { type: string; transactionCount?: number }[] = [];
+    await scrapeMax(CREDS, DATE_FROM, DATE_TO, msg => emitted.push(msg));
+
+    expect(emitted).toEqual([
+      { type: 'task-month-fetched', sourceId: 'src-1', month: '1234', transactionCount: 1 },
+    ]);
   });
 });
 

--- a/packages/scraper-app/src/server/scrapers/max.ts
+++ b/packages/scraper-app/src/server/scrapers/max.ts
@@ -9,6 +9,48 @@ export type MaxCreds = z.infer<typeof MaxAccountSchema>;
 
 export type Emitter = (msg: ServerMessage) => void;
 
+/**
+ * `runtimeReference.type === 0` marks a transaction that was only declared to Max and never
+ * received by the credit card company. Those records are missing many of the attributes a
+ * settled transaction carries (deal data, payment date, amounts), so they neither validate
+ * against the payload schema nor represent real charges — drop them before validation.
+ */
+const UNRECEIVED_RUNTIME_REFERENCE_TYPE = 0;
+
+function isUnreceivedTransaction(txn: unknown): boolean {
+  if (typeof txn !== 'object' || txn === null) {
+    return false;
+  }
+  const runtimeReference = (txn as { runtimeReference?: unknown }).runtimeReference;
+  if (typeof runtimeReference !== 'object' || runtimeReference === null) {
+    return false;
+  }
+  return (runtimeReference as { type?: unknown }).type === UNRECEIVED_RUNTIME_REFERENCE_TYPE;
+}
+
+/**
+ * Strips unreceived (`runtimeReference.type === 0`) transactions from a raw Max payload.
+ *
+ * Runs on the raw scraper output, before schema validation, since those records are missing
+ * required fields. Anything that is not shaped like the expected payload is passed through
+ * untouched so validation can report the real problem.
+ */
+export function filterUnreceivedMaxTransactions(raw: unknown): unknown {
+  if (!Array.isArray(raw)) {
+    return raw;
+  }
+  return raw.map(account => {
+    if (typeof account !== 'object' || account === null) {
+      return account;
+    }
+    const txns = (account as { txns?: unknown }).txns;
+    if (!Array.isArray(txns)) {
+      return account;
+    }
+    return { ...account, txns: txns.filter(txn => !isUnreceivedTransaction(txn)) };
+  });
+}
+
 export async function scrapeMax(
   creds: MaxCreds,
   dateFrom: Date,
@@ -25,7 +67,7 @@ export async function scrapeMax(
     );
 
     const accounts = await scraper.getTransactions();
-    const validated = validatePayload('max', accounts);
+    const validated = validatePayload('max', filterUnreceivedMaxTransactions(accounts));
 
     for (const account of validated) {
       emit({


### PR DESCRIPTION
## What

Max returns transactions with `runtimeReference.type === 0` for records that were only *declared* and never received by the credit card company. These records are missing many of the attributes a settled transaction carries (deal data, payment date, amounts), so a single one made the whole Max payload fail schema validation and aborted the scrape.

`scrapeMax` now strips them from the raw scraper output before validation.

## Changes

- `packages/scraper-app/src/server/scrapers/max.ts`: new exported `filterUnreceivedMaxTransactions(raw)` helper, applied to the scraper output before `validatePayload('max', …)`. It operates on the raw (unvalidated) payload and passes anything not shaped like a Max payload straight through, so genuine schema problems still surface as validation errors.
- Tests covering the filter directly (type-0 dropped, missing/`null` `runtimeReference` kept, non-payload input untouched) and end-to-end through `scrapeMax`, including that the emitted `task-month-fetched` count reflects the post-filter total.
- Changeset (`patch` for `@accounter/scraper-app`).

## Verification

- `yarn vitest run --project unit packages/scraper-app/src/server/scrapers/__tests__/max.test.ts` — 11 passed.
- `yarn eslint` and `yarn prettier` clean on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBkLeGvJzSk9jfwN1a52LM)_