### PR TITLE
refactor(server): exact, signed, one-to-one securities execution matching

### DIFF
--- a/.changeset/@accounter_client-4253-dependencies.md
+++ b/.changeset/@accounter_client-4253-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`@atlaskit/pragmatic-drag-and-drop-hitbox@2.1.0` ↗︎](https://www.npmjs.com/package/@atlaskit/pragmatic-drag-and-drop-hitbox/v/2.1.0) (from `2.0.0`, in `dependencies`)
+  - Updated dependency [`lucide-react@1.32.0` ↗︎](https://www.npmjs.com/package/lucide-react/v/1.32.0) (from `1.31.0`, in `dependencies`)

--- a/.changeset/@accounter_israeli-vat-scraper-4253-dependencies.md
+++ b/.changeset/@accounter_israeli-vat-scraper-4253-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/israeli-vat-scraper": patch
+---
+dependencies updates:
+  - Updated dependency [`puppeteer@25.8.0` ↗︎](https://www.npmjs.com/package/puppeteer/v/25.8.0) (from `25.7.0`, in `dependencies`)

--- a/.changeset/@accounter_modern-poalim-scraper-4253-dependencies.md
+++ b/.changeset/@accounter_modern-poalim-scraper-4253-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/modern-poalim-scraper": patch
+---
+dependencies updates:
+  - Updated dependency [`puppeteer@25.8.0` ↗︎](https://www.npmjs.com/package/puppeteer/v/25.8.0) (from `25.7.0`, in `dependencies`)

--- a/.changeset/@accounter_scraper-app-4253-dependencies.md
+++ b/.changeset/@accounter_scraper-app-4253-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/scraper-app": patch
+---
+dependencies updates:
+  - Updated dependency [`fast-xml-parser@5.11.0` ↗︎](https://www.npmjs.com/package/fast-xml-parser/v/5.11.0) (from `5.10.1`, in `dependencies`)

--- a/.changeset/@accounter_server-4253-dependencies.md
+++ b/.changeset/@accounter_server-4253-dependencies.md
@@ -1,0 +1,10 @@
+---
+"@accounter/server": patch
+---
+dependencies updates:
+  - Updated dependency [`@envelop/core@5.6.0` ↗︎](https://www.npmjs.com/package/@envelop/core/v/5.6.0) (from `5.5.1`, in `dependencies`)
+  - Updated dependency [`@envelop/generic-auth@11.2.0` ↗︎](https://www.npmjs.com/package/@envelop/generic-auth/v/11.2.0) (from `11.1.1`, in `dependencies`)
+  - Updated dependency [`@envelop/graphql-modules@9.2.0` ↗︎](https://www.npmjs.com/package/@envelop/graphql-modules/v/9.2.0) (from `9.1.1`, in `dependencies`)
+  - Updated dependency [`@graphql-yoga/plugin-defer-stream@3.22.0` ↗︎](https://www.npmjs.com/package/@graphql-yoga/plugin-defer-stream/v/3.22.0) (from `3.21.3`, in `dependencies`)
+  - Updated dependency [`googleapis@176.0.0` ↗︎](https://www.npmjs.com/package/googleapis/v/176.0.0) (from `174.0.1`, in `dependencies`)
+  - Updated dependency [`graphql-yoga@5.22.0` ↗︎](https://www.npmjs.com/package/graphql-yoga/v/5.22.0) (from `5.21.3`, in `dependencies`)

--- a/.changeset/security-executions-matcher.md
+++ b/.changeset/security-executions-matcher.md
@@ -20,10 +20,18 @@ The rule is now the two facts both sides report about the same event, and both a
   `settlement_currency` → `net_value_settlement_currency`, ILS → `net_value_nis`) rather than trying
   all three: the others are the same value through an exchange rate. Both sides come out of Postgres
   `numeric` as decimal strings reporting the same figure, so there is nothing for a tolerance to
-  absorb — a near miss is a different event. A buy debits and a sale, redemption, dividend or interest
+  absorb — a near miss is a different event. The comparison is on the canonicalized decimal
+  strings rather than through `Number`: the two sources spell one value differently (`1000` against
+  `1000.00`), and reconciling that through a binary float is a strange thing to do in a comparison
+  documented as exact — past 2^53, or with enough fraction digits, two different values land on one
+  double. A buy debits and a sale, redemption, dividend or interest
   payment credits; actions the bank files with no cash direction of their own (stock distributions,
   deposit transfers) are matched on date, amount and account alone rather than being force-fitted to a
-  sign the source never implies.
+  sign the source never implies. A trade type the translation has never seen is treated the same way
+  instead of throwing: one unknown word in the table would otherwise take down every charge that
+  looks at the same account, including those the row has nothing to do with. Rows that actually get
+  served still go through the throwing translation in the resolver, so the drift stays loud where it
+  matters.
 
 The Poalim account tuple is still required on top, so the same security trading in two of a tenant's
 portfolios cannot cross-match. Pairing is now explicitly **one-to-one and greedy**, oldest execution

--- a/.changeset/security-executions-matcher.md
+++ b/.changeset/security-executions-matcher.md
@@ -1,0 +1,40 @@
+---
+'@accounter/server': minor
+---
+
+Rewrite the securities execution↔transaction matcher around what both sources actually report.
+
+`accounter_schema.poalim_securities_transactions` carries no link to `accounter_schema.transactions`
+— the scrape has no per-execution id — so the pairing is derived. The first cut derived it loosely: a
+±5 day window over four candidate dates on each side, and a ±0.01 tolerance over three candidate
+amounts, with signs ignored. That accepted more than it should: any of twelve date pairs and three
+amount columns could carry a match, so an execution could attach to a cash movement it had nothing to
+do with, in the wrong direction.
+
+The rule is now the two facts both sides report about the same event, and both are exact:
+
+- **`value_date` = the transaction's effective debit date** (`debit_date_override ?? debit_date`).
+  The execution settles on the day the account moves; either side missing that date cannot pair.
+- **Net value in the transaction's own currency = the amount**, with the sign the trade type
+  implies. The comparable column is picked by currency (`trade_currency` → `net_value_trade_currency`,
+  `settlement_currency` → `net_value_settlement_currency`, ILS → `net_value_nis`) rather than trying
+  all three: the others are the same value through an exchange rate. Both sides come out of Postgres
+  `numeric` as decimal strings reporting the same figure, so there is nothing for a tolerance to
+  absorb — a near miss is a different event. A buy debits and a sale, redemption, dividend or interest
+  payment credits; actions the bank files with no cash direction of their own (stock distributions,
+  deposit transfers) are matched on date, amount and account alone rather than being force-fitted to a
+  sign the source never implies.
+
+The Poalim account tuple is still required on top, so the same security trading in two of a tenant's
+portfolios cannot cross-match. Pairing is now explicitly **one-to-one and greedy**, oldest execution
+first: a security can be executed several times in a day for the same amount, and each execution
+belongs to exactly one cash movement.
+
+The matcher is also usable from both ends. `matchSecurityExecutions` keeps its charge-side signature
+(matched executions grouped by security key), and the new `matchExecutionsToTransactions` returns the
+cash movement behind each execution — the direction a per-security history needs to link a trade back
+to its charge.
+
+Because the date rule is exact, the provider's prefilter is now `value_date = ANY(<the charge's debit
+dates>)` instead of a padded range over four date columns, and it selects `settlement_currency` for
+the currency pick.

--- a/packages/server/src/modules/foreign-securities/helpers/__tests__/match-security-executions.helper.test.ts
+++ b/packages/server/src/modules/foreign-securities/helpers/__tests__/match-security-executions.helper.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  matchExecutionsToTransactions,
   matchSecurityExecutions,
   type AccountTuple,
   type MatchableExecution,
@@ -20,12 +21,14 @@ const accountTuples = new Map([
 // Dates are constructed the way `DATE` columns come back from node-postgres: local midnight.
 const date = (value: string) => new Date(`${value}T00:00:00`);
 
+/** A buy: the account is debited on the execution's value date. */
 function transaction(overrides: Partial<MatchableTransaction> = {}): MatchableTransaction {
   return {
     id: 't1',
+    charge_id: 'c1',
     amount: '-1000.00',
-    event_date: date('2024-03-10'),
-    debit_date: null,
+    currency: 'USD',
+    debit_date: date('2024-03-12'),
     debit_date_override: null,
     account_id: ACCOUNT_ID,
     ...overrides,
@@ -40,165 +43,189 @@ function execution(overrides: Partial<MatchableExecution> = {}): MatchableExecut
     branch_number: ACCOUNT.branchNumber,
     account_number: ACCOUNT.accountNumber,
     trade_date: date('2024-03-10'),
-    value_date: null,
-    settlement_date: null,
-    payment_date: null,
+    value_date: date('2024-03-12'),
+    trade_type: 'קניה',
+    trade_currency: 'דולר ארה"ב',
+    settlement_currency: null,
     net_value_trade_currency: '1000.00',
     net_value_settlement_currency: null,
-    net_value_nis: null,
+    net_value_nis: '3700.00',
     ...overrides,
   };
 }
 
-describe('matchSecurityExecutions', () => {
-  it('matches on account, date and amount, grouped by security key', () => {
-    const matched = matchSecurityExecutions([transaction()], [execution()], accountTuples);
+const match = (
+  transactions: MatchableTransaction[],
+  executions: MatchableExecution[],
+): Map<string, MatchableTransaction> =>
+  matchExecutionsToTransactions(transactions, executions, accountTuples);
 
-    expect([...matched.keys()]).toEqual(['5129523']);
-    expect(matched.get('5129523')?.map(e => e.id)).toEqual(['e1']);
+describe('matchExecutionsToTransactions', () => {
+  it('pairs an execution with the cash movement on its value date', () => {
+    const matched = match([transaction()], [execution()]);
+
+    expect(matched.get('e1')?.id).toBe('t1');
   });
 
-  it('disambiguates same-day executions of the same security by amount', () => {
-    const matched = matchSecurityExecutions(
-      [transaction({ amount: '-2500.50' })],
-      [
-        execution({ id: 'wrong-amount', net_value_trade_currency: '1000.00' }),
-        execution({ id: 'right-amount', net_value_trade_currency: '2500.50' }),
-      ],
-      accountTuples,
+  it('requires the value date to be the effective debit date, not the trade date', () => {
+    expect(match([transaction({ debit_date: date('2024-03-10') })], [execution()]).size).toBe(0);
+  });
+
+  it('prefers a debit date override, as everywhere else', () => {
+    const matched = match(
+      [transaction({ debit_date: date('2024-03-31'), debit_date_override: date('2024-03-12') })],
+      [execution()],
     );
 
-    expect(matched.get('5129523')?.map(e => e.id)).toEqual(['right-amount']);
+    expect(matched.get('e1')?.id).toBe('t1');
   });
 
-  it('compares magnitudes, so a sell (credit) still matches its execution', () => {
-    const matched = matchSecurityExecutions(
+  it('drops a transaction with no debit date', () => {
+    expect(match([transaction({ debit_date: null })], [execution()]).size).toBe(0);
+  });
+
+  it('drops an execution with no value date', () => {
+    expect(match([transaction()], [execution({ value_date: null })]).size).toBe(0);
+  });
+
+  it('compares the amount exactly — a near miss is a different event', () => {
+    expect(match([transaction({ amount: '-1000.01' })], [execution()]).size).toBe(0);
+  });
+
+  it('ignores trailing zeros, which the two sources spell differently', () => {
+    const matched = match([transaction({ amount: '-1000' })], [execution()]);
+
+    expect(matched.get('e1')?.id).toBe('t1');
+  });
+
+  it('compares the net value quoted in the transaction currency', () => {
+    // Same execution, booked in ILS: the NIS column is the comparable one.
+    const matched = match(
+      [transaction({ amount: '-3700.00', currency: 'ILS' })],
+      [execution({ trade_currency: 'דולר ארה"ב' })],
+    );
+
+    expect(matched.get('e1')?.id).toBe('t1');
+  });
+
+  it('reads the settlement currency column when that is what the transaction is in', () => {
+    const matched = match(
+      [transaction({ amount: '-920.00', currency: 'EUR' })],
+      [execution({ settlement_currency: 'EUR', net_value_settlement_currency: '920.00' })],
+    );
+
+    expect(matched.get('e1')?.id).toBe('t1');
+  });
+
+  it('will not compare across currencies', () => {
+    expect(
+      match(
+        [transaction({ amount: '-1000.00', currency: 'EUR' })],
+        [execution({ net_value_nis: null })],
+      ).size,
+    ).toBe(0);
+  });
+
+  it('requires the direction the trade type implies', () => {
+    // A buy takes money out; a credit of the same size is some other event.
+    expect(match([transaction({ amount: '1000.00' })], [execution()]).size).toBe(0);
+  });
+
+  it('matches a sale against a credit', () => {
+    const matched = match(
       [transaction({ amount: '1000.00' })],
-      [execution({ net_value_trade_currency: '-1000.00' })],
-      accountTuples,
+      [execution({ trade_type: 'מכירה' })],
     );
 
-    expect(matched.get('5129523')).toHaveLength(1);
+    expect(matched.get('e1')?.id).toBe('t1');
   });
 
-  it('falls back to the settlement-currency and NIS net values', () => {
+  it('leaves the sign unconstrained for actions with no cash direction', () => {
+    const matched = match(
+      [transaction({ amount: '1000.00' })],
+      [execution({ trade_type: 'העברה לזכות הפקדון' })],
+    );
+
+    expect(matched.get('e1')?.id).toBe('t1');
+  });
+
+  it('will not cross-match between two portfolios', () => {
+    expect(match([transaction({ account_id: OTHER_ACCOUNT_ID })], [execution()]).size).toBe(0);
+  });
+
+  it('skips a transaction whose account has no Poalim identity', () => {
+    expect(match([transaction({ account_id: 'unmapped-account' })], [execution()]).size).toBe(0);
+  });
+
+  it('pairs one-to-one when a security is executed twice the same day for the same amount', () => {
+    const matched = match(
+      [transaction({ id: 't1' }), transaction({ id: 't2' })],
+      [execution({ id: 'e1' }), execution({ id: 'e2' })],
+    );
+
+    expect([...matched.entries()].map(([executionId, t]) => [executionId, t.id])).toEqual([
+      ['e1', 't1'],
+      ['e2', 't2'],
+    ]);
+  });
+
+  it('leaves a third execution unmatched when only two cash movements exist', () => {
+    const matched = match(
+      [transaction({ id: 't1' }), transaction({ id: 't2' })],
+      [execution({ id: 'e1' }), execution({ id: 'e2' }), execution({ id: 'e3' })],
+    );
+
+    expect(matched.size).toBe(2);
+    expect(matched.has('e3')).toBe(false);
+  });
+
+  it('consumes executions oldest first, whatever order they arrive in', () => {
+    const older = execution({ id: 'e-late-id', trade_date: date('2024-03-08') });
+    const newer = execution({ id: 'e-early-id', trade_date: date('2024-03-10') });
+
+    const matched = match([transaction()], [newer, older]);
+
+    expect(matched.has('e-late-id')).toBe(true);
+    expect(matched.has('e-early-id')).toBe(false);
+  });
+});
+
+describe('matchSecurityExecutions', () => {
+  it('groups the matched executions by security key', () => {
     const matched = matchSecurityExecutions(
-      [transaction({ amount: '-3600.25' })],
+      [transaction({ id: 't1' }), transaction({ id: 't2', amount: '-2000.00' })],
       [
-        execution({
-          net_value_trade_currency: null,
-          net_value_nis: '3600.25',
-        }),
+        execution({ id: 'e1', security: '5129523' }),
+        execution({ id: 'e2', security: '7654321', net_value_trade_currency: '2000.00' }),
       ],
       accountTuples,
     );
 
-    expect(matched.get('5129523')).toHaveLength(1);
+    expect([...matched.keys()].sort()).toEqual(['5129523', '7654321']);
+    expect(matched.get('5129523')?.map(e => e.id)).toEqual(['e1']);
+    expect(matched.get('7654321')?.map(e => e.id)).toEqual(['e2']);
   });
 
-  it('drops an execution whose amount is outside the tolerance', () => {
+  it('omits a security whose executions match nothing', () => {
     const matched = matchSecurityExecutions(
-      [transaction({ amount: '-1000.00' })],
-      [execution({ net_value_trade_currency: '1000.02' })],
+      [transaction()],
+      [execution({ id: 'e2', security: '7654321', net_value_trade_currency: '9999.00' })],
       accountTuples,
     );
 
     expect(matched.size).toBe(0);
   });
 
-  it('accepts an amount at the tolerance boundary', () => {
+  it('orders a security group by trade date', () => {
     const matched = matchSecurityExecutions(
-      [transaction({ amount: '-1000.00' })],
-      [execution({ net_value_trade_currency: '1000.01' })],
-      accountTuples,
-    );
-
-    expect(matched.get('5129523')).toHaveLength(1);
-  });
-
-  it('matches an execution whose settlement date lands on the debit date', () => {
-    const matched = matchSecurityExecutions(
-      [transaction({ event_date: date('2024-03-10'), debit_date: date('2024-03-12') })],
-      [execution({ trade_date: date('2024-02-01'), settlement_date: date('2024-03-12') })],
-      accountTuples,
-    );
-
-    expect(matched.get('5129523')).toHaveLength(1);
-  });
-
-  it('honours the debit date override over the raw debit date', () => {
-    const matched = matchSecurityExecutions(
+      [transaction({ id: 't1' }), transaction({ id: 't2' })],
       [
-        transaction({
-          event_date: date('2024-01-01'),
-          debit_date: date('2024-01-02'),
-          debit_date_override: date('2024-03-12'),
-        }),
-      ],
-      [execution({ trade_date: date('2024-03-12') })],
-      accountTuples,
-    );
-
-    expect(matched.get('5129523')).toHaveLength(1);
-  });
-
-  it('respects the date window edges', () => {
-    const withinWindow = matchSecurityExecutions(
-      [transaction()],
-      [execution({ trade_date: date('2024-03-15') })],
-      accountTuples,
-      { dateWindowDays: 5 },
-    );
-    expect(withinWindow.get('5129523')).toHaveLength(1);
-
-    const outsideWindow = matchSecurityExecutions(
-      [transaction()],
-      [execution({ trade_date: date('2024-03-16') })],
-      accountTuples,
-      { dateWindowDays: 5 },
-    );
-    expect(outsideWindow.size).toBe(0);
-  });
-
-  it('does not match an execution from another account', () => {
-    const matched = matchSecurityExecutions(
-      [transaction()],
-      [execution({ account_number: OTHER_ACCOUNT.accountNumber })],
-      new Map([[ACCOUNT_ID, ACCOUNT]]),
-    );
-
-    expect(matched.size).toBe(0);
-  });
-
-  it('skips transactions whose account has no resolved Poalim tuple', () => {
-    const matched = matchSecurityExecutions([transaction()], [execution()], new Map());
-
-    expect(matched.size).toBe(0);
-  });
-
-  it('returns each matched execution once, sorted by trade date', () => {
-    const matched = matchSecurityExecutions(
-      [transaction({ id: 'trade' }), transaction({ id: 'duplicate-leg' })],
-      [
-        execution({ id: 'later', trade_date: date('2024-03-12') }),
-        execution({ id: 'earlier', trade_date: date('2024-03-08') }),
+        execution({ id: 'e-newer', trade_date: date('2024-03-11') }),
+        execution({ id: 'e-older', trade_date: date('2024-03-09') }),
       ],
       accountTuples,
     );
 
-    expect(matched.get('5129523')?.map(e => e.id)).toEqual(['earlier', 'later']);
-  });
-
-  it('groups matches from several securities under their own keys', () => {
-    const matched = matchSecurityExecutions(
-      [transaction({ id: 't1', amount: '-1000.00' }), transaction({ id: 't2', amount: '-500.00' })],
-      [
-        execution({ id: 'a', security: '5129523', net_value_trade_currency: '1000.00' }),
-        execution({ id: 'b', security: '77774297', net_value_trade_currency: '500.00' }),
-      ],
-      accountTuples,
-    );
-
-    expect([...matched.keys()].sort()).toEqual(['5129523', '77774297']);
+    expect(matched.get('5129523')?.map(e => e.id)).toEqual(['e-older', 'e-newer']);
   });
 });

--- a/packages/server/src/modules/foreign-securities/helpers/__tests__/match-security-executions.helper.test.ts
+++ b/packages/server/src/modules/foreign-securities/helpers/__tests__/match-security-executions.helper.test.ts
@@ -98,6 +98,35 @@ describe('matchExecutionsToTransactions', () => {
     expect(matched.get('e1')?.id).toBe('t1');
   });
 
+  it('compares decimals exactly, past what a double can hold', () => {
+    // Both sides parse to the same double, so a Number-based compare would call these equal.
+    expect(
+      match(
+        [transaction({ amount: '-12345678901234567.01' })],
+        [execution({ net_value_trade_currency: '12345678901234567.02' })],
+      ).size,
+    ).toBe(0);
+
+    const matched = match(
+      [transaction({ amount: '-12345678901234567.01' })],
+      [execution({ net_value_trade_currency: '12345678901234567.010' })],
+    );
+    expect(matched.get('e1')?.id).toBe('t1');
+  });
+
+  it('reads a signed zero as a zero', () => {
+    const matched = match(
+      [transaction({ amount: '-0.00' })],
+      [execution({ net_value_trade_currency: '0' })],
+    );
+
+    expect(matched.get('e1')?.id).toBe('t1');
+  });
+
+  it('does not match an amount that is not a plain decimal', () => {
+    expect(match([transaction({ amount: 'NaN' })], [execution()]).size).toBe(0);
+  });
+
   it('compares the net value quoted in the transaction currency', () => {
     // Same execution, booked in ILS: the NIS column is the comparable one.
     const matched = match(
@@ -144,6 +173,17 @@ describe('matchExecutionsToTransactions', () => {
     const matched = match(
       [transaction({ amount: '1000.00' })],
       [execution({ trade_type: 'העברה לזכות הפקדון' })],
+    );
+
+    expect(matched.get('e1')?.id).toBe('t1');
+  });
+
+  it('tolerates a trade type it does not know rather than failing the whole charge', () => {
+    // The bank adding a word the translation has not learned must not take down a charge; the
+    // resolver is where that drift is meant to surface, and only for rows that get served.
+    const matched = match(
+      [transaction({ amount: '1000.00' })],
+      [execution({ trade_type: 'משהו חדש' })],
     );
 
     expect(matched.get('e1')?.id).toBe('t1');

--- a/packages/server/src/modules/foreign-securities/helpers/match-security-executions.helper.ts
+++ b/packages/server/src/modules/foreign-securities/helpers/match-security-executions.helper.ts
@@ -1,7 +1,7 @@
 import { Currency, SecurityTradeType } from '../../../shared/enums.js';
 import { formatCurrency } from '../../../shared/helpers/amount.js';
 import { dateToTimelessDateString } from '../../../shared/helpers/misc.js';
-import { toSecurityTradeType } from './security-execution-enums.helper.js';
+import { tryToSecurityTradeType } from './security-execution-enums.helper.js';
 
 /**
  * `accounter_schema.poalim_securities_transactions` carries no link to
@@ -77,6 +77,44 @@ const CASH_DIRECTION: Record<SecurityTradeType, -1 | 1 | null> = {
   [SecurityTradeType.TransferOutTwoSided]: null,
 };
 
+type DecimalValue = {
+  negative: boolean;
+  /** The value without its sign, in one canonical spelling: `1000`, `1000.1`, `0`. */
+  magnitude: string;
+};
+
+const DECIMAL = /^([+-]?)(\d*)(?:\.(\d*))?$/;
+
+/**
+ * `numeric` reaches us as a decimal string, and the two sources spell the same value
+ * differently — `1000` against `1000.00`. Going through `Number` to reconcile that would trade
+ * an exact decimal for a binary approximation, which is a strange thing to do in a comparison
+ * documented as exact: past 2^53, or with enough fraction digits, two different values can land
+ * on one double and two spellings of one value can land on different ones. Canonicalizing the
+ * string keeps the decimal exact at any size.
+ *
+ * Returns null for anything that is not a plain decimal, which cannot be compared and therefore
+ * cannot match.
+ */
+function parseDecimal(raw: string): DecimalValue | null {
+  const match = DECIMAL.exec(raw.trim());
+  if (!match) {
+    return null;
+  }
+
+  const [, sign, whole = '', fraction = ''] = match;
+  if (!whole && !fraction) {
+    return null;
+  }
+
+  const integerPart = whole.replace(/^0+/, '');
+  const fractionPart = fraction.replace(/0+$/, '');
+  const magnitude = fractionPart ? `${integerPart || '0'}.${fractionPart}` : integerPart || '0';
+
+  // -0 is 0; a zero has no direction to disagree about.
+  return { negative: sign === '-' && magnitude !== '0', magnitude };
+}
+
 /** The transaction's effective debit date — an override wins, as everywhere else. */
 function effectiveDebitDate(transaction: MatchableTransaction): Date | null {
   return transaction.debit_date_override ?? transaction.debit_date;
@@ -146,20 +184,24 @@ function matchesTransaction(
     return false;
   }
 
-  const executionValue = Number(executionAmount);
-  const transactionValue = Number(transaction.amount);
-  if (Number.isNaN(executionValue) || Number.isNaN(transactionValue)) {
+  const executionValue = parseDecimal(executionAmount);
+  const transactionValue = parseDecimal(transaction.amount);
+  if (!executionValue || !transactionValue) {
     return false;
   }
-  if (Math.abs(executionValue) !== Math.abs(transactionValue)) {
+  if (executionValue.magnitude !== transactionValue.magnitude) {
     return false;
   }
 
-  const direction = CASH_DIRECTION[toSecurityTradeType(execution.trade_type)];
-  if (direction == null || transactionValue === 0) {
+  // A trade type the translation does not know leaves the direction unconstrained rather than
+  // failing the match: the date, amount and account still have to agree, and an execution that
+  // gets this far reaches the resolver, which is where unknown vocabulary is meant to be loud.
+  const tradeType = tryToSecurityTradeType(execution.trade_type);
+  const direction = tradeType ? CASH_DIRECTION[tradeType] : null;
+  if (direction == null || transactionValue.magnitude === '0') {
     return true;
   }
-  return Math.sign(transactionValue) === direction;
+  return (transactionValue.negative ? -1 : 1) === direction;
 }
 
 /**

--- a/packages/server/src/modules/foreign-securities/helpers/match-security-executions.helper.ts
+++ b/packages/server/src/modules/foreign-securities/helpers/match-security-executions.helper.ts
@@ -1,32 +1,34 @@
+import { Currency, SecurityTradeType } from '../../../shared/enums.js';
+import { formatCurrency } from '../../../shared/helpers/amount.js';
 import { dateToTimelessDateString } from '../../../shared/helpers/misc.js';
+import { toSecurityTradeType } from './security-execution-enums.helper.js';
 
 /**
  * `accounter_schema.poalim_securities_transactions` carries no link to
  * `accounter_schema.transactions` — the scrape has no per-execution id and the bank never
- * cross-references the cash leg. Pairing is therefore derived, on three axes:
+ * cross-references the cash leg. Pairing is therefore derived, from the two facts both sides
+ * report about the same event:
  *
- * 1. the security key the transaction description carries (the caller already grouped by it),
- * 2. the Poalim account tuple (bank/branch/account) behind the transaction's `account_id`,
- * 3. a date within a few days of the transaction, **and** a matching amount.
+ * 1. the execution settles on the day the account is debited or credited
+ *    (`value_date` = the transaction's effective debit date), and
+ * 2. the execution's net value *in the transaction's currency* is the amount that moved,
+ *    with the direction the trade type implies.
  *
- * The amount is what makes this safe: a security can be traded several times on the same day,
- * so date alone would attach every one of them to every cash movement. A candidate that falls
- * in the window but matches no amount is dropped rather than shown as a maybe.
+ * Both are exact. Amounts come out of Postgres `numeric` as decimal strings and both sides
+ * report the same figure, so there is nothing for a tolerance to absorb — a near-miss is a
+ * different event, not a rounding difference. The account tuple is required on top: the same
+ * security trading in two of a tenant's portfolios would otherwise cross-match.
+ *
+ * Pairing is one-to-one and greedy: a security can be executed several times on one day for
+ * the same amount, and each execution belongs to exactly one cash movement.
  */
-
-/** How far apart an execution date and a transaction date may be and still pair up. */
-export const DEFAULT_DATE_WINDOW_DAYS = 5;
-
-/**
- * Absolute tolerance on the amount compare. The values come out of Postgres `numeric` as
- * decimal strings, so this only absorbs the bank's own rounding, not float drift.
- */
-export const DEFAULT_AMOUNT_TOLERANCE = 0.01;
 
 export type MatchableTransaction = {
   id: string;
+  charge_id: string;
   amount: string;
-  event_date: Date;
+  /** The raw column value; `accounter_schema.currency` is a string union, not the enum. */
+  currency: string;
   debit_date: Date | null;
   debit_date_override: Date | null;
   account_id: string;
@@ -40,8 +42,9 @@ export type MatchableExecution = {
   account_number: number;
   trade_date: Date;
   value_date: Date | null;
-  settlement_date: Date | null;
-  payment_date: Date | null;
+  trade_type: string;
+  trade_currency: string | null;
+  settlement_currency: string | null;
   net_value_trade_currency: string | null;
   net_value_settlement_currency: string | null;
   net_value_nis: string | null;
@@ -54,70 +57,71 @@ export type AccountTuple = {
   accountNumber: number;
 };
 
-export type MatchOptions = {
-  dateWindowDays?: number;
-  amountTolerance?: number;
+/**
+ * Which way cash moves for each kind of execution. `null` is "the bank reports no cash
+ * direction for this action" — those rows are matched on date, amount and account alone
+ * rather than being force-fitted to a sign the source never implies.
+ */
+const CASH_DIRECTION: Record<SecurityTradeType, -1 | 1 | null> = {
+  [SecurityTradeType.Buy]: -1,
+  [SecurityTradeType.Sell]: 1,
+  [SecurityTradeType.DividendPayment]: 1,
+  [SecurityTradeType.InterestPayment]: 1,
+  [SecurityTradeType.Redemption]: 1,
+  // Security movements, not cash: a distribution or a deposit transfer has no cash leg of its
+  // own, and the two-sided variants settle between accounts rather than against the balance.
+  [SecurityTradeType.StockDistribution]: null,
+  [SecurityTradeType.TransferIn]: null,
+  [SecurityTradeType.TransferOut]: null,
+  [SecurityTradeType.TransferInTwoSided]: null,
+  [SecurityTradeType.TransferOutTwoSided]: null,
 };
 
-const MS_PER_DAY = 86_400_000;
+/** The transaction's effective debit date — an override wins, as everywhere else. */
+function effectiveDebitDate(transaction: MatchableTransaction): Date | null {
+  return transaction.debit_date_override ?? transaction.debit_date;
+}
 
 /**
  * Both sides are calendar dates stored as `DATE` and parsed back to *local* midnight, so
- * subtracting the raw timestamps drifts by an hour across a DST boundary. Going through the
- * timeless string and re-reading it as UTC keeps the day count exact.
+ * comparing the raw timestamps drifts across a DST boundary. The timeless string is the day.
  */
-function toDayNumber(date: Date): number {
-  return Date.parse(`${dateToTimelessDateString(date)}T00:00:00Z`) / MS_PER_DAY;
-}
-
-function withinDays(a: Date, b: Date, windowDays: number): boolean {
-  return Math.abs(toDayNumber(a) - toDayNumber(b)) <= windowDays;
-}
-
-/** Sign is direction, which the two sources express differently; compare magnitudes. */
-function amountsMatch(a: string, b: string, tolerance: number): boolean {
-  const left = Math.abs(Number(a));
-  const right = Math.abs(Number(b));
-  if (Number.isNaN(left) || Number.isNaN(right)) {
-    return false;
-  }
-  return Math.abs(left - right) <= tolerance;
-}
-
-function transactionDates(transaction: MatchableTransaction): Date[] {
-  const effectiveDebitDate = transaction.debit_date_override ?? transaction.debit_date;
-  return effectiveDebitDate
-    ? [transaction.event_date, effectiveDebitDate]
-    : [transaction.event_date];
-}
-
-function executionDates(execution: MatchableExecution): Date[] {
-  return [
-    execution.trade_date,
-    execution.value_date,
-    execution.settlement_date,
-    execution.payment_date,
-  ].filter((date): date is Date => date != null);
+function sameDay(a: Date, b: Date): boolean {
+  return dateToTimelessDateString(a) === dateToTimelessDateString(b);
 }
 
 /**
- * The cash leg can be booked in the trade, settlement or reporting currency depending on the
- * action, so all three net values are candidates for the amount compare.
+ * The cash leg is booked in the trade or settlement currency depending on the action, and the
+ * bank reports a NIS figure for everything. Only the column quoted in the transaction's own
+ * currency is comparable — the others are the same value through an exchange rate.
+ *
+ * The feed spells its currencies out in Hebrew; `formatCurrency` knows those labels, and the
+ * nullable form keeps an unrecognized one from throwing mid-match.
  */
-function executionAmounts(execution: MatchableExecution): string[] {
-  return [
-    execution.net_value_trade_currency,
-    execution.net_value_settlement_currency,
-    execution.net_value_nis,
-  ].filter((amount): amount is string => amount != null);
+function executionAmountInCurrency(
+  execution: MatchableExecution,
+  currency: Currency,
+): string | null {
+  // `formatCurrency` reads a missing label as ILS, which would make every unreported
+  // settlement currency look like a shekel column; an absent label means "not reported".
+  const label = (raw: string | null) => (raw?.trim() ? formatCurrency(raw, true) : null);
+
+  if (label(execution.trade_currency) === currency) {
+    return execution.net_value_trade_currency;
+  }
+  if (label(execution.settlement_currency) === currency) {
+    return execution.net_value_settlement_currency;
+  }
+  if (currency === Currency.Ils) {
+    return execution.net_value_nis;
+  }
+  return null;
 }
 
 function matchesTransaction(
   execution: MatchableExecution,
   transaction: MatchableTransaction,
   accountTuple: AccountTuple,
-  dateWindowDays: number,
-  amountTolerance: number,
 ): boolean {
   if (
     execution.bank_number !== accountTuple.bankNumber ||
@@ -127,51 +131,94 @@ function matchesTransaction(
     return false;
   }
 
-  const dateMatches = executionDates(execution).some(executionDate =>
-    transactionDates(transaction).some(transactionDate =>
-      withinDays(executionDate, transactionDate, dateWindowDays),
-    ),
-  );
-  if (!dateMatches) {
+  const debitDate = effectiveDebitDate(transaction);
+  if (!debitDate || !execution.value_date || !sameDay(execution.value_date, debitDate)) {
     return false;
   }
 
-  return executionAmounts(execution).some(amount =>
-    amountsMatch(amount, transaction.amount, amountTolerance),
-  );
+  const currency = formatCurrency(transaction.currency, true);
+  if (!currency) {
+    return false;
+  }
+
+  const executionAmount = executionAmountInCurrency(execution, currency);
+  if (executionAmount == null) {
+    return false;
+  }
+
+  const executionValue = Number(executionAmount);
+  const transactionValue = Number(transaction.amount);
+  if (Number.isNaN(executionValue) || Number.isNaN(transactionValue)) {
+    return false;
+  }
+  if (Math.abs(executionValue) !== Math.abs(transactionValue)) {
+    return false;
+  }
+
+  const direction = CASH_DIRECTION[toSecurityTradeType(execution.trade_type)];
+  if (direction == null || transactionValue === 0) {
+    return true;
+  }
+  return Math.sign(transactionValue) === direction;
 }
 
 /**
- * Pairs the charge's transactions with the ingested executions and returns the matched
- * executions grouped by security key.
+ * The cash movement behind each execution, at most one per side.
  *
  * `accountTuples` maps a transaction's `account_id` to its Poalim identity; transactions whose
  * account is missing from the map (not a bank account, or not yet backfilled) are skipped —
  * without the tuple there is no way to tell one portfolio from another.
+ *
+ * Executions are consumed oldest first so the pairing is stable regardless of row order.
+ */
+export function matchExecutionsToTransactions<
+  TExecution extends MatchableExecution,
+  TTransaction extends MatchableTransaction,
+>(
+  transactions: readonly TTransaction[],
+  executions: readonly TExecution[],
+  accountTuples: ReadonlyMap<string, AccountTuple>,
+): Map<string, TTransaction> {
+  const matches = new Map<string, TTransaction>();
+  const takenTransactionIds = new Set<string>();
+
+  const ordered = [...executions].sort(
+    (a, b) => a.trade_date.getTime() - b.trade_date.getTime() || a.id.localeCompare(b.id),
+  );
+
+  for (const execution of ordered) {
+    const transaction = transactions.find(candidate => {
+      if (takenTransactionIds.has(candidate.id)) {
+        return false;
+      }
+      const accountTuple = accountTuples.get(candidate.account_id);
+      return accountTuple != null && matchesTransaction(execution, candidate, accountTuple);
+    });
+
+    if (transaction) {
+      takenTransactionIds.add(transaction.id);
+      matches.set(execution.id, transaction);
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * The same pairing seen from the charge: the matched executions, grouped by security key.
  */
 export function matchSecurityExecutions<TExecution extends MatchableExecution>(
   transactions: readonly MatchableTransaction[],
   executions: readonly TExecution[],
   accountTuples: ReadonlyMap<string, AccountTuple>,
-  options: MatchOptions = {},
 ): Map<string, TExecution[]> {
-  const dateWindowDays = options.dateWindowDays ?? DEFAULT_DATE_WINDOW_DAYS;
-  const amountTolerance = options.amountTolerance ?? DEFAULT_AMOUNT_TOLERANCE;
+  const matches = matchExecutionsToTransactions(transactions, executions, accountTuples);
 
   const matchedBySecurity = new Map<string, TExecution[]>();
-
   for (const execution of executions) {
-    const matched = transactions.some(transaction => {
-      const accountTuple = accountTuples.get(transaction.account_id);
-      return (
-        accountTuple != null &&
-        matchesTransaction(execution, transaction, accountTuple, dateWindowDays, amountTolerance)
-      );
-    });
-    if (!matched) {
+    if (!matches.has(execution.id)) {
       continue;
     }
-
     const group = matchedBySecurity.get(execution.security);
     if (group) {
       group.push(execution);

--- a/packages/server/src/modules/foreign-securities/helpers/security-execution-enums.helper.ts
+++ b/packages/server/src/modules/foreign-securities/helpers/security-execution-enums.helper.ts
@@ -60,6 +60,18 @@ function translate<T>(map: Record<string, T>, raw: string, field: string, zodCon
 export const toSecurityTradeType = (raw: string): SecurityTradeType =>
   translate(TRADE_TYPES, raw, 'trade type', 'TRADE_TYPES');
 
+/**
+ * The same translation for callers that must not fail on drift.
+ *
+ * Throwing is right when an execution is being *served* — the value would otherwise be
+ * silently dropped from the response. It is wrong while deciding whether a row is even
+ * relevant: one unknown trade type in the table would take down every charge that looks at
+ * the same account, including those the row has nothing to do with. Rows that do surface
+ * still reach `toSecurityTradeType` in the resolver, so the drift stays loud where it counts.
+ */
+export const tryToSecurityTradeType = (raw: string): SecurityTradeType | null =>
+  TRADE_TYPES[raw] ?? null;
+
 export const toSecurityTransactionType = (raw: string): SecurityTransactionType =>
   translate(TRANSACTION_TYPES, raw, 'transaction type', 'TRANSACTION_TYPES');
 

--- a/packages/server/src/modules/foreign-securities/providers/__tests__/foreign-securities.integration.test.ts
+++ b/packages/server/src/modules/foreign-securities/providers/__tests__/foreign-securities.integration.test.ts
@@ -49,11 +49,14 @@ type StubTransaction = {
   id: string;
   source_description: string | null;
   amount?: string;
-  event_date?: Date;
+  currency?: string;
   debit_date?: Date | null;
   debit_date_override?: Date | null;
   account_id?: string;
 };
+
+/** The day the fixtures settle on: execution value date and transaction debit date alike. */
+const VALUE_DATE = '2024-03-12';
 
 /**
  * The provider reads only the identity, description, account and date/amount fields off each
@@ -64,12 +67,13 @@ type StubTransaction = {
 function createStubTransactionsProvider(transactions: StubTransaction[]): TransactionsProvider {
   return {
     transactionsByChargeIDLoader: {
-      load: (_chargeId: string) =>
+      load: (chargeId: string) =>
         Promise.resolve(
           transactions.map(transaction => ({
+            charge_id: chargeId,
             amount: '-1000.00',
-            event_date: new Date('2024-03-10T00:00:00'),
-            debit_date: null,
+            currency: 'USD',
+            debit_date: new Date(`${VALUE_DATE}T00:00:00`),
             debit_date_override: null,
             account_id: ACCOUNT_ID,
             ...transaction,
@@ -156,6 +160,7 @@ type ExecutionFixture = {
   accountNumber?: number;
   security: string;
   tradeDate?: string;
+  valueDate?: string | null;
   tradeType?: string;
   netValueTradeCurrency?: string;
 };
@@ -167,6 +172,7 @@ async function insertExecution({
   accountNumber = ACCOUNT_NUMBER,
   security,
   tradeDate = '2024-03-10',
+  valueDate = VALUE_DATE,
   tradeType = 'קניה',
   netValueTradeCurrency = '1000.00',
 }: ExecutionFixture) {
@@ -174,9 +180,9 @@ async function insertExecution({
   // the two agree (an invariant the scraper's zod schema enforces).
   await pool.query(
     `INSERT INTO accounter_schema.poalim_securities_transactions (
-       owner_id, bank_number, branch_number, account_number, security, trade_date,
+       owner_id, bank_number, branch_number, account_number, security, trade_date, value_date,
        trade_type, transaction_type, nv, trade_price, net_value_trade_currency, trade_currency
-     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $7, 10, 100, $8, 'דולר ארה"ב')`,
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8, 10, 100, $9, 'דולר ארה"ב')`,
     [
       ownerId,
       BANK_NUMBER,
@@ -184,6 +190,7 @@ async function insertExecution({
       accountNumber,
       security,
       tradeDate,
+      valueDate,
       tradeType,
       netValueTradeCurrency,
     ],
@@ -425,9 +432,9 @@ describe('getChargeSecurities — matched executions', () => {
     expect(securities[0].executions).toEqual([]);
   });
 
-  it('excludes an execution far outside the transaction date window', async () => {
+  it('excludes an execution that settles on another day', async () => {
     await insertSecurity({ securityKey: '5129523' });
-    await insertExecution({ security: '5129523', tradeDate: '2024-01-05' });
+    await insertExecution({ security: '5129523', valueDate: '2024-01-05' });
     const provider = createProvider([
       { id: 't1', source_description: 'ניע"ז קניה 0005129523', amount: '-1000.00' },
     ]);

--- a/packages/server/src/modules/foreign-securities/providers/foreign-securities.provider.ts
+++ b/packages/server/src/modules/foreign-securities/providers/foreign-securities.provider.ts
@@ -6,7 +6,6 @@ import { FinancialAccountsProvider } from '../../financial-accounts/providers/fi
 import { FinancialBankAccountsProvider } from '../../financial-accounts/providers/financial-bank-accounts.provider.js';
 import { TransactionsProvider } from '../../transactions/providers/transactions.provider.js';
 import {
-  DEFAULT_DATE_WINDOW_DAYS,
   matchSecurityExecutions,
   type AccountTuple,
   type MatchableTransaction,
@@ -35,10 +34,9 @@ const getSecuritiesByKeys = sql<IGetSecuritiesByKeysQuery>`
   ORDER BY security_key, as_of_date DESC;`;
 
 /**
- * A coarse prefilter, not the match itself: the ANY(...) predicates form a cross-product over
- * the charge's keys and accounts, and the date range spans every transaction on the charge.
- * `matchSecurityExecutions` does the exact per-row pairing in memory — same shape as
- * `fetchPoalimSecuritiesTransactionsByKeys` in the ingestion provider.
+ * A prefilter, not the match itself: the ANY(...) predicates form a cross-product over the
+ * charge's keys, accounts and settlement days. `matchSecurityExecutions` does the per-row
+ * pairing in memory, where the account tuple, currency and direction are checked together.
  *
  * Tenant scoping is RLS again (FORCE ROW LEVEL SECURITY + tenant_isolation), hence no
  * owner_id predicate.
@@ -63,6 +61,7 @@ const getSecurityExecutions = sql<IGetSecurityExecutionsQuery>`
     net_value_settlement_currency,
     net_value_nis,
     trade_currency,
+    settlement_currency,
     trade_commission_value_trade_currency,
     management_fees_value_trade_currency,
     israe_tax_value,
@@ -76,14 +75,7 @@ const getSecurityExecutions = sql<IGetSecurityExecutionsQuery>`
     AND bank_number = ANY($bankNumbers!)
     AND branch_number = ANY($branchNumbers!)
     AND account_number = ANY($accountNumbers!)
-    AND (
-      trade_date BETWEEN $fromDate! AND $toDate!
-      OR value_date BETWEEN $fromDate! AND $toDate!
-      OR settlement_date BETWEEN $fromDate! AND $toDate!
-      OR payment_date BETWEEN $fromDate! AND $toDate!
-    );`;
-
-const MS_PER_DAY = 86_400_000;
+    AND value_date = ANY($valueDates!);`;
 
 @Injectable({
   scope: Scope.Operation,
@@ -162,12 +154,12 @@ export class ForeignSecuritiesProvider {
       return new Map();
     }
 
-    const dates = transactions.flatMap(transaction =>
-      [transaction.event_date, transaction.debit_date_override ?? transaction.debit_date]
-        .filter((date): date is Date => date != null)
-        .map(date => date.getTime()),
-    );
-    if (dates.length === 0) {
+    // An execution settles on the day its cash leg is debited, so those are the only days
+    // worth fetching. A transaction with no debit date can never pair up.
+    const valueDates = transactions
+      .map(transaction => transaction.debit_date_override ?? transaction.debit_date)
+      .filter((date): date is Date => date != null);
+    if (valueDates.length === 0) {
       return new Map();
     }
 
@@ -178,8 +170,7 @@ export class ForeignSecuritiesProvider {
         bankNumbers: [...new Set(tuples.map(tuple => tuple.bankNumber))],
         branchNumbers: [...new Set(tuples.map(tuple => tuple.branchNumber))],
         accountNumbers: [...new Set(tuples.map(tuple => tuple.accountNumber))],
-        fromDate: new Date(Math.min(...dates) - DEFAULT_DATE_WINDOW_DAYS * MS_PER_DAY),
-        toDate: new Date(Math.max(...dates) + DEFAULT_DATE_WINDOW_DAYS * MS_PER_DAY),
+        valueDates,
       },
       this.db,
     );


### PR DESCRIPTION
Step 2 of the [per-security businesses plan](../blob/feat/security-businesses-plan/docs/foreign-securities-businesses/plan.md). Stacked on #4252.

### The problem

The executions table has no link to `transactions`, so pairing is derived. The first cut derived it
loosely: a ±5 day window across four date columns on each side, and a ±0.01 tolerance across three
amount columns, signs ignored. Twelve date pairs × three amounts could carry a match — an execution
could attach to an unrelated cash movement, in the wrong direction.

### The rule now

- `value_date` **=** the transaction's effective debit date (`debit_date_override ?? debit_date`).
- Net value **in the transaction's own currency** = the amount, **exactly**, with the sign the trade
  type implies (buy debits; sale/redemption/dividend/interest credit; actions the bank files with no
  cash direction are matched on date+amount+account alone).
- Still scoped to the Poalim account tuple.
- Pairing is **one-to-one and greedy**, oldest execution first — a security can be executed several
  times a day for the same amount.

`matchExecutionsToTransactions` is added for the reverse direction (execution → its cash movement and
charge), which the security-history tab needs later.

### Note on behavior

This is deliberately stricter, so a charge's "Portfolio activity" table will show fewer rows where
the old fuzzy rule was over-matching — and none at all for an execution whose `value_date` the bank
left empty. Worth eyeballing one real charge after merge.

The provider's prefilter follows the rule: `value_date = ANY(<the charge's debit dates>)` instead of
a padded range over four columns, plus `settlement_currency` for the currency pick.

### Verification

- `yarn lint`, `yarn prettier`, server typecheck clean.
- `yarn test` — 3420 passed; the helper suite is rewritten around the new rule (value-date equality,
  override precedence, exact amount, currency-column selection, direction, account scoping, 1:1
  greediness, deterministic oldest-first order).
- `yarn test:integration` on `foreign-securities` — 20 passed; fixtures now carry `value_date` and a
  debit date, and the old "outside the date window" case became "settles on another day".

🤖 Generated with [Claude Code](https://claude.com/claude-code)