### PR TITLE
feat(server): recognize per-security businesses as the securities side

### DIFF
--- a/.changeset/security-businesses-recognition.md
+++ b/.changeset/security-businesses-recognition.md
@@ -31,7 +31,9 @@ this *the* foreign-securities business", answered by the new
   as before. `normalizeContext` stays synchronous and pure; the enrichment happens on the async paths
   that hit the DB anyway, with raw SQL rather than `SecurityBusinessesProvider` — that provider takes
   its owner id from the admin context, so injecting it back would close a DI cycle. Loading a context
-  is now two queries instead of one.
+  is now two queries instead of one, and the DataLoader path batches both over the whole key set
+  rather than enriching per owner, which would have been an N+1 behind a loader. The ids are merged
+  as a set, so the general foreign-securities business is not listed twice.
 
 `UserContext.foreignSecuritiesBusinessId` is exposed to the client, which needs it as the fallback
 counterparty option when no security could be resolved for a trade.

--- a/.changeset/security-businesses-recognition.md
+++ b/.changeset/security-businesses-recognition.md
@@ -1,0 +1,37 @@
+---
+'@accounter/server': minor
+---
+
+Recognize a per-security business as the foreign-securities side, everywhere the general business
+was the only answer.
+
+`foreignSecuritiesBusinessId` was doing three jobs on its own: typing a charge as
+`ForeignSecurities`, resolving a securities transaction to the `FOREIGN_SECURITIES` account, and —
+via `internalWalletsIds` — telling the ledger and the balance report that a securities movement is
+internal. All three assumed the securities side is exactly one business. Once a trade's counterparty
+is the security it traded, that assumption breaks: the charge would type as `Common`, the transaction
+would resolve to its raw account, and the ledger's counterparty override would stop firing.
+
+So the question those call sites ask is now "is this *a* foreign-securities business" rather than "is
+this *the* foreign-securities business", answered by the new
+`getForeignSecuritiesBusinessIds(injector)` — the general business plus every business carrying a
+`businesses_securities` row, both request-cached.
+
+- `charges/helpers/charge-type.ts` types a charge as `ForeignSecurities` when any of its businesses
+  is in that set. (Stored charge types are untouched — derivation only runs for NULL-typed charges.)
+- `financial-accounts/helpers/account-by-transaction.helper.ts` resolves the same
+  `FOREIGN_SECURITIES` account whichever of them the transaction points at: the portfolio is one
+  account regardless of which security was traded.
+- `AdminContextProvider` appends the tenant's security businesses to `internalWalletsIds`. **This is
+  what keeps the ledger byte-identical**: the main entry's counterparty does not come from
+  `transaction.business_id` at all — `ledgerEntryFromMainTransaction` replaces it with the tax
+  category of the account whose `account_number` is `foreign_securities`, and that override is gated
+  on the counterparty being an internal wallet. It also keeps fee classification
+  (`isSupplementalFeeTransaction`) and the balance report's internal-transfer filter behaving exactly
+  as before. `normalizeContext` stays synchronous and pure; the enrichment happens on the async paths
+  that hit the DB anyway, with raw SQL rather than `SecurityBusinessesProvider` — that provider takes
+  its owner id from the admin context, so injecting it back would close a DI cycle. Loading a context
+  is now two queries instead of one.
+
+`UserContext.foreignSecuritiesBusinessId` is exposed to the client, which needs it as the fallback
+counterparty option when no security could be resolved for a trade.

--- a/packages/server/src/modules/admin-context/__tests__/admin-context-integration.test.ts
+++ b/packages/server/src/modules/admin-context/__tests__/admin-context-integration.test.ts
@@ -4,6 +4,8 @@ import { AdminContextProvider } from '../providers/admin-context.provider.js';
 import type { TenantAwareDBClient } from '../../app-providers/tenant-db-client.js';
 import type { AuthContextProvider } from '../../auth/providers/auth-context.provider.js';
 
+const QUERIES_PER_CONTEXT_LOAD = 2;
+
 function createProvider(options: {
   businessId: string | null;
   activeReadScopeBusinessIds?: string[];
@@ -74,7 +76,9 @@ describe('AdminContext DI Integration', () => {
     expect(context.ownerId).toBe('owner-a');
     expect(context.defaultLocalCurrency).toBe('USD');
     expect(auth.getAuthContext).toHaveBeenCalledTimes(1);
-    expect(query).toHaveBeenCalledTimes(1);
+    // Two queries per load: the user_context row, then the tenant's security businesses,
+    // which join internalWalletsIds.
+    expect(query).toHaveBeenCalledTimes(QUERIES_PER_CONTEXT_LOAD);
   });
 
   it('uses single-business active scope as owner selection', async () => {
@@ -169,8 +173,8 @@ describe('AdminContext DI Integration', () => {
 
     expect(contextA.ownerId).toBe('owner-a');
     expect(contextB.ownerId).toBe('owner-b');
-    expect(requestA.query).toHaveBeenCalledTimes(1);
-    expect(requestB.query).toHaveBeenCalledTimes(1);
+    expect(requestA.query).toHaveBeenCalledTimes(QUERIES_PER_CONTEXT_LOAD);
+    expect(requestB.query).toHaveBeenCalledTimes(QUERIES_PER_CONTEXT_LOAD);
   });
 
   it('caches admin context within a single request', async () => {
@@ -192,7 +196,7 @@ describe('AdminContext DI Integration', () => {
 
     expect(first.ownerId).toBe('owner-a');
     expect(second.ownerId).toBe('owner-a');
-    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledTimes(QUERIES_PER_CONTEXT_LOAD);
   });
 
   it('fails closed when auth context is unavailable (RLS guard path)', async () => {

--- a/packages/server/src/modules/admin-context/__tests__/admin-context.provider.test.ts
+++ b/packages/server/src/modules/admin-context/__tests__/admin-context.provider.test.ts
@@ -168,38 +168,59 @@ describe('AdminContextProvider', () => {
   // businesses, which join internalWalletsIds.
   const QUERIES_PER_CONTEXT_LOAD = 2;
 
-  it('should cache the result', async () => {
-    dbProvider.query.mockResolvedValue({
-      rows: [{ owner_id: 'test-owner-id' }],
+  /**
+   * The two queries return different shapes, so they are stubbed separately: answering the
+   * security-businesses query with a user_context row would put an `undefined` id into
+   * internalWalletsIds and hide the very thing the enrichment is supposed to do.
+   */
+  function mockContextLoad(
+    context: Record<string, unknown>,
+    securityBusinesses: Array<{ id: string; owner_id: string }> = [],
+  ) {
+    dbProvider.query.mockResolvedValueOnce({
+      rows: [context],
       rowCount: 1,
     } as unknown as QueryResultWithRows);
+    dbProvider.query.mockResolvedValueOnce({
+      rows: securityBusinesses,
+      rowCount: securityBusinesses.length,
+    } as unknown as QueryResultWithRows);
+  }
+
+  it('should cache the result', async () => {
+    mockContextLoad({ owner_id: 'test-owner-id' });
 
     await provider.getAdminContext();
     await provider.getAdminContext();
     expect(dbProvider.query).toHaveBeenCalledTimes(QUERIES_PER_CONTEXT_LOAD);
   });
 
+  it('adds the security businesses to the internal wallets, once each', async () => {
+    mockContextLoad(
+      { owner_id: 'test-owner-id', foreign_securities_business_id: 'general-securities' },
+      [
+        { id: 'security-a', owner_id: 'test-owner-id' },
+        { id: 'security-b', owner_id: 'test-owner-id' },
+        // Already an internal wallet through the context itself.
+        { id: 'general-securities', owner_id: 'test-owner-id' },
+      ],
+    );
+
+    const context = await provider.getAdminContext();
+
+    const walletIds = context!.financialAccounts.internalWalletsIds;
+    expect(walletIds).toEqual(expect.arrayContaining(['security-a', 'security-b']));
+    expect(walletIds.filter(id => id === 'general-securities')).toHaveLength(1);
+    expect(walletIds).not.toContain(undefined);
+  });
+
   it('should invalidate cache on update', async () => {
-    dbProvider.query.mockResolvedValueOnce({
-      rows: [{ owner_id: 'test-owner-id', default_local_currency: 'USD' }],
-      rowCount: 1,
-    } as unknown as QueryResultWithRows); // get
-    dbProvider.query.mockResolvedValueOnce({
-      rows: [],
-      rowCount: 0,
-    } as unknown as QueryResultWithRows); // security businesses
+    mockContextLoad({ owner_id: 'test-owner-id', default_local_currency: 'USD' });
 
     await provider.getAdminContext();
     expect(dbProvider.query).toHaveBeenCalledTimes(QUERIES_PER_CONTEXT_LOAD);
 
-    dbProvider.query.mockResolvedValueOnce({
-        rows: [{ owner_id: 'test-owner-id', default_local_currency: 'EUR' }],
-        rowCount: 1
-    } as unknown as QueryResultWithRows); // update
-    dbProvider.query.mockResolvedValueOnce({
-      rows: [],
-      rowCount: 0,
-    } as unknown as QueryResultWithRows); // security businesses
+    mockContextLoad({ owner_id: 'test-owner-id', default_local_currency: 'EUR' });
 
     await provider.updateAdminContext({ defaultLocalCurrency: 'EUR' });
     expect(dbProvider.query).toHaveBeenCalledTimes(QUERIES_PER_CONTEXT_LOAD * 2);

--- a/packages/server/src/modules/admin-context/__tests__/admin-context.provider.test.ts
+++ b/packages/server/src/modules/admin-context/__tests__/admin-context.provider.test.ts
@@ -164,6 +164,10 @@ describe('AdminContextProvider', () => {
     expect(result?.defaultLocalCurrency).toBe('EUR');
   });
 
+  // Loading a context takes two queries: the user_context row, then the tenant's security
+  // businesses, which join internalWalletsIds.
+  const QUERIES_PER_CONTEXT_LOAD = 2;
+
   it('should cache the result', async () => {
     dbProvider.query.mockResolvedValue({
       rows: [{ owner_id: 'test-owner-id' }],
@@ -172,7 +176,7 @@ describe('AdminContextProvider', () => {
 
     await provider.getAdminContext();
     await provider.getAdminContext();
-    expect(dbProvider.query).toHaveBeenCalledTimes(1);
+    expect(dbProvider.query).toHaveBeenCalledTimes(QUERIES_PER_CONTEXT_LOAD);
   });
 
   it('should invalidate cache on update', async () => {
@@ -180,21 +184,30 @@ describe('AdminContextProvider', () => {
       rows: [{ owner_id: 'test-owner-id', default_local_currency: 'USD' }],
       rowCount: 1,
     } as unknown as QueryResultWithRows); // get
-    
+    dbProvider.query.mockResolvedValueOnce({
+      rows: [],
+      rowCount: 0,
+    } as unknown as QueryResultWithRows); // security businesses
+
     await provider.getAdminContext();
-    expect(dbProvider.query).toHaveBeenCalledTimes(1);
+    expect(dbProvider.query).toHaveBeenCalledTimes(QUERIES_PER_CONTEXT_LOAD);
 
     dbProvider.query.mockResolvedValueOnce({
         rows: [{ owner_id: 'test-owner-id', default_local_currency: 'EUR' }],
         rowCount: 1
     } as unknown as QueryResultWithRows); // update
-    
+    dbProvider.query.mockResolvedValueOnce({
+      rows: [],
+      rowCount: 0,
+    } as unknown as QueryResultWithRows); // security businesses
+
     await provider.updateAdminContext({ defaultLocalCurrency: 'EUR' });
-    expect(dbProvider.query).toHaveBeenCalledTimes(2); // +1 for update
+    expect(dbProvider.query).toHaveBeenCalledTimes(QUERIES_PER_CONTEXT_LOAD * 2);
 
     // The cache should now have the updated value from updateAdminContext
     const result = await provider.getAdminContext();
     expect(result?.defaultLocalCurrency).toBe('EUR');
-    expect(dbProvider.query).toHaveBeenCalledTimes(2); // No additional call, using cache
+    // No additional call, using cache
+    expect(dbProvider.query).toHaveBeenCalledTimes(QUERIES_PER_CONTEXT_LOAD * 2);
   });
 });

--- a/packages/server/src/modules/admin-context/providers/__tests__/admin-context-security-businesses.integration.test.ts
+++ b/packages/server/src/modules/admin-context/providers/__tests__/admin-context-security-businesses.integration.test.ts
@@ -1,0 +1,113 @@
+import { Pool } from 'pg';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { connectTestDb } from '../../../../__tests__/helpers/db-connection.js';
+import { seedAdminOnce } from '../../../../__tests__/helpers/db-fixtures.js';
+import { runMigrationsIfNeeded } from '../../../../__tests__/helpers/db-migrations.js';
+import { DBProvider } from '../../../app-providers/db.provider.js';
+import { TenantAwareDBClient } from '../../../app-providers/tenant-db-client.js';
+import type { AuthContextProvider } from '../../../auth/providers/auth-context.provider.js';
+import { AdminContextProvider } from '../admin-context.provider.js';
+
+let pool: Pool;
+let ownerId: string;
+
+const SECURITY_BUSINESS_ID = '00000000-0000-0000-0000-0000000006f5';
+
+function createMockAuthContextProvider(businessId: string): AuthContextProvider {
+  return {
+    getAuthContext: () =>
+      Promise.resolve({
+        authType: 'apiKey' as const,
+        token: 'test-token',
+        tenant: { businessId },
+        user: {
+          userId: 'api-key:test',
+          auth0UserId: null,
+          email: '',
+          roleId: 'admin',
+          permissions: [],
+          emailVerified: true,
+          permissionsVersion: 0,
+        },
+      }),
+  } as unknown as AuthContextProvider;
+}
+
+function createProvider() {
+  const dbClient = new TenantAwareDBClient(
+    new DBProvider(pool),
+    createMockAuthContextProvider(ownerId),
+  );
+  return new AdminContextProvider(createMockAuthContextProvider(ownerId), dbClient);
+}
+
+beforeAll(async () => {
+  pool = await connectTestDb();
+  await runMigrationsIfNeeded(pool);
+  // The seeded admin business is the one with a user_context row to normalize.
+  await seedAdminOnce(pool);
+
+  const { rows } = await pool.query(
+    `SELECT uc.owner_id
+     FROM accounter_schema.user_context uc
+     INNER JOIN accounter_schema.financial_entities fe ON fe.id = uc.owner_id
+     WHERE fe.name = 'Admin Business' AND fe.type = 'business'
+     LIMIT 1`,
+  );
+  ownerId = rows[0].owner_id;
+
+  await pool.query(
+    `INSERT INTO accounter_schema.financial_entities (id, name, type, owner_id)
+     VALUES ($1, 'ADMIN CONTEXT TEST SECURITY (TST)', 'business', $2)
+     ON CONFLICT (id) DO NOTHING`,
+    [SECURITY_BUSINESS_ID, ownerId],
+  );
+  await pool.query(
+    `INSERT INTO accounter_schema.businesses (id, owner_id, country)
+     VALUES ($1, $2, 'ISR')
+     ON CONFLICT (id) DO NOTHING`,
+    [SECURITY_BUSINESS_ID, ownerId],
+  );
+});
+
+afterAll(async () => {
+  await pool.query('DELETE FROM accounter_schema.businesses_securities WHERE id = $1', [
+    SECURITY_BUSINESS_ID,
+  ]);
+  await pool.query('DELETE FROM accounter_schema.businesses WHERE id = $1', [SECURITY_BUSINESS_ID]);
+  await pool.query('DELETE FROM accounter_schema.financial_entities WHERE id = $1', [
+    SECURITY_BUSINESS_ID,
+  ]);
+  // Do NOT close the pool here — it is shared with other concurrently-running suites.
+});
+
+/**
+ * `internalWalletsIds` is what keeps a securities movement internal: it drives the ledger's
+ * counterparty override, fee classification, and the balance report's internal-transfer
+ * filter. Once a trade's counterparty is the security rather than the general
+ * foreign-securities business, all three depend on the security being in this list.
+ */
+describe('admin context internal wallets', () => {
+  it('does not list a security business before one exists', async () => {
+    const context = await createProvider().getVerifiedAdminContext();
+
+    expect(context.financialAccounts.internalWalletsIds).not.toContain(SECURITY_BUSINESS_ID);
+  });
+
+  it('lists every security business as an internal wallet', async () => {
+    await pool.query(
+      `INSERT INTO accounter_schema.businesses_securities (id, owner_id, isin, symbol, eng_name)
+       VALUES ($1, $2, 'US0000000000', 'TST', 'ADMIN CONTEXT TEST SECURITY')
+       ON CONFLICT (id) DO NOTHING`,
+      [SECURITY_BUSINESS_ID, ownerId],
+    );
+
+    const context = await createProvider().getVerifiedAdminContext();
+
+    expect(context.financialAccounts.internalWalletsIds).toContain(SECURITY_BUSINESS_ID);
+    // The general business stays in the list; the securities are additions, not a replacement.
+    expect(context.financialAccounts.internalWalletsIds).toEqual(
+      expect.arrayContaining([SECURITY_BUSINESS_ID]),
+    );
+  });
+});

--- a/packages/server/src/modules/admin-context/providers/admin-context.provider.ts
+++ b/packages/server/src/modules/admin-context/providers/admin-context.provider.ts
@@ -14,6 +14,7 @@ import type {
   AdminContext,
   IGetAdminContextsQuery,
   IGetAdminContextsResult,
+  IGetSecurityBusinessIdsQuery,
   IUpdateAdminContextParams,
   IUpdateAdminContextQuery,
 } from '../types.js';
@@ -21,6 +22,16 @@ import type {
 const getAdminContexts = sql<IGetAdminContextsQuery>`
   SELECT *
   FROM accounter_schema.user_context
+  WHERE owner_id IN $$ownerIds;
+`;
+
+/**
+ * Deliberately raw SQL rather than going through SecurityBusinessesProvider: that provider
+ * takes its owner id from this one, so injecting it back would close a DI cycle.
+ */
+const getSecurityBusinessIds = sql<IGetSecurityBusinessIdsQuery>`
+  SELECT id, owner_id
+  FROM accounter_schema.businesses_securities
   WHERE owner_id IN $$ownerIds;
 `;
 
@@ -456,6 +467,39 @@ export class AdminContextProvider {
     };
   }
 
+  /**
+   * Every per-security business is an internal wallet too.
+   *
+   * A securities trade's counterparty is the security it traded rather than the general
+   * foreign-securities business, and `internalWalletsIds` is what decides that a securities
+   * movement is internal — it drives the ledger's counterparty override, fee classification,
+   * and the balance report's internal-transfer filter. Leaving the securities out would change
+   * all three the moment a transaction points at one.
+   *
+   * `normalizeContext` stays synchronous and pure; the enrichment happens on the async paths
+   * that read from the DB anyway.
+   */
+  private async withSecurityBusinesses(
+    context: AdminContext,
+    ownerIds: string[],
+  ): Promise<AdminContext> {
+    const securityBusinesses = await getSecurityBusinessIds.run({ ownerIds }, this.db);
+    if (securityBusinesses.length === 0) {
+      return context;
+    }
+
+    return {
+      ...context,
+      financialAccounts: {
+        ...context.financialAccounts,
+        internalWalletsIds: [
+          ...context.financialAccounts.internalWalletsIds,
+          ...securityBusinesses.map(securityBusiness => securityBusiness.id),
+        ],
+      },
+    };
+  }
+
   public async getAdminContext(): Promise<AdminContext | null> {
     if (this.cachedContext) {
       return this.cachedContext;
@@ -464,7 +508,9 @@ export class AdminContextProvider {
     const ownerId = await this.resolveOwnerIdForRequest();
 
     const contexts = await getAdminContexts.run({ ownerIds: [ownerId] }, this.db);
-    const context = contexts[0] ? this.normalizeContext(contexts[0]) : null;
+    const context = contexts[0]
+      ? await this.withSecurityBusinesses(this.normalizeContext(contexts[0]), [ownerId])
+      : null;
     this.cachedContext = context;
     return context;
   }
@@ -492,7 +538,10 @@ export class AdminContextProvider {
 
     const updatedContexts = await updateAdminContext.run({ ...params, ownerId }, this.db);
     if (updatedContexts.length >= 1) {
-      const normalizedContext = this.normalizeContext(updatedContexts[0]);
+      const normalizedContext = await this.withSecurityBusinesses(
+        this.normalizeContext(updatedContexts[0]),
+        [ownerId],
+      );
       this.cachedContext = normalizedContext;
       return normalizedContext;
     }
@@ -503,10 +552,12 @@ export class AdminContextProvider {
     const uniqueOwnerIds = Array.from(new Set(ownerIds));
     const contexts = await getAdminContexts.run({ ownerIds: uniqueOwnerIds }, this.db);
     const contextsByOwnerId = new Map(contexts.map(c => [c.owner_id, c]));
-    return ownerIds.map(id => {
-      const context = contextsByOwnerId.get(id);
-      return context ? this.normalizeContext(context) : null;
-    });
+    return Promise.all(
+      ownerIds.map(id => {
+        const context = contextsByOwnerId.get(id);
+        return context ? this.withSecurityBusinesses(this.normalizeContext(context), [id]) : null;
+      }),
+    );
   }
 
   public adminContextByOwnerIdLoader = new DataLoader((ownerIds: readonly string[]) =>

--- a/packages/server/src/modules/admin-context/providers/admin-context.provider.ts
+++ b/packages/server/src/modules/admin-context/providers/admin-context.provider.ts
@@ -479,12 +479,23 @@ export class AdminContextProvider {
    * `normalizeContext` stays synchronous and pure; the enrichment happens on the async paths
    * that read from the DB anyway.
    */
-  private async withSecurityBusinesses(
-    context: AdminContext,
-    ownerIds: string[],
-  ): Promise<AdminContext> {
+  private async securityBusinessIdsByOwner(ownerIds: string[]): Promise<Map<string, string[]>> {
     const securityBusinesses = await getSecurityBusinessIds.run({ ownerIds }, this.db);
-    if (securityBusinesses.length === 0) {
+
+    const byOwner = new Map<string, string[]>();
+    for (const securityBusiness of securityBusinesses) {
+      const ids = byOwner.get(securityBusiness.owner_id);
+      if (ids) {
+        ids.push(securityBusiness.id);
+      } else {
+        byOwner.set(securityBusiness.owner_id, [securityBusiness.id]);
+      }
+    }
+    return byOwner;
+  }
+
+  private withSecurityBusinesses(context: AdminContext, securityBusinessIds: string[]) {
+    if (securityBusinessIds.length === 0) {
       return context;
     }
 
@@ -492,12 +503,21 @@ export class AdminContextProvider {
       ...context,
       financialAccounts: {
         ...context.financialAccounts,
+        // De-duped: the general foreign-securities business is already in the list, and
+        // nothing rules out a future source putting a security there too.
         internalWalletsIds: [
-          ...context.financialAccounts.internalWalletsIds,
-          ...securityBusinesses.map(securityBusiness => securityBusiness.id),
+          ...new Set([...context.financialAccounts.internalWalletsIds, ...securityBusinessIds]),
         ],
       },
     };
+  }
+
+  private async withOwnSecurityBusinesses(
+    context: AdminContext,
+    ownerId: string,
+  ): Promise<AdminContext> {
+    const byOwner = await this.securityBusinessIdsByOwner([ownerId]);
+    return this.withSecurityBusinesses(context, byOwner.get(ownerId) ?? []);
   }
 
   public async getAdminContext(): Promise<AdminContext | null> {
@@ -509,7 +529,7 @@ export class AdminContextProvider {
 
     const contexts = await getAdminContexts.run({ ownerIds: [ownerId] }, this.db);
     const context = contexts[0]
-      ? await this.withSecurityBusinesses(this.normalizeContext(contexts[0]), [ownerId])
+      ? await this.withOwnSecurityBusinesses(this.normalizeContext(contexts[0]), ownerId)
       : null;
     this.cachedContext = context;
     return context;
@@ -538,9 +558,9 @@ export class AdminContextProvider {
 
     const updatedContexts = await updateAdminContext.run({ ...params, ownerId }, this.db);
     if (updatedContexts.length >= 1) {
-      const normalizedContext = await this.withSecurityBusinesses(
+      const normalizedContext = await this.withOwnSecurityBusinesses(
         this.normalizeContext(updatedContexts[0]),
-        [ownerId],
+        ownerId,
       );
       this.cachedContext = normalizedContext;
       return normalizedContext;
@@ -550,14 +570,22 @@ export class AdminContextProvider {
 
   private async batchAdminContextsByOwnerIds(ownerIds: readonly string[]) {
     const uniqueOwnerIds = Array.from(new Set(ownerIds));
-    const contexts = await getAdminContexts.run({ ownerIds: uniqueOwnerIds }, this.db);
+    // Both reads are batched over the whole key set: a per-owner enrichment here would be an
+    // N+1 behind a DataLoader, on a path resolvers hit with many owners at once.
+    const [contexts, securityBusinessIdsByOwner] = await Promise.all([
+      getAdminContexts.run({ ownerIds: uniqueOwnerIds }, this.db),
+      this.securityBusinessIdsByOwner(uniqueOwnerIds),
+    ]);
     const contextsByOwnerId = new Map(contexts.map(c => [c.owner_id, c]));
-    return Promise.all(
-      ownerIds.map(id => {
-        const context = contextsByOwnerId.get(id);
-        return context ? this.withSecurityBusinesses(this.normalizeContext(context), [id]) : null;
-      }),
-    );
+    return ownerIds.map(id => {
+      const context = contextsByOwnerId.get(id);
+      return context
+        ? this.withSecurityBusinesses(
+            this.normalizeContext(context),
+            securityBusinessIdsByOwner.get(id) ?? [],
+          )
+        : null;
+    });
   }
 
   public adminContextByOwnerIdLoader = new DataLoader((ownerIds: readonly string[]) =>

--- a/packages/server/src/modules/charges/helpers/charge-type.ts
+++ b/packages/server/src/modules/charges/helpers/charge-type.ts
@@ -2,6 +2,7 @@ import { Injector } from 'graphql-modules';
 import { ChargeTypeEnum } from '../../../shared/enums.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
 import { BusinessTripsProvider } from '../../business-trips/providers/business-trips.provider.js';
+import { getForeignSecuritiesBusinessIds } from '../../foreign-securities/helpers/foreign-securities-businesses.helper.js';
 import { TransactionsProvider } from '../../transactions/providers/transactions.provider.js';
 import type { charge_type, IGetChargesByIdsResult } from '../types.js';
 import { getChargeBusinesses } from './common.helper.js';
@@ -92,7 +93,6 @@ async function deriveChargeType(
   }
 
   const {
-    foreignSecurities: { foreignSecuritiesBusinessId },
     bankDeposits: { bankDepositBusinessId },
     dividends: { dividendBusinessIds },
     authorities: { vatBusinessId },
@@ -106,10 +106,12 @@ async function deriveChargeType(
     return ChargeTypeEnum.BankDeposit;
   }
 
+  // The securities side is the general business *and* every per-security business: a trade's
+  // counterparty is the security it traded, and the general one only where none was resolved.
+  const foreignSecuritiesBusinessIds = await getForeignSecuritiesBusinessIds(injector);
   if (
-    foreignSecuritiesBusinessId &&
-    (mainBusinessId === foreignSecuritiesBusinessId ||
-      allBusinessIds.includes(foreignSecuritiesBusinessId))
+    (mainBusinessId && foreignSecuritiesBusinessIds.has(mainBusinessId)) ||
+    allBusinessIds.some(businessId => foreignSecuritiesBusinessIds.has(businessId))
   ) {
     return ChargeTypeEnum.ForeignSecurities;
   }

--- a/packages/server/src/modules/common/__tests__/user-context.resolver.test.ts
+++ b/packages/server/src/modules/common/__tests__/user-context.resolver.test.ts
@@ -48,6 +48,7 @@ const adminContext = {
   locality: 'ISRAEL',
   financialAccounts: { internalWalletsIds: ['wallet-1', 'wallet-2'] },
   bankDeposits: { bankDepositBusinessId: null },
+  foreignSecurities: { foreignSecuritiesBusinessId: 'foreign-securities-1' },
 } as AdminContextFixture;
 
 const authContext = {
@@ -83,6 +84,8 @@ describe('userContext resolver (multi-business)', () => {
     expect(result.ledgerLock).toBe('2024-01-01');
     expect(result.locality).toBe('ISRAEL');
     expect(result.financialAccountsBusinessesIds).toEqual(['wallet-1', 'wallet-2']);
+    // The client needs it as the fallback counterparty option for a securities trade.
+    expect(result.foreignSecuritiesBusinessId).toBe('foreign-securities-1');
   });
 
   it('appends the bank deposit business id when present', async () => {

--- a/packages/server/src/modules/common/resolvers/user-context.resolver.ts
+++ b/packages/server/src/modules/common/resolvers/user-context.resolver.ts
@@ -48,6 +48,7 @@ export const userContextResolvers: CommonModule.Resolvers = {
           defaultCryptoConversionFiatCurrency: null,
           ledgerLock: null,
           financialAccountsBusinessesIds: null,
+          foreignSecuritiesBusinessId: null,
           locality: null,
         };
       }
@@ -55,6 +56,7 @@ export const userContextResolvers: CommonModule.Resolvers = {
       const {
         financialAccounts: { internalWalletsIds },
         bankDeposits: { bankDepositBusinessId },
+        foreignSecurities: { foreignSecuritiesBusinessId },
         defaultLocalCurrency,
         defaultCryptoConversionFiatCurrency,
         ledgerLock,
@@ -74,6 +76,7 @@ export const userContextResolvers: CommonModule.Resolvers = {
         defaultCryptoConversionFiatCurrency,
         ledgerLock,
         financialAccountsBusinessesIds,
+        foreignSecuritiesBusinessId,
         locality,
       };
     },

--- a/packages/server/src/modules/common/typeDefs/user-context.graphql.ts
+++ b/packages/server/src/modules/common/typeDefs/user-context.graphql.ts
@@ -23,6 +23,8 @@ export default gql`
     defaultCryptoConversionFiatCurrency: Currency
     ledgerLock: TimelessDate
     financialAccountsBusinessesIds: [UUID!]
+    " the general foreign-securities business, the fallback counterparty for a securities trade "
+    foreignSecuritiesBusinessId: UUID
     locality: String
   }
 `;

--- a/packages/server/src/modules/financial-accounts/helpers/account-by-transaction.helper.ts
+++ b/packages/server/src/modules/financial-accounts/helpers/account-by-transaction.helper.ts
@@ -1,5 +1,6 @@
 import type { Injector } from 'graphql-modules';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { getForeignSecuritiesBusinessIds } from '../../foreign-securities/helpers/foreign-securities-businesses.helper.js';
 import { TransactionsProvider } from '../../transactions/providers/transactions.provider.js';
 import { FinancialAccountsProvider } from '../providers/financial-accounts.provider.js';
 import type { IGetFinancialAccountsByAccountIDsResult } from '../types.js';
@@ -8,10 +9,7 @@ export async function getFinancialAccountByTransactionId(
   transactionId: string,
   injector: Injector,
 ): Promise<IGetFinancialAccountsByAccountIDsResult> {
-  const {
-    ownerId,
-    foreignSecurities: { foreignSecuritiesBusinessId },
-  } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
+  const { ownerId } = await injector.get(AdminContextProvider).getVerifiedAdminContext();
   const transaction = await injector
     .get(TransactionsProvider)
     .transactionByIdLoader.load(transactionId);
@@ -19,8 +17,12 @@ export async function getFinancialAccountByTransactionId(
     throw new Error(`Transaction ID="${transactionId}" is missing account_id`);
   }
 
+  // The securities portfolio is one account whatever the counterparty is — the general
+  // foreign-securities business or the specific security the trade was in.
+  const foreignSecuritiesBusinessIds = await getForeignSecuritiesBusinessIds(injector);
+
   let account: IGetFinancialAccountsByAccountIDsResult | undefined;
-  if (!!foreignSecuritiesBusinessId && transaction.business_id === foreignSecuritiesBusinessId) {
+  if (!!transaction.business_id && foreignSecuritiesBusinessIds.has(transaction.business_id)) {
     const accounts = await injector
       .get(FinancialAccountsProvider)
       .getFinancialAccountsByOwnerIdLoader.load(ownerId);

--- a/packages/server/src/modules/foreign-securities/helpers/foreign-securities-businesses.helper.ts
+++ b/packages/server/src/modules/foreign-securities/helpers/foreign-securities-businesses.helper.ts
@@ -1,0 +1,27 @@
+import type { Injector } from 'graphql-modules';
+import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
+import { SecurityBusinessesProvider } from '../providers/security-businesses.provider.js';
+
+/**
+ * Every business that stands for the foreign-securities portfolio: the tenant's general
+ * foreign-securities business, plus one business per traded security.
+ *
+ * A securities transaction's counterparty is the specific security once it is recognized, and
+ * the general business only where none could be resolved — so anything keyed on "is this the
+ * securities side" has to ask about the whole set, not just the general id.
+ *
+ * Both sources are request-cached (admin context per operation, security ids per provider), so
+ * calling this per transaction is cheap.
+ */
+export async function getForeignSecuritiesBusinessIds(injector: Injector): Promise<Set<string>> {
+  const [adminContext, securityBusinessIds] = await Promise.all([
+    injector.get(AdminContextProvider).getVerifiedAdminContext(),
+    injector.get(SecurityBusinessesProvider).getAllSecurityBusinessIds(),
+  ]);
+
+  const { foreignSecuritiesBusinessId } = adminContext.foreignSecurities;
+  if (!foreignSecuritiesBusinessId) {
+    return securityBusinessIds;
+  }
+  return new Set([...securityBusinessIds, foreignSecuritiesBusinessId]);
+}

--- a/packages/server/src/modules/ledger/helpers/__tests__/fee-transactions.test.ts
+++ b/packages/server/src/modules/ledger/helpers/__tests__/fee-transactions.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { AdminContext } from '../../../admin-context/types.js';
+import type { IGetTransactionsByChargeIdsResult } from '../../../transactions/types.js';
+import { isSupplementalFeeTransaction } from '../fee-transactions.js';
+import { LedgerError } from '../utils.helper.js';
+
+const GENERAL_SECURITIES_BUSINESS_ID = 'general-securities';
+const SECURITY_BUSINESS_ID = 'security-aapl';
+const SWIFT_BUSINESS_ID = 'swift';
+
+/**
+ * Only the fields the classification reads. Security businesses join `internalWalletsIds`
+ * in AdminContextProvider — see admin-context-security-businesses.integration.test.ts.
+ */
+const financialAccounts = {
+  internalWalletsIds: [GENERAL_SECURITIES_BUSINESS_ID, SECURITY_BUSINESS_ID],
+  swiftBusinessId: SWIFT_BUSINESS_ID,
+} as unknown as AdminContext['financialAccounts'];
+
+const feeTransaction = (businessId: string | null) =>
+  ({
+    id: 't1',
+    is_fee: true,
+    business_id: businessId,
+    source_reference: 'foreign_securities',
+  }) as unknown as IGetTransactionsByChargeIdsResult;
+
+describe('isSupplementalFeeTransaction', () => {
+  it('classifies a fee against the general foreign-securities business as supplemental', () => {
+    expect(isSupplementalFeeTransaction(feeTransaction(GENERAL_SECURITIES_BUSINESS_ID), financialAccounts)).toBe(
+      true,
+    );
+  });
+
+  it('classifies a fee against a per-security business as supplemental too', () => {
+    // The counterparty of a securities movement is now the security itself; the fee side of
+    // that charge must keep classifying the same way, or its ledger entry flips direction.
+    expect(isSupplementalFeeTransaction(feeTransaction(SECURITY_BUSINESS_ID), financialAccounts)).toBe(true);
+  });
+
+  it('keeps a Swift fee fundamental', () => {
+    expect(isSupplementalFeeTransaction(feeTransaction(SWIFT_BUSINESS_ID), financialAccounts)).toBe(
+      false,
+    );
+  });
+
+  it('is not a fee at all when the transaction is a main one', () => {
+    const mainTransaction = {
+      ...feeTransaction(SECURITY_BUSINESS_ID),
+      is_fee: false,
+    } as IGetTransactionsByChargeIdsResult;
+
+    expect(isSupplementalFeeTransaction(mainTransaction, financialAccounts)).toBe(false);
+  });
+
+  it('refuses to guess for an unknown business', () => {
+    expect(() => isSupplementalFeeTransaction(feeTransaction('some-supplier'), financialAccounts)).toThrow(
+      LedgerError,
+    );
+  });
+
+  it('refuses to guess without a counterparty', () => {
+    expect(() => isSupplementalFeeTransaction(feeTransaction(null), financialAccounts)).toThrow(
+      LedgerError,
+    );
+  });
+});

--- a/packages/server/src/test-utils/ledger-injector.ts
+++ b/packages/server/src/test-utils/ledger-injector.ts
@@ -18,6 +18,7 @@ import { BusinessesOperationProvider } from '../modules/financial-entities/provi
 import { BusinessesProvider } from '../modules/financial-entities/providers/businesses.provider.js';
 import { FinancialEntitiesProvider } from '../modules/financial-entities/providers/financial-entities.provider.js';
 import { TaxCategoriesProvider } from '../modules/financial-entities/providers/tax-categories.provider.js';
+import { SecurityBusinessesProvider } from '../modules/foreign-securities/providers/security-businesses.provider.js';
 import { BalanceCancellationProvider } from '../modules/ledger/providers/balance-cancellation.provider.js';
 import { LedgerProvider } from '../modules/ledger/providers/ledger.provider.js';
 import { UnbalancedBusinessesProvider } from '../modules/ledger/providers/unbalanced-businesses.provider.js';
@@ -170,6 +171,28 @@ export function createLedgerTestContext(options: {
       }
       case BusinessTripsProvider:
         return new BusinessTripsProvider(tenantAwareDB, adminContextProvider);
+      case SecurityBusinessesProvider: {
+        const businessesProvider = new BusinessesProvider(tenantAwareDB, adminContextProvider);
+        const taxCategoriesProvider = new TaxCategoriesProvider(
+          tenantAwareDB,
+          adminContextProvider,
+        );
+        const businessesOperationStub: Pick<BusinessesOperationProvider, 'deleteBusinessById'> = {
+          deleteBusinessById: async (_businessId: string) => {},
+        };
+        return new SecurityBusinessesProvider(
+          tenantAwareDB,
+          adminContextProvider,
+          new FinancialEntitiesProvider(
+            tenantAwareDB,
+            businessesProvider,
+            businessesOperationStub as unknown as BusinessesOperationProvider,
+            taxCategoriesProvider,
+          ),
+          businessesProvider,
+          taxCategoriesProvider,
+        );
+      }
       case ChargeSpreadProvider:
         return new ChargeSpreadProvider(tenantAwareDB, adminContextProvider);
       default:


### PR DESCRIPTION
Step 3 of the [per-security businesses plan](../blob/feat/security-businesses-plan/docs/foreign-securities-businesses/plan.md). Stacked on #4253.

`foreignSecuritiesBusinessId` was doing three jobs alone, all assuming the securities side is exactly
one business:

| call site | what breaks once a trade's counterparty is the security |
| --- | --- |
| `charges/helpers/charge-type.ts` | charge types as `Common` |
| `financial-accounts/helpers/account-by-transaction.helper.ts` | transaction resolves to its raw account, not `FOREIGN_SECURITIES` |
| `internalWalletsIds` | ledger counterparty override stops firing; fee classification and the balance-report filter change |

All three now ask "is this **a** foreign-securities business" via `getForeignSecuritiesBusinessIds()`
— the general business plus every business with a `businesses_securities` row (both request-cached).

### Why the ledger stays byte-identical

The main entry's counterparty never came from `transaction.business_id`: `ledgerEntryFromMainTransaction`
replaces it with the tax category of the account whose `account_number = 'foreign_securities'`, and
that override is gated on the counterparty being in `internalWalletsIds`. Putting the security
businesses in that list is the whole mechanism — no ledger code changes.

`normalizeContext` stays synchronous and pure; the enrichment happens on the async paths that hit the
DB anyway, in raw SQL rather than through `SecurityBusinessesProvider` (that provider takes its owner
id from the admin context — injecting it back would close a DI cycle). Loading an admin context is
now two queries instead of one.

Also exposes `UserContext.foreignSecuritiesBusinessId`, which the client needs as the fallback
counterparty option for a trade with no resolved security.

### Verification

- `yarn generate`, `yarn lint`, `yarn prettier`, server typecheck clean.
- `yarn test` — 3426 passed. New: `isSupplementalFeeTransaction` treats a per-security business as
  supplemental (its ledger entry would otherwise flip direction). Admin-context DI tests updated for
  the second query, and the user-context resolver test asserts the new field.
- `yarn test:integration` — 3864 passed, including a new suite asserting security businesses land in
  `internalWalletsIds` through the real `AdminContextProvider`.
- `SecurityBusinessesProvider` registered in the ledger test injector, which throws on unknown
  providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)