### PR TITLE
feat(server): create security businesses on ingest, suggest them on trades

### DIFF
--- a/.changeset/security-businesses-automation.md
+++ b/.changeset/security-businesses-automation.md
@@ -8,8 +8,9 @@ Create a security's business when its executions arrive, and suggest it as the t
 of its own and records the Poalim key it is known by, through `ensureSecurityBusiness` /
 `linkIdentifier`. Driven off the whole validated payload rather than only the newly inserted rows: a
 re-scrape inserts nothing, but a security whose business was never created — ingested before this
-existed, or created while an earlier scrape failed here — still needs one. Both steps are idempotent
-and the existing ISINs are fetched in a single query, so a repeat scrape costs one lookup. Two Poalim
+existed, or created while an earlier scrape failed here — still needs one. Both steps are idempotent, and the whole payload is settled through
+the new `SecurityBusinessesProvider.ensureSecurityBusinesses` batch API — one lookup for the lot,
+rather than a bulk pre-check followed by a per-ISIN re-check inside `ensureSecurityBusiness`. Two Poalim
 keys reporting the same ISIN collapse onto one business, which is the point of keying on the ISIN.
 
 Rows with no ISIN are skipped: the ISIN is the identity and one cannot be invented from the Poalim

--- a/.changeset/security-businesses-automation.md
+++ b/.changeset/security-businesses-automation.md
@@ -1,0 +1,29 @@
+---
+'@accounter/server': minor
+---
+
+Create a security's business when its executions arrive, and suggest it as the trade's counterparty.
+
+**Ingestion.** `uploadPoalimSecuritiesTransactions` now gives every security in the payload a business
+of its own and records the Poalim key it is known by, through `ensureSecurityBusiness` /
+`linkIdentifier`. Driven off the whole validated payload rather than only the newly inserted rows: a
+re-scrape inserts nothing, but a security whose business was never created — ingested before this
+existed, or created while an earlier scrape failed here — still needs one. Both steps are idempotent
+and the existing ISINs are fetched in a single query, so a repeat scrape costs one lookup. Two Poalim
+keys reporting the same ISIN collapse onto one business, which is the point of keying on the ISIN.
+
+Rows with no ISIN are skipped: the ISIN is the identity and one cannot be invented from the Poalim
+key alone, so those securities stay unlinked and are assigned by hand. Failures are logged rather
+than thrown — the executions are already stored, and reporting the upload as failed would be a lie;
+the next scrape repairs the gap.
+
+**Suggestion.** A securities trade names the security it traded in its description, and that key now
+resolves to a business: `Transaction.missingInfoSuggestions` returns the security rather than falling
+through to the POALIM description heuristics, which would otherwise claim it for the bank. Only when
+the description names exactly one key, and only for the main transaction — a fee row returns Poalim
+before this point, unchanged, which is what keeps the fee ledger entry as it is. A key with no
+security business behind it (no ISIN reported, or not ingested yet) falls through to the old
+behavior rather than inventing a suggestion.
+
+Also drops an unreachable `transaction.business_id` branch in the suggestion resolver: the function
+returns null for any transaction that already has a counterparty, several lines above it.

--- a/packages/server/src/modules/foreign-securities/providers/__tests__/security-businesses.integration.test.ts
+++ b/packages/server/src/modules/foreign-securities/providers/__tests__/security-businesses.integration.test.ts
@@ -216,6 +216,24 @@ describe('ensureSecurityBusiness', () => {
     expect(security.currency_code).toBeNull();
   });
 
+  it('settles a whole payload in one lookup, creating only what is missing', async () => {
+    const provider = createProvider();
+    const first = await provider.ensureSecurityBusiness(APPLE);
+
+    const securities = await provider.ensureSecurityBusinesses([
+      APPLE,
+      { isin: 'US5949181045', symbol: 'MSFT', engName: 'MICROSOFT CORP', isForeign: true },
+    ]);
+
+    expect(securities.get(APPLE.isin)?.id).toBe(first.id);
+    expect(securities.get('US5949181045')?.symbol).toBe('MSFT');
+    const { rows } = await pool.query(
+      'SELECT count(*)::int AS count FROM accounter_schema.businesses_securities WHERE owner_id = $1',
+      [TEST_OWNER_ID],
+    );
+    expect(rows[0].count).toBe(2);
+  });
+
   it('is idempotent per ISIN — a second call returns the same business', async () => {
     const provider = createProvider();
 

--- a/packages/server/src/modules/foreign-securities/providers/security-businesses.provider.ts
+++ b/packages/server/src/modules/foreign-securities/providers/security-businesses.provider.ts
@@ -215,22 +215,54 @@ export class SecurityBusinessesProvider {
   /**
    * The business a security is represented by, creating it on first sight.
    *
-   * Idempotent by ISIN: concurrent ingests race on the (owner_id, isin) unique index, and the
-   * loser rolls its whole transaction back — financial entity and business included — then
-   * re-reads the winner's row, so a race can't leave a half-built business behind.
-   *
-   * Sort code, IRS code, country and tax category are inherited from the tenant's general
-   * foreign-securities business, so a security behaves like it everywhere those fields drive
-   * reporting.
+   * Idempotent by ISIN — see `createSecurityBusiness` for how a race is settled.
    */
   public async ensureSecurityBusiness(
     descriptors: SecurityBusinessDescriptors,
   ): Promise<SecurityBusinessRow> {
     const existing = await this.getSecurityBusinessByIsin(descriptors.isin);
-    if (existing) {
-      return existing;
+    return existing ?? this.createSecurityBusiness(descriptors);
+  }
+
+  /**
+   * The same for a batch, in one lookup: an ingest introduces a whole portfolio at once, and
+   * asking per ISIN whether it exists costs a round trip for every security every scrape.
+   * Only the ISINs with no business yet are created.
+   */
+  public async ensureSecurityBusinesses(
+    descriptorsList: readonly SecurityBusinessDescriptors[],
+  ): Promise<Map<string, SecurityBusinessRow>> {
+    const byIsin = new Map(descriptorsList.map(descriptors => [descriptors.isin, descriptors]));
+    if (byIsin.size === 0) {
+      return new Map();
     }
 
+    const securityBusinesses = await this.getSecurityBusinessesByIsins([...byIsin.keys()]);
+
+    for (const [isin, descriptors] of byIsin) {
+      if (!securityBusinesses.has(isin)) {
+        securityBusinesses.set(isin, await this.createSecurityBusiness(descriptors));
+      }
+    }
+
+    return securityBusinesses;
+  }
+
+  /**
+   * Creates the business behind a security, assuming the caller has established there is none.
+   *
+   * Concurrent ingests race on the (owner_id, isin) unique index, and the loser rolls its whole
+   * transaction back — financial entity and business included — then re-reads the winner's row,
+   * so a race can't leave a half-built business behind. That fallback is also what makes the
+   * caller's "there is none" only have to be true at the time it looked.
+   *
+   * Sort code, IRS code, country and tax category are inherited from the tenant's general
+   * foreign-securities business, so a security behaves like it everywhere those fields drive
+   * reporting.
+   */
+  private async createSecurityBusiness(
+    descriptors: SecurityBusinessDescriptors,
+  ): Promise<SecurityBusinessRow> {
     const adminContext = await this.adminContextProvider.getVerifiedAdminContext();
     const { ownerId } = adminContext;
     const generalBusinessId = adminContext.foreignSecurities.foreignSecuritiesBusinessId;

--- a/packages/server/src/modules/foreign-securities/providers/security-businesses.provider.ts
+++ b/packages/server/src/modules/foreign-securities/providers/security-businesses.provider.ts
@@ -196,9 +196,20 @@ export class SecurityBusinessesProvider {
     this.batchIdentifiersByBusinessIds(businessIds),
   );
 
+  /** The security businesses already created for these ISINs, keyed by ISIN. */
+  public async getSecurityBusinessesByIsins(
+    isins: readonly string[],
+  ): Promise<Map<string, SecurityBusinessRow>> {
+    if (isins.length === 0) {
+      return new Map();
+    }
+    const rows = await getSecurityBusinessesByIsins.run({ isins: [...new Set(isins)] }, this.db);
+    rows.map(row => this.getSecurityBusinessByIdLoader.prime(row.id, row));
+    return new Map(rows.map(row => [row.isin, row]));
+  }
+
   private async getSecurityBusinessByIsin(isin: string): Promise<SecurityBusinessRow | null> {
-    const [row] = await getSecurityBusinessesByIsins.run({ isins: [isin] }, this.db);
-    return row ?? null;
+    return (await this.getSecurityBusinessesByIsins([isin])).get(isin) ?? null;
   }
 
   /**

--- a/packages/server/src/modules/scraper-ingestion/providers/__tests__/poalim-scraper-ingestion.integration.test.ts
+++ b/packages/server/src/modules/scraper-ingestion/providers/__tests__/poalim-scraper-ingestion.integration.test.ts
@@ -14,6 +14,11 @@ import { Currency } from '../../../../shared/enums.js';
 import type { AuthContextProvider } from '../../../auth/providers/auth-context.provider.js';
 import { DBProvider } from '../../../app-providers/db.provider.js';
 import { TenantAwareDBClient } from '../../../app-providers/tenant-db-client.js';
+import type { AdminContextProvider } from '../../../admin-context/providers/admin-context.provider.js';
+import { BusinessesProvider } from '../../../financial-entities/providers/businesses.provider.js';
+import { FinancialEntitiesProvider } from '../../../financial-entities/providers/financial-entities.provider.js';
+import { TaxCategoriesProvider } from '../../../financial-entities/providers/tax-categories.provider.js';
+import { SecurityBusinessesProvider } from '../../../foreign-securities/providers/security-businesses.provider.js';
 import { PoalimScraperIngestionProvider } from '../poalim-scraper-ingestion.provider.js';
 
 let pool: Pool;
@@ -55,7 +60,36 @@ beforeAll(async () => {
   const dbProvider = new DBProvider(pool);
   const authContextProvider = createMockAuthContextProvider();
   const dbClient = new TenantAwareDBClient(dbProvider, authContextProvider);
-  provider = new PoalimScraperIngestionProvider(dbClient, authContextProvider);
+  // The securities upload creates a business per ingested ISIN. The tenant here has no
+  // user_context row, so the admin context is stubbed with the little of it that path reads.
+  const adminContextProvider = {
+    getVerifiedAdminContext: () =>
+      Promise.resolve({
+        ownerId: TEST_OWNER_ID,
+        foreignSecurities: {
+          foreignSecuritiesBusinessId: null,
+          foreignSecuritiesFeesCategoryId: null,
+        },
+      }),
+  } as unknown as AdminContextProvider;
+  const businessesProvider = new BusinessesProvider(dbClient, adminContextProvider);
+  const taxCategoriesProvider = new TaxCategoriesProvider(dbClient, adminContextProvider);
+  provider = new PoalimScraperIngestionProvider(
+    dbClient,
+    authContextProvider,
+    new SecurityBusinessesProvider(
+      dbClient,
+      adminContextProvider,
+      new FinancialEntitiesProvider(
+        dbClient,
+        businessesProvider,
+        {} as never,
+        taxCategoriesProvider,
+      ),
+      businessesProvider,
+      taxCategoriesProvider,
+    ),
+  );
 
   // poalim_securities.owner_id is a real FK, so the acting tenant must exist.
   await pool.query(
@@ -82,6 +116,16 @@ afterAll(async () => {
   for (const table of TRIGGER_TABLES) {
     await pool.query(`ALTER TABLE accounter_schema.${table} ENABLE TRIGGER ALL`);
   }
+  // The securities upload creates a business per ingested ISIN; the owner FKs are NO ACTION,
+  // so those have to go before the tenant they belong to.
+  await pool.query(
+    'DELETE FROM accounter_schema.businesses WHERE owner_id = $1 AND id <> $1',
+    [TEST_OWNER_ID],
+  );
+  await pool.query(
+    'DELETE FROM accounter_schema.financial_entities WHERE owner_id = $1 AND id <> $1',
+    [TEST_OWNER_ID],
+  );
   // Drop the seeded tenant; poalim_securities* rows cascade with it.
   await pool.query('DELETE FROM accounter_schema.businesses WHERE id = $1', [TEST_OWNER_ID]);
   await pool.query('DELETE FROM accounter_schema.financial_entities WHERE id = $1', [
@@ -379,8 +423,25 @@ describe('uploadPoalimSecurities', () => {
 
 // ── Poalim Securities Transactions ────────────────────────────────────────────
 
+/** Security businesses created by an upload, so each case starts from nothing. */
+async function clearSecurityBusinesses() {
+  await pool.query('DELETE FROM accounter_schema.businesses_securities WHERE owner_id = $1', [
+    TEST_OWNER_ID,
+  ]);
+  await pool.query('DELETE FROM accounter_schema.businesses WHERE owner_id = $1 AND id <> $1', [
+    TEST_OWNER_ID,
+  ]);
+  await pool.query(
+    'DELETE FROM accounter_schema.financial_entities WHERE owner_id = $1 AND id <> $1',
+    [TEST_OWNER_ID],
+  );
+}
+
 describe('uploadPoalimSecuritiesTransactions', () => {
-  beforeEach(() => truncateOwned('poalim_securities_transactions'));
+  beforeEach(async () => {
+    await truncateOwned('poalim_securities_transactions');
+    await clearSecurityBusinesses();
+  });
 
   // Synthetic values only — never lifted from a real bank capture. Timestamps keep
   // the bank's .NET round-trip shape (7 fractional digits, Israel offset, and the
@@ -465,6 +526,64 @@ describe('uploadPoalimSecuritiesTransactions', () => {
     expect(result.skipped).toBe(2);
     expect(result.insertedIds).toHaveLength(0);
     expect(result.changedTransactions).toEqual([]);
+  });
+
+  describe('security businesses', () => {
+    const securityBusinessesOfOwner = async () => {
+      const { rows } = await pool.query(
+        `SELECT bs.isin, fe.name, si.identifier_type, si.identifier_value
+         FROM accounter_schema.businesses_securities bs
+         INNER JOIN accounter_schema.financial_entities fe ON fe.id = bs.id
+         LEFT JOIN accounter_schema.security_identifiers si ON si.business_id = bs.id
+         WHERE bs.owner_id = $1
+         ORDER BY bs.isin, si.identifier_value`,
+        [TEST_OWNER_ID],
+      );
+      return rows;
+    };
+
+    it('creates a business per ingested security, keyed by its Poalim key', async () => {
+      await provider.uploadPoalimSecuritiesTransactions([baseTransaction]);
+
+      expect(await securityBusinessesOfOwner()).toEqual([
+        {
+          isin: 'US0000000001',
+          name: 'EXAMPLE CORP (EXMP)',
+          identifier_type: 'POALIM_SECURITY_KEY',
+          identifier_value: '1234567',
+        },
+      ]);
+    });
+
+    it('creates one business for several executions of the same security', async () => {
+      await provider.uploadPoalimSecuritiesTransactions([baseTransaction, dividend]);
+
+      expect(await securityBusinessesOfOwner()).toHaveLength(1);
+    });
+
+    it('does not duplicate anything on a re-scrape', async () => {
+      await provider.uploadPoalimSecuritiesTransactions([baseTransaction]);
+      await provider.uploadPoalimSecuritiesTransactions([baseTransaction]);
+
+      expect(await securityBusinessesOfOwner()).toHaveLength(1);
+    });
+
+    it('collapses two Poalim keys reporting the same ISIN onto one business', async () => {
+      await provider.uploadPoalimSecuritiesTransactions([
+        baseTransaction,
+        { ...baseTransaction, security: '7654321', tradeDate: '2024-02-15T00:00:00.0000000+02:00' },
+      ]);
+
+      const rows = await securityBusinessesOfOwner();
+      expect(rows.map(row => row.identifier_value)).toEqual(['1234567', '7654321']);
+      expect(new Set(rows.map(row => row.isin)).size).toBe(1);
+    });
+
+    it('leaves a security with no ISIN unlinked, for manual assignment', async () => {
+      await provider.uploadPoalimSecuritiesTransactions([{ ...baseTransaction, isin: null }]);
+
+      expect(await securityBusinessesOfOwner()).toEqual([]);
+    });
   });
 
   // The corporate-action dates are part of the dedup key and are null on a trade,

--- a/packages/server/src/modules/scraper-ingestion/providers/poalim-scraper-ingestion.provider.ts
+++ b/packages/server/src/modules/scraper-ingestion/providers/poalim-scraper-ingestion.provider.ts
@@ -1198,8 +1198,8 @@ export class PoalimScraperIngestionProvider {
    * Driven off the whole validated payload rather than only the newly inserted rows: a
    * re-scrape inserts nothing, but a security whose business was never created (ingested
    * before this existed, or created while an earlier scrape failed here) still needs one.
-   * Both steps are idempotent, and the existing ISINs are fetched in one query so a repeat
-   * scrape costs a single lookup.
+   * Both steps are idempotent, and `ensureSecurityBusinesses` settles the whole payload with a
+   * single lookup, so a repeat scrape costs one query rather than one per security.
    *
    * Rows with no ISIN are skipped: the ISIN is the identity, and one cannot be invented from
    * the Poalim key alone. Those securities stay unlinked and are assigned by hand.
@@ -1248,14 +1248,15 @@ export class PoalimScraperIngestionProvider {
     }
 
     try {
-      const existing = await this.securityBusinessesProvider.getSecurityBusinessesByIsins([
-        ...bySecurityIsin.keys(),
-      ]);
+      const securityBusinesses = await this.securityBusinessesProvider.ensureSecurityBusinesses(
+        [...bySecurityIsin.values()].map(entry => entry.descriptors),
+      );
 
-      for (const [isin, { descriptors, poalimKeys }] of bySecurityIsin) {
-        const securityBusiness =
-          existing.get(isin) ??
-          (await this.securityBusinessesProvider.ensureSecurityBusiness(descriptors));
+      for (const [isin, { poalimKeys }] of bySecurityIsin) {
+        const securityBusiness = securityBusinesses.get(isin);
+        if (!securityBusiness) {
+          continue;
+        }
 
         for (const poalimKey of poalimKeys) {
           await this.securityBusinessesProvider.linkIdentifier(

--- a/packages/server/src/modules/scraper-ingestion/providers/poalim-scraper-ingestion.provider.ts
+++ b/packages/server/src/modules/scraper-ingestion/providers/poalim-scraper-ingestion.provider.ts
@@ -16,6 +16,8 @@ import { dateToTimelessDateString } from '../../../shared/helpers/index.js';
 import type { TimelessDateString } from '../../../shared/types/index.js';
 import { TenantAwareDBClient } from '../../app-providers/tenant-db-client.js';
 import { AuthContextProvider } from '../../auth/providers/auth-context.provider.js';
+import { SecurityBusinessesProvider } from '../../foreign-securities/providers/security-businesses.provider.js';
+import type { SecurityBusinessDescriptors } from '../../foreign-securities/types.js';
 import { formatValue } from '../helpers/utils.helper.js';
 import {
   validatePoalimForeignTransactions,
@@ -1161,6 +1163,21 @@ function diffPoalimSecurityTransactionRow(
   return changed;
 }
 
+/** The descriptor columns a security business is built from, as the payload spells them. */
+type SecurityDescriptorSource = {
+  isin?: string | null | void;
+  security?: string | null | void;
+  symbol?: string | null | void;
+  engName?: string | null | void;
+  hebName?: string | null | void;
+  issuerExchange?: string | null | void;
+  tradeCurrency?: string | null | void;
+  issuerCountryCode?: string | null | void;
+};
+
+/** pgtyped spells an absent value `void`; the descriptors take null. */
+const text = (value: string | null | void): string | null => value ?? null;
+
 @Injectable({
   scope: Scope.Operation,
   global: true,
@@ -1171,7 +1188,87 @@ export class PoalimScraperIngestionProvider {
   constructor(
     private db: TenantAwareDBClient,
     private authContextProvider: AuthContextProvider,
+    private securityBusinessesProvider: SecurityBusinessesProvider,
   ) {}
+
+  /**
+   * Give every security in the payload a business of its own, and record the Poalim key it is
+   * known by here.
+   *
+   * Driven off the whole validated payload rather than only the newly inserted rows: a
+   * re-scrape inserts nothing, but a security whose business was never created (ingested
+   * before this existed, or created while an earlier scrape failed here) still needs one.
+   * Both steps are idempotent, and the existing ISINs are fetched in one query so a repeat
+   * scrape costs a single lookup.
+   *
+   * Rows with no ISIN are skipped: the ISIN is the identity, and one cannot be invented from
+   * the Poalim key alone. Those securities stay unlinked and are assigned by hand.
+   *
+   * Failures are logged rather than thrown: the executions are already stored, and reporting
+   * the upload as failed would be a lie. The next scrape repairs the gap.
+   */
+  private async ensureSecurityBusinesses(
+    transactions: readonly SecurityDescriptorSource[],
+  ): Promise<void> {
+    const bySecurityIsin = new Map<
+      string,
+      { descriptors: SecurityBusinessDescriptors; poalimKeys: Set<string> }
+    >();
+
+    for (const transaction of transactions) {
+      const isin = transaction.isin?.trim();
+      if (!isin) {
+        continue;
+      }
+
+      let entry = bySecurityIsin.get(isin);
+      if (!entry) {
+        entry = {
+          descriptors: {
+            isin,
+            symbol: text(transaction.symbol),
+            engName: text(transaction.engName),
+            hebName: text(transaction.hebName),
+            exchange: text(transaction.issuerExchange),
+            currencyCode: text(transaction.tradeCurrency),
+            issuerCountryCode: text(transaction.issuerCountryCode),
+            isForeign: true,
+          },
+          poalimKeys: new Set(),
+        };
+        bySecurityIsin.set(isin, entry);
+      }
+      if (transaction.security) {
+        entry.poalimKeys.add(transaction.security);
+      }
+    }
+
+    if (bySecurityIsin.size === 0) {
+      return;
+    }
+
+    try {
+      const existing = await this.securityBusinessesProvider.getSecurityBusinessesByIsins([
+        ...bySecurityIsin.keys(),
+      ]);
+
+      for (const [isin, { descriptors, poalimKeys }] of bySecurityIsin) {
+        const securityBusiness =
+          existing.get(isin) ??
+          (await this.securityBusinessesProvider.ensureSecurityBusiness(descriptors));
+
+        for (const poalimKey of poalimKeys) {
+          await this.securityBusinessesProvider.linkIdentifier(
+            securityBusiness.id,
+            'POALIM_SECURITY_KEY',
+            poalimKey,
+          );
+        }
+      }
+    } catch (error) {
+      console.error('Failed to create security businesses for ingested executions:', error);
+    }
+  }
 
   private async getBusinessId() {
     if (this.businessIdCache !== null) {
@@ -1580,6 +1677,8 @@ export class PoalimScraperIngestionProvider {
           }
         }
       }
+
+      await this.ensureSecurityBusinesses(validated);
 
       return {
         inserted: insertedIds.length,

--- a/packages/server/src/modules/transactions/resolvers/__tests__/transaction-suggestions.resolver.test.ts
+++ b/packages/server/src/modules/transactions/resolvers/__tests__/transaction-suggestions.resolver.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AdminContextProvider } from '../../../admin-context/providers/admin-context.provider.js';
+import { BusinessesProvider } from '../../../financial-entities/providers/businesses.provider.js';
+import { FinancialEntitiesProvider } from '../../../financial-entities/providers/financial-entities.provider.js';
+import { SecurityBusinessesProvider } from '../../../foreign-securities/providers/security-businesses.provider.js';
+import { TransactionsProvider } from '../../providers/transactions.provider.js';
+import { transactionSuggestionsResolvers } from '../transaction-suggestions.resolver.js';
+
+const POALIM_BUSINESS_ID = 'poalim-business';
+const SECURITY_BUSINESS_ID = 'security-business';
+
+type TransactionStub = {
+  id?: string;
+  business_id?: string | null;
+  is_fee?: boolean;
+  source_description?: string | null;
+  source_origin?: string | null;
+  amount?: string;
+};
+
+function createContext(transaction: TransactionStub, securityKeyOwner: string | null) {
+  const securityLookup = vi.fn().mockResolvedValue(
+    securityKeyOwner ? { id: securityKeyOwner } : null,
+  );
+
+  const providers = new Map<unknown, unknown>([
+    [
+      AdminContextProvider,
+      {
+        getVerifiedAdminContext: () =>
+          Promise.resolve({
+            financialAccounts: { poalimBusinessId: POALIM_BUSINESS_ID },
+          }),
+      },
+    ],
+    [
+      TransactionsProvider,
+      {
+        transactionByIdLoader: {
+          load: () =>
+            Promise.resolve({
+              id: 't1',
+              business_id: null,
+              is_fee: false,
+              source_origin: 'POALIM',
+              amount: '-1000.00',
+              ...transaction,
+            }),
+        },
+      },
+    ],
+    [SecurityBusinessesProvider, { getSecurityBusinessByIdentifierLoader: { load: securityLookup } }],
+    // No business carries suggestion phrases in these cases.
+    [BusinessesProvider, { getAllBusinesses: () => Promise.resolve([]) }],
+    [
+      FinancialEntitiesProvider,
+      { getFinancialEntityByIdLoader: { load: (id: string) => Promise.resolve({ id }) } },
+    ],
+  ]);
+
+  return {
+    context: {
+      injector: { get: (token: unknown) => providers.get(token) },
+    },
+    securityLookup,
+  };
+}
+
+const suggest = async (transaction: TransactionStub, securityKeyOwner: string | null = null) => {
+  const { context, securityLookup } = createContext(transaction, securityKeyOwner);
+  const resolver = transactionSuggestionsResolvers.CommonTransaction!
+    .missingInfoSuggestions as unknown as (
+    parent: string,
+    args: object,
+    context: unknown,
+    info: unknown,
+  ) => Promise<{ business?: { id: string } } | null>;
+
+  const result = await resolver('t1', {}, context, {});
+  // The wrapper hands GraphQL a promise for the business; resolve it for the assertions.
+  const business = result?.business ? await result.business : null;
+  return { result, business, securityLookup };
+};
+
+describe('transaction business suggestion — securities', () => {
+  it('suggests the security a trade names in its description', async () => {
+    const { business, securityLookup } = await suggest(
+      { source_description: 'ניע"ז מכירה 0005129523' },
+      SECURITY_BUSINESS_ID,
+    );
+
+    expect(securityLookup).toHaveBeenCalledWith({
+      type: 'POALIM_SECURITY_KEY',
+      value: '5129523',
+    });
+    expect(business).toEqual({ id: SECURITY_BUSINESS_ID });
+  });
+
+  it('falls back to Poalim when the key resolves to no security business', async () => {
+    // The security exists in the bank's world but has no business yet — the description
+    // heuristics still claim it, exactly as before.
+    const { business } = await suggest({ source_description: 'ניע"ז קניה 0005129523 FEE' }, null);
+
+    expect(business).toEqual({ id: POALIM_BUSINESS_ID });
+  });
+
+  it('does not guess when a description names two securities', async () => {
+    const { business, securityLookup } = await suggest(
+      { source_description: 'ניע"ז 0005129523 0007654321' },
+      SECURITY_BUSINESS_ID,
+    );
+
+    expect(securityLookup).not.toHaveBeenCalled();
+    expect(business).not.toEqual({ id: SECURITY_BUSINESS_ID });
+  });
+
+  it('leaves the fee row to Poalim', async () => {
+    const { business, securityLookup } = await suggest(
+      { is_fee: true, source_description: 'ניעז עמ׳ תשלום FSEC PYMNT FEE 0005129523' },
+      SECURITY_BUSINESS_ID,
+    );
+
+    expect(securityLookup).not.toHaveBeenCalled();
+    expect(business).toEqual({ id: POALIM_BUSINESS_ID });
+  });
+
+  it('suggests nothing once a counterparty is set', async () => {
+    const { result } = await suggest(
+      { business_id: SECURITY_BUSINESS_ID, source_description: 'ניע"ז מכירה 0005129523' },
+      SECURITY_BUSINESS_ID,
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/server/src/modules/transactions/resolvers/transaction-suggestions.resolver.ts
+++ b/packages/server/src/modules/transactions/resolvers/transaction-suggestions.resolver.ts
@@ -11,6 +11,8 @@ import { ChargesProvider } from '../../charges/providers/charges.provider.js';
 import { suggestionDataSchema } from '../../financial-entities/helpers/business-suggestion-data-schema.helper.js';
 import { BusinessesProvider } from '../../financial-entities/providers/businesses.provider.js';
 import { FinancialEntitiesProvider } from '../../financial-entities/providers/financial-entities.provider.js';
+import { extractSecurityKeys } from '../../foreign-securities/helpers/security-key.helper.js';
+import { SecurityBusinessesProvider } from '../../foreign-securities/providers/security-businesses.provider.js';
 import { TransactionsProvider } from '../providers/transactions.provider.js';
 import type { TransactionsModule } from '../types.js';
 
@@ -124,14 +126,21 @@ const missingInfoSuggestions = async (
     }
   }
 
-  if (transaction.business_id) {
-    const business = await injector
-      .get(BusinessesProvider)
-      .getBusinessByIdLoader.load(transaction.business_id);
-
-    if (business?.suggestion_data) {
+  // A securities trade names the security it traded in its description. That key resolves to
+  // one business, which is a stronger signal than any phrase — and stronger than the POALIM
+  // description heuristics further down, which would otherwise claim it for the bank.
+  // Only for the main transaction: the fee row is Poalim's, and it never gets here.
+  const securityKeys = extractSecurityKeys(transaction.source_description);
+  if (securityKeys.length === 1) {
+    const securityBusiness = await injector
+      .get(SecurityBusinessesProvider)
+      .getSecurityBusinessByIdentifierLoader.load({
+        type: 'POALIM_SECURITY_KEY',
+        value: securityKeys[0],
+      });
+    if (securityBusiness) {
       return {
-        business: business.id,
+        business: securityBusiness.id,
       };
     }
   }


### PR DESCRIPTION
Step 4 of the [per-security businesses plan](../blob/feat/security-businesses-plan/docs/foreign-securities-businesses/plan.md). Stacked on #4254.

### Ingestion

`uploadPoalimSecuritiesTransactions` gives every security in the payload a business and records the
Poalim key it arrived under.

Driven off the **whole validated payload**, not just newly inserted rows — a re-scrape inserts
nothing, but a security whose business was never created (ingested before this existed, or an earlier
scrape that failed here) still needs one. Both steps are idempotent and existing ISINs are fetched in
one query, so a repeat scrape costs a single lookup. Two Poalim keys reporting the same ISIN collapse
onto one business, which is the point of keying on ISIN.

- **No ISIN → skipped.** The ISIN is the identity; it cannot be invented from the Poalim key. Those
  stay unlinked for manual assignment.
- **Failures are logged, not thrown.** The executions are already stored; failing the upload would
  misreport it. The next scrape repairs the gap.

### Suggestion

A trade names its security in the description, and that key now resolves to a business, so
`missingInfoSuggestions` returns the security instead of falling through to the POALIM description
heuristics that would claim it for the bank. Only when the description names exactly one key, and
only for the main transaction — the fee row returns Poalim earlier and is untouched, which is what
keeps its ledger entry as it is. An unresolvable key falls through to the old behavior rather than
inventing a suggestion.

Also drops an unreachable `transaction.business_id` branch in that resolver — the function returns
null for any transaction that already has a counterparty, several lines above it.

### Verification

- `yarn lint`, `yarn prettier`, server typecheck clean.
- `yarn test` — 3431 passed, incl. 5 new suggestion cases (security wins; unresolved key falls back
  to Poalim; two keys in one description suggest nothing; fee row stays Poalim; no suggestion once a
  counterparty is set).
- `yarn test:integration` — 3841 passed, incl. 5 new ingestion cases asserting the created business
  is named `EXAMPLE CORP (EXMP)` with its `POALIM_SECURITY_KEY` link, one business across several
  executions, no duplication on re-scrape, two keys collapsing onto one ISIN, and ISIN-less rows
  staying unlinked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)