### PR TITLE
feat: securities screen listing every currently held security

### DIFF
--- a/.changeset/securities-holdings-screen.md
+++ b/.changeset/securities-holdings-screen.md
@@ -1,0 +1,43 @@
+---
+'@accounter/server': patch
+'@accounter/client': patch
+---
+
+Add a `/securities` screen listing every security currently held.
+
+Until now a security's numbers were only reachable one at a time: you had to already know the
+business, open `/businesses/{id}`, and click its security tab. The only query that computed a
+position, `securityBusinessHistory(businessId:)`, required a business id and always paid for the
+full execution list plus the transaction/charge match behind it.
+
+**Server.** New `securityHoldings(includeClosed: Boolean = false): [SecurityHolding!]!` query, where
+`SecurityHolding` is `{ id, security, position }` — the existing `SecurityBusiness` and
+`SecurityPosition` types, without the execution list. It is backed by a new
+`ForeignSecuritiesProvider.getExecutionsBySecurityBusiness()`, which reuses the existing
+`getSecurityExecutionsByKeys` statement unchanged: that SQL already filters on
+`security = ANY(...)` and returns the key on every row, so the union of every security business's
+Poalim keys is fetched in one round trip and split up in memory. It deliberately skips the
+transaction match, which exists only to draw charge links a holdings list does not show — so the
+whole portfolio costs one query instead of four per security. A security business with no
+`POALIM_SECURITY_KEY` identifier keeps an entry with no executions rather than disappearing.
+
+Closed positions are filtered with a new `isOpenPosition` helper rather than `quantity !== 0`:
+quantities are floats summed over fractional ETF and mutual-fund units, so a fully sold position
+lands on a floating-point residue, not on zero. `Math.abs` is deliberate — a negative quantity means
+the scraped history starts mid-life and is a data-quality signal worth surfacing, not a closed
+position.
+
+**Client.** A top-level "Securities" screen: one row per security with its current hold, average
+cost, total bought/sold, descriptor badges and history dates, searchable across name/symbol/ISIN/
+exchange/currency/Poalim key, sortable on every numeric and date column, with a "show closed
+positions" toggle that re-queries the server. Each row links to the security's own page for the full
+execution history. Money cells render each security's own `formatted` amount and there is no summed
+total — rows can be quoted in different trade currencies and nothing is converted.
+
+The descriptor badges are extracted into a shared `SecurityDescriptorBadges` component (behind a
+`SecurityDescriptorFields` fragment) so the table and the security page's header card cannot drift.
+
+Also corrects the derivation caveat on the security page, which read "Holdings are not scraped" —
+the executions *are* scraped; what the bank does not report is a holding. Both the page and the new
+screen now say the position is added up from the scraped trades rather than read from a reported
+balance.

--- a/codegen.ts
+++ b/codegen.ts
@@ -160,6 +160,7 @@ const config: CodegenConfig = {
             '../modules/foreign-securities/types.js#SecurityBusinessHistoryProto',
           SecurityHistoryExecution:
             '../modules/foreign-securities/types.js#SecurityHistoryExecutionProto',
+          SecurityHolding: '../modules/foreign-securities/types.js#SecurityHoldingProto',
           SecurityPosition: '../modules/foreign-securities/types.js#SecurityPositionWithIdProto',
           SecurityExecution: '../modules/foreign-securities/types.js#SecurityExecutionRow',
           SecurityIdentifier: '../modules/foreign-securities/types.js#SecurityIdentifierRow',

--- a/packages/client/src/components/business/security-section.tsx
+++ b/packages/client/src/components/business/security-section.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement } from 'react';
 import { useQuery } from 'urql';
-import { Badge } from '@/components/ui/badge.js';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.js';
 import { BusinessSecuritySectionDocument } from '@/gql/graphql.js';
+import { SecurityDescriptorBadges } from '../securities/security-descriptor-badges.js';
 import {
   formatSecurityDate,
   formatSecurityNumber,
@@ -20,12 +20,7 @@ import {
         symbol
         engName
         hebName
-        exchange
-        currencyCode
-        itemType
-        stockType
-        isEtf
-        isForeign
+        ...SecurityDescriptorFields
         identifiers {
           id
           type
@@ -102,15 +97,7 @@ export function SecuritySection({ businessId }: Props): ReactElement {
               {security.symbol && <span className="text-gray-500"> ({security.symbol})</span>}
             </CardTitle>
             {security.hebName && <CardDescription>{security.hebName}</CardDescription>}
-            <div className="flex flex-row flex-wrap items-center gap-2">
-              <Badge variant="secondary">{security.isin}</Badge>
-              {security.exchange && <Badge variant="secondary">{security.exchange}</Badge>}
-              {security.currencyCode && <Badge variant="secondary">{security.currencyCode}</Badge>}
-              {security.itemType && <Badge variant="outline">{security.itemType}</Badge>}
-              {security.stockType && <Badge variant="outline">{security.stockType}</Badge>}
-              {security.isEtf && <Badge variant="outline">ETF</Badge>}
-              {security.isForeign && <Badge variant="outline">Foreign</Badge>}
-            </div>
+            <SecurityDescriptorBadges security={security} />
           </div>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
@@ -123,11 +110,11 @@ export function SecuritySection({ businessId }: Props): ReactElement {
           </div>
           <div className="text-xs text-gray-400">
             {position.historyStartDate
-              ? `Derived from ingested trades since ${formatSecurityDate(position.historyStartDate)}` +
+              ? `Added up from the scraped trades since ${formatSecurityDate(position.historyStartDate)}` +
                 (position.lastExecutionDate
                   ? `, last one ${formatSecurityDate(position.lastExecutionDate)}`
                   : '') +
-                '. Holdings are not scraped, so anything held before that date is not counted here.'
+                '. The bank does not report a holding, so anything held before that date is not counted here.'
               : 'No executions ingested for this security yet.'}
             {poalimKeys.length > 0 && ` · Poalim key ${poalimKeys.join(', ')}`}
           </div>

--- a/packages/client/src/components/layout/sidelinks.tsx
+++ b/packages/client/src/components/layout/sidelinks.tsx
@@ -7,6 +7,7 @@ import {
   Book,
   BookOpenCheck,
   Calculator,
+  CandlestickChart,
   ChartColumnDecreasing,
   ChartNoAxesCombined,
   CheckCheck,
@@ -282,6 +283,12 @@ export const sidelinks: SideLink[] = [
     title: 'Salaries',
     label: '',
     icon: <BadgeDollarSign size={18} />,
+  },
+  {
+    href: ROUTES.SECURITIES,
+    title: 'Securities',
+    label: '',
+    icon: <CandlestickChart size={18} />,
   },
   {
     href: ROUTES.TAGS,

--- a/packages/client/src/components/screens/securities/__tests__/index.test.tsx
+++ b/packages/client/src/components/screens/securities/__tests__/index.test.tsx
@@ -1,0 +1,226 @@
+// @vitest-environment happy-dom
+
+import { useState, type ReactElement } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { FiltersContext } from '../../../../providers/filters-context.js';
+import { Securities } from '../index.js';
+
+const { useQueryMock } = vi.hoisted(() => ({ useQueryMock: vi.fn() }));
+
+vi.mock('urql', () => ({
+  useQuery: useQueryMock,
+}));
+
+vi.mock('../../../common/index.js', async () => {
+  const pagination =
+    await vi.importActual<typeof import('../../../common/data-table-pagination.js')>(
+      '../../../common/data-table-pagination.js',
+    );
+  const skeleton =
+    await vi.importActual<typeof import('../../../common/loaders/table-skeleton.js')>(
+      '../../../common/loaders/table-skeleton.js',
+    );
+  return {
+    // Keep the real pagination bar: it is what the screen pushes into the filters context, and
+    // the render loop the harness guards against went through it.
+    DataTablePagination: pagination.DataTablePagination,
+    TableSkeleton: skeleton.TableSkeleton,
+  };
+});
+
+/**
+ * The descriptor badges read their fields through `getFragmentData`, which asserts on the
+ * fragment document at runtime. Stubbing it keeps these cases about the screen rather than about
+ * fragment masking.
+ */
+vi.mock('../../../securities/security-descriptor-badges.js', () => ({
+  SecurityDescriptorBadges: () => null,
+}));
+
+function holding(index: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id: `security-${index}`,
+    security: {
+      id: `security-${index}`,
+      isin: `US000000${String(index).padStart(4, '0')}`,
+      symbol: `SYM${index}`,
+      engName: `Example Corp ${index}`,
+      hebName: null,
+      currencyCode: 'USD',
+      exchange: 'NYQ',
+      identifiers: [{ id: `identifier-${index}`, type: 'POALIM_SECURITY_KEY', value: `10${index}` }],
+    },
+    position: {
+      id: `security-${index}`,
+      quantity: index + 1,
+      averageCost: { raw: 100 + index, formatted: `$${100 + index}` },
+      totalBought: { raw: 1000 + index, formatted: `$${1000 + index}` },
+      totalSold: { raw: 0, formatted: '$0' },
+      historyStartDate: '2024-01-05',
+      lastExecutionDate: '2024-03-10',
+    },
+    ...overrides,
+  };
+}
+
+const securityHoldings = Array.from({ length: 120 }, (_, index) => holding(index));
+
+/**
+ * Types into a controlled input. Assigning `.value` directly is invisible to React — it tracks
+ * the last value it wrote and skips the change as a no-op — so go through the prototype's setter
+ * before dispatching, which is what React's own test utilities do.
+ */
+function typeInto(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+/** A render loop never settles, so it would hang the runner instead of failing. */
+const MAX_RENDERS = 50;
+let renderCount = 0;
+
+/** Mirrors DashboardLayoutRoute: the filters context is parent state, so every
+ * `setFiltersContext` call re-renders the screen below it. */
+function Screen(): ReactElement {
+  renderCount += 1;
+  if (renderCount > MAX_RENDERS) {
+    throw new Error(`Render loop detected: the screen re-rendered more than ${MAX_RENDERS} times`);
+  }
+  const [filtersContext, setFiltersContext] = useState<ReactElement | null>(null);
+  return (
+    <FiltersContext.Provider value={{ filtersContext, setFiltersContext }}>
+      {filtersContext}
+      <Securities />
+    </FiltersContext.Provider>
+  );
+}
+
+/** The name cell renders a `Link`, so the screen needs a router around it. */
+function Harness(): ReactElement {
+  return <RouterProvider router={createMemoryRouter([{ path: '/', element: <Screen /> }])} />;
+}
+
+describe('Securities screen', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let consoleError: MockInstance<typeof console.error>;
+
+  const mockHoldings = (holdings: unknown[]) =>
+    useQueryMock.mockReturnValue([
+      { data: { securityHoldings: holdings }, fetching: false, error: undefined },
+      vi.fn(),
+    ]);
+
+  beforeEach(() => {
+    renderCount = 0;
+    useQueryMock.mockReset();
+    mockHoldings(securityHoldings);
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    consoleError.mockRestore();
+  });
+
+  // Regression guard inherited from the sort-codes screen: an effect depending on the `useTable`
+  // handle re-runs forever against the parent's `setFiltersContext` state.
+  it('renders without exceeding the maximum update depth', () => {
+    expect(() => {
+      act(() => root.render(<Harness />));
+    }).not.toThrow();
+
+    const loopErrors = consoleError.mock.calls.filter(call =>
+      call.some(arg => String(arg).includes('Maximum update depth exceeded')),
+    );
+    expect(loopErrors).toHaveLength(0);
+    expect(renderCount).toBeLessThan(MAX_RENDERS);
+    expect(container.textContent).toContain('Securities (120)');
+  });
+
+  it('publishes the pagination bar into the filters context', () => {
+    act(() => root.render(<Harness />));
+
+    // 120 rows at a page size of 100 => 2 pages, rendered by DataTablePagination.
+    expect(container.textContent).toContain('Page 1 of 2');
+  });
+
+  it('asks the server for closed positions only once the toggle is on', () => {
+    act(() => root.render(<Harness />));
+
+    expect(useQueryMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ variables: { includeClosed: false } }),
+    );
+
+    const toggle = container.querySelector('#include-closed');
+    expect(toggle).not.toBeNull();
+    act(() => {
+      (toggle as HTMLElement).click();
+    });
+
+    expect(useQueryMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ variables: { includeClosed: true } }),
+    );
+  });
+
+  it('narrows the table to what the search matches', () => {
+    mockHoldings([holding(1), holding(2)]);
+    act(() => root.render(<Harness />));
+
+    expect(container.textContent).toContain('Example Corp 1');
+    expect(container.textContent).toContain('Example Corp 2');
+
+    const input = container.querySelector('input[placeholder^="Search"]') as HTMLInputElement;
+    act(() => typeInto(input, 'SYM2'));
+
+    expect(container.textContent).not.toContain('Example Corp 1');
+    expect(container.textContent).toContain('Example Corp 2');
+    expect(container.textContent).toContain('Securities (1)');
+  });
+
+  it('renders an em dash for a position with no currency to report amounts in', () => {
+    mockHoldings([
+      holding(1, {
+        position: {
+          id: 'security-1',
+          quantity: 4,
+          averageCost: null,
+          totalBought: null,
+          totalSold: null,
+          historyStartDate: null,
+          lastExecutionDate: null,
+        },
+      }),
+    ]);
+
+    expect(() => {
+      act(() => root.render(<Harness />));
+    }).not.toThrow();
+    expect(container.textContent).toContain('—');
+  });
+
+  it('links each security to its own page', () => {
+    mockHoldings([holding(7)]);
+    act(() => root.render(<Harness />));
+
+    const link = container.querySelector('a[href="/businesses/security-7"]');
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toContain('Example Corp 7');
+  });
+
+  it('points at the toggle when nothing is held', () => {
+    mockHoldings([]);
+    act(() => root.render(<Harness />));
+
+    expect(container.textContent).toContain('No open positions');
+    expect(container.textContent).toContain('Show closed positions');
+  });
+});

--- a/packages/client/src/components/screens/securities/columns.tsx
+++ b/packages/client/src/components/screens/securities/columns.tsx
@@ -1,0 +1,156 @@
+import { Link } from 'react-router-dom';
+import type { ColumnDef, Row } from '@tanstack/react-table';
+import type { TableFeaturesConfig } from '@/lib/table-features.js';
+import type { SecurityHoldingsScreenQuery } from '../../../gql/graphql.js';
+import { ROUTES } from '../../../router/routes.js';
+import { DataTableColumnHeader } from '../../common/data-table-column-header.js';
+import { SecurityDescriptorBadges } from '../../securities/security-descriptor-badges.js';
+import {
+  formatSecurityDate,
+  formatSecurityNumber,
+} from '../../securities/security-executions-table.js';
+
+export type SecurityHoldingRow = SecurityHoldingsScreenQuery['securityHoldings'][number];
+
+type HoldingRow = Row<TableFeaturesConfig, SecurityHoldingRow>;
+
+/** Everything the search box matches on, for one holding. */
+export function holdingSearchFields(holding: SecurityHoldingRow): (string | null | undefined)[] {
+  const { security } = holding;
+  return [
+    security.engName,
+    security.hebName,
+    security.symbol,
+    security.isin,
+    security.exchange,
+    security.currencyCode,
+    ...security.identifiers.map(identifier => identifier.value),
+  ];
+}
+
+/** What a row is called: the English name where there is one, the ISIN otherwise. */
+const displayName = (holding: SecurityHoldingRow): string =>
+  holding.security.engName ?? holding.security.isin;
+
+/**
+ * Money columns sort on the raw number, with missing amounts last ascending. Deliberately
+ * currency-blind: rows can be quoted in different trade currencies, so this orders magnitudes
+ * rather than value. The currency badge is what lets a reader compare like with like.
+ *
+ * `?.raw` and not `.raw`: the amount is nullable — a security with no ingested executions has no
+ * currency to report one in — while `FinancialAmount.raw` itself is non-null.
+ */
+const sortByAmount =
+  (field: 'averageCost' | 'totalBought' | 'totalSold') => (a: HoldingRow, b: HoldingRow) =>
+    (a.original.position[field]?.raw ?? -Infinity) - (b.original.position[field]?.raw ?? -Infinity);
+
+/** TimelessDate is an ISO `YYYY-MM-DD` string, so lexical order is chronological. */
+const sortByDate =
+  (field: 'historyStartDate' | 'lastExecutionDate') => (a: HoldingRow, b: HoldingRow) =>
+    (a.original.position[field] ?? '').localeCompare(b.original.position[field] ?? '');
+
+export const columns: ColumnDef<TableFeaturesConfig, SecurityHoldingRow>[] = [
+  {
+    id: 'security',
+    accessorFn: displayName,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Security" />,
+    cell: ({ row }) => {
+      const { security } = row.original;
+      return (
+        // The security's business id is its own id, so this lands on its page — which is where
+        // the full execution history lives.
+        <Link
+          to={ROUTES.BUSINESSES.DETAIL(security.id)}
+          state={{ from: ROUTES.SECURITIES }}
+          className="font-medium text-blue-600 hover:underline"
+        >
+          {displayName(row.original)}
+          {security.symbol && <span className="text-gray-500"> ({security.symbol})</span>}
+          {security.hebName && (
+            <span className="block text-xs text-muted-foreground">{security.hebName}</span>
+          )}
+        </Link>
+      );
+    },
+  },
+  {
+    id: 'isin',
+    accessorFn: row => row.security.isin,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="ISIN" />,
+    cell: ({ row }) => <span className="font-mono text-xs">{row.original.security.isin}</span>,
+  },
+  {
+    id: 'descriptors',
+    header: 'Details',
+    enableSorting: false,
+    cell: ({ row }) => (
+      <SecurityDescriptorBadges security={row.original.security} withIsin={false} />
+    ),
+  },
+  {
+    id: 'quantity',
+    accessorFn: row => row.position.quantity,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Current hold" />,
+    // Quantities can be fractional for ETFs and mutual funds.
+    cell: ({ row }) => (
+      <span className="tabular-nums">
+        {formatSecurityNumber(row.original.position.quantity, 4)}
+      </span>
+    ),
+  },
+  {
+    id: 'averageCost',
+    accessorFn: row => row.position.averageCost?.raw ?? null,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Average cost" />,
+    sortFn: sortByAmount('averageCost'),
+    cell: ({ row }) => (
+      <span className="whitespace-nowrap tabular-nums">
+        {row.original.position.averageCost?.formatted ?? '—'}
+      </span>
+    ),
+  },
+  {
+    id: 'totalBought',
+    accessorFn: row => row.position.totalBought?.raw ?? null,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Total bought" />,
+    sortFn: sortByAmount('totalBought'),
+    cell: ({ row }) => (
+      <span className="whitespace-nowrap tabular-nums">
+        {row.original.position.totalBought?.formatted ?? '—'}
+      </span>
+    ),
+  },
+  {
+    id: 'totalSold',
+    accessorFn: row => row.position.totalSold?.raw ?? null,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Total sold" />,
+    sortFn: sortByAmount('totalSold'),
+    cell: ({ row }) => (
+      <span className="whitespace-nowrap tabular-nums">
+        {row.original.position.totalSold?.formatted ?? '—'}
+      </span>
+    ),
+  },
+  {
+    id: 'lastExecutionDate',
+    accessorFn: row => row.position.lastExecutionDate,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="Last execution" />,
+    sortFn: sortByDate('lastExecutionDate'),
+    cell: ({ row }) => (
+      <span className="whitespace-nowrap">
+        {formatSecurityDate(row.original.position.lastExecutionDate) || '—'}
+      </span>
+    ),
+  },
+  {
+    id: 'historyStartDate',
+    accessorFn: row => row.position.historyStartDate,
+    header: ({ column }) => <DataTableColumnHeader column={column} title="History since" />,
+    sortFn: sortByDate('historyStartDate'),
+    cell: ({ row }) => (
+      <span className="whitespace-nowrap">
+        {formatSecurityDate(row.original.position.historyStartDate) || '—'}
+      </span>
+    ),
+  },
+];

--- a/packages/client/src/components/screens/securities/index.tsx
+++ b/packages/client/src/components/screens/securities/index.tsx
@@ -1,0 +1,219 @@
+import { useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
+import { CandlestickChart, Search } from 'lucide-react';
+import { useQuery } from 'urql';
+import { flexRender, useTable } from '@tanstack/react-table';
+import { tableFeaturesConfig } from '@/lib/table-features.js';
+import { SecurityHoldingsScreenDocument } from '../../../gql/graphql.js';
+import { FiltersContext } from '../../../providers/filters-context.js';
+import { DataTablePagination, TableSkeleton } from '../../common/index.js';
+import { PageLayout } from '../../layout/page-layout.js';
+import { Alert, AlertDescription, AlertTitle } from '../../ui/alert.js';
+import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '../../ui/empty.js';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '../../ui/input-group.js';
+import { Label } from '../../ui/label.js';
+import { Spinner } from '../../ui/spinner.js';
+import { Switch } from '../../ui/switch.js';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../ui/table.js';
+import { columns, holdingSearchFields } from './columns.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  query SecurityHoldingsScreen($includeClosed: Boolean!) {
+    securityHoldings(includeClosed: $includeClosed) {
+      id
+      security {
+        id
+        isin
+        symbol
+        engName
+        hebName
+        currencyCode
+        exchange
+        ...SecurityDescriptorFields
+        identifiers {
+          id
+          type
+          value
+        }
+      }
+      position {
+        id
+        quantity
+        averageCost {
+          raw
+          formatted
+        }
+        totalBought {
+          raw
+          formatted
+        }
+        totalSold {
+          raw
+          formatted
+        }
+        historyStartDate
+        lastExecutionDate
+      }
+    }
+  }
+`;
+
+export const Securities = (): ReactElement => {
+  const [includeClosed, setIncludeClosed] = useState(false);
+  const [search, setSearch] = useState('');
+  const [{ data, fetching, error }] = useQuery({
+    query: SecurityHoldingsScreenDocument,
+    variables: { includeClosed },
+  });
+  const { setFiltersContext } = useContext(FiltersContext);
+
+  const holdings = useMemo(() => data?.securityHoldings ?? [], [data?.securityHoldings]);
+
+  const filtered = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    if (!needle) {
+      return holdings;
+    }
+    return holdings.filter(holding =>
+      holdingSearchFields(holding).some(field => field?.toLowerCase().includes(needle)),
+    );
+  }, [holdings, search]);
+
+  const table = useTable({
+    features: tableFeaturesConfig,
+    data: filtered,
+    columns,
+    getRowId: row => row.id,
+    initialState: {
+      // The biggest live positions first — the reason to open this screen.
+      sorting: [{ id: 'quantity', desc: true }],
+      pagination: { pageIndex: 0, pageSize: 100 },
+    },
+  });
+
+  // `useTable` hands back a fresh object on every render and `getPageOptions()` a fresh array, so
+  // neither can be an effect dependency: the effect would re-run on every render, and setting the
+  // filters context re-renders this screen, looping forever ("Maximum update depth exceeded").
+  // The pagination bar only reads these primitives, so depend on them instead.
+  const { pageIndex, pageSize } = table.state.pagination;
+  const pageCount = table.getPageCount();
+
+  useEffect(() => {
+    setFiltersContext(
+      <div className="flex items-center justify-end gap-10 space-x-2 py-4">
+        <DataTablePagination table={table} />
+      </div>,
+    );
+  }, [setFiltersContext, pageIndex, pageSize, pageCount]);
+
+  return (
+    <PageLayout
+      title={`Securities (${filtered.length})`}
+      description="What you hold, added up from the scraped executions"
+      headerActions={
+        <div className="flex flex-row flex-wrap items-center gap-4">
+          {fetching && <Spinner />}
+          <InputGroup className="max-w-xs">
+            <InputGroupInput
+              placeholder="Search name, symbol, ISIN..."
+              value={search}
+              onChange={e => {
+                setSearch(e.target.value);
+                // Narrowing the set would otherwise strand the reader on a page that no
+                // longer exists.
+                table.setPageIndex(0);
+              }}
+              className="ps-10"
+            />
+            <InputGroupAddon>
+              <Search />
+            </InputGroupAddon>
+          </InputGroup>
+          <div className="flex flex-row items-center gap-2">
+            <Switch
+              id="include-closed"
+              checked={includeClosed}
+              onCheckedChange={checked => {
+                setIncludeClosed(checked);
+                table.setPageIndex(0);
+              }}
+            />
+            <Label htmlFor="include-closed" className="whitespace-nowrap">
+              Show closed positions
+            </Label>
+          </div>
+        </div>
+      }
+    >
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Could not load securities</AlertTitle>
+          <AlertDescription>{error.message}</AlertDescription>
+        </Alert>
+      ) : fetching ? (
+        <div className="rounded-md border p-4">
+          <TableSkeleton columns={columns.length} rows={10} />
+        </div>
+      ) : holdings.length === 0 ? (
+        <Empty className="py-8 sm:py-12">
+          <EmptyMedia>
+            <CandlestickChart className="size-8 sm:size-10 text-muted-foreground" />
+          </EmptyMedia>
+          <EmptyTitle>{includeClosed ? 'No securities yet' : 'No open positions'}</EmptyTitle>
+          <EmptyDescription>
+            {includeClosed
+              ? 'Securities appear here once trades naming them have been ingested.'
+              : 'Nothing is currently held. Turn on "Show closed positions" to see securities that were sold out.'}
+          </EmptyDescription>
+        </Empty>
+      ) : (
+        <div className="flex flex-col gap-4">
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                {table.getHeaderGroups().map(headerGroup => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map(header => (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(header.column.columnDef.header, header.getContext())}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {table.getRowModel().rows.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={columns.length} className="text-center py-8">
+                      No securities match this search
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  table.getRowModel().rows.map(row => (
+                    <TableRow key={row.id}>
+                      {row.getVisibleCells().map(cell => (
+                        <TableCell key={cell.id}>
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+          {/* The same caveat the security page states per security, said once for the screen. */}
+          <p className="text-xs text-gray-400">
+            Holdings are added up from the scraped executions, not read from a balance the bank
+            reports. Anything held before a security&apos;s first scraped trade is therefore not
+            counted, and a change in units with no execution behind it — a split, say — is
+            invisible. Amounts are in each security&apos;s own trade currency and are never
+            converted, so they do not compare across currencies.
+          </p>
+        </div>
+      )}
+    </PageLayout>
+  );
+};

--- a/packages/client/src/components/securities/security-descriptor-badges.tsx
+++ b/packages/client/src/components/securities/security-descriptor-badges.tsx
@@ -1,0 +1,50 @@
+import type { ReactElement } from 'react';
+import {
+  SecurityDescriptorFieldsFragmentDoc,
+  type SecurityDescriptorFieldsFragment,
+} from '../../gql/graphql.js';
+import { getFragmentData, type FragmentType } from '../../gql/index.js';
+import { Badge } from '../ui/badge.js';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
+/* GraphQL */ `
+  fragment SecurityDescriptorFields on SecurityBusiness {
+    id
+    isin
+    exchange
+    currencyCode
+    itemType
+    stockType
+    isEtf
+    isForeign
+  }
+`;
+
+interface Props {
+  security: FragmentType<typeof SecurityDescriptorFieldsFragmentDoc>;
+  /** Drop the ISIN badge where the ISIN already has a column of its own. */
+  withIsin?: boolean;
+}
+
+/**
+ * The descriptor badges of a security, shared by its own page and the holdings table so the
+ * two always read the same. Identity facts get `secondary`, classification gets `outline`.
+ */
+export function SecurityDescriptorBadges({ security, withIsin = true }: Props): ReactElement {
+  const descriptors: SecurityDescriptorFieldsFragment = getFragmentData(
+    SecurityDescriptorFieldsFragmentDoc,
+    security,
+  );
+
+  return (
+    <div className="flex flex-row flex-wrap items-center gap-2">
+      {withIsin && <Badge variant="secondary">{descriptors.isin}</Badge>}
+      {descriptors.exchange && <Badge variant="secondary">{descriptors.exchange}</Badge>}
+      {descriptors.currencyCode && <Badge variant="secondary">{descriptors.currencyCode}</Badge>}
+      {descriptors.itemType && <Badge variant="outline">{descriptors.itemType}</Badge>}
+      {descriptors.stockType && <Badge variant="outline">{descriptors.stockType}</Badge>}
+      {descriptors.isEtf && <Badge variant="outline">ETF</Badge>}
+      {descriptors.isForeign && <Badge variant="outline">Foreign</Badge>}
+    </div>
+  );
+}

--- a/packages/client/src/router/config.tsx
+++ b/packages/client/src/router/config.tsx
@@ -175,6 +175,9 @@ const AnnualAudit = lazy(() =>
 const Salaries = lazy(() =>
   import('../components/salaries/index.js').then(m => ({ default: m.Salaries })),
 );
+const Securities = lazy(() =>
+  import('../components/screens/securities/index.js').then(m => ({ default: m.Securities })),
+);
 const TagsManager = lazy(() =>
   import('../components/tags/index.js').then(m => ({ default: m.TagsManager })),
 );
@@ -655,6 +658,11 @@ export const routes: RouteObject[] = [
             path: 'salaries',
             element: withSuspense(Salaries, <TableSkeleton />),
             handle: { title: 'Salaries', breadcrumb: 'Salaries' },
+          },
+          {
+            path: 'securities',
+            element: withSuspense(Securities, <TableSkeleton />),
+            handle: { title: 'Securities', breadcrumb: 'Securities' },
           },
           {
             path: 'tags',

--- a/packages/client/src/router/routes.ts
+++ b/packages/client/src/router/routes.ts
@@ -147,6 +147,7 @@ export const ROUTES = {
 
   ACCOUNTANT_APPROVALS: '/accountant-approvals',
   SALARIES: '/salaries',
+  SECURITIES: '/securities',
   TAGS: '/tags',
   TAX_CATEGORIES: '/tax-categories',
   SORT_CODES: '/sort-codes',

--- a/packages/server/src/modules/foreign-securities/helpers/__tests__/security-position.helper.test.ts
+++ b/packages/server/src/modules/foreign-securities/helpers/__tests__/security-position.helper.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   calculateSecurityPosition,
+  isOpenPosition,
   type PositionExecution,
 } from '../security-position.helper.js';
 
@@ -92,5 +93,36 @@ describe('calculateSecurityPosition', () => {
 
   it('carries the currency the executions are quoted in', () => {
     expect(calculateSecurityPosition([execution()]).currency).toBe('דולר ארה"ב');
+  });
+});
+
+describe('isOpenPosition', () => {
+  it('reads an untouched security as closed', () => {
+    expect(isOpenPosition(calculateSecurityPosition([]))).toBe(false);
+  });
+
+  it('reads a fully sold fractional holding as closed despite the float residue', () => {
+    // Fractional units are the norm for ETFs and mutual funds, and summing them does not land
+    // back on zero — which is the whole reason the predicate needs an epsilon.
+    const position = calculateSecurityPosition([
+      execution({ nv: '0.1' }),
+      execution({ nv: '0.2' }),
+      execution({ nv: '0.3', trade_type: 'מכירה', net_value_trade_currency: '30.00' }),
+    ]);
+
+    expect(position.quantity).not.toBe(0);
+    expect(isOpenPosition(position)).toBe(false);
+  });
+
+  it('reads a holding still visible at four decimals as open', () => {
+    expect(isOpenPosition({ quantity: 0.0001 })).toBe(true);
+  });
+
+  it('reads a residue below the printed precision as closed', () => {
+    expect(isOpenPosition({ quantity: 5e-7 })).toBe(false);
+  });
+
+  it('reads a negative holding as open, since it means the history starts mid-life', () => {
+    expect(isOpenPosition({ quantity: -5 })).toBe(true);
   });
 });

--- a/packages/server/src/modules/foreign-securities/helpers/security-position.helper.ts
+++ b/packages/server/src/modules/foreign-securities/helpers/security-position.helper.ts
@@ -47,6 +47,24 @@ export type SecurityPositionProto = {
   lastExecutionDate: TimelessDateString | null;
 };
 
+/**
+ * How close to zero counts as zero. Units are fractional for ETFs and mutual funds, so a
+ * fully-sold position lands on a floating-point residue rather than on 0, and `quantity !== 0`
+ * would keep every closed position in a holdings list. The threshold sits two orders of
+ * magnitude below the four decimals the UI prints, so nothing visible on screen is ever hidden.
+ */
+const QUANTITY_EPSILON = 1e-6;
+
+/**
+ * Whether anything is still held.
+ *
+ * `Math.abs` on purpose: a negative quantity means the ingested history starts mid-life — units
+ * were sold that were never seen bought — and that is a data-quality signal worth surfacing,
+ * not a closed position to filter away.
+ */
+export const isOpenPosition = (position: Pick<SecurityPositionProto, 'quantity'>): boolean =>
+  Math.abs(position.quantity) > QUANTITY_EPSILON;
+
 const toNumber = (value: string | null): number => {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;

--- a/packages/server/src/modules/foreign-securities/providers/__tests__/foreign-securities.integration.test.ts
+++ b/packages/server/src/modules/foreign-securities/providers/__tests__/foreign-securities.integration.test.ts
@@ -10,6 +10,7 @@ import type { FinancialAccountsProvider } from '../../../financial-accounts/prov
 import type { FinancialBankAccountsProvider } from '../../../financial-accounts/providers/financial-bank-accounts.provider.js';
 import type { TransactionsProvider } from '../../../transactions/providers/transactions.provider.js';
 import { ForeignSecuritiesProvider } from '../foreign-securities.provider.js';
+import { SecurityBusinessesProvider } from '../security-businesses.provider.js';
 
 let pool: Pool;
 
@@ -21,6 +22,12 @@ const OTHER_OWNER_ID = '00000000-0000-0000-0000-0000000006ed';
 const CHARGE_ID = '00000000-0000-0000-0000-00000000c001';
 
 const ACCOUNT_ID = '00000000-0000-0000-0000-00000000a001';
+
+// The synthetic security businesses. Fixed ids so cleanup and assertions are deterministic.
+const APPLE_BUSINESS_ID = '00000000-0000-0000-0000-0000000005a1';
+const MSFT_BUSINESS_ID = '00000000-0000-0000-0000-0000000005a2';
+const ISIN_ONLY_BUSINESS_ID = '00000000-0000-0000-0000-0000000005a3';
+const SECURITY_BUSINESS_IDS = [APPLE_BUSINESS_ID, MSFT_BUSINESS_ID, ISIN_ONLY_BUSINESS_ID];
 const BANK_NUMBER = 12;
 const BRANCH_NUMBER = 615;
 const ACCOUNT_NUMBER = 100000;
@@ -122,8 +129,16 @@ function createProvider(
     createStubTransactionsProvider(transactions),
     createStubFinancialAccountsProvider(accountNumber),
     createStubFinancialBankAccountsProvider(),
-    // Only the security-history path uses it, which these cases do not take.
-    {} as never,
+    // The holdings path reads security businesses and their identifiers, so this one has to be
+    // real. Only `db` is exercised: the four remaining constructor deps drive the create path,
+    // which these cases seed around by inserting the rows directly.
+    new SecurityBusinessesProvider(
+      dbClient,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    ),
   );
 }
 
@@ -165,6 +180,8 @@ type ExecutionFixture = {
   valueDate?: string | null;
   tradeType?: string;
   netValueTradeCurrency?: string;
+  /** Units moved. Fractional on purpose in the holdings cases — ETFs trade that way. */
+  nv?: string;
 };
 
 // Synthetic values only — never lifted from a real bank capture.
@@ -177,6 +194,7 @@ async function insertExecution({
   valueDate = VALUE_DATE,
   tradeType = 'קניה',
   netValueTradeCurrency = '1000.00',
+  nv = '10',
 }: ExecutionFixture) {
   // trade_type/transaction_type carry the bank's own Hebrew vocabulary; on a plain buy or sale
   // the two agree (an invariant the scraper's zod schema enforces).
@@ -184,7 +202,7 @@ async function insertExecution({
     `INSERT INTO accounter_schema.poalim_securities_transactions (
        owner_id, bank_number, branch_number, account_number, security, trade_date, value_date,
        trade_type, transaction_type, nv, trade_price, net_value_trade_currency, trade_currency
-     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8, 10, 100, $9, 'דולר ארה"ב')`,
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8, $10, 100, $9, 'דולר ארה"ב')`,
     [
       ownerId,
       BANK_NUMBER,
@@ -195,8 +213,51 @@ async function insertExecution({
       valueDate,
       tradeType,
       netValueTradeCurrency,
+      nv,
     ],
   );
+}
+
+/**
+ * A security business and the Poalim keys it answers to, inserted directly rather than through
+ * `SecurityBusinessesProvider.ensureSecurityBusiness` — that path needs an admin context and a
+ * general foreign-securities business, neither of which the holdings query reads.
+ */
+async function insertSecurityBusiness({
+  id,
+  isin,
+  engName = 'Example Corp',
+  securityKeys = [],
+  ownerId = TEST_OWNER_ID,
+}: {
+  id: string;
+  isin: string;
+  engName?: string;
+  securityKeys?: string[];
+  ownerId?: string;
+}) {
+  await pool.query(
+    `INSERT INTO accounter_schema.financial_entities (id, owner_id, name, type)
+     VALUES ($1, $2, $3, 'business')`,
+    [id, ownerId, `${engName} (${isin})`],
+  );
+  await pool.query(
+    `INSERT INTO accounter_schema.businesses (id, owner_id) VALUES ($1, $2)`,
+    [id, ownerId],
+  );
+  await pool.query(
+    `INSERT INTO accounter_schema.businesses_securities (id, owner_id, isin, eng_name, symbol)
+     VALUES ($1, $2, $3, $4, 'EXMP')`,
+    [id, ownerId, isin, engName],
+  );
+  for (const securityKey of securityKeys) {
+    await pool.query(
+      `INSERT INTO accounter_schema.security_identifiers
+         (owner_id, business_id, identifier_type, identifier_value)
+       VALUES ($1, $2, 'POALIM_SECURITY_KEY', $3)`,
+      [ownerId, id, securityKey],
+    );
+  }
 }
 
 beforeAll(async () => {
@@ -222,12 +283,15 @@ beforeAll(async () => {
     grants: [
       { table: 'poalim_securities', privileges: 'SELECT' },
       { table: 'poalim_securities_transactions', privileges: 'SELECT' },
+      { table: 'businesses_securities', privileges: 'SELECT' },
+      { table: 'security_identifiers', privileges: 'SELECT' },
     ],
   });
 });
 
 afterAll(async () => {
   await dropRlsRole(pool);
+  await deleteSecurityBusinesses();
   // poalim_securities and poalim_securities_transactions rows cascade with the owning business.
   for (const ownerId of [TEST_OWNER_ID, OTHER_OWNER_ID]) {
     await pool.query('DELETE FROM accounter_schema.businesses WHERE id = $1', [ownerId]);
@@ -250,7 +314,22 @@ beforeEach(async () => {
     'DELETE FROM accounter_schema.poalim_securities_transactions WHERE owner_id = ANY($1)',
     [owners],
   );
+  await deleteSecurityBusinesses();
 });
+
+/**
+ * The synthetic security businesses, by explicit id so the tenants' own business rows survive
+ * between tests. `businesses` first: its FK to `financial_entities` does not cascade, while
+ * businesses_securities and security_identifiers do cascade from `businesses`.
+ */
+async function deleteSecurityBusinesses() {
+  await pool.query('DELETE FROM accounter_schema.businesses WHERE id = ANY($1)', [
+    SECURITY_BUSINESS_IDS,
+  ]);
+  await pool.query('DELETE FROM accounter_schema.financial_entities WHERE id = ANY($1)', [
+    SECURITY_BUSINESS_IDS,
+  ]);
+}
 
 describe('getChargeSecurities', () => {
   it('resolves a key from a transaction description to its ingested security', async () => {
@@ -473,6 +552,123 @@ describe('getChargeSecurities — matched executions', () => {
           `SELECT security FROM accounter_schema.poalim_securities_transactions
            WHERE security = ANY($1)`,
           [['5129523']],
+        );
+        return result.rows;
+      });
+
+      expect(rows).toEqual([]);
+    } finally {
+      await client.query('ROLLBACK');
+      client.release();
+    }
+  });
+});
+
+describe('getExecutionsBySecurityBusiness', () => {
+  it('gives every security business its own executions, chronologically', async () => {
+    await insertSecurityBusiness({
+      id: APPLE_BUSINESS_ID,
+      isin: 'US0378331005',
+      engName: 'APPLE INC',
+      securityKeys: ['1097'],
+    });
+    await insertSecurityBusiness({
+      id: MSFT_BUSINESS_ID,
+      isin: 'US5949181045',
+      engName: 'MICROSOFT CORP',
+      securityKeys: ['2044'],
+    });
+    await insertExecution({ security: '1097', tradeDate: '2024-03-10' });
+    await insertExecution({ security: '1097', tradeDate: '2024-01-05' });
+    await insertExecution({ security: '2044', tradeDate: '2024-02-02' });
+
+    const executionsByBusinessId = await createProvider([]).getExecutionsBySecurityBusiness();
+
+    expect(executionsByBusinessId.get(APPLE_BUSINESS_ID)).toHaveLength(2);
+    // The SQL orders globally by trade_date, so each business's slice stays chronological —
+    // which is what the position derivation reads its currency and start date off.
+    expect(
+      executionsByBusinessId.get(APPLE_BUSINESS_ID)?.map(execution => execution.trade_date),
+    ).toEqual([new Date('2024-01-05T00:00:00'), new Date('2024-03-10T00:00:00')]);
+    expect(executionsByBusinessId.get(MSFT_BUSINESS_ID)).toHaveLength(1);
+  });
+
+  it('collapses several Poalim keys onto the one security business they name', async () => {
+    await insertSecurityBusiness({
+      id: APPLE_BUSINESS_ID,
+      isin: 'US0378331005',
+      securityKeys: ['1097', '1098'],
+    });
+    await insertExecution({ security: '1097' });
+    await insertExecution({ security: '1098' });
+
+    const executionsByBusinessId = await createProvider([]).getExecutionsBySecurityBusiness();
+
+    expect(executionsByBusinessId.get(APPLE_BUSINESS_ID)).toHaveLength(2);
+  });
+
+  it('keeps a security business with no Poalim key, with nothing against it', async () => {
+    // Its ISIN was ingested but no execution ever named it by key. It is still a security the
+    // tenant has, so it has to stay listable — a zero position, not a missing row.
+    await insertSecurityBusiness({
+      id: ISIN_ONLY_BUSINESS_ID,
+      isin: 'IL0010811243',
+      securityKeys: [],
+    });
+
+    const executionsByBusinessId = await createProvider([]).getExecutionsBySecurityBusiness();
+
+    expect(executionsByBusinessId.has(ISIN_ONLY_BUSINESS_ID)).toBe(true);
+    expect(executionsByBusinessId.get(ISIN_ONLY_BUSINESS_ID)).toEqual([]);
+  });
+
+  it('ignores executions whose key belongs to no security business', async () => {
+    await insertSecurityBusiness({
+      id: APPLE_BUSINESS_ID,
+      isin: 'US0378331005',
+      securityKeys: ['1097'],
+    });
+    await insertExecution({ security: '1097' });
+    await insertExecution({ security: '9999' });
+
+    const executionsByBusinessId = await createProvider([]).getExecutionsBySecurityBusiness();
+
+    expect(executionsByBusinessId.size).toBe(1);
+    expect(executionsByBusinessId.get(APPLE_BUSINESS_ID)).toHaveLength(1);
+  });
+
+  it('has no entries at all when the tenant has no security businesses', async () => {
+    await insertExecution({ security: '1097' });
+
+    const executionsByBusinessId = await createProvider([]).getExecutionsBySecurityBusiness();
+
+    expect(executionsByBusinessId.size).toBe(0);
+  });
+
+  /**
+   * As with the poalim_* tables above, a provider-level assertion proves nothing here: the
+   * suite connects as a superuser, who bypasses RLS. This runs the query shape the holdings
+   * path depends on under the non-superuser role the server actually operates behind.
+   */
+  it("does not expose another tenant's security businesses under tenant_isolation", async () => {
+    await insertSecurityBusiness({
+      id: APPLE_BUSINESS_ID,
+      isin: 'US0378331005',
+      securityKeys: ['1097'],
+      ownerId: OTHER_OWNER_ID,
+    });
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      // Session variables must be set as superuser, before privileges are dropped.
+      await client.query(`SELECT set_config('app.current_business_id', $1, true)`, [TEST_OWNER_ID]);
+
+      const rows = await runAsRlsRole(client, async () => {
+        const result = await client.query(
+          `SELECT bs.isin, si.identifier_value
+           FROM accounter_schema.businesses_securities bs
+           LEFT JOIN accounter_schema.security_identifiers si ON si.business_id = bs.id`,
         );
         return result.rows;
       });

--- a/packages/server/src/modules/foreign-securities/providers/foreign-securities.provider.ts
+++ b/packages/server/src/modules/foreign-securities/providers/foreign-securities.provider.ts
@@ -263,6 +263,76 @@ export class ForeignSecuritiesProvider {
   }
 
   /**
+   * Every ingested execution of every security business the tenant has, grouped by the business
+   * it belongs to. Each business gets an entry, so "nothing ingested" is distinguishable from
+   * "not a security".
+   *
+   * One query for the whole portfolio: `getSecurityExecutionsByKeys` already filters on
+   * `security = ANY(...)` and returns the key on every row, so the union of every business's
+   * Poalim keys can be asked for at once and split back up in memory.
+   *
+   * Unlike `getSecurityBusinessHistory` this never looks at transactions or accounts — those
+   * exist only to pair an execution with the cash movement behind it, which a position does not
+   * need, and they cost a transactions query plus an account lookup per security.
+   */
+  public async getExecutionsBySecurityBusiness(): Promise<Map<string, SecurityExecutionRow[]>> {
+    const securityBusinesses = await this.securityBusinessesProvider.getAllSecurityBusinesses();
+
+    const executionsByBusinessId = new Map<string, SecurityExecutionRow[]>(
+      securityBusinesses.map(securityBusiness => [securityBusiness.id, []]),
+    );
+    if (securityBusinesses.length === 0) {
+      return executionsByBusinessId;
+    }
+
+    // One batched query behind the loader, not one per business.
+    const identifierLists =
+      await this.securityBusinessesProvider.getIdentifiersByBusinessIdLoader.loadMany(
+        securityBusinesses.map(securityBusiness => securityBusiness.id),
+      );
+
+    // The executions table is keyed by Poalim's security key, and one business can carry several
+    // of them — that is what the identifiers bridge is for — so invert into key -> business. The
+    // unique index on (owner_id, identifier_type, identifier_value) is what makes one key resolve
+    // to exactly one business, so a plain Map is enough.
+    const businessIdByKey = new Map<string, string>();
+    for (const identifiers of identifierLists) {
+      // loadMany reports a rejected key as an Error rather than throwing; one bad business must
+      // not blank the whole list.
+      if (identifiers instanceof Error) {
+        continue;
+      }
+      for (const identifier of identifiers) {
+        if (identifier.identifier_type === 'POALIM_SECURITY_KEY') {
+          businessIdByKey.set(identifier.identifier_value, identifier.business_id);
+        }
+      }
+    }
+
+    if (businessIdByKey.size === 0) {
+      return executionsByBusinessId;
+    }
+
+    // ORDER BY trade_date, id is global to the result, so each key's slice stays chronological —
+    // which is what `calculateSecurityPosition` reads its currency off.
+    const executions = await getSecurityExecutionsByKeys.run(
+      { securities: [...businessIdByKey.keys()] },
+      this.db,
+    );
+
+    for (const execution of executions) {
+      const businessId = businessIdByKey.get(execution.security);
+      if (!businessId) {
+        continue;
+      }
+      // An identifier can outlive the business it pointed at; skip rather than invent a bucket.
+      executionsByBusinessId.get(businessId)?.push(execution);
+    }
+
+    return executionsByBusinessId;
+  }
+
+  /**
    * The securities a charge's transactions reference, keyed off the security key each
    * description carries. Keys with no ingested row are still returned, with a null
    * `details`, so a stale or missing scrape is visible instead of silently dropping data.

--- a/packages/server/src/modules/foreign-securities/resolvers/security-businesses.resolver.ts
+++ b/packages/server/src/modules/foreign-securities/resolvers/security-businesses.resolver.ts
@@ -4,7 +4,7 @@ import { formatFinancialAmount } from '../../../shared/helpers/amount.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
 import { ChargesProvider } from '../../charges/providers/charges.provider.js';
 import { BusinessesProvider } from '../../financial-entities/providers/businesses.provider.js';
-import { calculateSecurityPosition } from '../helpers/security-position.helper.js';
+import { calculateSecurityPosition, isOpenPosition } from '../helpers/security-position.helper.js';
 import { ForeignSecuritiesProvider } from '../providers/foreign-securities.provider.js';
 import { SecurityBusinessesProvider } from '../providers/security-businesses.provider.js';
 import type { ForeignSecuritiesModule } from '../types.js';
@@ -28,6 +28,35 @@ export const securityBusinessesResolvers: ForeignSecuritiesModule.Resolvers = {
       return businesses.filter(
         (business): business is Exclude<(typeof businesses)[number], Error | undefined | null> =>
           business != null && !(business instanceof Error),
+      );
+    },
+    securityHoldings: async (_, { includeClosed }, { injector }) => {
+      const securityBusinesses = await injector
+        .get(SecurityBusinessesProvider)
+        .getAllSecurityBusinesses();
+      const executionsByBusinessId = await injector
+        .get(ForeignSecuritiesProvider)
+        .getExecutionsBySecurityBusiness();
+
+      return (
+        securityBusinesses
+          .map(securityBusiness => ({
+            id: securityBusiness.id,
+            security: securityBusiness,
+            position: {
+              id: securityBusiness.id,
+              ...calculateSecurityPosition(executionsByBusinessId.get(securityBusiness.id) ?? []),
+            },
+          }))
+          // Closed positions are the bulk of a long-lived portfolio, so the screen asks for them
+          // explicitly. A security with nothing ingested against it reads as closed too.
+          .filter(holding => includeClosed || isOpenPosition(holding.position))
+          // Ordered here so an unsorted render is stable across requests.
+          .sort((a, b) =>
+            (a.security.eng_name ?? a.security.isin).localeCompare(
+              b.security.eng_name ?? b.security.isin,
+            ),
+          )
       );
     },
     securityBusinessHistory: async (_, { businessId }, { injector }) => {

--- a/packages/server/src/modules/foreign-securities/typeDefs/security-businesses.graphql.ts
+++ b/packages/server/src/modules/foreign-securities/typeDefs/security-businesses.graphql.ts
@@ -6,6 +6,16 @@ export default gql`
     allSecurityBusinesses: [LtdFinancialEntity!]! @requiresAuth
     " The full ingested life of one security: its holding and every execution "
     securityBusinessHistory(businessId: UUID!): SecurityBusinessHistory! @requiresAuth
+    " Every security the tenant holds, with the position its executions add up to. Closed positions — sold out, or never ingested — are left out unless asked for "
+    securityHoldings(includeClosed: Boolean = false): [SecurityHolding!]! @requiresAuth
+  }
+
+  " One security and what is held of it, without the execution history behind it "
+  type SecurityHolding {
+    " The security's business id — the same id its own page is keyed by "
+    id: UUID!
+    security: SecurityBusiness!
+    position: SecurityPosition!
   }
 
   " Everything a security business page shows "

--- a/packages/server/src/modules/foreign-securities/types.ts
+++ b/packages/server/src/modules/foreign-securities/types.ts
@@ -70,6 +70,16 @@ export type SecurityHistoryExecutionProto = {
   transaction: { id: string; charge_id: string } | null;
 };
 
+/**
+ * One security plus the position its executions imply, for the tenant-wide holdings list.
+ * The execution list itself is deliberately absent — see the `SecurityHolding` type.
+ */
+export type SecurityHoldingProto = {
+  id: string;
+  security: SecurityBusinessRow;
+  position: SecurityPositionWithIdProto;
+};
+
 export type SecurityBusinessHistoryProto = {
   id: string;
   security: SecurityBusinessRow;


### PR DESCRIPTION
## Context

A security's numbers were only reachable one at a time: you had to already know the business, open `/businesses/{id}`, and click its security tab. The only query that computed a position, `securityBusinessHistory(businessId:)`, required a business id and always paid for the full execution list plus the transaction/charge match behind it. Nothing answered "what do I currently hold?".

## Server

New `securityHoldings(includeClosed: Boolean = false): [SecurityHolding!]!`, where `SecurityHolding` is `{ id, security, position }` — the existing `SecurityBusiness` and `SecurityPosition` types, without the execution list. A separate type rather than a lazified `SecurityBusinessHistory`: `executions` is non-null there, so a list query would have to either run the per-security transaction match for every row or demote the field to a lazy resolver, making the detail query's cost depend on selection shape. Both types reuse the same field resolvers, so no field logic is duplicated.

It is backed by a new `ForeignSecuritiesProvider.getExecutionsBySecurityBusiness()`, which reuses the existing `getSecurityExecutionsByKeys` statement **unchanged** — that SQL already filters on `security = ANY(...)` and returns the key on every row, so the union of every security business's Poalim keys is fetched in one round trip and split up in memory. It deliberately skips `getTransactionsByFilters` / `getAccountTuples` / `matchExecutionsToTransactions`, which exist only to draw charge links a holdings list does not show. Net: **one query for the whole portfolio instead of four per security.** A security business with no `POALIM_SECURITY_KEY` identifier keeps an entry with no executions rather than disappearing.

Closed positions are filtered with a new `isOpenPosition` helper rather than `quantity !== 0`: quantities are floats summed over fractional ETF and mutual-fund units, so a fully sold position lands on a floating-point residue, not on zero. `Math.abs` is deliberate — a negative quantity means the scraped history starts mid-life and is a data-quality signal worth surfacing, not a closed position.

## Client

A top-level **Securities** screen: one row per security with its current hold, average cost, total bought/sold, descriptor badges and history dates. Searchable across name / symbol / ISIN / exchange / currency / Poalim key, sortable on every numeric and date column, with a "show closed positions" toggle that re-queries the server. Each row links to the security's own page for the full execution history.

Money cells render each security's own `formatted` amount and there is **no summed total** — rows can be quoted in different trade currencies and nothing is converted, so a sum would be meaningless. Money sorting compares raw numbers and is currency-blind by nature; the currency badge is what lets a reader compare like with like.

The descriptor badges are extracted into a shared `SecurityDescriptorBadges` component (behind a `SecurityDescriptorFields` fragment) so the table and the security page's header card cannot drift.

## Wording fix

The derivation caveat read "Holdings are not scraped" — but the executions *are* scraped; what the bank does not report is a holding. Both the security page and the new screen now say the position is added up from the scraped trades rather than read from a reported balance.

## Testing

- `isOpenPosition` unit tests: exact zero, the realistic float residue from fractional units, `0.0001` (visible at four decimals) as open, `5e-7` as closed, negative as open.
- `getExecutionsBySecurityBusiness` integration tests: per-business slicing in chronological order, two Poalim keys collapsing onto one business, a key-less security business kept with `[]`, orphan execution keys ignored, empty portfolio, and an RLS boundary test over `businesses_securities` + `security_identifiers` under the non-superuser role. The suite's provider factory previously stubbed `SecurityBusinessesProvider` as `{} as never`; it now builds a real one over the same `TenantAwareDBClient`.
- Screen tests: the render-loop guard inherited from the sort-codes screen, pagination reaching the filters context, the toggle changing the `includeClosed` variable, search narrowing rows, a null-amount position rendering `—` without throwing, the row link, and the empty state pointing at the toggle.

`yarn test` (3579 passed), the foreign-securities integration suite against a local DB (20 passed), `yarn generate`, both `tsc --noEmit`, and eslint all clean — the one remaining warning is the same deliberate `table` dep omission `sort-codes/index.tsx` already carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)