### PR TITLE
fix(client): trim redundant decimal padding from securities quantities and prices

### DIFF
--- a/.changeset/securities-trim-decimal-padding.md
+++ b/.changeset/securities-trim-decimal-padding.md
@@ -1,0 +1,13 @@
+---
+'@accounter/client': patch
+---
+
+Stop padding securities quantities and prices to four decimals.
+
+The bank reports quantities and trade prices with four decimal places, but almost all of them are
+trailing zeros — a holding of 100 shares read as `100.0000`. The securities screen, the security
+section on a business page, and the Portfolio activity table inside a charge now render these
+through a single `formatSecurityDecimal` helper that keeps up to four fraction digits without a
+minimum, so `100.0000` shows as `100` and `12.5000` as `12.5` while genuinely fractional ETF and
+mutual-fund values keep every digit they need. Replaces the fixed-precision `formatSecurityNumber`,
+which had no other callers left.

--- a/packages/client/src/components/business/security-section.tsx
+++ b/packages/client/src/components/business/security-section.tsx
@@ -5,7 +5,7 @@ import { BusinessSecuritySectionDocument } from '@/gql/graphql.js';
 import { SecurityDescriptorBadges } from '../securities/security-descriptor-badges.js';
 import {
   formatSecurityDate,
-  formatSecurityNumber,
+  formatSecurityDecimal,
   SecurityExecutionsTable,
 } from '../securities/security-executions-table.js';
 
@@ -103,7 +103,7 @@ export function SecuritySection({ businessId }: Props): ReactElement {
         <CardContent className="flex flex-col gap-4">
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             {/* Quantities can be fractional for ETFs and mutual funds. */}
-            <Stat label="Current hold" value={formatSecurityNumber(position.quantity, 4)} />
+            <Stat label="Current hold" value={formatSecurityDecimal(position.quantity)} />
             <Stat label="Average cost" value={position.averageCost?.formatted ?? '—'} />
             <Stat label="Total bought" value={position.totalBought?.formatted ?? '—'} />
             <Stat label="Total sold" value={position.totalSold?.formatted ?? '—'} />

--- a/packages/client/src/components/screens/securities/columns.tsx
+++ b/packages/client/src/components/screens/securities/columns.tsx
@@ -7,7 +7,7 @@ import { DataTableColumnHeader } from '../../common/data-table-column-header.js'
 import { SecurityDescriptorBadges } from '../../securities/security-descriptor-badges.js';
 import {
   formatSecurityDate,
-  formatSecurityNumber,
+  formatSecurityDecimal,
 } from '../../securities/security-executions-table.js';
 
 export type SecurityHoldingRow = SecurityHoldingsScreenQuery['securityHoldings'][number];
@@ -93,9 +93,7 @@ export const columns: ColumnDef<TableFeaturesConfig, SecurityHoldingRow>[] = [
     header: ({ column }) => <DataTableColumnHeader column={column} title="Current hold" />,
     // Quantities can be fractional for ETFs and mutual funds.
     cell: ({ row }) => (
-      <span className="tabular-nums">
-        {formatSecurityNumber(row.original.position.quantity, 4)}
-      </span>
+      <span className="tabular-nums">{formatSecurityDecimal(row.original.position.quantity)}</span>
     ),
   },
   {

--- a/packages/client/src/components/securities/security-executions-table.tsx
+++ b/packages/client/src/components/securities/security-executions-table.tsx
@@ -4,7 +4,6 @@ import {
   type SecurityExecutionFieldsFragment,
 } from '../../gql/graphql.js';
 import { getFragmentData, type FragmentType } from '../../gql/index.js';
-import { formatStringifyAmount } from '../../helpers/numbers.js';
 import { ChargeNavigateButton } from '../common/buttons/charge-navigate-button.js';
 import { Badge } from '../ui/badge.js';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table.js';
@@ -36,8 +35,17 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '.
   }
 `;
 
-export const formatSecurityNumber = (value: number | null | undefined, digits = 2): string =>
-  value == null ? '' : formatStringifyAmount(value, digits);
+/**
+ * Quantities and prices arrive with four decimals, but nearly all of them are trailing zeros.
+ * Keep up to four digits for the fractional ETF/mutual-fund values, drop whatever is only padding.
+ */
+export const formatSecurityDecimal = (value: number | null | undefined): string =>
+  value == null
+    ? ''
+    : new Intl.NumberFormat('en-US', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 4,
+      }).format(value);
 
 export const formatSecurityDate = (value: string | Date | null | undefined): string =>
   value ? new Date(value).toLocaleDateString() : '';
@@ -110,8 +118,8 @@ export function SecurityExecutionsTable({ rows, withChargeLink }: Props): ReactE
                 </div>
               </TableCell>
               {/* Quantities can be fractional for ETFs and mutual funds. */}
-              <TableCell>{formatSecurityNumber(execution.quantity, 4)}</TableCell>
-              <TableCell>{formatSecurityNumber(execution.tradePrice, 4)}</TableCell>
+              <TableCell>{formatSecurityDecimal(execution.quantity)}</TableCell>
+              <TableCell>{formatSecurityDecimal(execution.tradePrice)}</TableCell>
               <TableCell className="whitespace-nowrap">{execution.netValue?.formatted}</TableCell>
               <TableCell className="whitespace-nowrap">
                 {(execution.tradeCommission ?? execution.managementFees)?.formatted}

--- a/packages/client/src/components/securities/security-executions-table.tsx
+++ b/packages/client/src/components/securities/security-executions-table.tsx
@@ -35,17 +35,18 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '.
   }
 `;
 
+/** Shared by every cell below, so the formatter is built once rather than per row. */
+const securityDecimalFormat = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 4,
+});
+
 /**
  * Quantities and prices arrive with four decimals, but nearly all of them are trailing zeros.
  * Keep up to four digits for the fractional ETF/mutual-fund values, drop whatever is only padding.
  */
 export const formatSecurityDecimal = (value: number | null | undefined): string =>
-  value == null
-    ? ''
-    : new Intl.NumberFormat('en-US', {
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 4,
-      }).format(value);
+  value == null ? '' : securityDecimalFormat.format(value);
 
 export const formatSecurityDate = (value: string | Date | null | undefined): string =>
   value ? new Date(value).toLocaleDateString() : '';


### PR DESCRIPTION
Quantities and trade prices come from the bank with four decimal places, and nearly all of them are trailing zeros — a holding of 100 shares rendered as `100.0000`, a price of 12.5 as `12.5000`.

A single `formatSecurityDecimal` helper now formats both with `minimumFractionDigits: 0, maximumFractionDigits: 4`, so the padding disappears while genuinely fractional ETF and mutual-fund values keep every digit they need.

Applied at all four call sites:
- `screens/securities/columns.tsx` — "Current hold" column on the securities screen
- `business/security-section.tsx` — "Current hold" stat on the business security tab
- `securities/security-executions-table.tsx` — Quantity and Price cells, shared by the security page and a charge's "Portfolio activity" panel

`formatSecurityNumber` (fixed precision) is removed — it had no callers left after the swap.

## Verification
- `tsc --noEmit` on `@accounter/client`: clean
- securities unit tests: 7/7 pass
- eslint + prettier: clean on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)