### PR TITLE
feat(poalim-scraper): page securities executions with the bank's cursor

### DIFF
--- a/.changeset/poalim-securities-cursor-paging.md
+++ b/.changeset/poalim-securities-cursor-paging.md
@@ -1,0 +1,28 @@
+---
+'@accounter/modern-poalim-scraper': patch
+'@accounter/scraper-app': patch
+---
+
+Page Poalim securities executions with the bank's own cursor, and stop the scraper-app from
+answering misrouted uploads with its SPA.
+
+`getSecuritiesTransactions` used to detect a full 150-row response and re-request the window with its
+ceiling pulled back to the oldest day that page reached. The endpoint actually returns an opaque
+cursor at `Account.PageState`, so `fetchAllExecutions` now repeats the request with the date window
+**unchanged**, passing the previous response's cursor as a `pageState` query param, and follows it
+until it comes back null. Row counts no longer decide anything — a short page with a cursor keeps
+paging and a long page without one stops. This removes the walk-back's blind spot, where more than
+150 executions on a single day could not be paged past. The loop is bounded by a raised round cap and
+stops early if the cursor ever repeats itself; either case reports a truncation, which is now
+surfaced to `scraper-app` as a per-account warning instead of being dropped (the rows still upload,
+since ingestion is idempotent).
+
+The scraper-app's SPA fallback no longer catches API calls, websocket upgrades, or non-GET verbs.
+`reply.sendFile` responds with a 200, so a mistyped URL — notably a vault `serverUrl` pointing at the
+scraper-app itself rather than the Accounter server — used to return `index.html` with a 200 and
+surface as `Invalid execution result: result is not object or array` out of graphql-request. Those
+requests now get a plain 404. Relatedly, `/api/vault/test-connection` reported such a config as
+healthy: it only checked the status code, and probed with `Authorization: Bearer` rather than the
+`X-API-Key` header the upload client and the server actually use. It now sends the right header and
+requires a parseable GraphQL result, naming the missing `/graphql` path when the endpoint answers
+with something that is not JSON.

--- a/packages/modern-poalim-scraper/src/scrapers/__tests__/hapoalim-securities-paging.test.ts
+++ b/packages/modern-poalim-scraper/src/scrapers/__tests__/hapoalim-securities-paging.test.ts
@@ -1,20 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
-  calendarDay,
+  executionIdentity,
   fetchAllExecutions,
   MYTRADE_EXECUTIONS_MAX_ROUNDS,
-  MYTRADE_EXECUTIONS_PAGE_SIZE,
-  oldestExecutionDay,
 } from '../hapoalim-securities-paging.js';
 
 /** A .NET round-trip timestamp for a calendar day, as the bank sends them. */
 const at = (day: string) => `${day}T00:00:00.0000000+03:00`;
-
-/** `YYYY-MM-DD` of a local date — `toISOString` would shift the day west of UTC. */
-const localDay = (date: Date) =>
-  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(
-    date.getDate(),
-  ).padStart(2, '0')}`;
 
 /** An execution identified by its security number and value date. */
 const execution = (security: string, day: string) => ({
@@ -33,16 +25,13 @@ const execution = (security: string, day: string) => ({
   CancelDate: null,
 });
 
-const page = (executions: unknown[]) => ({ Account: { PageState: 'opaque', Execution: executions } });
-
-/** A full page whose executions descend one day at a time from `endDay`. */
-function fullPageEndingOn(endDay: string, prefix: string) {
-  const end = new Date(`${endDay}T00:00:00Z`);
-  return Array.from({ length: MYTRADE_EXECUTIONS_PAGE_SIZE }, (_, index) => {
-    const day = new Date(end.getTime() - index * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-    return execution(`${prefix}${index}`, day);
-  });
-}
+/**
+ * A response. `pageState` is the cursor the bank hands back: a string means "there is
+ * more", null means the window is exhausted.
+ */
+const page = (executions: unknown[], pageState: string | null = null) => ({
+  Account: { PageState: pageState, Execution: executions },
+});
 
 const window = { fromDate: new Date(2024, 0, 1), toDate: new Date(2024, 11, 31) };
 
@@ -50,218 +39,216 @@ const window = { fromDate: new Date(2024, 0, 1), toDate: new Date(2024, 11, 31) 
 const isException = (candidate: unknown) => 'Exception' in (candidate as Record<string, unknown>);
 
 describe('fetchAllExecutions', () => {
-  it('does not ask for a second page when the first is short', async () => {
+  it('issues one request when the first page has no cursor', async () => {
     const fetchPage = vi.fn().mockResolvedValue(page([execution('1234567', '2024-06-01')]));
 
     const result = await fetchAllExecutions({ ...window, fetchPage });
 
     expect(fetchPage).toHaveBeenCalledTimes(1);
-    expect(result.rounds).toBe(1);
+    expect(fetchPage).toHaveBeenCalledWith({ fromDate: window.fromDate, toDate: window.toDate });
     expect(result.executions).toHaveLength(1);
+    expect(result.rounds).toBe(1);
     expect(result.truncated).toBeUndefined();
   });
 
-  it('pages back over the oldest day of a full page until a short page arrives', async () => {
-    // 150 executions ending on 2024-06-01 reach back to 2024-01-04.
-    const first = fullPageEndingOn('2024-06-01', 'a');
-    const second = [execution('7654321', '2024-01-03')];
+  it('treats a missing cursor as exhausted', async () => {
+    const fetchPage = vi.fn().mockResolvedValue({
+      Account: { Execution: [execution('1234567', '2024-06-01')] },
+    });
+
+    const result = await fetchAllExecutions({ ...window, fetchPage });
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(result.executions).toHaveLength(1);
+  });
+
+  it('treats an empty-string cursor as exhausted', async () => {
+    const fetchPage = vi.fn().mockResolvedValue(page([execution('1234567', '2024-06-01')], '   '));
+
+    const result = await fetchAllExecutions({ ...window, fetchPage });
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(result.executions).toHaveLength(1);
+  });
+
+  it('follows the cursor with the date window unchanged', async () => {
     const fetchPage = vi
       .fn()
-      .mockResolvedValueOnce(page(first))
-      .mockResolvedValueOnce(page(second));
+      .mockResolvedValueOnce(page([execution('1', '2024-06-01')], 'cursor-1'))
+      .mockResolvedValueOnce(page([execution('2', '2024-05-01')], 'cursor-2'))
+      .mockResolvedValueOnce(page([execution('3', '2024-04-01')]));
+
+    const result = await fetchAllExecutions({ ...window, fetchPage });
+
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+    // Round 1 carries no cursor; every later round repeats the same window and only
+    // moves `pageState` — the whole point of the change away from a date walk-back.
+    expect(fetchPage).toHaveBeenNthCalledWith(1, {
+      fromDate: window.fromDate,
+      toDate: window.toDate,
+    });
+    expect(fetchPage).toHaveBeenNthCalledWith(2, {
+      fromDate: window.fromDate,
+      toDate: window.toDate,
+      pageState: 'cursor-1',
+    });
+    expect(fetchPage).toHaveBeenNthCalledWith(3, {
+      fromDate: window.fromDate,
+      toDate: window.toDate,
+      pageState: 'cursor-2',
+    });
+    expect(result.executions).toHaveLength(3);
+    expect(result.rounds).toBe(3);
+    expect(result.truncated).toBeUndefined();
+  });
+
+  it('passes an opaque base64 cursor through verbatim', async () => {
+    const cursor =
+      'eyJOcGNucHRuMSI6W3siTWlzcGFyQmFuayI6MCwiTWlzcGFyU25pZiI6MCwiTWlzcGFyQ2hlc2hib24iOjAsIk1pc3BhclJhdHoiOjEwMDk5OTksIlRhYXJpY2g4TmVjaG9udXQiOjIwMjUwOTA1fV19';
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce(page([execution('1', '2024-06-01')], cursor))
+      .mockResolvedValueOnce(page([execution('2', '2024-05-01')]));
+
+    await fetchAllExecutions({ ...window, fetchPage });
+
+    expect(fetchPage).toHaveBeenNthCalledWith(2, expect.objectContaining({ pageState: cursor }));
+  });
+
+  it('keeps paging on a short page that still has a cursor', async () => {
+    // Row count is no longer a signal — only the cursor is.
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce(page([execution('1', '2024-06-01')], 'cursor-1'))
+      .mockResolvedValueOnce(page([execution('2', '2024-05-01')]));
 
     const result = await fetchAllExecutions({ ...window, fetchPage });
 
     expect(fetchPage).toHaveBeenCalledTimes(2);
-    // The second round asks for the same window, ceilinged at the oldest day reached.
-    expect(fetchPage.mock.calls[1]![0]).toEqual({
-      fromDate: window.fromDate,
-      toDate: new Date(2024, 0, 4),
-    });
-    expect(result.executions).toHaveLength(MYTRADE_EXECUTIONS_PAGE_SIZE + 1);
-    expect(result.truncated).toBeUndefined();
+    expect(result.executions).toHaveLength(2);
   });
 
-  it('drops the executions the overlapping ceiling day repeats', async () => {
-    const first = fullPageEndingOn('2024-06-01', 'a');
-    const boundary = first.at(-1)!;
-    const fetchPage = vi
-      .fn()
-      .mockResolvedValueOnce(page(first))
-      // The re-requested ceiling day comes back with the row already seen, plus an
-      // older one that the first page had no room for.
-      .mockResolvedValueOnce(page([boundary, execution('9999999', '2024-01-04')]));
+  it('stops on a long page with no cursor', async () => {
+    const rows = Array.from({ length: 150 }, (_, index) => execution(`${index}`, '2024-06-01'));
+    const fetchPage = vi.fn().mockResolvedValue(page(rows));
 
     const result = await fetchAllExecutions({ ...window, fetchPage });
 
-    expect(result.executions).toHaveLength(MYTRADE_EXECUTIONS_PAGE_SIZE + 1);
-    expect(result.executions.filter(row => row === boundary)).toHaveLength(1);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(result.executions).toHaveLength(150);
+    expect(result.truncated).toBeUndefined();
   });
 
-  it('stops instead of looping when a full page sits on a single day', async () => {
-    const sameDay = Array.from({ length: MYTRADE_EXECUTIONS_PAGE_SIZE }, (_, index) =>
-      execution(`b${index}`, '2024-06-01'),
-    );
-    const fetchPage = vi.fn().mockResolvedValue(page(sameDay));
+  it('drops rows two pages share', async () => {
+    const shared = execution('1234567', '2024-06-01');
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce(page([shared, execution('2', '2024-05-02')], 'cursor-1'))
+      .mockResolvedValueOnce(page([shared, execution('3', '2024-04-03')]));
+
+    const result = await fetchAllExecutions({ ...window, fetchPage });
+
+    expect(result.executions).toHaveLength(3);
+  });
+
+  it('stops when the cursor comes back unchanged', async () => {
     const warn = vi.fn();
+    const fetchPage = vi.fn().mockResolvedValue(page([execution('1', '2024-06-01')], 'stuck'));
 
     const result = await fetchAllExecutions({ ...window, fetchPage, warn });
 
-    // Round 1 ends the window at 2024-12-31, round 2 at 2024-06-01 — which the
-    // page cannot get past, so there is no round 3.
     expect(fetchPage).toHaveBeenCalledTimes(2);
-    expect(result.executions).toHaveLength(MYTRADE_EXECUTIONS_PAGE_SIZE);
-    expect(result.truncated).toContain('2024-06-01');
-    expect(warn).toHaveBeenCalledWith(result.truncated);
+    expect(result.rounds).toBe(2);
+    expect(result.truncated).toContain('same paging cursor twice');
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
-  it('gives up after the round cap and says how far it got', async () => {
-    // Every page is full and reaches exactly one day further back than its
-    // ceiling, so the walk-back makes progress but never terminates on its own.
-    const fetchPage = vi.fn().mockImplementation(({ toDate }: { toDate: Date }) => {
-      const ceilingDay = localDay(toDate);
-      const olderDay = localDay(new Date(toDate.getFullYear(), toDate.getMonth(), toDate.getDate() - 1));
-      const rows = Array.from({ length: MYTRADE_EXECUTIONS_PAGE_SIZE }, (_, index) =>
-        execution(`c${ceilingDay}-${index}`, index === 0 ? olderDay : ceilingDay),
-      );
-      return Promise.resolve(page(rows));
-    });
+  it('gives up at the round cap when the cursor never goes null', async () => {
     const warn = vi.fn();
-
-    const result = await fetchAllExecutions({
-      fromDate: new Date(2020, 0, 1),
-      toDate: new Date(2024, 11, 31),
-      fetchPage,
-      warn,
+    let round = 0;
+    const fetchPage = vi.fn().mockImplementation(() => {
+      round += 1;
+      return Promise.resolve(page([execution(`${round}`, '2024-06-01')], `cursor-${round}`));
     });
+
+    const result = await fetchAllExecutions({ ...window, fetchPage, warn });
 
     expect(fetchPage).toHaveBeenCalledTimes(MYTRADE_EXECUTIONS_MAX_ROUNDS);
     expect(result.rounds).toBe(MYTRADE_EXECUTIONS_MAX_ROUNDS);
+    expect(result.executions).toHaveLength(MYTRADE_EXECUTIONS_MAX_ROUNDS);
     expect(result.truncated).toContain(`${MYTRADE_EXECUTIONS_MAX_ROUNDS} rounds`);
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
-  it('stops once a full page reaches past the start of the window', async () => {
-    const fetchPage = vi.fn().mockResolvedValue(page(fullPageEndingOn('2024-06-01', 'd')));
-
-    const result = await fetchAllExecutions({
-      // The first page reaches back to 2024-01-04, before this floor.
-      fromDate: new Date(2024, 2, 1),
-      toDate: new Date(2024, 11, 31),
-      fetchPage,
-    });
-
-    expect(fetchPage).toHaveBeenCalledTimes(1);
-    expect(result.truncated).toBeUndefined();
-  });
-
-  it('keeps the first page and stops when a round comes back empty-handed', async () => {
-    const fetchPage = vi.fn().mockResolvedValue(null);
-
-    const result = await fetchAllExecutions({ ...window, fetchPage });
-
-    expect(fetchPage).toHaveBeenCalledTimes(1);
-    expect(result.firstPage).toBeNull();
-    expect(result.executions).toEqual([]);
-    // Nothing on round 1 is the ordinary "no activity" answer, not a partial fetch.
-    expect(result.truncated).toBeUndefined();
-  });
-
-  it('stops on an error payload without swallowing it', async () => {
-    const errorPage = { Exception: { Message: 'InvalidSessionException' } };
-    const fetchPage = vi.fn().mockResolvedValue(errorPage);
-
-    const result = await fetchAllExecutions({
-      ...window,
-      fetchPage,
-      isErrorPage: isException,
-    });
-
-    expect(fetchPage).toHaveBeenCalledTimes(1);
-    expect(result.firstPage).toBe(errorPage);
-    expect(result.failedPage).toBe(errorPage);
-    expect(result.executions).toEqual([]);
-  });
-
-  // A session that expires mid-walk-back leaves the window half-fetched; reporting
-  // only the first page would make that look like a finished job.
-  it('reports an error payload that arrives after a good page', async () => {
-    const errorPage = { Exception: { Message: 'InvalidSessionException' } };
-    const good = page(fullPageEndingOn('2024-06-01', 'e'));
-    const fetchPage = vi.fn().mockResolvedValueOnce(good).mockResolvedValueOnce(errorPage);
-
-    const result = await fetchAllExecutions({ ...window, fetchPage, isErrorPage: isException });
-
-    expect(fetchPage).toHaveBeenCalledTimes(2);
-    expect(result.firstPage).toBe(good);
-    expect(result.failedPage).toBe(errorPage);
-    expect(result.executions).toHaveLength(MYTRADE_EXECUTIONS_PAGE_SIZE);
-  });
-
-  it('says so when a later round comes back with nothing', async () => {
+  it('reports a round that comes back with nothing while the cursor is open', async () => {
+    const warn = vi.fn();
     const fetchPage = vi
       .fn()
-      .mockResolvedValueOnce(page(fullPageEndingOn('2024-06-01', 'f')))
+      .mockResolvedValueOnce(page([execution('1', '2024-06-01')], 'cursor-1'))
       .mockResolvedValueOnce(null);
-    const warn = vi.fn();
 
     const result = await fetchAllExecutions({ ...window, fetchPage, warn });
 
-    expect(result.failedPage).toBeNull();
+    expect(result.executions).toHaveLength(1);
     expect(result.truncated).toContain('came back with nothing');
-    expect(result.truncated).toContain('2024-01-04');
-    expect(warn).toHaveBeenCalledWith(result.truncated);
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
-  it('leaves no reason behind when the window is fetched whole', async () => {
-    const fetchPage = vi.fn().mockResolvedValue(page([execution('1234567', '2024-06-01')]));
+  it('says nothing when the very first round comes back empty', async () => {
+    const warn = vi.fn();
+    const fetchPage = vi.fn().mockResolvedValue(null);
 
-    const result = await fetchAllExecutions({ ...window, fetchPage });
+    const result = await fetchAllExecutions({ ...window, fetchPage, warn });
 
-    expect(result.failedPage).toBeNull();
+    expect(result.firstPage).toBeNull();
+    expect(result.executions).toEqual([]);
     expect(result.truncated).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
   });
 
-  it('treats a response with no Execution list as an empty page', async () => {
+  it('keeps an error payload from the first round', async () => {
+    const errorPage = { Exception: { '-ExceptionType': 'x', Message: 'boom' } };
+    const fetchPage = vi.fn().mockResolvedValue(errorPage);
+
+    const result = await fetchAllExecutions({ ...window, fetchPage, isErrorPage: isException });
+
+    expect(result.failedPage).toBe(errorPage);
+    expect(result.executions).toEqual([]);
+  });
+
+  it('keeps an error payload that arrives after a good page', async () => {
+    const errorPage = { Exception: { '-ExceptionType': 'x', Message: 'boom' } };
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce(page([execution('1', '2024-06-01')], 'cursor-1'))
+      .mockResolvedValueOnce(errorPage);
+
+    const result = await fetchAllExecutions({ ...window, fetchPage, isErrorPage: isException });
+
+    expect(result.failedPage).toBe(errorPage);
+    expect(result.executions).toHaveLength(1);
+  });
+
+  it('tolerates a page with no execution list', async () => {
     const fetchPage = vi.fn().mockResolvedValue({ Account: { PageState: null } });
 
     const result = await fetchAllExecutions({ ...window, fetchPage });
 
     expect(result.executions).toEqual([]);
+    expect(result.truncated).toBeUndefined();
   });
 });
 
-describe('oldestExecutionDay', () => {
-  it('takes the minimum rather than trusting the response order', () => {
-    expect(
-      oldestExecutionDay([
-        execution('1', '2024-03-05'),
-        execution('2', '2024-01-09'),
-        execution('3', '2024-02-01'),
-      ]),
-    ).toBe('2024-01-09');
+describe('executionIdentity', () => {
+  it('matches two rows that agree on the ingestion dedup key', () => {
+    const row = execution('1234567', '2024-06-01');
+    expect(executionIdentity({ ...row, EngName: 'ACME' })).toBe(
+      executionIdentity({ ...row, EngName: 'other' }),
+    );
   });
 
-  it('falls back to the trade date when an execution has no value date', () => {
-    expect(
-      oldestExecutionDay([{ ...execution('1', '2024-03-05'), ValueDate: null }]),
-    ).toBe('2024-03-05');
-  });
-
-  it('ignores rows with no usable date at all', () => {
-    expect(oldestExecutionDay([{ ValueDate: null, TradeDate: null }])).toBeNull();
-    expect(oldestExecutionDay([])).toBeNull();
-  });
-});
-
-describe('calendarDay', () => {
-  it('reads the day off the string, without a timezone in the way', () => {
-    // Parsed as a Date in a western timezone this is 2024-03-04.
-    expect(calendarDay('2024-03-05T00:00:00.0000000+03:00')).toBe('2024-03-05');
-  });
-
-  it('rejects the year-1 sentinel and anything unparseable', () => {
-    expect(calendarDay('0001-01-01T00:00:00.0000000')).toBeNull();
-    expect(calendarDay('05/03/2024')).toBeNull();
-    expect(calendarDay(null)).toBeNull();
+  it('separates rows that differ on a key field', () => {
+    const row = execution('1234567', '2024-06-01');
+    expect(executionIdentity(row)).not.toBe(executionIdentity({ ...row, TradePrice: 101 }));
   });
 });

--- a/packages/modern-poalim-scraper/src/scrapers/hapoalim-securities-paging.ts
+++ b/packages/modern-poalim-scraper/src/scrapers/hapoalim-securities-paging.ts
@@ -1,31 +1,27 @@
 /**
  * Paging for the Poalim "mytrade" order executions history.
  *
- * The endpoint caps a response at {@link MYTRADE_EXECUTIONS_PAGE_SIZE} executions
- * and returns the most recent ones in the requested window, with no flag saying it
- * truncated. A full page therefore has to be re-requested with the window's
- * ceiling pulled back to the oldest day that page reached, until a short page
- * proves the window is exhausted.
+ * The endpoint pages with an opaque cursor: every response carries
+ * `Account.PageState`, and a non-null value means there is more to fetch. The next
+ * request repeats the *same* date window and hands the cursor back as a `pageState`
+ * query param. Row counts say nothing — a short page can still have a cursor, and a
+ * long one can be the last.
  *
- * The driver lives here, apart from the browser-driven scraper, so the walk-back
- * can be exercised without a bank session — see `__tests__`.
+ * The driver lives here, apart from the browser-driven scraper, so the paging can be
+ * exercised without a bank session — see `__tests__`.
  */
 
 /**
- * The most executions one response can carry. A response of exactly this length
- * means "there is probably older activity in this window", nothing more.
+ * Backstop on the paging loop. A cursor page can hold anything from one execution to
+ * a few hundred, so this is not a record budget — it only catches a cursor that never
+ * goes null, which is a runaway loop rather than a portfolio. Each round costs a full
+ * browser tab and SPA boot, so the loop must stay bounded.
  */
-export const MYTRADE_EXECUTIONS_PAGE_SIZE = 150;
-
-/**
- * Backstop on the walk-back. At a full page per round this covers 3000 executions
- * in one window; anything beyond it is a runaway loop, not a portfolio.
- */
-export const MYTRADE_EXECUTIONS_MAX_ROUNDS = 20;
+export const MYTRADE_EXECUTIONS_MAX_ROUNDS = 100;
 
 /** A page of executions as it arrives — before the schema has vouched for it. */
 export type RawExecutionsPage = {
-  Account?: { Execution?: unknown[] } | null;
+  Account?: { Execution?: unknown[]; PageState?: string | null | undefined } | null;
 } | null;
 
 export const rawExecutions = (page: RawExecutionsPage): unknown[] => {
@@ -34,50 +30,23 @@ export const rawExecutions = (page: RawExecutionsPage): unknown[] => {
 };
 
 /**
- * The `YYYY-MM-DD` prefix of a .NET round-trip timestamp.
+ * The cursor for the next round, or null when the window is exhausted.
  *
- * Read off the string rather than through a `Date`: the timestamps carry Israel's
- * UTC offset, and going via a `Date` would move the calendar day by one on a
- * machine running in a western timezone — which, used as the next window's
- * ceiling, would silently skip a day of executions. Returns null for the
- * `0001-01-01` sentinel and for anything unparseable.
+ * The bank's value is an opaque base64 blob — never parsed, only handed back verbatim
+ * on the next request. A missing or empty value counts as exhausted.
  */
-export function calendarDay(value: unknown): string | null {
-  const match = typeof value === 'string' ? /^(\d{4})-\d{2}-\d{2}/.exec(value) : null;
-  if (!match || Number(match[1]) < 1900) {
-    return null;
-  }
-  return match[0];
+function pageCursor(page: RawExecutionsPage): string | null {
+  const cursor = page?.Account?.PageState;
+  return typeof cursor === 'string' && cursor.trim() !== '' ? cursor : null;
 }
 
 /**
- * The oldest calendar day a page of executions reached, as `YYYY-MM-DD`.
+ * Identity of an execution, for dropping any rows consecutive pages share.
  *
- * The endpoint answers newest-first, so this is the last row's value date — but it
- * is taken as a minimum over the whole page rather than off the last row, so an
- * unsorted response cannot cut the walk-back short. Rows with no value date
- * (corporate actions that never settle) fall back to their trade date.
- */
-export function oldestExecutionDay(executions: readonly unknown[]): string | null {
-  let oldest: string | null = null;
-  for (const execution of executions) {
-    const row = execution as Record<string, unknown> | null;
-    const day = calendarDay(row?.['ValueDate']) ?? calendarDay(row?.['TradeDate']);
-    if (day && (oldest === null || day < oldest)) {
-      oldest = day;
-    }
-  }
-  return oldest;
-}
-
-/**
- * Identity of an execution, for dropping the rows consecutive pages share.
- *
- * The walk-back re-requests the ceiling day rather than the day before it, since
- * one day can hold both fetched and unfetched executions — so the pages overlap by
- * a day. The fields are the ones the ingestion dedup key is built from (see
- * `ON CONFLICT` in poalim-scraper-ingestion.provider.ts), so two rows that agree
- * on them are the same execution to everything downstream.
+ * The cursor should hand back each execution once, so this is a safety net rather than
+ * load-bearing. The fields are the ones the ingestion dedup key is built from (see
+ * `ON CONFLICT` in poalim-scraper-ingestion.provider.ts), so two rows that agree on
+ * them are the same execution to everything downstream.
  */
 export function executionIdentity(execution: unknown): string {
   const row = (execution ?? {}) as Record<string, unknown>;
@@ -98,29 +67,11 @@ export function executionIdentity(execution: unknown): string {
   ]);
 }
 
-/** The window's ceiling is requested at day granularity (the API takes ddMMyyyy). */
-const sameDay = (a: Date, b: Date) =>
-  a.getFullYear() === b.getFullYear() &&
-  a.getMonth() === b.getMonth() &&
-  a.getDate() === b.getDate();
-
-/** A local `Date` as `YYYY-MM-DD`, for messages — `toISOString` would shift the day. */
-const toLocalDay = (date: Date) =>
-  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(
-    date.getDate(),
-  ).padStart(2, '0')}`;
-
-/** `YYYY-MM-DD` back to a local `Date`, so the day survives the round trip. */
-function dayToLocalDate(day: string): Date {
-  const [year, month, date] = day.split('-').map(Number);
-  return new Date(year!, month! - 1, date!);
-}
-
 export type FetchAllExecutionsResult<TPage extends RawExecutionsPage> = {
   /** The first response, kept whole: it carries the envelope the merge builds on. */
   firstPage: TPage | null;
   /**
-   * The error payload that ended the walk-back, from whichever round produced it.
+   * The error payload that ended the paging, from whichever round produced it.
    * Set means the window was only partly fetched, so `executions` is incomplete and
    * the caller must report this rather than the merged result — a later round
    * failing is just as fatal as the first one failing.
@@ -131,22 +82,23 @@ export type FetchAllExecutionsResult<TPage extends RawExecutionsPage> = {
   /** How many requests were issued. */
   rounds: number;
   /**
-   * Set when the walk-back stopped with the window still unfinished and no error
-   * payload to blame — a full page it could not get past, the round cap, or a round
-   * that came back with nothing. Already logged; carried for callers.
+   * Set when paging stopped with a cursor still open and no error payload to blame —
+   * a cursor that stopped advancing, the round cap, or a round that came back with
+   * nothing. Already logged; carried for callers.
    */
   truncated?: string | undefined;
 };
 
 /**
- * Requests the window repeatedly, pulling its ceiling back over the oldest day
- * each full page reached, and returns the merged, deduplicated executions.
+ * Requests the window repeatedly, following `Account.PageState` until it comes back
+ * null, and returns the merged, deduplicated executions.
  *
- * Stops on a short page (the window is exhausted), on a page that could not be read
- * (an error payload lands in `failedPage`, a null response in `truncated`), when the
- * ceiling can no longer move (a single day holding a full page), and at
- * {@link MYTRADE_EXECUTIONS_MAX_ROUNDS} rounds. Every outcome other than the short
- * page leaves a reason in `failedPage` or `truncated`: a caller that ignores both
+ * The date window is fixed: every round asks for the same `fromDate`/`toDate` and only
+ * the cursor moves. Stops on a null cursor (the window is exhausted), on a page that
+ * could not be read (an error payload lands in `failedPage`, a null response in
+ * `truncated`), on a cursor that repeats itself, and at
+ * {@link MYTRADE_EXECUTIONS_MAX_ROUNDS} rounds. Every outcome other than the null
+ * cursor leaves a reason in `failedPage` or `truncated`: a caller that ignores both
  * cannot tell a complete window from a partial one.
  */
 export async function fetchAllExecutions<TPage extends RawExecutionsPage>({
@@ -159,7 +111,11 @@ export async function fetchAllExecutions<TPage extends RawExecutionsPage>({
 }: {
   fromDate: Date;
   toDate: Date;
-  fetchPage: (window: { fromDate: Date; toDate: Date }) => Promise<TPage | null>;
+  fetchPage: (request: {
+    fromDate: Date;
+    toDate: Date;
+    pageState?: string;
+  }) => Promise<TPage | null>;
   isErrorPage?: (page: TPage) => boolean;
   label?: string;
   warn?: (message: string) => void;
@@ -168,13 +124,13 @@ export async function fetchAllExecutions<TPage extends RawExecutionsPage>({
   let failedPage: TPage | null = null;
   const executions: unknown[] = [];
   const seen = new Set<string>();
-  let ceiling = toDate;
+  let pageState: string | undefined;
   let rounds = 0;
   let truncated: string | undefined;
 
   for (let round = 1; round <= MYTRADE_EXECUTIONS_MAX_ROUNDS; round++) {
     rounds = round;
-    const page = await fetchPage({ fromDate, toDate: ceiling });
+    const page = await fetchPage({ fromDate, toDate, ...(pageState ? { pageState } : {}) });
     firstPage ??= page;
     if (!page) {
       // Round 1 returning nothing is the ordinary "no portfolio activity" answer;
@@ -182,7 +138,7 @@ export async function fetchAllExecutions<TPage extends RawExecutionsPage>({
       if (round > 1) {
         truncated =
           `Securities executions for ${label} stopped after round ${round - 1}: the next request ` +
-          `came back with nothing, so the window before ${toLocalDay(ceiling)} was not fetched ` +
+          `came back with nothing while the paging cursor was still open ` +
           `(stopped at ${executions.length} executions).`;
         warn(truncated);
       }
@@ -190,14 +146,13 @@ export async function fetchAllExecutions<TPage extends RawExecutionsPage>({
     }
 
     // An error payload carries no executions. It is kept whatever round it arrives
-    // on: after a good first page it would otherwise look like a finished walk-back.
+    // on: after a good first page it would otherwise look like a finished walk.
     if (isErrorPage(page)) {
       failedPage = page;
       break;
     }
 
-    const rows = rawExecutions(page);
-    for (const row of rows) {
+    for (const row of rawExecutions(page)) {
       const identity = executionIdentity(row);
       if (!seen.has(identity)) {
         seen.add(identity);
@@ -205,46 +160,32 @@ export async function fetchAllExecutions<TPage extends RawExecutionsPage>({
       }
     }
 
-    if (rows.length < MYTRADE_EXECUTIONS_PAGE_SIZE) {
+    const nextPageState = pageCursor(page);
+
+    // The window is exhausted. This is the normal exit, whatever the row count was.
+    if (nextPageState === null) {
       break;
     }
 
-    const oldestDay = oldestExecutionDay(rows);
-    if (!oldestDay) {
+    // The cursor is not moving, so the next round would return the same page.
+    if (nextPageState === pageState) {
       truncated =
-        `Securities executions for ${label} filled a page but carry no usable date; ` +
-        `stopped at ${executions.length} executions — older activity in the window was not fetched.`;
+        `Securities executions for ${label} stopped after round ${round}: the endpoint returned ` +
+        `the same paging cursor twice, so it is not advancing ` +
+        `(stopped at ${executions.length} executions).`;
       warn(truncated);
-      break;
-    }
-
-    const nextCeiling = dayToLocalDate(oldestDay);
-
-    // No progress: the page is a full 150 executions sitting on (or after) the day
-    // the window already ends on, so re-requesting it would return the same rows.
-    if (sameDay(nextCeiling, ceiling) || nextCeiling > ceiling) {
-      truncated =
-        `${label} has at least ${MYTRADE_EXECUTIONS_PAGE_SIZE} securities executions on ${oldestDay} — ` +
-        `the endpoint cannot page past a single day, so any beyond that were not fetched.`;
-      warn(truncated);
-      break;
-    }
-
-    // The full page already reached the floor of the window; nothing older to ask for.
-    if (nextCeiling < fromDate) {
       break;
     }
 
     if (round === MYTRADE_EXECUTIONS_MAX_ROUNDS) {
       truncated =
-        `Securities executions for ${label} still filled a page after ${MYTRADE_EXECUTIONS_MAX_ROUNDS} rounds; ` +
-        `stopped at ${executions.length} executions, fetched back to ${oldestDay} — ` +
-        `request a narrower range to get the rest.`;
+        `Securities executions for ${label} were still paging after ${MYTRADE_EXECUTIONS_MAX_ROUNDS} ` +
+        `rounds; stopped at ${executions.length} executions — request a narrower range to get the rest.`;
       warn(truncated);
       break;
     }
 
-    ceiling = nextCeiling;
+    pageState = nextPageState;
   }
 
   return { firstPage, failedPage, executions, rounds, truncated };

--- a/packages/modern-poalim-scraper/src/scrapers/hapoalim.ts
+++ b/packages/modern-poalim-scraper/src/scrapers/hapoalim.ts
@@ -645,46 +645,52 @@ export async function hapoalim(
       data: HapoalimSecuritiesTransactions | null;
       isValid: boolean | null;
       errors?: unknown;
+      truncated?: string;
     }> => {
       const tradeAccountNumber = `${account.branchNumber}-${account.accountNumber}`;
 
-      const { firstPage, failedPage, executions } =
+      const { firstPage, failedPage, executions, truncated } =
         await fetchAllExecutions<HapoalimSecuritiesTransactions>({
           fromDate: range?.fromDate ?? startDate,
           toDate: range?.toDate ?? now,
           label: `account ${tradeAccountNumber}`,
           isErrorPage: page => describeMytradeError(page) !== null,
-          fetchPage: ({ fromDate, toDate }) =>
+          // The window is the same every round — only `pageState` moves. The cursor is
+          // an opaque base64 blob, so it has to be URL-encoded rather than interpolated.
+          fetchPage: ({ fromDate, toDate, pageState }) =>
             fetchFromMytrade<HapoalimSecuritiesTransactions>(
               `${apiSiteUrl}/mytrade/api/v2/json2/order/executions/history?account=${tradeAccountNumber}` +
-                `&fromDate=${toMytradeDateString(fromDate)}&toDate=${toMytradeDateString(toDate)}`,
+                `&fromDate=${toMytradeDateString(fromDate)}&toDate=${toMytradeDateString(toDate)}` +
+                (pageState ? `&pageState=${encodeURIComponent(pageState)}` : ''),
               'GET',
             ),
         });
 
       // Every round answers the same shape, so the first page carries the response
-      // envelope (`PageState`) and the merged executions replace its own. A page
-      // with no `Account` at all — an error payload — is passed through verbatim,
-      // for the error branches below to report on.
+      // envelope and the merged executions replace its own. Its `PageState` is the
+      // round-1 cursor, long spent — the merged object is not a page, so it is nulled
+      // out; `truncated` is what says whether anything was left unfetched. A page with
+      // no `Account` at all — an error payload — is passed through verbatim, for the
+      // error branches below to report on.
       const data =
         firstPage && 'Account' in firstPage
           ? ({
               ...firstPage,
-              Account: { ...firstPage.Account, Execution: executions },
+              Account: { ...firstPage.Account, Execution: executions, PageState: null },
             } as HapoalimSecuritiesTransactions)
           : firstPage;
 
       if (!options?.validateSchema) {
-        return { data, isValid: null };
+        return { data, isValid: null, ...(truncated ? { truncated } : {}) };
       }
 
       if (!data) {
         console.log(`No securities transactions found for account ${tradeAccountNumber}`);
-        return { data, isValid: true };
+        return { data, isValid: true, ...(truncated ? { truncated } : {}) };
       }
 
-      // A failed round is reported whichever round it was: the walk-back only got
-      // part of the window, so the merged executions must not pass as the whole of it.
+      // A failed round is reported whichever round it was: paging only got part of
+      // the window, so the merged executions must not pass as the whole of it.
       const reportedPage = failedPage ?? firstPage;
       const error = describeMytradeError(reportedPage);
       if (error) {
@@ -695,6 +701,9 @@ export async function hapoalim(
       return {
         data: validation.data ?? null,
         isValid: validation.success,
+        // Paging that stopped early is not a validation failure — the rows fetched are
+        // real and ingest is idempotent, so they upload and a later run backfills.
+        ...(truncated ? { truncated } : {}),
         // The schema is strict enough that a raw issue list is unreadable: it
         // points at Account.Execution.37.TradeType without saying which row that
         // is. The helper names the security and trade date per issue.

--- a/packages/modern-poalim-scraper/src/zod-schemas/hapoalim-securities-transactions-schema.ts
+++ b/packages/modern-poalim-scraper/src/zod-schemas/hapoalim-securities-transactions-schema.ts
@@ -478,9 +478,10 @@ const PoalimSecurityTransactionSchema = PoalimSecurityTransactionFields.superRef
 });
 
 /**
- * Only `Account` is modelled. `PageState` is the bank's opaque paging cursor —
- * it is carried through untouched (and unused: the endpoint is queried with an
- * explicit date range rather than paged).
+ * Only `Account` is modelled. `PageState` is the bank's opaque paging cursor: the
+ * scraper follows it round by round until it comes back null (see
+ * `hapoalim-securities-paging.ts`), and nulls it on the merged result, which is the
+ * whole window rather than a page.
  */
 export const HapoalimSecuritiesTransactionsSchema = z.strictObject({
   Account: z.strictObject({

--- a/packages/scraper-app/src/server/__tests__/spa-fallback.test.ts
+++ b/packages/scraper-app/src/server/__tests__/spa-fallback.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The SPA fallback must not answer anything but a browser navigation.
+ *
+ * `reply.sendFile` responds with a 200, so a catch-all that also caught API calls and
+ * non-GET verbs turned a mistyped URL into HTML-with-a-200. That is how pointing the
+ * vault's `serverUrl` at this app instead of the Accounter server surfaced as
+ * "Invalid execution result: result is not object or array" out of graphql-request,
+ * rather than as a plain 404.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { buildServer } from '../index.js';
+
+let app: FastifyInstance;
+
+beforeEach(async () => {
+  app = await buildServer();
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+describe('SPA fallback', () => {
+  it('404s a POST to an unknown path instead of serving the SPA', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      payload: { query: '{ __typename }' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).not.toContain('<!doctype');
+    expect(res.json()).toMatchObject({ error: 'not-found', method: 'POST', url: '/graphql' });
+  });
+
+  it('404s an unknown /api path rather than serving the SPA', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/nope' });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).not.toContain('<!doctype');
+    expect(res.json()).toMatchObject({ error: 'not-found', url: '/api/nope' });
+  });
+
+  it('still routes requests that do match a route', async () => {
+    const res = await app.inject({ method: 'GET', url: '/healthz' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true });
+  });
+});

--- a/packages/scraper-app/src/server/__tests__/vault-routes.test.ts
+++ b/packages/scraper-app/src/server/__tests__/vault-routes.test.ts
@@ -3,7 +3,7 @@ import { access, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Fastify, { type FastifyInstance } from 'fastify';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import { defaultVault, encryptVault, saveVaultFile } from '../vault.js';
 import { isLocked, lockVault } from '../vault-store.js';
 import { registerVaultRoutes } from '../vault-routes.js';
@@ -319,5 +319,116 @@ describe('POST /api/vault/upload', () => {
     await uploadVault(app, { force: true });
     const res = await app.inject({ method: 'GET', url: '/api/vault/status' });
     expect(res.json()).toMatchObject({ locked: true });
+  });
+});
+
+// ── Tests for GET /api/vault/test-connection ─────────────────────────────────
+
+describe('GET /api/vault/test-connection', () => {
+  const SERVER_URL = 'http://localhost:4000/graphql';
+  const API_KEY = 'scraper-key-1';
+
+  let vaultPath: string;
+  let app: FastifyInstance;
+  let fetchSpy: MockInstance<typeof globalThis.fetch>;
+
+  function mockReply(body: string, init?: { status?: number; contentType?: string }) {
+    fetchSpy.mockResolvedValue(
+      new Response(body, {
+        status: init?.status ?? 200,
+        headers: { 'content-type': init?.contentType ?? 'application/json' },
+      }),
+    );
+  }
+
+  beforeEach(async () => {
+    vaultPath = makeTmpPath();
+    app = await buildApp(vaultPath);
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+    await app.inject({
+      method: 'POST',
+      url: '/api/vault/create',
+      payload: { password: PASSWORD, serverUrl: SERVER_URL, apiKey: API_KEY },
+    });
+  });
+
+  afterEach(async () => {
+    fetchSpy.mockRestore();
+    lockVault();
+    await app.close();
+    await rm(vaultPath, { force: true });
+    delete process.env['VAULT_PATH'];
+  });
+
+  it('probes with the same X-API-Key header the upload client sends', async () => {
+    mockReply(JSON.stringify({ data: { __typename: 'Query' } }));
+
+    await app.inject({ method: 'GET', url: '/api/vault/test-connection' });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe(SERVER_URL);
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers['X-API-Key']).toBe(API_KEY);
+    expect(headers['Authorization']).toBeUndefined();
+  });
+
+  it('reports ok for a real GraphQL result', async () => {
+    mockReply(JSON.stringify({ data: { __typename: 'Query' } }));
+
+    const res = await app.inject({ method: 'GET', url: '/api/vault/test-connection' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ ok: true });
+    expect(res.json().latencyMs).toBeTypeOf('number');
+  });
+
+  it('fails on a 200 that is really a SPA index.html', async () => {
+    // The regression this route missed: a serverUrl pointing at a SPA (this very app)
+    // answers an unknown path with index.html and a 200, which used to read as healthy.
+    mockReply('<!doctype html>\n<html lang="en"><head><title>Scraper App</title></head></html>', {
+      contentType: 'text/html',
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/api/vault/test-connection' });
+
+    expect(res.json().ok).toBe(false);
+    expect(res.json().error).toContain('did not return JSON');
+    expect(res.json().error).toContain('/graphql');
+  });
+
+  it('surfaces a GraphQL error message', async () => {
+    mockReply(JSON.stringify({ errors: [{ message: 'Unauthorized' }] }));
+
+    const res = await app.inject({ method: 'GET', url: '/api/vault/test-connection' });
+
+    expect(res.json()).toMatchObject({ ok: false, error: 'Unauthorized' });
+  });
+
+  it('fails on valid JSON that is not a GraphQL result', async () => {
+    mockReply(JSON.stringify({ hello: 'world' }));
+
+    const res = await app.inject({ method: 'GET', url: '/api/vault/test-connection' });
+
+    expect(res.json()).toMatchObject({ ok: false });
+    expect(res.json().error).toContain('did not return a GraphQL result');
+  });
+
+  it('reports the status and body of a non-2xx response', async () => {
+    mockReply('nope', { status: 502, contentType: 'text/plain' });
+
+    const res = await app.inject({ method: 'GET', url: '/api/vault/test-connection' });
+
+    expect(res.json()).toMatchObject({ ok: false, error: 'HTTP 502: nope' });
+  });
+
+  it('returns 401 when the vault is locked', async () => {
+    lockVault();
+
+    const res = await app.inject({ method: 'GET', url: '/api/vault/test-connection' });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json()).toEqual({ error: 'vault-locked' });
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/scraper-app/src/server/index.ts
+++ b/packages/scraper-app/src/server/index.ts
@@ -21,8 +21,23 @@ export async function buildServer(): Promise<FastifyInstance> {
   const uiRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '../ui');
   if (existsSync(uiRoot)) {
     await app.register(staticPlugin, { root: uiRoot, prefix: '/', wildcard: true });
-    // Serve index.html for any path that doesn't match a static asset (SPA client-side routing)
-    app.setNotFoundHandler((_req, reply) => reply.sendFile('index.html'));
+    // Serve index.html for any path that doesn't match a static asset (SPA client-side routing).
+    //
+    // Only for browser navigations, though. `sendFile` answers with a 200, so letting
+    // this handler catch an API call, a websocket upgrade or a non-GET verb turns a
+    // mistyped URL into HTML-with-a-200 — which is how pointing the vault's serverUrl at
+    // this app instead of the Accounter server surfaced as an unreadable
+    // "Invalid execution result: result is not object or array" from graphql-request.
+    app.setNotFoundHandler((req, reply) => {
+      const isNavigation =
+        (req.method === 'GET' || req.method === 'HEAD') &&
+        !req.url.startsWith('/api/') &&
+        !req.url.startsWith('/ws');
+      if (!isNavigation) {
+        return reply.status(404).send({ error: 'not-found', method: req.method, url: req.url });
+      }
+      return reply.sendFile('index.html');
+    });
   }
 
   return app;

--- a/packages/scraper-app/src/server/payload-schemas/poalim-securities-transactions.schema.ts
+++ b/packages/scraper-app/src/server/payload-schemas/poalim-securities-transactions.schema.ts
@@ -479,8 +479,9 @@ const ExecutionItemSchema = ExecutionFields.superRefine((row, ctx) => {
 });
 
 /**
- * `Account.PageState` is the bank's opaque paging cursor and is not consumed —
- * the endpoint is queried with an explicit date range instead.
+ * `Account.PageState` is the bank's opaque paging cursor. The scraper follows it to
+ * fetch the whole window and nulls it on the merged payload that arrives here, so this
+ * side only ever has to accept it — never act on it.
  */
 export const PoalimSecuritiesTransactionsPayloadSchema = z.strictObject({
   Account: z.strictObject({

--- a/packages/scraper-app/src/server/scrapers/poalim.ts
+++ b/packages/scraper-app/src/server/scrapers/poalim.ts
@@ -81,6 +81,7 @@ export async function scrapePoalim(
     swift: DecoratedSwiftTransactions | null;
     securitiesInfo: PoalimSecuritiesInfoPayload | null;
     securitiesTransactions: PoalimSecuritiesTransactionsPayload | null;
+    securitiesTransactionsWarning?: string;
     bankAccount: { bankNumber: number; branchNumber: number; accountNumber: number };
   }[]
 > {
@@ -196,6 +197,7 @@ export async function scrapePoalim(
       swift: DecoratedSwiftTransactions | null;
       securitiesInfo: PoalimSecuritiesInfoPayload | null;
       securitiesTransactions: PoalimSecuritiesTransactionsPayload | null;
+      securitiesTransactionsWarning?: string;
       bankAccount: { bankNumber: number; branchNumber: number; accountNumber: number };
     }[] = [];
     const isBusiness = creds.options?.isBusinessAccount ?? false;
@@ -208,6 +210,7 @@ export async function scrapePoalim(
       let swift: DecoratedSwiftTransactions | null = null;
       let securitiesInfo: PoalimSecuritiesInfoPayload | null = null;
       let securitiesTransactions: PoalimSecuritiesTransactionsPayload | null = null;
+      let securitiesTransactionsWarning: string | undefined;
       const accountId = `${account.branchNumber}-${account.accountNumber}`;
       const accountRef = {
         bankNumber: account.bankNumber,
@@ -311,6 +314,7 @@ export async function scrapePoalim(
           data: securitiesTransactionsData,
           isValid: securitiesTransactionsValid,
           errors: securitiesTransactionsErrors,
+          truncated: securitiesTransactionsTruncated,
         } = await scraper.getSecuritiesTransactions(accountRef, {
           fromDate: dateFrom,
           toDate: dateTo,
@@ -326,6 +330,9 @@ export async function scrapePoalim(
             securitiesTransactionsData,
           );
         }
+        // Paging stopped with the bank's cursor still open: what came back is real and
+        // still worth uploading, but it is not the whole window, so say so.
+        securitiesTransactionsWarning = securitiesTransactionsTruncated;
       }
 
       accountsData.push({
@@ -334,6 +341,7 @@ export async function scrapePoalim(
         swift,
         securitiesInfo,
         securitiesTransactions,
+        ...(securitiesTransactionsWarning ? { securitiesTransactionsWarning } : {}),
         bankAccount: accountRef,
       });
     }

--- a/packages/scraper-app/src/server/vault-routes.ts
+++ b/packages/scraper-app/src/server/vault-routes.ts
@@ -120,9 +120,10 @@ export async function registerVaultRoutes(app: FastifyInstance): Promise<void> {
     }
     const t0 = Date.now();
     try {
-      // Same header the upload client sends (see graphql/client.ts) — the server reads
-      // `x-api-key` and claims an `Authorization: Bearer` header for the JWT path
-      // instead, so probing with Bearer would never exercise the real auth route.
+      // Probe with the same header the upload client sends (see graphql/client.ts).
+      // The server takes the scraper key from `x-api-key`; an `Authorization: Bearer`
+      // header is claimed first and routed to JWT verification, so probing with Bearer
+      // would test a different code path than the one uploads actually use.
       const res = await fetch(serverUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },

--- a/packages/scraper-app/src/server/vault-routes.ts
+++ b/packages/scraper-app/src/server/vault-routes.ts
@@ -120,16 +120,47 @@ export async function registerVaultRoutes(app: FastifyInstance): Promise<void> {
     }
     const t0 = Date.now();
     try {
+      // Same header the upload client sends (see graphql/client.ts) — the server reads
+      // `x-api-key` and claims an `Authorization: Bearer` header for the JWT path
+      // instead, so probing with Bearer would never exercise the real auth route.
       const res = await fetch(serverUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+        headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
         body: JSON.stringify({ query: '{ __typename }' }),
         signal: AbortSignal.timeout(10_000),
       });
       const latencyMs = Date.now() - t0;
+      const text = await res.text().catch(() => '');
       if (!res.ok) {
-        const text = await res.text().catch(() => res.statusText);
-        return { ok: false, error: `HTTP ${res.status}: ${text}`, latencyMs };
+        return { ok: false, error: `HTTP ${res.status}: ${text || res.statusText}`, latencyMs };
+      }
+
+      // A 2xx is not enough: anything serving a SPA answers an unknown path with
+      // index.html and a 200. Only a parseable GraphQL result proves this URL is
+      // really the Accounter endpoint.
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        return {
+          ok: false,
+          error:
+            `${serverUrl} did not return JSON — it is probably not the Accounter GraphQL ` +
+            `endpoint. The URL must include the path, e.g. http://localhost:4000/graphql`,
+          latencyMs,
+        };
+      }
+
+      const body = parsed as {
+        data?: { __typename?: unknown } | null;
+        errors?: { message?: string }[] | null;
+      } | null;
+      const gqlError = body?.errors?.[0]?.message;
+      if (gqlError) {
+        return { ok: false, error: gqlError, latencyMs };
+      }
+      if (typeof body?.data?.__typename !== 'string') {
+        return { ok: false, error: `${serverUrl} did not return a GraphQL result`, latencyMs };
       }
       return { ok: true, latencyMs };
     } catch (err) {

--- a/packages/scraper-app/src/server/websocket.ts
+++ b/packages/scraper-app/src/server/websocket.ts
@@ -438,6 +438,15 @@ function buildTask(
 
             const securitiesTransactionsPayload = accountData.securitiesTransactions;
             if (securitiesTransactionsPayload) {
+              if (accountData.securitiesTransactionsWarning) {
+                emit({
+                  type: 'task-account-warning',
+                  sourceId: src.id,
+                  accountId,
+                  txnType: 'securitiesTransactions',
+                  message: accountData.securitiesTransactionsWarning,
+                });
+              }
               // Executions are settled by definition — nothing pending to filter out.
               const executionsCount = securitiesTransactionsPayload.Account.Execution.length;
               emit({

--- a/packages/scraper-app/src/shared/ws-protocol.ts
+++ b/packages/scraper-app/src/shared/ws-protocol.ts
@@ -221,6 +221,19 @@ export const TaskAccountTxnsDoneSchema = z.object({
   skipped: z.number(),
 });
 
+/**
+ * A fetch that succeeded but is known to be incomplete — currently only securities
+ * executions whose paging stopped with the bank's cursor still open. The rows still
+ * upload; this is what tells the operator the window was not fully covered.
+ */
+export const TaskAccountWarningSchema = z.object({
+  type: z.literal('task-account-warning'),
+  sourceId: z.string(),
+  accountId: z.string(),
+  txnType: z.enum(['ils', 'foreign', 'swift', 'securitiesInfo', 'securitiesTransactions']),
+  message: z.string(),
+});
+
 export const ServerMessageSchema = z.discriminatedUnion('type', [
   ConnectedSchema,
   PongSchema,
@@ -243,6 +256,7 @@ export const ServerMessageSchema = z.discriminatedUnion('type', [
   TaskAccountTxnsFetchingSchema,
   TaskAccountTxnsUploadingSchema,
   TaskAccountTxnsDoneSchema,
+  TaskAccountWarningSchema,
 ]);
 
 export type ServerMessage = z.infer<typeof ServerMessageSchema>;

--- a/packages/scraper-app/src/ui/components/task-row.tsx
+++ b/packages/scraper-app/src/ui/components/task-row.tsx
@@ -141,6 +141,7 @@ function TxnTypeCell({
       )}
       {state.warning && (
         <span
+          role="img"
           title={state.warning}
           style={{ marginLeft: 4, color: '#b45309', cursor: 'help' }}
           aria-label={state.warning}

--- a/packages/scraper-app/src/ui/components/task-row.tsx
+++ b/packages/scraper-app/src/ui/components/task-row.tsx
@@ -122,7 +122,9 @@ function MonthStepsTable({ steps }: { steps: MonthStep[] }) {
 function TxnTypeCell({
   state,
 }: {
-  state: { phase: string; count?: number; inserted?: number; skipped?: number } | undefined;
+  state:
+    | { phase: string; count?: number; inserted?: number; skipped?: number; warning?: string }
+    | undefined;
 }) {
   if (!state) return <td style={{ padding: '2px 8px 2px 0', color: '#d1d5db' }}>—</td>;
   const badge = TXN_PHASE_BADGE[state.phase] ?? TXN_PHASE_BADGE['fetching']!;
@@ -136,6 +138,15 @@ function TxnTypeCell({
       )}
       {state.phase === 'uploading' && state.count != null && (
         <span style={{ marginLeft: 4, color: '#6b7280', fontSize: '0.9em' }}>{state.count}</span>
+      )}
+      {state.warning && (
+        <span
+          title={state.warning}
+          style={{ marginLeft: 4, color: '#b45309', cursor: 'help' }}
+          aria-label={state.warning}
+        >
+          ⚠
+        </span>
       )}
     </td>
   );

--- a/packages/scraper-app/src/ui/lib/ws.ts
+++ b/packages/scraper-app/src/ui/lib/ws.ts
@@ -37,6 +37,8 @@ export type TxnTypeState = {
   count?: number;
   inserted?: number;
   skipped?: number;
+  /** Fetched successfully but known to be incomplete — see `task-account-warning`. */
+  warning?: string;
 };
 
 export type AccountStep = {
@@ -270,7 +272,11 @@ export function useRunSocket(): UseRunSocketResult {
             const accountSteps = state.accountSteps ?? [];
             const [updated, step] = findOrCreateAccountStep(accountSteps, msg.accountId);
             const txnPatch: Partial<AccountStep> = {
-              [msg.txnType]: { phase: 'uploading' as const, count: msg.count },
+              [msg.txnType]: {
+                ...step[msg.txnType],
+                phase: 'uploading' as const,
+                count: msg.count,
+              },
             };
             next.set(msg.sourceId, {
               ...state,
@@ -284,9 +290,28 @@ export function useRunSocket(): UseRunSocketResult {
             const [updated, step] = findOrCreateAccountStep(accountSteps, msg.accountId);
             const txnPatch: Partial<AccountStep> = {
               [msg.txnType]: {
+                ...step[msg.txnType],
                 phase: 'done' as const,
                 inserted: msg.inserted,
                 skipped: msg.skipped,
+              },
+            };
+            next.set(msg.sourceId, {
+              ...state,
+              accountSteps: updateAccountStep(updated, msg.accountId, { ...step, ...txnPatch }),
+            });
+            break;
+          }
+          case 'task-account-warning': {
+            const state = get(msg.sourceId);
+            const accountSteps = state.accountSteps ?? [];
+            const [updated, step] = findOrCreateAccountStep(accountSteps, msg.accountId);
+            // The fetch succeeded, so the phase is left alone — only the caveat is added.
+            const txnPatch: Partial<AccountStep> = {
+              [msg.txnType]: {
+                phase: 'fetching' as const,
+                ...step[msg.txnType],
+                warning: msg.message,
               },
             };
             next.set(msg.sourceId, {


### PR DESCRIPTION
## Why

A Poalim scrape failed with:

```
Invalid execution result: result is not object or array.
Got: <!doctype html> ... <title>Scraper App</title>
```

The root cause was operator config — the vault's `serverUrl` pointed at the scraper-app's own origin (`:4001`) instead of the Accounter server (`:4000/graphql`). Confirmed by reproduction: `POST :4001/graphql` returned the exact bytes of `dist/ui/index.html`, same asset hash as in the error.

A config typo should not produce an opaque HTML-parse error, so this hardens the two gaps that made it one. While in the securities scraper, it also replaces the executions pagination strategy with the cursor the endpoint actually offers.

## Cursor paging for securities executions

`fetchAllExecutions` used to detect a full 150-row response and re-request the window with its **ceiling pulled back** to the oldest day that page reached. The endpoint instead returns an opaque cursor at `Account.PageState`.

It now repeats the request with the **date window unchanged**, passing the previous response's cursor as a `pageState` query param, and follows it while it is non-null. Row counts no longer decide anything — a short page with a cursor keeps paging, a long page without one stops.

```
round 1                        → PageState 'c1'
round 2  (&pageState=c1, same fromDate/toDate) → PageState 'c2'
round 3  (&pageState=c2, same fromDate/toDate) → PageState null   ⇒ done
```

The cursor is base64-encoded JSON and is treated as opaque — passed back verbatim, URL-encoded (it may contain `+`, `/`, `=`).

**This also fixes a real blind spot:** the walk-back could not page past a single day, so more than 150 executions on one date were silently dropped.

Guards, since each round costs a browser tab and SPA boot:

- Round cap raised 20 → 100 (a cursor page carries no implied record count, so the old cap no longer meant 3000 executions).
- Stop early if the cursor comes back unchanged — it is not advancing.

Both record a truncation reason, which is now **surfaced** rather than discarded at `hapoalim.ts:651`: a new `task-account-warning` WS message renders as a ⚠ on the account row. The rows still upload — ingestion is `ON CONFLICT ... DO NOTHING` on a wide natural key ([`poalim-scraper-ingestion.provider.ts`](../blob/main/packages/server/src/modules/scraper-ingestion/providers/poalim-scraper-ingestion.provider.ts)), so overlapping pages cannot duplicate rows and a later full run backfills.

The merged envelope gets `PageState: null`, since it represents the whole window rather than a page. Dead code from the walk-back is removed: `MYTRADE_EXECUTIONS_PAGE_SIZE`, `calendarDay`, `oldestExecutionDay`, and three date helpers (each was used only inside this module and its test).

## Misroute hardening

**SPA fallback** (`scraper-app/src/server/index.ts`) — `reply.sendFile` responds with a **200**, so the catch-all answered *any* unmatched request, `POST` and `/api/*` included. Now limited to GET/HEAD navigations outside `/api/` and `/ws`.

| Request | Before | After |
| --- | --- | --- |
| `POST /graphql` | `index.html`, **200** | `{"error":"not-found",…}`, **404** |
| `GET /api/nope` | `index.html`, 200 | 404 JSON |
| `GET /` , `/deep/spa/route` | 200 html | 200 html (unchanged) |
| `GET /healthz` | 200 | 200 |

**`/api/vault/test-connection`** — reported the broken config as *healthy*: it only checked the status code, and probed with `Authorization: Bearer` rather than the `X-API-Key` header the upload client and server actually use. Worse, a Bearer header is claimed first and forced down the JWT path (`auth-plugin.ts:108-115`), so the probe could never succeed on the real auth route. It now sends the right header and requires a parseable GraphQL result, naming the missing `/graphql` path when the response is not JSON. The `{ ok, latencyMs, error }` contract is unchanged, so no UI change was needed.

## Tests

- `hapoalim-securities-paging.test.ts` rewritten (17 tests): round 2 repeats the *identical* `fromDate`/`toDate`; a 3-row page with a cursor keeps going while a 150-row page without one stops; a real base64 cursor passes through verbatim; repeat-cursor and round-cap truncation; error payloads on first and later rounds.
- **New** `spa-fallback.test.ts` — `POST` to an unknown path 404s with JSON and no `<!doctype`.
- `vault-routes.test.ts` — test-connection had **zero** coverage; now 7 tests, including the exact regression (a 200 `text/html` body must fail) and an assertion that `X-API-Key` is sent with no `Authorization` header.

## Verification

- `yarn test` — 278 files / 3589 tests pass
- `yarn lint` — 0 errors (861 warnings, all pre-existing)
- `yarn generate` — no tracked changes; both packages typecheck
- SPA fallback verified live against a built server (table above)

**Not verified — needs a live bank session:** an actual scrape confirming `&pageState=` on the wire across rounds with identical dates, >150 executions uploaded, and a re-run inserting 0. Also untested live: the connection test against a real server, which needs the vault password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
