### PR TITLE
feat(client): searchable tax category and sort code selects in business batch update

### DIFF
--- a/.changeset/batch-update-businesses-select-inputs.md
+++ b/.changeset/batch-update-businesses-select-inputs.md
@@ -1,0 +1,16 @@
+---
+'@accounter/client': patch
+---
+
+Replace the free-text tax category and sort code inputs in the businesses batch-update dialog with
+searchable selects.
+
+Tax category previously required pasting a raw UUID; it now uses a `ComboBox` populated from
+`useGetTaxCategories()`, matching the Country picker in the same dialog. Sort code previously was a
+numeric text input; it now uses the shared `SortCodeSelect`, scoped to the active business from
+`UserContext`. Since a selected sort code is always a valid key, the numeric-format guard now only
+applies to the IRS code field.
+
+`SortCodeSelect` option labels changed from `key - name` to `name (key)` (searchable by both name
+and key), which also applies to its other usages in the business configurations section and the tax
+category form.

--- a/packages/client/src/components/businesses/batch-update-dialog.tsx
+++ b/packages/client/src/components/businesses/batch-update-dialog.tsx
@@ -1,10 +1,12 @@
-import { useState, type ReactElement } from 'react';
+import { useContext, useState, type ReactElement } from 'react';
 import type { BatchUpdateBusinessInput } from '../../gql/graphql.js';
 import { useBatchUpdateBusinesses } from '../../hooks/use-batch-update-businesses.js';
 import { useAllCountries } from '../../hooks/use-get-countries.js';
 import { useGetTags } from '../../hooks/use-get-tags.js';
+import { useGetTaxCategories } from '../../hooks/use-get-tax-categories.js';
 import { cn } from '../../lib/utils.js';
-import { ComboBox, MultiSelect } from '../common/index.js';
+import { UserContext } from '../../providers/index.js';
+import { ComboBox, MultiSelect, SortCodeSelect } from '../common/index.js';
 import { Button } from '../ui/button.js';
 import {
   Dialog,
@@ -58,7 +60,8 @@ const EMPTY_FORM: FormState = {
   exemptDealer: 'unset',
 };
 
-// `country` is rendered separately as a searchable ComboBox; the rest are simple inputs.
+// `country`, `taxCategory` and `sortCode` are rendered separately as searchable selects; the rest
+// are simple inputs.
 // `fullWidth` fields span both columns on wider screens.
 const FIELDS: {
   key: keyof FormState;
@@ -69,9 +72,7 @@ const FIELDS: {
 }[] = [
   { key: 'city', label: 'City' },
   { key: 'zipCode', label: 'Zip code' },
-  { key: 'sortCode', label: 'Sort code', numeric: true },
   { key: 'irsCode', label: 'IRS code', numeric: true },
-  { key: 'taxCategory', label: 'Tax category (UUID)', fullWidth: true },
   { key: 'description', label: 'Suggestion description', fullWidth: true },
 ];
 
@@ -138,14 +139,16 @@ export function BatchUpdateBusinessesDialog({
   const { fetching, batchUpdateBusinesses } = useBatchUpdateBusinesses();
   const { countries, fetching: fetchingCountries } = useAllCountries();
   const { selectableTags, fetching: fetchingTags } = useGetTags();
+  const { selectableTaxCategories, fetching: fetchingTaxCategories } = useGetTaxCategories();
+  const { userContext } = useContext(UserContext);
 
   const fields = buildFields(form);
   const isFormEmpty = Object.keys(fields).length === 0;
-  // sortCode/irsCode map to GraphQL Int, so only whole non-negative integers are valid — reject
-  // decimals and scientific notation that Number() would otherwise coerce.
+  // irsCode maps to GraphQL Int, so only whole non-negative integers are valid — reject decimals
+  // and scientific notation that Number() would otherwise coerce. sortCode comes from a select, so
+  // it is always a valid key.
   const hasInvalidNumericFields =
-    (form.sortCode.trim() !== '' && !INTEGER_PATTERN.test(form.sortCode.trim())) ||
-    (form.irsCode.trim() !== '' && !INTEGER_PATTERN.test(form.irsCode.trim()));
+    form.irsCode.trim() !== '' && !INTEGER_PATTERN.test(form.irsCode.trim());
 
   const onSubmit = async (): Promise<void> => {
     if (Object.keys(fields).length === 0) {
@@ -182,6 +185,28 @@ export function BatchUpdateBusinessesDialog({
               onChange={value => setForm(prev => ({ ...prev, country: value ?? '' }))}
               disabled={fetchingCountries}
               placeholder="Select country"
+            />
+          </div>
+          <div className="grid gap-1 sm:col-span-2">
+            <Label>Tax category</Label>
+            <ComboBox
+              data={selectableTaxCategories}
+              value={form.taxCategory || null}
+              onChange={value => setForm(prev => ({ ...prev, taxCategory: value ?? '' }))}
+              disabled={fetchingTaxCategories}
+              placeholder="Select tax category"
+            />
+          </div>
+          <div className="grid gap-1">
+            <Label>Sort code</Label>
+            <SortCodeSelect
+              ownerId={userContext?.context.adminBusinessId}
+              value={form.sortCode || null}
+              onChange={value =>
+                setForm(prev => ({ ...prev, sortCode: value === null ? '' : value.toString() }))
+              }
+              placeholder="Select sort code"
+              triggerClassName="w-full justify-start"
             />
           </div>
           {FIELDS.map(field => (

--- a/packages/client/src/components/common/inputs/sort-code-select.tsx
+++ b/packages/client/src/components/common/inputs/sort-code-select.tsx
@@ -29,7 +29,8 @@ type SortCodeSelectProps = {
  * General, reusable sort code selector.
  *
  * Fetches the sort codes for the given business owner and renders a searchable
- * shadcn combo box. Each option displays both the sort code key and its name.
+ * shadcn combo box. Each option displays the sort code name and its key, and is
+ * searchable by both.
  */
 export function SortCodeSelect({
   ownerId,
@@ -51,7 +52,7 @@ export function SortCodeSelect({
   const options = useMemo(() => {
     const list = sortCodes.map(sortCode => ({
       value: sortCode.key.toString(),
-      label: sortCode.name ? `${sortCode.key} - ${sortCode.name}` : sortCode.key.toString(),
+      label: sortCode.name ? `${sortCode.name} (${sortCode.key})` : sortCode.key.toString(),
     }));
     // Keep the currently selected value visible even while the list is still
     // loading or if it no longer exists among the fetched sort codes.


### PR DESCRIPTION
## What

The businesses batch-update dialog had two free-text fields that were awkward to use:

- **Tax category** required pasting a raw UUID → now a searchable `ComboBox` fed by `useGetTaxCategories()`, matching the Country picker directly above it.
- **Sort code** was a numeric text input → now the shared `SortCodeSelect`, scoped to the active business from `UserContext`.

`form.taxCategory` / `form.sortCode` still hold the id/key as strings, so `buildFields` and the mutation input are unchanged. The numeric-format guard now only applies to IRS code, since a selected sort code is always a valid key.

## Shared component change

`SortCodeSelect` option labels changed from `key - name` to `name (key)`, per the requested format. Search matches both — the ComboBox uses the key as the item `value` and the label as a keyword. This also affects the other two usages: the business configurations section and the tax category form.

## Verification

- `tsc --noEmit` on `@accounter/client` — clean
- ESLint + Prettier on changed files — clean
- `vitest run --project unit` for businesses + tax-categories — 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)