### PR TITLE
Expose clients on the MCP connector

### DIFF
--- a/.changeset/mcp-clients-tool.md
+++ b/.changeset/mcp-clients-tool.md
@@ -1,0 +1,51 @@
+---
+'@accounter/server': minor
+'@accounter/mcp-server': minor
+---
+
+Expose clients over the MCP connector.
+
+Some businesses are also clients — they carry a `clients` row that adds contact emails, a default
+document type, and a map of external-system ids. None of that reached the connector. The business
+directory came back with no signal about which rows were clients, so an assistant could not tell a
+supplier from a customer; and `accounter_get_contracts` had filtered by `clientIds` all along with
+nothing on the connector able to enumerate them.
+
+**A flag on the directory.** `accounter_list_businesses` rows now carry `isClient`, and the tool
+takes an `isClient` filter. The filter is a real upstream predicate rather than a pass over the
+returned page — `Query.allBusinesses` gained an `isClient` argument, applied ahead of the count and
+the slice, so `pagination` and `totalCount` describe the filtered directory and no page comes back
+short. That distinction matters more here than for `activeOnly`: clients are a small slice of the
+directory, so filtering an already-sliced page would answer "the clients on page 1" while reading as
+"the clients".
+
+**A tool for the detail.** `accounter_list_clients` returns emails, the client-level default
+document type, and the configured integrations, filtered by name or by `clientBusinessIds`. It is
+separate from the directory rather than more fields on it because the directory is thousands of rows
+against a hard payload cap, and hanging six integration ids off every row would spend that budget on
+the majority that have none. It is also where any future client data belongs. Unconfigured
+integrations are omitted rather than returned as `null`, and only `greenInvoiceInfo { greenInvoiceId }`
+is selected — every other field on that type is fetched from the external Green Invoice API, one
+request per client.
+
+Client ids need no translation anywhere: a client's id **is** its business id, so the directory's
+`id`, this tool's `businessId`, and the contracts filter's `clientIds` are one value.
+
+**Four server-side fixes underneath.** All pre-existing, all in the path of reading a client:
+
+- `ClientIntegrations` field resolvers parsed stored jsonb with a strict schema that threw on `NULL`
+  and on any unknown key. Those resolvers run once per client, and the connector discards partial
+  data whenever a response carries an `errors` entry — so one malformed row would have emptied an
+  entire `allClients` call rather than degrading one record. Reading now goes through a lenient
+  parser that treats `NULL` as unconfigured, strips unknown keys, and degrades a wrong-typed field to
+  `null` without costing its siblings. Every one of the thirteen call sites was reading stored data,
+  so all of them moved; the strict schema stays exported for a write path that wants it.
+- `Client.generatedDocumentType` was declared non-null with no resolver — the column is
+  `document_type`, so the default resolver returned `undefined` and any query selecting it errored.
+  Nothing selected it, which is why the break was invisible.
+- The same field was accepted by `insertClient`/`updateClient` and never written: neither statement
+  touched `document_type`. It now persists.
+- `Client` gained `ownerId`, which every connector row is required to carry.
+
+Note that `generatedDocumentType` is the client-level default only. What actually gets issued is the
+contract's own `documentType`, which `accounter_get_contracts` already returns.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -18,14 +18,14 @@ Phase 1 (read-only) is feature-complete. The server provides: strict startup env
 transport with `/health`, `/metrics`, the OAuth protected-resource metadata endpoint, and the MCP
 route (`POST /mcp`, JSON-RPC 2.0) with graceful shutdown; Auth0 bearer-token verification; identity
 mapping to an internal user + business-membership context with memberships resolved from the
-Accounter GraphQL server; a curated registry of fourteen read-only tools
+Accounter GraphQL server; a curated registry of fifteen read-only tools
 (`accounter_list_business_memberships`, `accounter_explain_terminology`, `accounter_search_charges`,
 `accounter_get_charges`, `accounter_get_transactions`, `accounter_get_documents`,
-`accounter_get_ledger_records`, `accounter_get_contracts`, `accounter_list_security_holdings`,
-`accounter_get_security_executions`, `accounter_list_tags`, `accounter_list_tax_categories`,
-`accounter_list_businesses`, `accounter_balance_report`) each gated by strict input validation, a
-per-tool authorization policy, and business-scope narrowing forwarded upstream as
-`x-business-scope`; a hardened upstream GraphQL client (timeout, bounded retries, header
+`accounter_get_ledger_records`, `accounter_list_clients`, `accounter_get_contracts`,
+`accounter_list_security_holdings`, `accounter_get_security_executions`, `accounter_list_tags`,
+`accounter_list_tax_categories`, `accounter_list_businesses`, `accounter_balance_report`) each gated
+by strict input validation, a per-tool authorization policy, and business-scope narrowing forwarded
+upstream as `x-business-scope`; a hardened upstream GraphQL client (timeout, bounded retries, header
 propagation, sanitized errors); a unified error taxonomy; per-`tools/call` rate limiting; in-process
 operational metrics (request/outcome counters, a latency histogram, auth-failure counters) exposed
 at `GET /metrics`; and OpenTelemetry tracing exported to Grafana Tempo (opt-in), correlated with the
@@ -169,6 +169,15 @@ scope, because it _is_ the scope.
   (account, amount, local currency amount), so results spanning businesses or charges group without
   a second call. Date ranges are bounded (≤ 1096 days) and rows capped (≤ 500, default 200) with a
   `truncated` flag.
+- **`accounter_list_clients`** — the **clients** you bill: the businesses carrying a `clients` row,
+  with their contact emails, the client-level default document type, and the external-system ids
+  configured for each (Green Invoice, Hive, Linear, Slack, Notion, Workflowy). Filters by
+  `nameContains` and by `clientBusinessIds`; each row reports its `ownerId`. A client's `businessId`
+  **is** its business id, so it is the same value `accounter_list_businesses` returns as `id` and
+  the same value `accounter_get_contracts` takes as `clientIds` — this is the tool that resolves a
+  client by name before asking about its contracts. Unconfigured integrations are omitted rather
+  than returned as `null`, and `generatedDocumentType` is the client-level default only: what
+  actually gets issued is the contract's own `documentType`. Rows capped (≤ 300, default 150).
 - **`accounter_get_contracts`** — read-only **client billing contracts**. Filters by `clientIds`, by
   `contractIds`, and by `isActive`. The owning ("admin") business axis is the membership axis — a
   contract is always owned by a business you are a member of — so `memberBusinessIds` doubles as the
@@ -205,13 +214,16 @@ scope, because it _is_ the scope.
   bookkeeping sort code, active flag), optionally filtered by name, active status, or
   `memberBusinessIds`. Same deterministic sort + cap.
 - **`accounter_list_businesses`** — list the full business directory (id, name, `ownerId`, active
-  flag) — every business visible to the caller, not just their memberships — optionally filtered by
-  name (forwarded to the upstream `allBusinesses(name:)` filter), active status, or
-  `memberBusinessIds`, and paginated with `limit` + 1-based `page` (forwarded as the upstream
-  `limit`/`page` args; the response echoes `pagination`). Same deterministic sort + cap. Note that
-  `activeOnly`/`nameContains` narrowing happens within the fetched page, so a page can come back
-  short. Use `accounter_list_business_memberships` instead for just the caller's own memberships and
-  roles.
+  flag, and `isClient`) — every business visible to the caller, not just their memberships —
+  optionally filtered by name (forwarded to the upstream `allBusinesses(name:)` filter), active
+  status, client status, or `memberBusinessIds`, and paginated with `limit` + 1-based `page`
+  (forwarded as the upstream `limit`/`page` args; the response echoes `pagination`). Same
+  deterministic sort + cap. Note that `activeOnly`/`nameContains` narrowing happens within the
+  fetched page, so a page can come back short — `isClient` is the exception, forwarded to the
+  upstream `allBusinesses(isClient:)` predicate so counts and paging describe the filtered
+  directory. Use `accounter_list_business_memberships` instead for just the caller's own memberships
+  and roles, and `accounter_list_clients` to enumerate clients with their emails and integrations
+  rather than paging this directory for them.
 - **`accounter_balance_report`** — read-only balance report (transactions) for **exactly one** of
   your businesses over a bounded date range (≤ 1096 days), selected by the required singular
   `memberBusinessId`. Requires `business_owner`/`accountant` role; rows are capped at 1000 with a
@@ -529,9 +541,26 @@ curl -s -X POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
 curl -s -X POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
   -H "Authorization: Bearer $TOKEN" \
   -d '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"accounter_get_security_executions","arguments":{"securityBusinessIds":["<securityBusinessId from step 8>"],"includeCharges":true,"pageSize":5}}}'
+
+# 10. Clients, then the contracts behind one. Expect integrations to carry only
+#     the keys actually configured, and no Green Invoice API call in the server log.
+curl -s -X POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"accounter_list_clients","arguments":{}}}'
+
+# 11. The businessId from step 10 is already a clientIds value — no translation.
+curl -s -X POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"accounter_get_contracts","arguments":{"clientIds":["<businessId from step 10>"]}}}'
+
+# 12. The same clients, seen from the directory: every row carries isClient, and
+#     the filter is applied upstream so totalCount describes the filtered set.
+curl -s -X POST http://localhost:3100/mcp -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"accounter_list_businesses","arguments":{"isClient":true}}}'
 ```
 
-The automated equivalent of steps 1–9 (with the Auth0 verifier and upstream mocked) lives in
+The automated equivalent of steps 1–12 (with the Auth0 verifier and upstream mocked) lives in
 `src/__tests__/mcp-e2e.test.ts` and runs with `yarn workspace @accounter/mcp-server test`.
 
 ## Troubleshooting

--- a/packages/mcp-server/src/__tests__/mcp-e2e.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-e2e.test.ts
@@ -93,6 +93,51 @@ function upstreamData(query: string, authorization?: string): unknown {
       allTags: [{ id: 'tag-1', name: 'food', namePath: ['food'], ownerId: AUTHORIZED_BUSINESS }],
     };
   }
+  if (query.includes('contractsByFilters')) {
+    return {
+      contractsByFilters: [
+        {
+          id: 'contract-1',
+          ownerId: AUTHORIZED_BUSINESS,
+          isActive: true,
+          startDate: '2026-01-01',
+          endDate: '2026-12-31',
+          billingCycle: 'MONTHLY',
+          documentType: 'INVOICE',
+          product: null,
+          plan: null,
+          purchaseOrders: [],
+          remarks: null,
+          amount: { raw: 1000, formatted: '$1,000.00', currency: 'USD' },
+          client: {
+            id: 'client-1',
+            originalBusiness: { id: 'client-1', name: 'Client Ltd' },
+          },
+        },
+      ],
+    };
+  }
+  if (query.includes('allClients')) {
+    return {
+      allClients: [
+        {
+          id: 'client-1',
+          ownerId: AUTHORIZED_BUSINESS,
+          emails: ['billing@client.example'],
+          generatedDocumentType: 'PROFORMA',
+          originalBusiness: { id: 'client-1', name: 'Client Ltd' },
+          integrations: {
+            hiveId: 'hive-1',
+            linearId: null,
+            slackChannelKey: null,
+            notionId: null,
+            workflowyUrl: null,
+            greenInvoiceInfo: { greenInvoiceId: 'gi-1' },
+          },
+        },
+      ],
+    };
+  }
   if (query.includes('taxCategories')) {
     return {
       taxCategories: [
@@ -348,6 +393,7 @@ describe('authenticated tool invocation', () => {
         'accounter_balance_report',
         'accounter_list_security_holdings',
         'accounter_get_security_executions',
+        'accounter_list_clients',
       ]),
     );
     // Discovery leads the list, and the internal smoke tool is not advertised.
@@ -357,6 +403,51 @@ describe('authenticated tool invocation', () => {
     // upgrades into: the write tools must not appear.
     expect(tools).not.toContain('accounter_update_charges_tags');
     expect(tools).not.toContain('accounter_upload_documents');
+  });
+
+  it('lists clients with their integrations flattened and scoped to the caller', async () => {
+    const result = await callTool('accounter_list_clients', {}, 'owner-token');
+    expect(result.isError).toBeUndefined();
+    const { clients, scope } = result.structuredContent as {
+      clients: Array<{
+        businessId: string;
+        name: string;
+        ownerId: string;
+        emails: string[];
+        generatedDocumentType: string;
+        integrations: Record<string, string>;
+      }>;
+      scope: { memberBusinessIds: string[] };
+    };
+
+    expect(clients).toHaveLength(1);
+    expect(clients[0].businessId).toBe('client-1');
+    expect(clients[0].name).toBe('Client Ltd');
+    expect(clients[0].ownerId).toBe(AUTHORIZED_BUSINESS);
+    expect(clients[0].emails).toEqual(['billing@client.example']);
+    expect(clients[0].generatedDocumentType).toBe('PROFORMA');
+    // Green Invoice's id is flattened up out of its nested wrapper, and the five
+    // unconfigured integrations are absent rather than null.
+    expect(clients[0].integrations).toEqual({ greenInvoiceId: 'gi-1', hiveId: 'hive-1' });
+    expect(scope.memberBusinessIds).toEqual([AUTHORIZED_BUSINESS]);
+  });
+
+  // The whole reason this tool sits ahead of contracts: the id it returns is the
+  // one the contracts filter takes, with no translation in between.
+  it('returns client ids that feed straight into the contracts filter', async () => {
+    const listed = await callTool('accounter_list_clients', {}, 'owner-token');
+    const { clients } = listed.structuredContent as { clients: Array<{ businessId: string }> };
+
+    const contracts = await callTool(
+      'accounter_get_contracts',
+      { clientIds: [clients[0].businessId] },
+      'owner-token',
+    );
+    expect(contracts.isError).toBeUndefined();
+    const { contracts: rows } = contracts.structuredContent as {
+      contracts: Array<{ client: { businessId: string } }>;
+    };
+    expect(rows[0].client.businessId).toBe(clients[0].businessId);
   });
 
   it('rejects a write tool as unknown while writes are disabled', async () => {

--- a/packages/mcp-server/src/tools/__tests__/clients.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/clients.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { listClientsTool, MAX_CLIENTS } from '../clients.js';
+import { executeRegisteredTool } from '../execute.js';
+
+function authContext(memberBusinessIds: string[]): McpAuthContext {
+  const principal: AuthPrincipal = {
+    subject: 'user-1',
+    issuer: 'https://tenant.auth0.com/',
+    audience: 'aud',
+    scopes: [],
+    email: null,
+    expiresAt: undefined,
+    claims: { sub: 'user-1' },
+  };
+  return buildAuthContext(
+    principal,
+    memberBusinessIds.map(memberBusinessId => ({ memberBusinessId, roleId: 'accountant' })),
+  );
+}
+
+function clientReturning(data: unknown, capture?: (init: RequestInit) => void) {
+  const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+    capture?.(init);
+    return { ok: true, status: 200, json: async () => ({ data }) } as unknown as Response;
+  });
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+// Always through `executeRegisteredTool`, never the handler directly, so input
+// validation, the authorization policy and scope resolution are exercised too.
+const runTool = (client: UpstreamGraphQLClient, auth: McpAuthContext, rawArgs: unknown) =>
+  executeRegisteredTool({
+    tool: listClientsTool,
+    rawArgs,
+    auth,
+    correlationId: 'c',
+    client,
+    authorization: 'Bearer t',
+  });
+
+const NO_INTEGRATIONS = {
+  hiveId: null,
+  linearId: null,
+  slackChannelKey: null,
+  notionId: null,
+  workflowyUrl: null,
+  greenInvoiceInfo: null,
+};
+
+function rawClient(
+  id: string,
+  name: string,
+  ownerId = 'b1',
+  integrations: Record<string, unknown> = NO_INTEGRATIONS,
+) {
+  return {
+    id,
+    ownerId,
+    emails: [],
+    generatedDocumentType: 'PROFORMA',
+    originalBusiness: { id, name },
+    integrations,
+  };
+}
+
+type ClientRow = {
+  businessId: string;
+  name: string;
+  ownerId: string;
+  emails: string[];
+  generatedDocumentType: string;
+  integrations: Record<string, string>;
+};
+
+const rowsOf = (result: { structuredContent?: unknown }) =>
+  (result.structuredContent as { clients: ClientRow[] }).clients;
+
+describe('listClientsTool', () => {
+  const client = () =>
+    clientReturning({
+      allClients: [
+        rawClient('3', 'Zebra'),
+        rawClient('1', 'apple'),
+        rawClient('2', 'Banana'),
+      ],
+    });
+
+  it('returns clients sorted by name (case-insensitive), then business id', async () => {
+    const result = await runTool(client(), authContext(['b1']), {});
+    expect(rowsOf(result).map(c => c.name)).toEqual(['apple', 'Banana', 'Zebra']);
+  });
+
+  it('filters by nameContains (case-insensitive)', async () => {
+    const result = await runTool(client(), authContext(['b1']), { nameContains: 'an' });
+    const structured = result.structuredContent as { clients: ClientRow[]; totalCount: number };
+    expect(structured.clients.map(c => c.name)).toEqual(['Banana']);
+    expect(structured.totalCount).toBe(1);
+  });
+
+  it('filters by clientBusinessIds', async () => {
+    const result = await runTool(client(), authContext(['b1']), { clientBusinessIds: ['1', '3'] });
+    expect(rowsOf(result).map(c => c.businessId)).toEqual(['1', '3']);
+  });
+
+  it('emits the business id once, under businessId', async () => {
+    const result = await runTool(client(), authContext(['b1']), { clientBusinessIds: ['1'] });
+    const [row] = rowsOf(result);
+    expect(row.businessId).toBe('1');
+    // No second spelling of the same value — `Client.id` upstream *is* the
+    // business id, and emitting both would imply two identifiers to track.
+    expect(row).not.toHaveProperty('id');
+  });
+
+  it('echoes the effective scope and tags every row with ownerId', async () => {
+    const result = await runTool(client(), authContext(['b1', 'b2']), {});
+    const structured = result.structuredContent as {
+      clients: ClientRow[];
+      scope: { memberBusinessIds: string[] };
+    };
+    expect(structured.scope).toEqual({ memberBusinessIds: ['b1', 'b2'] });
+    expect(structured.clients.every(c => c.ownerId === 'b1')).toBe(true);
+  });
+
+  // Defense in depth on top of RLS. Upstream should never return this row; if it
+  // does — an RLS regression — the tool must not pass it on.
+  it('drops a row whose ownerId is outside the resolved scope', async () => {
+    const upstream = clientReturning({
+      allClients: [rawClient('1', 'Mine', 'b1'), rawClient('2', 'Theirs', 'b-other')],
+    });
+    const result = await runTool(upstream, authContext(['b1']), {});
+    expect(rowsOf(result).map(c => c.name)).toEqual(['Mine']);
+  });
+
+  it('omits unconfigured integrations and flattens the Green Invoice id', async () => {
+    const upstream = clientReturning({
+      allClients: [
+        rawClient('1', 'Acme', 'b1', {
+          hiveId: 'hive-1',
+          linearId: null,
+          slackChannelKey: 'C123',
+          notionId: null,
+          workflowyUrl: null,
+          greenInvoiceInfo: { greenInvoiceId: 'gi-1' },
+        }),
+      ],
+    });
+    const result = await runTool(upstream, authContext(['b1']), {});
+    // Exactly the configured three — absent, not null, for the rest.
+    expect(rowsOf(result)[0].integrations).toEqual({
+      greenInvoiceId: 'gi-1',
+      hiveId: 'hive-1',
+      slackChannelKey: 'C123',
+    });
+  });
+
+  it('emits an empty integrations object when none are configured', async () => {
+    const result = await runTool(client(), authContext(['b1']), { clientBusinessIds: ['1'] });
+    expect(rowsOf(result)[0].integrations).toEqual({});
+  });
+
+  // A `greenInvoiceInfo` present but carrying a null id is "not configured", the
+  // same as an absent wrapper — the two must not read differently.
+  it('treats a null greenInvoiceId as unconfigured', async () => {
+    const upstream = clientReturning({
+      allClients: [
+        rawClient('1', 'Acme', 'b1', { ...NO_INTEGRATIONS, greenInvoiceInfo: { greenInvoiceId: null } }),
+      ],
+    });
+    const result = await runTool(upstream, authContext(['b1']), {});
+    expect(rowsOf(result)[0].integrations).toEqual({});
+  });
+
+  it('caps the page at limit while totalCount still counts every match', async () => {
+    const upstream = clientReturning({
+      allClients: [rawClient('1', 'apple'), rawClient('2', 'Banana'), rawClient('3', 'Zebra')],
+    });
+    const result = await runTool(upstream, authContext(['b1']), { limit: 2 });
+    const structured = result.structuredContent as {
+      clients: ClientRow[];
+      returnedCount: number;
+      totalCount: number;
+      truncated: boolean;
+    };
+    expect(structured.clients.map(c => c.name)).toEqual(['apple', 'Banana']);
+    expect(structured.returnedCount).toBe(2);
+    expect(structured.totalCount).toBe(3);
+    expect(structured.truncated).toBe(true);
+  });
+
+  it('rejects a limit above the cap', async () => {
+    const result = await runTool(client(), authContext(['b1']), { limit: MAX_CLIENTS + 1 });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
+  });
+
+  it('enforces business scope (denies a caller with no memberships)', async () => {
+    const result = await runTool(client(), authContext([]), {});
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('AUTHORIZATION_ERROR');
+  });
+
+  it('rejects a memberBusinessId outside the caller memberships', async () => {
+    const result = await runTool(client(), authContext(['b1']), {
+      memberBusinessIds: ['not-mine'],
+    });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('AUTHORIZATION_ERROR');
+  });
+
+  it('forwards the resolved scope upstream as x-business-scope', async () => {
+    let sentInit: RequestInit | undefined;
+    const upstream = clientReturning({ allClients: [] }, init => (sentInit = init));
+    await runTool(upstream, authContext(['b1', 'b2']), { memberBusinessIds: ['b2'] });
+    const headers = sentInit!.headers as Record<string, string>;
+    expect(headers['x-business-scope']).toBe('b2');
+  });
+
+  /**
+   * The reason this tool selects `greenInvoiceInfo { greenInvoiceId }` and
+   * nothing else: every other field on `GreenInvoiceClient` is fetched from the
+   * external Green Invoice API, one request per client. A future edit that adds
+   * `name` or `emails` "for convenience" would turn one list call into N
+   * third-party calls, and nothing else in the suite would notice.
+   */
+  it('selects only greenInvoiceId beneath greenInvoiceInfo', async () => {
+    let sentInit: RequestInit | undefined;
+    const upstream = clientReturning({ allClients: [] }, init => (sentInit = init));
+    await runTool(upstream, authContext(['b1']), {});
+
+    const { query } = JSON.parse(sentInit!.body as string) as { query: string };
+    const nested = query.match(/greenInvoiceInfo\s*\{([^}]*)\}/);
+    expect(nested).not.toBeNull();
+    expect(nested![1]!.trim().split(/\s+/)).toEqual(['greenInvoiceId']);
+  });
+
+  it('reports no matches without erroring', async () => {
+    const result = await runTool(clientReturning({ allClients: [] }), authContext(['b1']), {});
+    expect(result.isError).toBeUndefined();
+    const structured = result.structuredContent as { clients: ClientRow[]; totalCount: number };
+    expect(structured.clients).toEqual([]);
+    expect(structured.totalCount).toBe(0);
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/lookups.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/lookups.test.ts
@@ -146,9 +146,12 @@ describe('listBusinessesTool', () => {
     clientReturning({
       allBusinesses: {
         nodes: [
-          { id: '3', name: 'Zebra', ownerId: 'o1', isActive: true },
+          { id: '3', name: 'Zebra', ownerId: 'o1', isActive: true, isClient: true },
+          // No `isClient` key at all: stands in for a node that did not resolve
+          // to LtdFinancialEntity, which the row mapper must read as `false`
+          // rather than `undefined`.
           { id: '1', name: 'apple', ownerId: 'o1', isActive: false },
-          { id: '2', name: 'Banana', ownerId: 'o1', isActive: true },
+          { id: '2', name: 'Banana', ownerId: 'o1', isActive: true, isClient: false },
         ],
       },
     });
@@ -185,6 +188,53 @@ describe('listBusinessesTool', () => {
     const result = await runTool(listBusinessesTool, client(), authContext([]), {});
     expect(result.isError).toBe(true);
     expect((result.structuredContent as { code: string }).code).toBe('AUTHORIZATION_ERROR');
+  });
+
+  it('reports isClient per row, defaulting a missing flag to false', async () => {
+    const result = await runTool(listBusinessesTool, client(), authContext(['b1']), {});
+    const rows = (
+      result.structuredContent as { businesses: Array<{ name: string; isClient: boolean }> }
+    ).businesses;
+    expect(rows.map(b => [b.name, b.isClient])).toEqual([
+      ['apple', false],
+      ['Banana', false],
+      ['Zebra', true],
+    ]);
+  });
+
+  // `isClient` is a real upstream predicate, unlike `activeOnly`: it must reach
+  // the server so paging and counts describe the filtered directory. Filtering
+  // the returned page instead would silently answer a narrower question.
+  it('forwards isClient upstream rather than filtering the page locally', async () => {
+    let sentInit: RequestInit | undefined;
+    const capturing = clientReturning(
+      { allBusinesses: { nodes: [{ id: '1', name: 'apple', ownerId: 'o1', isActive: true, isClient: true }] } },
+      init => (sentInit = init),
+    );
+    const result = await runTool(listBusinessesTool, capturing, authContext(['b1']), {
+      isClient: true,
+    });
+
+    const { variables } = JSON.parse(sentInit!.body as string) as {
+      variables: Record<string, unknown>;
+    };
+    expect(variables.isClient).toBe(true);
+    // Everything upstream returned survives — the handler adds no second pass.
+    expect((result.structuredContent as { businesses: unknown[] }).businesses).toHaveLength(1);
+  });
+
+  it('sends isClient as null when omitted, so upstream applies no predicate', async () => {
+    let sentInit: RequestInit | undefined;
+    const capturing = clientReturning(
+      { allBusinesses: { nodes: [] } },
+      init => (sentInit = init),
+    );
+    await runTool(listBusinessesTool, capturing, authContext(['b1']), {});
+
+    const { variables } = JSON.parse(sentInit!.body as string) as {
+      variables: Record<string, unknown>;
+    };
+    expect(variables.isClient).toBeNull();
   });
 
   // `allBusinesses(page:, limit:)` used to be left unset, so the directory was

--- a/packages/mcp-server/src/tools/__tests__/schema-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/schema-contract.test.ts
@@ -122,6 +122,51 @@ describe('generated schema contract', () => {
   it('Transaction exposes eventExchangeRates', () => {
     expect(loadSchema()).toMatch(/^interface Transaction \{[^}]*eventExchangeRates: ExchangeRates/m);
   });
+
+  // Same row-attribution rule as Tag/TaxCategory/Transaction above: without it
+  // `accounter_list_clients` cannot tag rows, and its defense-in-depth owner
+  // filter — which drops any row outside the resolved scope — would drop every
+  // row instead of none, turning a missing field into an empty result.
+  it('Client exposes a non-null ownerId', () => {
+    expect(typeBlock(loadSchema(), 'Client')).toContain('ownerId: UUID!');
+  });
+
+  /**
+   * `accounter_list_businesses` reads `isClient` through an inline fragment on
+   * `LtdFinancialEntity`, because `allBusinesses` is typed to the `Business`
+   * interface which does not carry the field. That selection is only total
+   * because `Business.__resolveType` returns `LtdFinancialEntity` for every
+   * node. Pin the field here; the resolver half is pinned by the directory
+   * tool's own suite, which asserts the `?? false` fallback rather than
+   * assuming the fragment always matches.
+   */
+  it('LtdFinancialEntity exposes a non-null isClient', () => {
+    expect(typeBlock(loadSchema(), 'LtdFinancialEntity')).toContain('isClient: Boolean!');
+  });
+
+  // The flag is only useful as a filter if upstream can apply it before paging.
+  // Filtering an already-sliced page would report "the clients on page 1" while
+  // reading as "the clients".
+  it('allBusinesses accepts an isClient predicate', () => {
+    // Matched up to the return type rather than with a `[^)]*` run: the
+    // argument's own description contains parentheses.
+    const args = loadSchema().match(/allBusinesses\([\s\S]*?\): PaginatedBusinesses/);
+    expect(args?.[0]).toContain('isClient: Boolean');
+  });
+
+  /**
+   * The connector reads a client's Green Invoice id through
+   * `integrations { greenInvoiceInfo { greenInvoiceId } }` and selects nothing
+   * else on that type on purpose: `greenInvoiceId` resolves from a value already
+   * in hand, while its siblings each call the external Green Invoice API. If the
+   * nested shape were flattened upstream the selection would break loudly, which
+   * is the good outcome — this pins it so the reason is on record.
+   */
+  it('ClientIntegrations exposes greenInvoiceInfo', () => {
+    expect(typeBlock(loadSchema(), 'ClientIntegrations')).toContain(
+      'greenInvoiceInfo: GreenInvoiceClient',
+    );
+  });
 });
 
 /**

--- a/packages/mcp-server/src/tools/__tests__/scope-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/scope-contract.test.ts
@@ -5,6 +5,7 @@ import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
 import { listBusinessMembershipsTool } from '../businesses.js';
 import { getChargesTool } from '../charge-details.js';
 import { searchChargesTool } from '../charges.js';
+import { listClientsTool } from '../clients.js';
 import { getContractsTool } from '../contracts.js';
 import { getDocumentsTool } from '../document-details.js';
 import { executeRegisteredTool } from '../execute.js';
@@ -56,6 +57,7 @@ function clientReturning(data: unknown) {
 const BUSINESS_SCOPED_TOOLS = [
   searchChargesTool,
   getLedgerRecordsTool,
+  listClientsTool,
   getContractsTool,
   listSecurityHoldingsTool,
   getSecurityExecutionsTool,
@@ -72,6 +74,7 @@ const BUSINESS_SCOPED_TOOLS = [
 const MULTI_BUSINESS_TOOLS = [
   searchChargesTool,
   getLedgerRecordsTool,
+  listClientsTool,
   getContractsTool,
   listSecurityHoldingsTool,
   getSecurityExecutionsTool,
@@ -188,6 +191,29 @@ describe('echoed effective scope', () => {
       listBusinessesTool,
       { allBusinesses: { nodes: [{ id: 'b1', name: 'c', ownerId: 'b1', isActive: true }] } },
       'businesses',
+    ],
+    [
+      listClientsTool,
+      {
+        allClients: [
+          {
+            id: 'b1',
+            ownerId: 'b1',
+            emails: [],
+            generatedDocumentType: 'PROFORMA',
+            originalBusiness: { id: 'b1', name: 'c' },
+            integrations: {
+              hiveId: null,
+              linearId: null,
+              slackChannelKey: null,
+              notionId: null,
+              workflowyUrl: null,
+              greenInvoiceInfo: null,
+            },
+          },
+        ],
+      },
+      'clients',
     ],
   ] as const;
 

--- a/packages/mcp-server/src/tools/__tests__/scope-forwarding.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/scope-forwarding.test.ts
@@ -88,6 +88,7 @@ function dataFor(query: string): unknown {
   if (query.includes('transactionsByIDs')) return { transactionsByIDs: [] };
   if (query.includes('documentsByIds')) return { documentsByIds: [] };
   if (query.includes('allTags')) return { allTags: [] };
+  if (query.includes('allClients')) return { allClients: [] };
   if (query.includes('securityHoldings')) return { securityHoldings: [] };
   if (query.includes('securityExecutions')) {
     return { securityExecutions: { nodes: [], pageInfo: { totalPages: 0, totalRecords: 0 } } };

--- a/packages/mcp-server/src/tools/__tests__/usage-log.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/usage-log.test.ts
@@ -56,6 +56,7 @@ function dataFor(query: string): unknown {
   if (query.includes('transactionsByIDs')) return { transactionsByIDs: [] };
   if (query.includes('documentsByIds')) return { documentsByIds: [] };
   if (query.includes('allTags')) return { allTags: [] };
+  if (query.includes('allClients')) return { allClients: [] };
   if (query.includes('securityHoldings')) return { securityHoldings: [] };
   if (query.includes('securityExecutions')) {
     return { securityExecutions: { nodes: [], pageInfo: { totalPages: 0, totalRecords: 0 } } };

--- a/packages/mcp-server/src/tools/clients.ts
+++ b/packages/mcp-server/src/tools/clients.ts
@@ -1,0 +1,240 @@
+import { z } from 'zod';
+import type { McpListClientsQuery } from '../gql/index.js';
+import { shapeListResult } from './output.js';
+import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
+import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
+
+/**
+ * Read-only client directory.
+ *
+ * A *client* is a business the caller sells to: one that carries a row in the
+ * `clients` table, which adds emails, a default document type, and a map of
+ * external-system ids. Membership of that table is the only thing that makes a
+ * business a client — there is no separate entity and no "client" charge type.
+ *
+ * Why this is its own tool rather than more fields on `accounter_list_businesses`:
+ * the directory is thousands of rows of which clients are a small slice, and it
+ * is answered against a hard payload cap. Hanging emails and six integration ids
+ * off every row would spend that budget on the majority of rows that have none.
+ * So the directory carries the one-bit `isClient` flag and this tool owns the
+ * detail — which is also where any future client data belongs.
+ *
+ * It closes a real gap besides: `accounter_get_contracts` filters by `clientIds`,
+ * and before this tool nothing enumerated them. The ids are interchangeable —
+ * a client's id *is* its business id.
+ */
+
+export const LIST_CLIENTS_TOOL_NAME = 'accounter_list_clients';
+
+/** Hard caps keeping responses bounded (spec §9.1, §9.3). */
+export const MAX_CLIENTS = 300;
+export const DEFAULT_CLIENTS = 150;
+export const MAX_CLIENT_FILTER_IDS = 50;
+
+const listClientsInput = z.object({
+  memberBusinessIds: memberBusinessIdsInput,
+  nameContains: z
+    .string()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("Case-insensitive substring to filter by the client business's name."),
+  // Named for the axis it filters, not for what it holds: `scope-contract.test.ts`
+  // rejects a top-level `businessIds`/`businessId` on any scoped tool, because
+  // that name sits one letter from the *counterparty* filters on other tools and
+  // has already caused one scoping bug. These are client ids that happen to also
+  // be business ids.
+  clientBusinessIds: z
+    .array(z.string().min(1))
+    .max(MAX_CLIENT_FILTER_IDS)
+    .optional()
+    .describe(
+      'Only these clients, identified by business id — the `id` of an `isClient: true` row from ' +
+        '`accounter_list_businesses`, or a `client.businessId` from `accounter_get_contracts`.',
+    ),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(MAX_CLIENTS)
+    .optional()
+    .default(DEFAULT_CLIENTS)
+    .describe(`Maximum clients to return (capped at ${MAX_CLIENTS}).`),
+});
+
+type ListClientsInput = z.infer<typeof listClientsInput>;
+
+// `originalBusiness` is typed `LtdFinancialEntity!` upstream, so it needs no
+// inline fragment — unlike `accounter_list_businesses`, whose rows come back as
+// the `Business` interface.
+//
+// `greenInvoiceInfo` is selected down to `greenInvoiceId` and nothing else, and
+// that restraint is load-bearing rather than tidiness: that single field
+// resolves as an identity function over a value already in hand, while every
+// other field on `GreenInvoiceClient` (`name`, `emails`, `country`, `phone`,
+// `taxId`, …) is fetched from the **external Green Invoice API**, and
+// `businessId` costs a database round trip. Adding any one of them would turn a
+// single list call into one third-party HTTP request per client.
+const LIST_CLIENTS_QUERY = /* GraphQL */ `
+  query McpListClients {
+    allClients {
+      id
+      ownerId
+      emails
+      generatedDocumentType
+      originalBusiness {
+        id
+        name
+      }
+      integrations {
+        hiveId
+        linearId
+        slackChannelKey
+        notionId
+        workflowyUrl
+        greenInvoiceInfo {
+          greenInvoiceId
+        }
+      }
+    }
+  }
+`;
+
+type RawClient = McpListClientsQuery['allClients'][number];
+
+/**
+ * External-system ids configured for a client.
+ *
+ * Every key is optional and an unconfigured one is **omitted entirely** rather
+ * than emitted as `null` — there is no null-vs-absent distinction to preserve
+ * here (unlike the `@include`-gated fields on the charge tools), and a client
+ * with a single Slack channel should cost one key rather than six. That matters
+ * against the payload guard: a fully-configured row runs ~280 bytes.
+ */
+export interface NormalizedClientIntegrations {
+  greenInvoiceId?: string;
+  hiveId?: string;
+  linearId?: string;
+  slackChannelKey?: string;
+  notionId?: string;
+  workflowyUrl?: string;
+}
+
+export interface NormalizedClient {
+  /**
+   * The client's id, which *is* its business id — the same value as an
+   * `accounter_list_businesses` row's `id` and an `accounter_get_contracts`
+   * `clientIds` entry. Emitted once under this name rather than as both `id`
+   * and `businessId`, so nothing suggests there are two identifiers to track.
+   */
+  businessId: string;
+  name: string;
+  /** Owning (admin) business, so results spanning owners can be grouped. */
+  ownerId: string;
+  emails: string[];
+  generatedDocumentType: string;
+  integrations: NormalizedClientIntegrations;
+}
+
+function normalizeIntegrations(
+  integrations: RawClient['integrations'],
+): NormalizedClientIntegrations {
+  const normalized: NormalizedClientIntegrations = {};
+  const greenInvoiceId = integrations.greenInvoiceInfo?.greenInvoiceId;
+  if (greenInvoiceId) normalized.greenInvoiceId = greenInvoiceId;
+  if (integrations.hiveId) normalized.hiveId = integrations.hiveId;
+  if (integrations.linearId) normalized.linearId = integrations.linearId;
+  if (integrations.slackChannelKey) normalized.slackChannelKey = integrations.slackChannelKey;
+  if (integrations.notionId) normalized.notionId = integrations.notionId;
+  if (integrations.workflowyUrl) normalized.workflowyUrl = integrations.workflowyUrl;
+  return normalized;
+}
+
+function normalizeClient(client: RawClient): NormalizedClient {
+  return {
+    businessId: client.originalBusiness.id,
+    name: client.originalBusiness.name,
+    ownerId: client.ownerId,
+    emails: [...client.emails],
+    generatedDocumentType: client.generatedDocumentType,
+    integrations: normalizeIntegrations(client.integrations),
+  };
+}
+
+// Fixed-locale collator so ordering is deterministic across hosts/runtimes
+// rather than depending on the ambient default locale (mirrors `lookups.ts`).
+// Deliberately re-stated here instead of imported: the two tools sort different
+// row shapes, and coupling them would make a change to either one's ordering an
+// unannounced change to the other's.
+const NAME_COLLATOR = new Intl.Collator('en', { sensitivity: 'base' });
+
+/** Stable order: by name (case-insensitive, fixed-locale), tie-broken by id. */
+function byNameThenBusinessId(a: NormalizedClient, b: NormalizedClient): number {
+  return (
+    NAME_COLLATOR.compare(a.name, b.name) ||
+    (a.businessId < b.businessId ? -1 : a.businessId > b.businessId ? 1 : 0)
+  );
+}
+
+async function handler(
+  input: ListClientsInput,
+  context: ToolExecutionContext,
+): Promise<ToolResult> {
+  const data = await context.client.query<McpListClientsQuery>(
+    { query: LIST_CLIENTS_QUERY },
+    context.upstream,
+  );
+
+  // Filtering happens here rather than upstream because `allClients` takes no
+  // arguments, and giving it some would buy nothing: a client is a billing
+  // relationship, so the whole set is tens to low hundreds of rows and arrives
+  // in one memoized query. (Revisit past ~500 clients — at which point the
+  // payload guard bites before the query does.)
+  const requestedIds = input.clientBusinessIds?.length ? new Set(input.clientBusinessIds) : null;
+  const needle = input.nameContains?.toLowerCase();
+  // Defense-in-depth owner filter on top of RLS, matching `get_documents`. This
+  // is a genuine second barrier rather than a restatement of the upstream one:
+  // it would catch an upstream RLS regression, which an upstream filter argument
+  // — running in the same server on the same connection — could not.
+  const scopeIds = new Set(context.readScope.memberBusinessIds);
+
+  const clients = (data.allClients ?? [])
+    .map(normalizeClient)
+    .filter(client => scopeIds.has(client.ownerId))
+    .filter(client => requestedIds === null || requestedIds.has(client.businessId))
+    .filter(client => needle === undefined || client.name.toLowerCase().includes(needle))
+    .sort(byNameThenBusinessId);
+
+  // `total` counts every match, so `truncated` and the continuation hint
+  // describe the cap rather than the page.
+  const total = clients.length;
+
+  return shapeListResult({
+    items: clients.slice(0, input.limit),
+    itemsKey: 'clients',
+    total,
+    extra: { scope: { memberBusinessIds: context.readScope.memberBusinessIds } },
+    summarize: (shown, count, truncated) =>
+      count === 0
+        ? 'No clients matched the given filters.'
+        : `Found ${count} ${count === 1 ? 'client' : 'clients'}${
+            truncated ? `; showing ${shown}` : ''
+          }.`,
+  });
+}
+
+export const listClientsTool: ToolDefinition<typeof listClientsInput> = {
+  name: LIST_CLIENTS_TOOL_NAME,
+  description:
+    'List the businesses you bill as clients, with their contact emails and the external-system ids ' +
+    'configured for each (Green Invoice, Hive, Linear, Slack, Notion, Workflowy). A client row is ' +
+    "what makes a business a client; every row's `businessId` is the same id `accounter_list_businesses` " +
+    'returns and the value `accounter_get_contracts` takes as `clientIds`, so this is the place to ' +
+    'resolve a client by name before asking about its contracts. `generatedDocumentType` is the ' +
+    "client-level default only — what actually gets issued is the contract's own `documentType`. " +
+    'Read-only. ' +
+    SCOPE_DESCRIPTION_SUFFIX,
+  inputSchema: listClientsInput,
+  policy: { requiresBusinessScope: true, dataClassification: 'business' },
+  handler,
+};

--- a/packages/mcp-server/src/tools/lookups.ts
+++ b/packages/mcp-server/src/tools/lookups.ts
@@ -193,6 +193,16 @@ const listBusinessesInput = z.object({
   memberBusinessIds: memberBusinessIdsInput,
   nameContains,
   activeOnly: z.boolean().optional().default(false).describe('Return only active businesses.'),
+  isClient: z
+    .boolean()
+    .optional()
+    .describe(
+      'Return only businesses that are clients (true), or only those that are not (false). Omit ' +
+        'for both. Unlike `activeOnly`, this is a real upstream predicate applied before paging, ' +
+        'so `pagination` and `totalCount` describe the filtered directory and no page comes back ' +
+        'short on account of it. To enumerate clients *with* their emails and integrations, use ' +
+        '`accounter_list_clients` instead of paging this directory.',
+    ),
   limit,
   // `allBusinesses(page:)` is the third upstream argument, and pinning it to the
   // first page made the directory unwalkable past `limit` rows with no way to
@@ -226,13 +236,21 @@ type ListBusinessesInput = z.infer<typeof listBusinessesInput>;
 // dropped rows from this one. That is the intended reading: the counts describe
 // what upstream holds, `returnedCount` describes what came back.
 const LIST_BUSINESSES_QUERY = /* GraphQL */ `
-  query McpListBusinesses($name: String, $page: Int, $limit: Int) {
-    allBusinesses(name: $name, page: $page, limit: $limit) {
+  query McpListBusinesses($name: String, $page: Int, $limit: Int, $isClient: Boolean) {
+    allBusinesses(name: $name, page: $page, limit: $limit, isClient: $isClient) {
       nodes {
         id
         name
         ownerId
         isActive
+        # isClient hangs off LtdFinancialEntity, not off the Business interface
+        # that allBusinesses is typed to, so it needs a fragment. The branch is a
+        # formality rather than a real choice: Business.__resolveType returns
+        # 'LtdFinancialEntity' unconditionally, so this matches every node.
+        # schema-contract.test.ts pins both halves of that assumption.
+        ... on LtdFinancialEntity {
+          isClient
+        }
       }
       pageInfo {
         totalPages
@@ -243,6 +261,23 @@ const LIST_BUSINESSES_QUERY = /* GraphQL */ `
     }
   }
 `;
+
+/** One row of the upstream business directory, as the generated query types it. */
+type RawBusinessNode = NonNullable<McpListBusinessesQuery['allBusinesses']>['nodes'][number];
+
+/**
+ * Read `isClient` off a directory row.
+ *
+ * The generated node type is a union — `isClient` is selected through an inline
+ * fragment, so only the `LtdFinancialEntity` arm carries it. Every node takes
+ * that arm at runtime (see the query comment), but the compiler cannot know
+ * that, so narrow structurally. The `false` fallback is unreachable in practice
+ * and deliberately not an error: a business that somehow resolved to another
+ * type is not a client.
+ */
+function rawBusinessIsClient(business: RawBusinessNode): boolean {
+  return 'isClient' in business ? business.isClient : false;
+}
 
 async function listBusinessesHandler(
   input: ListBusinessesInput,
@@ -256,6 +291,9 @@ async function listBusinessesHandler(
         // Upstream slices `[page * limit, (page + 1) * limit]`, so it is 0-based.
         page: input.page - 1,
         limit: input.limit,
+        // Null rather than undefined: an omitted `isClient` must reach upstream
+        // as "no predicate", and `null` is what the resolver tests for.
+        isClient: input.isClient ?? null,
       },
     },
     context.upstream,
@@ -271,6 +309,7 @@ async function listBusinessesHandler(
     name: business.name,
     ownerId: business.ownerId,
     isActive: business.isActive,
+    isClient: rawBusinessIsClient(business),
   }));
 
   // `totalRecords` counts upstream's whole (name-filtered) directory rather than
@@ -318,7 +357,7 @@ const DIRECTORY_SCOPE_DESCRIPTION_SUFFIX =
 export const listBusinessesTool: ToolDefinition<typeof listBusinessesInput> = {
   name: LIST_BUSINESSES_TOOL_NAME,
   description:
-    'List the full business directory (id, name, ownerId, active flag) — every business visible to you, not just the ones you are a member of — optionally filtered by name or active status, with `limit`/`page` pagination over the name-ordered directory. For your own memberships and roles use `accounter_list_business_memberships`. Read-only. ' +
+    'List the full business directory (id, name, ownerId, active flag, and whether the business is a client) — every business visible to you, not just the ones you are a member of — optionally filtered by name, active status, or client status, with `limit`/`page` pagination over the name-ordered directory. For your own memberships and roles use `accounter_list_business_memberships`; for client emails and integrations use `accounter_list_clients`, whose ids are these same business ids. Read-only. ' +
     DIRECTORY_SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: listBusinessesInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/registry-instance.ts
+++ b/packages/mcp-server/src/tools/registry-instance.ts
@@ -1,6 +1,7 @@
 import { listBusinessMembershipsTool } from './businesses.js';
 import { getChargesTool } from './charge-details.js';
 import { searchChargesTool } from './charges.js';
+import { listClientsTool } from './clients.js';
 import { getContractsTool } from './contracts.js';
 import { getDocumentsTool } from './document-details.js';
 import { uploadDocumentsTool } from './documents-write.js';
@@ -41,6 +42,11 @@ toolRegistry.register(getDocumentsTool);
 // Ledger records are the accounting layer under a charge, so they follow the
 // charge/transaction/document drill-down rather than sitting with the lookups.
 toolRegistry.register(getLedgerRecordsTool);
+// Clients immediately before contracts, for the same reason securities'
+// portfolio precedes its executions: a contract is filtered by `clientIds`, and
+// this is the only tool that enumerates them — so discovery is listed ahead of
+// the tool that consumes it.
+toolRegistry.register(listClientsTool);
 toolRegistry.register(getContractsTool);
 // Securities are their own drill-down, not reference data: the portfolio is the
 // entry point and the execution history is what it drills into, so the pair sits

--- a/packages/mcp-server/src/tools/terminology-data.ts
+++ b/packages/mcp-server/src/tools/terminology-data.ts
@@ -16,7 +16,7 @@
  * result or an input schema and needs to know what it means and what it is
  * *not*. Prefer stating the trap over restating the field name.
  *
- * Budget: at 67 entries the index is ~11 KB and the full glossary ~40 KB against
+ * Budget: at 69 entries the index is ~11 KB and the full glossary ~41 KB against
  * the 60 KB `MAX_TOOL_RESULT_BYTES` guard, so there is room for roughly 30 more
  * before a request for every topic starts truncating. `terminology.test.ts`
  * asserts the whole glossary still fits in one response, so overshooting fails
@@ -645,8 +645,43 @@ const ENTITY_ENTRIES: readonly GlossaryEntry[] = [
     detail:
       'One table holds them all, which is why the full business directory is much larger than the handful you are a member of. Carries the tax identifiers and behaviour flags that drive validation: government/VAT id, country (compared against your locality to decide whether VAT applies at all), VAT-exempt-dealer status, whether a receipt alone suffices, whether documents are required. Businesses also carry matching phrases used to guess a counterparty from a bank description.',
     aliases: ['businesses', 'Business', 'LtdFinancialEntity'],
-    seeAlso: ['financial-entity', 'owner', 'counterparty', 'member-business-id'],
-    tools: ['accounter_list_businesses', 'accounter_list_business_memberships'],
+    seeAlso: ['financial-entity', 'owner', 'counterparty', 'member-business-id', 'client'],
+    tools: [
+      'accounter_list_businesses',
+      'accounter_list_business_memberships',
+      'accounter_list_clients',
+    ],
+  },
+  {
+    term: 'client',
+    topic: 'entity',
+    summary:
+      'A business you sell to — one that carries a clients row, which adds emails and external-system ids.',
+    detail:
+      "The presence of a clients row is what makes a business a client — the same shape as businesses_admin or businesses_securities, and the reason `isClient` is a flag on a business rather than a separate entity. A client's id IS its business id: the `id` of an `isClient: true` row from the directory, this tool's `businessId`, and the `clientIds` filter on contracts are all the same value, so no translation is ever needed between them. Two traps. First, scope: the business directory deliberately reaches wider than your own businesses, but the client list does not — it is strictly owner-scoped, so a client absent from it is out of scope rather than nonexistent. Second, direction: client means the sell side, and nothing more. There is no client charge type, and `isClient` says nothing about the direction of any particular charge — a client can also invoice you.",
+    aliases: ['clients', 'Client', 'clientInfo', 'isClient', 'clientIds', 'clientBusinessIds'],
+    seeAlso: ['business', 'counterparty', 'owner', 'client-integrations'],
+    tools: ['accounter_list_clients', 'accounter_get_contracts', 'accounter_list_businesses'],
+  },
+  {
+    term: 'client-integrations',
+    topic: 'entity',
+    summary:
+      "A client's ids in external systems — Green Invoice, Hive, Linear, Slack, Notion, Workflowy. Not accounting data.",
+    detail:
+      "An open-ended map stored per client, holding this client's identifier in some other tool. Only greenInvoiceId is acted on by the system itself — it is what document issuing and invoice sync address the client by; the rest are cross-links for people, and nothing reads them. Absent means not configured: an unset integration is omitted from the row rather than returned as null, so a missing key is a statement about setup, not about the client. Never read one of these as a business id or a charge id — they are identifiers in someone else's namespace and are meaningless to every other tool here.",
+    aliases: [
+      'integrations',
+      'ClientIntegrations',
+      'greenInvoiceId',
+      'hiveId',
+      'linearId',
+      'slackChannelKey',
+      'notionId',
+      'workflowyUrl',
+    ],
+    seeAlso: ['client', 'business'],
+    tools: ['accounter_list_clients'],
   },
   {
     term: 'tax-category',

--- a/packages/server/src/modules/documents/helpers/issue-document.helper.ts
+++ b/packages/server/src/modules/documents/helpers/issue-document.helper.ts
@@ -26,7 +26,7 @@ import type { IGetContractsByIdsResult } from '../../contracts/types.js';
 import { FinancialAccountsProvider } from '../../financial-accounts/providers/financial-accounts.provider.js';
 import { FinancialBankAccountsProvider } from '../../financial-accounts/providers/financial-bank-accounts.provider.js';
 import type { IGetFinancialBankAccountsByIdsResult } from '../../financial-accounts/types.js';
-import { validateClientIntegrations } from '../../financial-entities/helpers/clients.helper.js';
+import { parseStoredClientIntegrations } from '../../financial-entities/helpers/clients.helper.js';
 import { BusinessesProvider } from '../../financial-entities/providers/businesses.provider.js';
 import { ClientsProvider } from '../../financial-entities/providers/clients.provider.js';
 import {
@@ -314,7 +314,7 @@ export const convertContractToDraft = async (
     throw new GraphQLError(`Client not found for business ID="${contract.client_id}"`);
   }
 
-  const greenInvoiceId = validateClientIntegrations(client.integrations)?.greenInvoiceId;
+  const greenInvoiceId = parseStoredClientIntegrations(client.integrations)?.greenInvoiceId;
 
   if (!greenInvoiceId) {
     throw new GraphQLError(`Green invoice match not found for business ID="${contract.client_id}"`);

--- a/packages/server/src/modules/documents/resolvers/documents-issuing.resolver.ts
+++ b/packages/server/src/modules/documents/resolvers/documents-issuing.resolver.ts
@@ -18,7 +18,7 @@ import { ChargesProvider } from '../../charges/providers/charges.provider.js';
 import { buildContractDocumentDescription } from '../../contracts/helpers/contracts.helper.js';
 import { ContractsProvider } from '../../contracts/providers/contracts.provider.js';
 import { IGetContractsByIdsResult } from '../../contracts/types.js';
-import { validateClientIntegrations } from '../../financial-entities/helpers/clients.helper.js';
+import { parseStoredClientIntegrations } from '../../financial-entities/helpers/clients.helper.js';
 import { BusinessesProvider } from '../../financial-entities/providers/businesses.provider.js';
 import { ClientsProvider } from '../../financial-entities/providers/clients.provider.js';
 import {
@@ -131,7 +131,7 @@ export const documentsIssuingResolvers: DocumentsModule.Resolvers = {
         ),
       ).then(res => res.filter(Boolean) as _DOLLAR_defs_Document[]);
 
-      const greenInvoiceClientId = validateClientIntegrations(
+      const greenInvoiceClientId = parseStoredClientIntegrations(
         client?.integrations ?? {},
       ).greenInvoiceId;
       if (!greenInvoiceClientId) {
@@ -296,7 +296,7 @@ export const documentsIssuingResolvers: DocumentsModule.Resolvers = {
 
       const paymentPromise = getPaymentsFromTransactions(injector, transactions ?? []);
 
-      const greenInvoiceClientId = validateClientIntegrations(
+      const greenInvoiceClientId = parseStoredClientIntegrations(
         client?.integrations ?? {},
       ).greenInvoiceId;
       if (!greenInvoiceClientId) {
@@ -432,7 +432,7 @@ export const documentsIssuingResolvers: DocumentsModule.Resolvers = {
         throw new GraphQLError(`Client not found for business ID="${contract.client_id}"`);
       }
 
-      const greenInvoiceId = validateClientIntegrations(client.integrations)?.greenInvoiceId;
+      const greenInvoiceId = parseStoredClientIntegrations(client.integrations)?.greenInvoiceId;
 
       if (!greenInvoiceId) {
         throw new GraphQLError(

--- a/packages/server/src/modules/financial-entities/helpers/__tests__/clients.helper.test.ts
+++ b/packages/server/src/modules/financial-entities/helpers/__tests__/clients.helper.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ClientIntegrationsSchema,
+  parseStoredClientIntegrations,
+} from '../clients.helper.js';
+
+/**
+ * These are read-path regression guards, not schema tests.
+ *
+ * The stored parser used to be the strict one, which threw a `GraphQLError` on
+ * anything it did not recognize. Because the `ClientIntegrations` field
+ * resolvers run once per client, a single unreadable row failed the whole
+ * `allClients` query — and the MCP connector discards partial data whenever a
+ * response carries an `errors` entry, so a list call came back empty rather than
+ * short. Every case below is a value that must degrade to "not configured".
+ */
+describe('parseStoredClientIntegrations', () => {
+  const VALID = {
+    greenInvoiceId: '3f2504e0-4f89-41d3-9a0c-0305e82c3301',
+    hiveId: 'hive-1',
+    linearId: 'lin-1',
+    slackChannelKey: 'C123',
+    notionId: 'notion-1',
+    workflowyUrl: 'https://workflowy.com/#/abc',
+  };
+
+  it('round-trips a fully populated value', () => {
+    expect(parseStoredClientIntegrations(VALID)).toEqual(VALID);
+  });
+
+  // The column is nullable, and `updateClient`'s COALESCE can land NULL.
+  it.each([null, undefined])('treats %s as no integrations', input => {
+    expect(parseStoredClientIntegrations(input)).toEqual({});
+  });
+
+  it('accepts an empty object', () => {
+    expect(parseStoredClientIntegrations({})).toEqual({});
+  });
+
+  // Written by an older deploy, or left behind by a removed field.
+  it('strips unknown keys instead of rejecting the record', () => {
+    const parsed = parseStoredClientIntegrations({ hiveId: 'hive-1', legacyKey: 'x' });
+    expect(parsed).toEqual({ hiveId: 'hive-1' });
+  });
+
+  // The point of the per-field `.catch(null)`: one bad value must not cost the
+  // siblings that parsed fine.
+  it('degrades a wrong-typed field to null and keeps the rest', () => {
+    const parsed = parseStoredClientIntegrations({ greenInvoiceId: 'not-a-uuid', hiveId: 'hive-1' });
+    expect(parsed.greenInvoiceId).toBeNull();
+    expect(parsed.hiveId).toBe('hive-1');
+  });
+
+  it('returns no integrations when the stored value is not an object at all', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(parseStoredClientIntegrations('nonsense')).toEqual({});
+      expect(parseStoredClientIntegrations(42)).toEqual({});
+      expect(consoleError).toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('never throws, whatever it is handed', () => {
+    for (const input of [null, undefined, '', 0, [], [1, 2], { a: 1 }, Symbol('x')]) {
+      expect(() => parseStoredClientIntegrations(input)).not.toThrow();
+    }
+  });
+});
+
+/**
+ * The strict schema stays available for a write path that wants to reject an
+ * unrecognized key outright — that direction has the opposite failure cost, so
+ * the two behaviours must not drift back together.
+ */
+describe('ClientIntegrationsSchema', () => {
+  it('rejects an unknown key', () => {
+    expect(ClientIntegrationsSchema.safeParse({ hiveId: 'h', nope: 1 }).success).toBe(false);
+  });
+
+  it('rejects null', () => {
+    expect(ClientIntegrationsSchema.safeParse(null).success).toBe(false);
+  });
+});

--- a/packages/server/src/modules/financial-entities/helpers/clients.helper.ts
+++ b/packages/server/src/modules/financial-entities/helpers/clients.helper.ts
@@ -1,7 +1,12 @@
-import { GraphQLError } from 'graphql';
 import { z } from 'zod';
 
-// Zod schema matching the GraphQL `ClientIntegrations` type
+/**
+ * Zod schema matching the GraphQL `ClientIntegrations` type.
+ *
+ * Strict, and exported for a write path that wants to reject an unrecognized
+ * key outright. Do NOT reach for it to read a value that is already stored —
+ * see `parseStoredClientIntegrations` for why that direction must not throw.
+ */
 export const ClientIntegrationsSchema = z
   .object({
     greenInvoiceId: z.uuid().optional().nullable(),
@@ -15,14 +20,47 @@ export const ClientIntegrationsSchema = z
 
 export type ClientIntegrations = z.infer<typeof ClientIntegrationsSchema>;
 
-export function validateClientIntegrations(input: unknown): ClientIntegrations {
-  try {
-    const { data, success, error } = ClientIntegrationsSchema.safeParse(input);
-    if (!success) {
-      throw new Error(`Parsing error: ${error}`);
-    }
-    return data;
-  } catch (error) {
-    throw new GraphQLError(`Failed to validate client integrations: ${error}`);
+// Per-field `.catch(null)` so one bad value degrades that field alone instead of
+// the whole record, and unknown keys are stripped rather than rejected (a plain
+// `z.object` strips by default).
+const storedClientIntegrationsSchema = z.object({
+  greenInvoiceId: z.uuid().nullish().catch(null),
+  hiveId: z.string().nullish().catch(null),
+  linearId: z.string().nullish().catch(null),
+  slackChannelKey: z.string().nullish().catch(null),
+  notionId: z.string().nullish().catch(null),
+  workflowyUrl: z.string().nullish().catch(null),
+});
+
+/**
+ * Parse an `integrations` jsonb value that is already in the database.
+ *
+ * Deliberately lenient, because reading and writing have opposite failure costs.
+ * Rejecting a bad *payload* on a write is the point. Throwing on a bad *stored*
+ * value takes down far more than the offending row: field resolvers run this
+ * once per client, and the MCP connector discards partial data whenever a
+ * response carries any `errors` entry — so a single malformed row would empty an
+ * entire `allClients` result instead of degrading one record.
+ *
+ * Three ways a stored value can be bad, all of which must survive:
+ * - `NULL` — the column is nullable, and `updateClient`'s COALESCE can land NULL.
+ * - unknown keys — written by an older deploy, or left behind by a removed field.
+ * - a wrong-typed value — hand-edited or migrated data.
+ *
+ * Every caller already guards the field it wants (`?? null`, or a domain error
+ * on a missing `greenInvoiceId`), so an unreadable value surfaces as "not
+ * configured" rather than as a failed request.
+ */
+export function parseStoredClientIntegrations(input: unknown): ClientIntegrations {
+  if (input == null) {
+    return {};
   }
+  const { data, success, error } = storedClientIntegrationsSchema.safeParse(input);
+  if (success) {
+    return data;
+  }
+  // Reached only when the value is not an object at all — the per-field
+  // `.catch(null)` above absorbs everything else.
+  console.error(`Ignoring unparsable stored client integrations: ${error}`);
+  return {};
 }

--- a/packages/server/src/modules/financial-entities/providers/__tests__/clients.provider.test.ts
+++ b/packages/server/src/modules/financial-entities/providers/__tests__/clients.provider.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AdminContextProvider } from '../../../admin-context/providers/admin-context.provider.js';
+import type { TenantAwareDBClient } from '../../../app-providers/tenant-db-client.js';
+import { ClientsProvider } from '../clients.provider.js';
+
+/**
+ * `generatedDocumentType` was accepted by both mutations and written by neither:
+ * the INSERT omitted `document_type` entirely — leaning on the column's
+ * 'PROFORMA' default — and the UPDATE had no clause for it. The field therefore
+ * reported success while silently discarding the caller's choice, and no test
+ * would have caught it, because the resolvers happily built params the SQL never
+ * read. These pin the value all the way to the statement.
+ */
+function createProvider() {
+  const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+  const db = { query } as unknown as TenantAwareDBClient;
+  const adminContextProvider = {
+    getVerifiedAdminContext: vi.fn().mockResolvedValue({ ownerId: 'owner-a' }),
+  } as unknown as AdminContextProvider;
+
+  return { provider: new ClientsProvider(db, adminContextProvider), query };
+}
+
+describe('ClientsProvider document_type persistence', () => {
+  it('writes document_type on insert', async () => {
+    const { provider, query } = createProvider();
+
+    await provider.insertClient({
+      businessId: 'business-a',
+      emails: ['a@example.com'],
+      integrations: {},
+      generatedDocumentType: 'INVOICE',
+    });
+
+    const [queryText, values] = query.mock.calls[0];
+    expect(queryText).toContain('document_type');
+    expect(values).toContain('INVOICE');
+  });
+
+  it('updates document_type, leaving it untouched when not supplied', async () => {
+    const { provider, query } = createProvider();
+
+    await provider.updateClient({
+      businessId: 'business-a',
+      generatedDocumentType: 'RECEIPT',
+    });
+
+    const [queryText, values] = query.mock.calls[0];
+    // COALESCE, not a bare assignment: an omitted field must keep the stored
+    // value rather than null it out.
+    expect(queryText).toContain('document_type = COALESCE');
+    expect(values).toContain('RECEIPT');
+  });
+
+  it('leaves document_type null in the params when the caller omits it', async () => {
+    const { provider, query } = createProvider();
+
+    await provider.updateClient({ businessId: 'business-a', emails: ['a@example.com'] });
+
+    const [, values] = query.mock.calls[0];
+    // The COALESCE above turns this null into "keep what is stored".
+    expect(values).not.toContain('RECEIPT');
+  });
+});

--- a/packages/server/src/modules/financial-entities/providers/clients.provider.ts
+++ b/packages/server/src/modules/financial-entities/providers/clients.provider.ts
@@ -4,7 +4,7 @@ import { sql } from '@pgtyped/runtime';
 import { reassureOwnerIdExists } from '../../../shared/helpers/index.js';
 import { AdminContextProvider } from '../../admin-context/providers/admin-context.provider.js';
 import { TenantAwareDBClient } from '../../app-providers/tenant-db-client.js';
-import { validateClientIntegrations } from '../helpers/clients.helper.js';
+import { parseStoredClientIntegrations } from '../helpers/clients.helper.js';
 import type {
   IDeleteClientQuery,
   IGetAllClientsQuery,
@@ -51,6 +51,10 @@ const updateClient = sql<IUpdateClientQuery>`
     $integrations,
     integrations,
     NULL
+  ),
+  document_type = COALESCE(
+    $generatedDocumentType,
+    document_type
   )
   WHERE
     business_id = $businessId
@@ -64,8 +68,8 @@ const deleteClient = sql<IDeleteClientQuery>`
 `;
 
 const insertClient = sql<IInsertClientQuery>`
-    INSERT INTO accounter_schema.clients (business_id, emails, integrations, owner_id)
-    VALUES ($businessId, $emails, $integrations, $ownerId)
+    INSERT INTO accounter_schema.clients (business_id, emails, integrations, document_type, owner_id)
+    VALUES ($businessId, $emails, $integrations, $generatedDocumentType, $ownerId)
     RETURNING *;`;
 
 @Injectable({
@@ -86,16 +90,14 @@ export class ClientsProvider {
     this.allClientsPython = getAllClients.run(undefined, this.db).then(clients => {
       clients.map(client => {
         this.getClientByIdLoader.prime(client.business_id, client);
-        try {
-          const { greenInvoiceId } = validateClientIntegrations(client.integrations ?? {});
-          if (greenInvoiceId) {
-            this.getClientByGreenInvoiceIdLoader.prime(greenInvoiceId, {
-              ...client,
-              green_invoice_business_id: greenInvoiceId,
-            });
-          }
-        } catch {
-          // swallow errors
+        // `parseStoredClientIntegrations` never throws, so a client whose stored
+        // integrations are unreadable is simply not primed on this loader.
+        const { greenInvoiceId } = parseStoredClientIntegrations(client.integrations);
+        if (greenInvoiceId) {
+          this.getClientByGreenInvoiceIdLoader.prime(greenInvoiceId, {
+            ...client,
+            green_invoice_business_id: greenInvoiceId,
+          });
         }
       });
       return clients;

--- a/packages/server/src/modules/financial-entities/resolvers/businesses.resolver.ts
+++ b/packages/server/src/modules/financial-entities/resolvers/businesses.resolver.ts
@@ -15,6 +15,7 @@ import { updateSingleBusiness } from '../helpers/update-business.helper.js';
 import { filterBusinessByName } from '../helpers/utils.helper.js';
 import { BusinessesOperationProvider } from '../providers/businesses-operation.provider.js';
 import { BusinessesProvider } from '../providers/businesses.provider.js';
+import { ClientsProvider } from '../providers/clients.provider.js';
 import { FinancialEntitiesProvider } from '../providers/financial-entities.provider.js';
 import { TaxCategoriesProvider } from '../providers/tax-categories.provider.js';
 import type {
@@ -43,11 +44,28 @@ export const businessesResolvers: FinancialEntitiesModule.Resolvers &
 
       return businesses as IGetBusinessesByIdsResult[];
     },
-    allBusinesses: async (_, { page, limit, name }, { injector }) => {
+    allBusinesses: async (_, { page, limit, name, isClient }, { injector }) => {
       const businesses = await injector.get(BusinessesProvider).getAllBusinesses();
 
-      const filteredBusinesses = businesses.filter(business =>
-        filterBusinessByName(business, name),
+      // Resolved once for the whole call, not per row: `getAllClients()` is
+      // operation-memoized and RLS-scoped, so this costs at most one extra query.
+      // Applying the predicate *here* — ahead of the count and the slice — is the
+      // entire point of accepting it as an argument: `pageInfo` then describes the
+      // filtered directory and every page comes back full. A caller filtering an
+      // already-sliced page could do neither.
+      const clientBusinessIds =
+        isClient == null
+          ? null
+          : new Set(
+              (await injector.get(ClientsProvider).getAllClients()).map(
+                client => client.business_id,
+              ),
+            );
+
+      const filteredBusinesses = businesses.filter(
+        business =>
+          filterBusinessByName(business, name) &&
+          (clientBusinessIds === null || clientBusinessIds.has(business.id) === isClient),
       );
 
       page ??= 0;

--- a/packages/server/src/modules/financial-entities/resolvers/clients.resolvers.ts
+++ b/packages/server/src/modules/financial-entities/resolvers/clients.resolvers.ts
@@ -1,10 +1,11 @@
 import { GraphQLError } from 'graphql';
 import type { ClientIntegrationsInput, Resolvers } from '../../../__generated__/types.js';
+import { normalizeDocumentType } from '../../documents/resolvers/common.js';
 import {
   addGreenInvoiceClient,
   updateGreenInvoiceClient,
 } from '../../green-invoice/helpers/green-invoice-clients.helper.js';
-import { validateClientIntegrations } from '../helpers/clients.helper.js';
+import { parseStoredClientIntegrations } from '../helpers/clients.helper.js';
 import { BusinessesProvider } from '../providers/businesses.provider.js';
 import { ClientsProvider } from '../providers/clients.provider.js';
 import type {
@@ -54,7 +55,7 @@ export const clientsResolvers: FinancialEntitiesModule.Resolvers &
         if (!currentClient) {
           throw new GraphQLError(`Client with ID="${businessId}" not found`);
         }
-        const currentIntegrations = validateClientIntegrations(currentClient.integrations);
+        const currentIntegrations = parseStoredClientIntegrations(currentClient.integrations);
         updatedIntegrations = {
           ...currentIntegrations,
           ...updatedIntegrations,
@@ -64,6 +65,7 @@ export const clientsResolvers: FinancialEntitiesModule.Resolvers &
         businessId,
         emails: fields.emails ? [...fields.emails] : undefined,
         newBusinessId: fields.newBusinessId,
+        generatedDocumentType: fields.generatedDocumentType,
         integrations: updatedIntegrations,
       };
       try {
@@ -95,6 +97,7 @@ export const clientsResolvers: FinancialEntitiesModule.Resolvers &
         const newClient: IInsertClientParams = {
           businessId: fields.businessId,
           emails: fields.emails ? [...fields.emails] : [],
+          generatedDocumentType: fields.generatedDocumentType,
           integrations: fields.integrations ?? {},
         };
         const [insertClient] = await injector.get(ClientsProvider).insertClient(newClient);
@@ -118,6 +121,7 @@ export const clientsResolvers: FinancialEntitiesModule.Resolvers &
   },
   Client: {
     id: business => business.business_id,
+    ownerId: business => business.owner_id,
     originalBusiness: async (business, _, { injector }) => {
       const businessMatch = await injector
         .get(BusinessesProvider)
@@ -130,17 +134,20 @@ export const clientsResolvers: FinancialEntitiesModule.Resolvers &
       return businessMatch;
     },
     emails: business => business.emails ?? [],
+    // The client-level default. NOT what actually gets issued for a given
+    // billing agreement — that is `Contract.documentType`, set per contract.
+    generatedDocumentType: business => normalizeDocumentType(business.document_type),
     integrations: business => business,
   },
   ClientIntegrations: {
     id: business => `${business.business_id}-integrations`,
-    hiveId: business => validateClientIntegrations(business.integrations).hiveId ?? null,
-    linearId: business => validateClientIntegrations(business.integrations).linearId ?? null,
+    hiveId: business => parseStoredClientIntegrations(business.integrations).hiveId ?? null,
+    linearId: business => parseStoredClientIntegrations(business.integrations).linearId ?? null,
     slackChannelKey: business =>
-      validateClientIntegrations(business.integrations).slackChannelKey ?? null,
-    notionId: business => validateClientIntegrations(business.integrations).notionId ?? null,
+      parseStoredClientIntegrations(business.integrations).slackChannelKey ?? null,
+    notionId: business => parseStoredClientIntegrations(business.integrations).notionId ?? null,
     workflowyUrl: business =>
-      validateClientIntegrations(business.integrations).workflowyUrl ?? null,
+      parseStoredClientIntegrations(business.integrations).workflowyUrl ?? null,
   },
   LtdFinancialEntity: {
     clientInfo: async (business, _, { injector }) => {

--- a/packages/server/src/modules/financial-entities/typeDefs/businesses.graphql.ts
+++ b/packages/server/src/modules/financial-entities/typeDefs/businesses.graphql.ts
@@ -4,7 +4,13 @@ export default gql`
   extend type Query {
     business(id: UUID!): Business! @requiresAuth
     businesses(ids: [UUID!]!): [Business!]! @requiresAuth
-    allBusinesses(page: Int, limit: Int, name: String): PaginatedBusinesses @requiresAuth
+    allBusinesses(
+      page: Int
+      limit: Int
+      name: String
+      " narrow to businesses that are (true) or are not (false) clients; omit for both "
+      isClient: Boolean
+    ): PaginatedBusinesses @requiresAuth
   }
 
   " represent a financial entity of any type that may hold financial accounts (company, business, individual) "

--- a/packages/server/src/modules/financial-entities/typeDefs/clients.graphql.ts
+++ b/packages/server/src/modules/financial-entities/typeDefs/clients.graphql.ts
@@ -18,6 +18,8 @@ export default gql`
   " business extended with green invoice data "
   type Client {
     id: UUID!
+    " the (admin) business this client record belongs to "
+    ownerId: UUID!
     originalBusiness: LtdFinancialEntity!
     emails: [String!]!
     generatedDocumentType: DocumentType!

--- a/packages/server/src/modules/green-invoice/helpers/green-invoice-clients.helper.ts
+++ b/packages/server/src/modules/green-invoice/helpers/green-invoice-clients.helper.ts
@@ -187,14 +187,11 @@ export async function updateGreenInvoiceClient(
     localClientPromise,
   ]);
 
-  let greenInvoiceId: string | undefined;
-  try {
-    greenInvoiceId =
-      parseStoredClientIntegrations(localClient?.integrations ?? {}).greenInvoiceId ?? undefined;
-  } catch {
-    // swallow errors
-    return;
-  }
+  // No try/catch: `parseStoredClientIntegrations` never throws, so an unreadable
+  // stored value simply leaves `greenInvoiceId` undefined and falls into the
+  // guard below — which warns, rather than returning silently as the old catch did.
+  const greenInvoiceId =
+    parseStoredClientIntegrations(localClient?.integrations).greenInvoiceId ?? undefined;
   if (!localBusiness?.name || !greenInvoiceId) {
     // We cannot update a client in Green Invoice without its ID.
     console.warn(

--- a/packages/server/src/modules/green-invoice/helpers/green-invoice-clients.helper.ts
+++ b/packages/server/src/modules/green-invoice/helpers/green-invoice-clients.helper.ts
@@ -6,7 +6,7 @@ import {
 import type { ClientUpdateInput, UpdateBusinessInput } from '../../../__generated__/types.js';
 import { CountryCode } from '../../../shared/enums.js';
 import { GreenInvoiceClientProvider } from '../../app-providers/green-invoice-client.js';
-import { validateClientIntegrations } from '../../financial-entities/helpers/clients.helper.js';
+import { parseStoredClientIntegrations } from '../../financial-entities/helpers/clients.helper.js';
 import { BusinessesProvider } from '../../financial-entities/providers/businesses.provider.js';
 import { ClientsProvider } from '../../financial-entities/providers/clients.provider.js';
 import {
@@ -99,7 +99,7 @@ export async function addGreenInvoiceClient(clientId: string, injector: Injector
       throw new Error('Failed to create Green Invoice client');
     }
 
-    const integrations = validateClientIntegrations(localClient.integrations);
+    const integrations = parseStoredClientIntegrations(localClient.integrations);
 
     // add green invoice id to local client
     await injector.get(ClientsProvider).updateClient({
@@ -190,7 +190,7 @@ export async function updateGreenInvoiceClient(
   let greenInvoiceId: string | undefined;
   try {
     greenInvoiceId =
-      validateClientIntegrations(localClient?.integrations ?? {}).greenInvoiceId ?? undefined;
+      parseStoredClientIntegrations(localClient?.integrations ?? {}).greenInvoiceId ?? undefined;
   } catch {
     // swallow errors
     return;

--- a/packages/server/src/modules/green-invoice/helpers/green-invoice.helper.ts
+++ b/packages/server/src/modules/green-invoice/helpers/green-invoice.helper.ts
@@ -1251,16 +1251,11 @@ export async function convertDocumentInputIntoGreenInvoiceInput(
     if (!clientInfo) {
       throw new GraphQLError(`Client with business ID ${initialInput.client.id} not found`);
     }
-    let greenInvoiceId: string | null;
-    try {
-      greenInvoiceId =
-        parseStoredClientIntegrations(clientInfo.integrations ?? {}).greenInvoiceId ?? null;
-    } catch (error) {
-      console.error('Failed to validate client integrations', error);
-      throw new GraphQLError(
-        `Client with business ID ${initialInput.client.id} has invalid integrations`,
-      );
-    }
+    // Unreadable stored integrations are indistinguishable from unconfigured
+    // ones here: `parseStoredClientIntegrations` degrades rather than throws, and
+    // either way this client has no Green Invoice id to issue against.
+    const greenInvoiceId =
+      parseStoredClientIntegrations(clientInfo.integrations).greenInvoiceId ?? null;
     if (!greenInvoiceId) {
       throw new GraphQLError(
         `Client with business ID ${initialInput.client.id} not found in Green Invoice`,

--- a/packages/server/src/modules/green-invoice/helpers/green-invoice.helper.ts
+++ b/packages/server/src/modules/green-invoice/helpers/green-invoice.helper.ts
@@ -35,7 +35,7 @@ import { IGenerateChargeResult } from '../../charges/types.js';
 import { DocumentsProvider } from '../../documents/providers/documents.provider.js';
 import { IssuedDocumentsProvider } from '../../documents/providers/issued-documents.provider.js';
 import type { document_status, IInsertDocumentsParams } from '../../documents/types.js';
-import { validateClientIntegrations } from '../../financial-entities/helpers/clients.helper.js';
+import { parseStoredClientIntegrations } from '../../financial-entities/helpers/clients.helper.js';
 import { ClientsProvider } from '../../financial-entities/providers/clients.provider.js';
 
 export function normalizeGreenInvoiceDocumentType(
@@ -1254,7 +1254,7 @@ export async function convertDocumentInputIntoGreenInvoiceInput(
     let greenInvoiceId: string | null;
     try {
       greenInvoiceId =
-        validateClientIntegrations(clientInfo.integrations ?? {}).greenInvoiceId ?? null;
+        parseStoredClientIntegrations(clientInfo.integrations ?? {}).greenInvoiceId ?? null;
     } catch (error) {
       console.error('Failed to validate client integrations', error);
       throw new GraphQLError(

--- a/packages/server/src/modules/green-invoice/resolvers/green-invoice.resolvers.ts
+++ b/packages/server/src/modules/green-invoice/resolvers/green-invoice.resolvers.ts
@@ -9,7 +9,7 @@ import type {
   IInsertDocumentsResult,
   IUpdateIssuedDocumentParams,
 } from '../../documents/types.js';
-import { validateClientIntegrations } from '../../financial-entities/helpers/clients.helper.js';
+import { parseStoredClientIntegrations } from '../../financial-entities/helpers/clients.helper.js';
 import { ClientsProvider } from '../../financial-entities/providers/clients.provider.js';
 import {
   convertGreenInvoiceDocumentToDocumentDraft,
@@ -30,7 +30,7 @@ export const greenInvoiceResolvers: GreenInvoiceModule.Resolvers = {
           throw new GraphQLError(`Client not found for ID="${clientId}"`);
         }
 
-        const greenInvoiceId = validateClientIntegrations(client.integrations)?.greenInvoiceId;
+        const greenInvoiceId = parseStoredClientIntegrations(client.integrations)?.greenInvoiceId;
         if (!greenInvoiceId) {
           throw new GraphQLError(`Client ID="${clientId}" is missing Green Invoice integration`);
         }
@@ -175,7 +175,7 @@ export const greenInvoiceResolvers: GreenInvoiceModule.Resolvers = {
   },
   ClientIntegrations: {
     greenInvoiceInfo: business =>
-      validateClientIntegrations(business.integrations).greenInvoiceId ?? null,
+      parseStoredClientIntegrations(business.integrations).greenInvoiceId ?? null,
   },
   GreenInvoiceClient: {
     greenInvoiceId: clientId => clientId,


### PR DESCRIPTION
Some businesses are also **clients** — they carry a `clients` row that adds contact emails, a default document type, and a map of external-system ids. None of that reached the connector. The business directory came back with no signal about which rows were clients, so an assistant could not tell a supplier from a customer; and `accounter_get_contracts` had filtered by `clientIds` all along with nothing on the connector able to enumerate them.

## A flag on the directory

`accounter_list_businesses` rows now carry `isClient`, and the tool takes an `isClient` filter.

The filter is a **real upstream predicate**, not a pass over the returned page: `Query.allBusinesses` gained an `isClient` argument, applied ahead of the count and the slice, so `pagination` and `totalCount` describe the filtered directory and no page comes back short. That distinction matters more here than for `activeOnly` — clients are a small slice of the directory, so filtering an already-sliced page would answer *"the clients on page 1"* while reading as *"the clients"*.

It needed no SQL and no migration. `Query.allBusinesses` was never SQL-paginated — it loads the whole directory via a memoized `getAllBusinesses()` and filters, sorts and slices in memory — so the predicate is a client-id `Set` from the operation-memoized, RLS-scoped `getAllClients()`, folded into the existing filter. Cost is at most one extra query.

## A tool for the detail

`accounter_list_clients` returns `businessId`, `name`, `ownerId`, `emails`, `generatedDocumentType` and the configured integrations, filtered by `nameContains` or `clientBusinessIds`. Registered immediately before `accounter_get_contracts` — discovery ahead of the tool that consumes it, mirroring the securities pair.

Separate from the directory rather than more fields on it: the directory is thousands of rows against a hard payload cap, and hanging six integration ids off every row would spend that budget on the majority that have none. It is also where future client data belongs.

Two deliberate shapes:

- **Unconfigured integrations are omitted**, not returned as `null`. A client with one Slack channel costs one key, not six.
- **Only `greenInvoiceInfo { greenInvoiceId }` is selected.** That field resolves from a value already in hand; every *other* field on `GreenInvoiceClient` is fetched from the external Green Invoice API and `businessId` costs a DB round trip, so adding one would turn a single list call into N third-party requests. There is a test that fails if anything else is ever selected there.

Client ids need no translation anywhere: a client's id **is** its business id, so the directory's `id`, this tool's `businessId`, and the contracts filter's `clientIds` are one value. An e2e test pins that join.

## Four server-side fixes underneath

All pre-existing, all in the path of reading a client:

- **`ClientIntegrations` field resolvers parsed stored jsonb with a strict schema** that threw on `NULL` and on any unknown key. Those resolvers run once per client, and the connector discards partial data whenever a response carries an `errors` entry — so one malformed row would have emptied an entire `allClients` call rather than degrading one record. Reading now goes through a lenient parser that treats `NULL` as unconfigured, strips unknown keys, and degrades a wrong-typed field to `null` without costing its siblings. **All thirteen call sites turned out to be reading stored data**, none validating a payload, and every one already guarded its result — so all of them moved rather than leaving nine known-fatal reads behind. The strict schema stays exported for a write path that wants it.
- **`Client.generatedDocumentType` was declared non-null with no resolver.** The column is `document_type`, so the default resolver returned `undefined` and any query selecting it errored. Nothing selected it, which is why the break was invisible.
- **The same field was accepted by `insertClient`/`updateClient` and never written** — neither statement touched `document_type`. It now persists, via `COALESCE` so an omitted field keeps the stored value.
- **`Client` gained `ownerId`**, which every connector row is required to carry.

Note `generatedDocumentType` is the client-level *default* only. What actually gets issued is the contract's own `documentType`, which `accounter_get_contracts` already returns — the tool description says so.

## Tests

New: `clients.test.ts` (16), `clients.helper.test.ts` (10 — the read-path regression guards), `clients.provider.test.ts` (3 — `document_type` reaching the statement). Extended: `isClient` cases in `lookups.test.ts`, four pins in `schema-contract.test.ts`, the registry-wide `scope-contract` / `scope-forwarding` / `usage-log` suites, and two e2e tool calls. The e2e harness had no `contractsByFilters` fixture — the contracts tool was never exercised there — so this adds one.

```
yarn test        → 284 files, 3723 passed, 6 skipped
yarn lint        → 0 errors
tsc --noEmit     → clean, server + mcp-server
```

⚠️ The root `.env` points at the production DB, so a plain `yarn test` fails `rls-all-tables.test.ts` on connection timeout. The numbers above are from a run with `POSTGRES_*` overridden to the local dev DB; the same override was used for `generate:sql` so pgtyped introspected local, not production.

Not done: a live end-to-end run against a real stack (README smoke-test steps 10–12), which needs a running server and an Auth0 token. The mocked equivalent is in `mcp-e2e.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
