### PR TITLE
feat(client): default VAT report to previous month

### DIFF
--- a/.changeset/vat-report-default-prev-month.md
+++ b/.changeset/vat-report-default-prev-month.md
@@ -1,0 +1,14 @@
+---
+'@accounter/client': patch
+---
+
+Default the VAT monthly report to the previous month instead of the current one.
+
+The current month is still ongoing, so its VAT report is always incomplete — opening the screen on
+it meant every user's first action was stepping the month picker back one. The report now opens on
+the previous month.
+
+The default is shared through a new `getDefaultVatReportMonth` helper in the report's `utils.ts`,
+so the initial filter state, the filter modal's "Clear" reset and the month picker's fallback all
+resolve to the same month. An explicit month in the `vatMonthlyReportFilters` URL param still wins,
+so existing links keep pointing at the month they encode.

--- a/packages/client/src/components/reports/vat-monthly-report/index.tsx
+++ b/packages/client/src/components/reports/vat-monthly-report/index.tsx
@@ -8,7 +8,7 @@ import {
   VatMonthlyReportDocument,
   type VatReportFilter,
 } from '../../../gql/graphql.js';
-import { dedupeFragments, type TimelessDateString } from '../../../helpers/index.js';
+import { dedupeFragments } from '../../../helpers/index.js';
 import { useUrlQuery } from '../../../hooks/use-url-query.js';
 import { FiltersContext } from '../../../providers/filters-context.js';
 import { UserContext } from '../../../providers/user-provider.js';
@@ -21,6 +21,7 @@ import { MiscTable } from './misc-table.js';
 import { MissingInfoTable } from './missing-info-table.js';
 import { PCNGenerator } from './pcn-generator.js';
 import { ReportSummary } from './report-summary.js';
+import { getDefaultVatReportMonth } from './utils.js';
 import { VatMonthlyReportFilter } from './vat-monthly-report-filters.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
@@ -53,7 +54,7 @@ export const VatMonthlyReport = (): ReactElement => {
         ) as VatReportFilter)
       : {
           financialEntityId: userContext?.context.adminBusinessId ?? '',
-          monthDate: format(new Date(), 'yyyy-MM-15') as TimelessDateString,
+          monthDate: getDefaultVatReportMonth(),
         },
   );
   // Single selection source of truth, shared by every sub-table so charges picked in one table

--- a/packages/client/src/components/reports/vat-monthly-report/utils.ts
+++ b/packages/client/src/components/reports/vat-monthly-report/utils.ts
@@ -1,4 +1,15 @@
+import { format, subMonths } from 'date-fns';
 import type { Pcn874RecordType } from '../../../gql/graphql.js';
+import type { TimelessDateString } from '../../../helpers/index.js';
+
+/**
+ * The month the VAT report opens on by default: the previous month. The current month is still
+ * ongoing, so its report is incomplete - the previous month is the one users actually work on.
+ * Anchored to the 15th, matching how `monthDate` is represented throughout the report filters.
+ */
+export function getDefaultVatReportMonth(): TimelessDateString {
+  return format(subMonths(new Date(), 1), 'yyyy-MM-15') as TimelessDateString;
+}
 
 export function getRecordTypeName(recordType: Pcn874RecordType): string {
   switch (recordType) {

--- a/packages/client/src/components/reports/vat-monthly-report/vat-monthly-report-filters.tsx
+++ b/packages/client/src/components/reports/vat-monthly-report/vat-monthly-report-filters.tsx
@@ -14,6 +14,7 @@ import { UserContext } from '../../../providers/user-provider.js';
 import { chargesTypeFilterOptions } from '../../charges/charges-filters.js';
 import { PopUpModal } from '../../common/index.js';
 import { Button } from '../../ui/button.js';
+import { getDefaultVatReportMonth } from './utils.js';
 
 interface VatMonthlyReportFilterFormProps {
   filter: VatReportFilter;
@@ -31,6 +32,8 @@ function VatMonthlyReportFilterForm({
   });
   const { selectableAdminBusinesses: adminBusinesses, fetching: feLoading } =
     useGetAdminBusinesses();
+
+  const defaultPickerMonth = new Date(filter?.monthDate ?? getDefaultVatReportMonth());
 
   const onSubmit: SubmitHandler<VatReportFilter> = data => {
     setFilter(data);
@@ -86,8 +89,8 @@ function VatMonthlyReportFilterForm({
           )}
         />
         <MonthPickerInput
-          defaultValue={filter?.monthDate ? new Date(filter.monthDate) : new Date()}
-          defaultDate={filter?.monthDate ? new Date(filter.monthDate) : new Date()}
+          defaultValue={defaultPickerMonth}
+          defaultDate={defaultPickerMonth}
           onChange={onSelectDate}
           popoverProps={{ withinPortal: true }}
         />
@@ -135,7 +138,7 @@ export function VatMonthlyReportFilter({
   function onSetFilter(newFilter?: VatReportFilter): void {
     newFilter ||= {
       financialEntityId: userContext?.context.adminBusinessId ?? filter.financialEntityId,
-      monthDate: format(new Date(), 'yyyy-MM-15') as TimelessDateString,
+      monthDate: getDefaultVatReportMonth(),
     };
     // looks for actual changes before triggering update
     if (!equal(newFilter, filter)) {


### PR DESCRIPTION
## What

The VAT monthly report opened on the **current** month. It now opens on the **previous** month.

## Why

The current month is still ongoing, so its VAT report is always incomplete — opening the screen on it meant every user's first action was stepping the month picker back one.

## How

Added a shared `getDefaultVatReportMonth()` helper to the report's `utils.ts` (`subMonths(new Date(), 1)`, anchored to the 15th to match how `monthDate` is represented throughout the report filters), and routed all three default-month sites through it so they can't drift apart:

- `index.tsx` — the initial `filter` state
- `vat-monthly-report-filters.tsx` — the filter modal's **Clear** reset
- `vat-monthly-report-filters.tsx` — the `MonthPickerInput` fallback when no `monthDate` is set

An explicit month in the `vatMonthlyReportFilters` URL param still takes precedence, so existing links keep pointing at the month they encode.

## Validation

- `tsc --noEmit` on `@accounter/client` — clean
- `eslint` + `prettier --check` on the changed files — clean
- `yarn vitest run --project unit packages/client` — 32 files, 247 passed / 1 skipped

Changeset included (`@accounter/client`: patch).

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5EtPD8hr2cpcUuM7nCvGG)_