### PR TITLE
feat(charges): filter charges with no tags

### DIFF
--- a/.changeset/charge-filters-without-tags.md
+++ b/.changeset/charge-filters-without-tags.md
@@ -1,0 +1,16 @@
+---
+'@accounter/server': minor
+'@accounter/client': minor
+'@accounter/mcp-server': minor
+---
+
+Filter charges that carry no tags at all.
+
+Server: `ChargeFilter` gains a `withoutTags: Boolean` predicate, honored by `allCharges` and
+`chargesWithMissingRequiredInfo` (both go through the shared charge listing helper). It narrows to
+charges with an empty tag set, and is independent of `byTags`, which narrows to charges carrying
+specific tags.
+
+Client: the charges filters modal gains a "Without Tags" toggle in the Missing Information section.
+
+MCP: `accounter_search_charges` and `accounter_get_charges` expose the new `withoutTags` filter.

--- a/packages/client/src/components/charges/charges-filters.tsx
+++ b/packages/client/src/components/charges/charges-filters.tsx
@@ -574,6 +574,31 @@ function ChargesFiltersForm({
 
               <FormField
                 control={form.control}
+                name="withoutTags"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-center justify-between">
+                    <div className="space-y-0.5">
+                      <FormLabel>Without Tags</FormLabel>
+                    </div>
+                    <FormControl>
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <Switch
+                            defaultChecked={filter.withoutTags ?? false}
+                            onCheckedChange={field.onChange}
+                          />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Show only charges that have no tags</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
                 name="unbalanced"
                 render={({ field }) => (
                   <FormItem className="flex flex-row items-center justify-between">

--- a/packages/client/src/components/charges/charges-filters.tsx
+++ b/packages/client/src/components/charges/charges-filters.tsx
@@ -582,9 +582,9 @@ function ChargesFiltersForm({
                     </div>
                     <FormControl>
                       <Tooltip>
-                        <TooltipTrigger>
+                        <TooltipTrigger asChild>
                           <Switch
-                            defaultChecked={filter.withoutTags ?? false}
+                            checked={field.value ?? false}
                             onCheckedChange={field.onChange}
                           />
                         </TooltipTrigger>

--- a/packages/client/src/components/charges/charges-filters.tsx
+++ b/packages/client/src/components/charges/charges-filters.tsx
@@ -583,10 +583,7 @@ function ChargesFiltersForm({
                     <FormControl>
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <Switch
-                            checked={field.value ?? false}
-                            onCheckedChange={field.onChange}
-                          />
+                          <Switch checked={field.value ?? false} onCheckedChange={field.onChange} />
                         </TooltipTrigger>
                         <TooltipContent>
                           <p>Show only charges that have no tags</p>

--- a/packages/mcp-server/src/tools/__tests__/charges.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/charges.test.ts
@@ -260,6 +260,7 @@ describe('searchChargesTool — successful read', () => {
       withoutInvoice: true,
       withoutLedger: false,
       withoutReceipt: false,
+      withoutTags: true,
       withoutTransactions: false,
     });
 
@@ -277,6 +278,7 @@ describe('searchChargesTool — successful read', () => {
       withoutInvoice: true,
       withoutLedger: false,
       withoutReceipt: false,
+      withoutTags: true,
       withoutTransactions: false,
       // Scoping still goes through byOwners, never the counterparty predicate.
       byOwners: ['b1'],

--- a/packages/mcp-server/src/tools/__tests__/detail-tools.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/detail-tools.test.ts
@@ -409,6 +409,7 @@ describe('getChargesTool', () => {
         withoutInvoice: false,
         withoutLedger: false,
         withoutReceipt: false,
+        withoutTags: false,
         withoutTransactions: false,
       },
       includeTransactions: false,
@@ -448,6 +449,7 @@ describe('getChargesTool', () => {
       withoutInvoice: false,
       withoutLedger: false,
       withoutReceipt: false,
+      withoutTags: false,
       withoutTransactions: false,
     });
     expect(variables.includeTransactions).toBe(false);

--- a/packages/mcp-server/src/tools/charge-filters.ts
+++ b/packages/mcp-server/src/tools/charge-filters.ts
@@ -186,6 +186,10 @@ export const CHARGE_FILTER_SHAPE = {
     .boolean()
     .optional()
     .describe('Include only charges with no linked receipt document.'),
+  withoutTags: z
+    .boolean()
+    .optional()
+    .describe('Include only charges carrying no tags at all (untagged charges).'),
   withoutTransactions: z
     .boolean()
     .optional()
@@ -262,6 +266,7 @@ export function buildChargeFilters(
   if (input.withoutInvoice !== undefined) filters.withoutInvoice = input.withoutInvoice;
   if (input.withoutLedger !== undefined) filters.withoutLedger = input.withoutLedger;
   if (input.withoutReceipt !== undefined) filters.withoutReceipt = input.withoutReceipt;
+  if (input.withoutTags !== undefined) filters.withoutTags = input.withoutTags;
   if (input.withoutTransactions !== undefined) {
     filters.withoutTransactions = input.withoutTransactions;
   }

--- a/packages/server/src/modules/charges/helpers/filtered-charges.helper.ts
+++ b/packages/server/src/modules/charges/helpers/filtered-charges.helper.ts
@@ -92,6 +92,7 @@ export async function fetchFilteredCharges(
       withOpenDocuments: filters?.withOpenDocuments,
       withoutTransactions: filters?.withoutTransactions,
       withoutLedger: filters?.withoutLedger,
+      withoutTags: filters?.withoutTags,
       freeText: filters?.freeText?.trim().toLowerCase(),
       tags: filters?.byTags,
       accountantStatuses: filters?.accountantStatus as accountant_statusArray | undefined,

--- a/packages/server/src/modules/charges/providers/charges.provider.ts
+++ b/packages/server/src/modules/charges/providers/charges.provider.ts
@@ -750,6 +750,7 @@ const getChargesByFilters = sql<IGetChargesByFiltersQuery>`
   AND ($withoutLedger = FALSE OR COALESCE(ec.ledger_count, 0) = 0)
   AND ($isAccountantStatuses = 0 OR ec.accountant_status = ANY ($accountantStatuses::accounter_schema.accountant_status[]))
   AND ($isTags = 0 OR ec.tags && $tags)
+  AND ($withoutTags = FALSE OR COALESCE(array_length(ec.tags, 1), 0) = 0)
   AND ($isBusinessTripIds = 0 OR ec.business_trip_id = ANY ($businessTripIds::uuid[]))
   AND ($isAccountIds = 0 OR ec.account_array && $accountIds::uuid[])
   AND ($withMissingCounterparty = FALSE OR COALESCE(ec.missing_counterparty_transactions, false) = true OR COALESCE(ec.missing_counterparty_documents, false) = true)
@@ -1263,6 +1264,7 @@ export class ChargesProvider {
       withOpenDocuments: params.withOpenDocuments ?? false,
       withoutTransactions: params.withoutTransactions ?? false,
       withoutLedger: params.withoutLedger ?? false,
+      withoutTags: params.withoutTags ?? false,
       accountantStatuses: isAccountantStatuses ? params.accountantStatuses! : null,
       // strip thousands separators so amount searches match the plain value stored in the DB
       freeTextNumeric: params.freeText ? params.freeText.replaceAll(',', '') : null,

--- a/packages/server/src/modules/charges/resolvers/__tests__/all-charges-filters.test.ts
+++ b/packages/server/src/modules/charges/resolvers/__tests__/all-charges-filters.test.ts
@@ -93,4 +93,17 @@ describe('Query.allCharges filter forwarding', () => {
     // Free text is normalized for the trigram search.
     expect(params.freeText).toBe('coffee');
   });
+
+  it('forwards the untagged-charges predicate', async () => {
+    const params = await paramsFor({ withoutTags: true });
+    expect(params.withoutTags).toBe(true);
+  });
+
+  // `byTags` narrows to specific tags while `withoutTags` asks for charges with
+  // none at all — passing one must never populate the other.
+  it('keeps withoutTags independent of byTags', async () => {
+    const params = await paramsFor({ byTags: ['tag-1'] });
+    expect(params.tags).toEqual(['tag-1']);
+    expect(params.withoutTags).toBeUndefined();
+  });
 });

--- a/packages/server/src/modules/charges/typeDefs/charge-validation.graphql.ts
+++ b/packages/server/src/modules/charges/typeDefs/charge-validation.graphql.ts
@@ -81,7 +81,7 @@ export default gql`
     unbalanced: Boolean
     " Include only charges that doesn't have ledger records linked "
     withoutLedger: Boolean
-    " Include only charges that doesn't have any tag linked "
+    " Include only charges that don't have any tags linked "
     withoutTags: Boolean
     withOpenDocuments: Boolean
   }

--- a/packages/server/src/modules/charges/typeDefs/charge-validation.graphql.ts
+++ b/packages/server/src/modules/charges/typeDefs/charge-validation.graphql.ts
@@ -81,6 +81,8 @@ export default gql`
     unbalanced: Boolean
     " Include only charges that doesn't have ledger records linked "
     withoutLedger: Boolean
+    " Include only charges that doesn't have any tag linked "
+    withoutTags: Boolean
     withOpenDocuments: Boolean
   }
 `;


### PR DESCRIPTION
Adds a "charges with no tags" predicate across the schema, the charges filters UI, and the MCP charge tools.

`byTags` narrows to charges carrying *specific* tags; there was no way to ask for charges carrying *none*. The new `withoutTags: Boolean` on `ChargeFilter` does that, and the two are independent — passing one never populates the other.

## Changes

**Server**
- `ChargeFilter.withoutTags: Boolean` (in the `charge-validation` extension, alongside the other "missing info" toggles).
- SQL predicate in `getChargesByFilters`: `($withoutTags = FALSE OR COALESCE(array_length(ec.tags, 1), 0) = 0)`, plus the provider param default.
- Forwarded in `fetchFilteredCharges`, so both `allCharges` and `chargesWithMissingRequiredInfo` honor it.

**Client**
- "Without Tags" switch in the charges filters modal's *Missing Information* group, with a tooltip.

**MCP server**
- `withoutTags` added to `CHARGE_FILTER_SHAPE` and `buildChargeFilters`, so `accounter_search_charges` and `accounter_get_charges` both expose it. `schema-contract.test.ts` derives its field set from `schema.graphql`, so the two stay in sync automatically.

## Tests

- New `allCharges` forwarding tests: `withoutTags` reaches the provider, and `byTags` does not set it.
- Extended the MCP pass-through filter tests to include `withoutTags`.
- `yarn test`: 3723 passed. The one failing file (`packages/migrations/src/__tests__/rls-all-tables.test.ts`) fails on this sandbox for a missing `POSTGRES_SSL` env var, unrelated to this change.
- `yarn lint` clean (0 errors), `yarn prettier:check` clean for all touched files, client and mcp-server builds pass. SQL codegen (pgtyped) needs a live Postgres, which is not available here — CI covers it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DR7CmiLTwvMe8YazDCZR7d)_