### PR TITLE
feat(charges): implement the ChargeFilter exclusion predicates

### DIFF
--- a/.changeset/charges-filter-exclusion-predicates.md
+++ b/.changeset/charges-filter-exclusion-predicates.md
@@ -1,0 +1,44 @@
+---
+'@accounter/server': patch
+'@accounter/mcp-server': patch
+---
+
+Implement the `ChargeFilter` exclusion predicates, and expose them through the MCP charge tools.
+
+`excludedBusinesses`, `excludedFinancialAccounts`, `excludedTags` and `excludedFreeText` were added
+to the schema alongside the charges filter redesign so the client could send them, with the SQL
+deliberately deferred. Until now `allCharges` accepted all four and silently ignored them — picking
+"exclude" in the filter modal returned an unfiltered result with no indication the constraint had
+been dropped. They now have real predicates.
+
+`getChargesByFilters` already aggregates each charge's businesses, tags and accounts into arrays
+before its closing `WHERE`, so the three entity exclusions are array **non**-overlap rather than the
+`NOT EXISTS` the follow-up doc originally called for — a charge is dropped when any of its
+businesses / tags / accounts appears in the exclusion list. Each is wrapped in `COALESCE`, because
+those arrays come from `LEFT JOIN`s and `NULL && array` is `NULL`: without it, a tag exclusion would
+have dropped every charge that has no tags at all.
+
+`excludedFreeText` is a set-membership test. A new `excluded_matches` CTE mirrors the existing
+`search_matches` across the same eight sources — charge description, transaction
+description/reference, document description/remarks/serial, transaction and document amounts, and
+counterparty names via transactions, creditor and debtor — and `filtered_charges` requires the charge
+not to appear in it. Every branch requires the parameter to be non-null, the inverse of
+`search_matches`, whose first branch deliberately passes everything through when `$freeText` is null.
+A charge with no text never enters the set, so "does not mention X" keeps charges with no
+description — the NULL-safety concern the follow-up doc raised does not arise, because nothing
+negates an `ILIKE`. Thousands separators are stripped as they are for `freeText`, so excluding
+`1,234.56` also excludes `1234.56`.
+
+Include and exclude are separate predicates, `AND`ed, so a value named in both lists is excluded —
+exclude wins. The client's tri-state cannot produce that, but the API allows it.
+
+All four are removed from the MCP server's `UNSUPPORTED_UPSTREAM_CHARGE_FILTER_FIELDS` and exposed on
+`accounter_get_charges` and `accounter_search_charges`, which makes "mentions X but not Y" and
+"everything except these accounts" expressible by a model for the first time. `unbalanced` and
+`businessTrip` stay on that list — they remain accepted-but-ignored.
+
+One editing hazard found and documented: **pgTyped silently truncates the generated parameter list at
+the first `--` comment inside the closing `WHERE` clause.** An explanatory comment placed there cut
+`IGetChargesByFiltersParams` from 30-odd entries to ten, taking `tags`, `accountIds` and `sortColumn`
+with it. Comments inside CTEs are unaffected. There is now a note above the `sql` template, and
+`docs/charges-filters/backend-followup.md` records it.

--- a/.changeset/charges-filter-exclusion-predicates.md
+++ b/.changeset/charges-filter-exclusion-predicates.md
@@ -37,6 +37,15 @@ All four are removed from the MCP server's `UNSUPPORTED_UPSTREAM_CHARGE_FILTER_F
 "everything except these accounts" expressible by a model for the first time. `unbalanced` and
 `businessTrip` stay on that list — they remain accepted-but-ignored.
 
+Both text predicates are now normalized at the provider: a value that is empty once trimmed becomes
+`NULL` rather than reaching SQL as an empty string, which would degrade to `ILIKE '%%'`. As an
+exclusion that would have dropped nearly every charge — reachable through the MCP tools, whose
+`.min(2)` accepted two spaces — and the same latent bug existed on the pre-existing `freeText` path,
+where it instead drops the charges whose description is `NULL`. The mapping layer and the MCP input
+schema now reject whitespace-only text as well, so it fails at the edge. The numeric variants are
+only set when the term contains a digit, since those branches compare against `amount::TEXT` and a
+digit-free term can never match one.
+
 One editing hazard found and documented: **pgTyped silently truncates the generated parameter list at
 the first `--` comment inside the closing `WHERE` clause.** An explanatory comment placed there cut
 `IGetChargesByFiltersParams` from 30-odd entries to ten, taking `tags`, `accountIds` and `sortColumn`

--- a/docs/charges-filters/backend-followup.md
+++ b/docs/charges-filters/backend-followup.md
@@ -1,95 +1,89 @@
-# Charges filter — deferred backend work
+# Charges filter — exclusion predicates
 
-The charges filter redesign added four fields to the `ChargeFilter` GraphQL input **in the typeDefs
-only**, so the client could build and send them. The server currently **accepts and silently ignores
-all four**: `allCharges` destructures `filters` field-by-field in
-[`filtered-charges.helper.ts`](../../packages/server/src/modules/charges/helpers/filtered-charges.helper.ts),
-so unknown keys never reach the provider and no predicate is applied.
+> **Status: implemented.** The four `excluded*` fields were added to the `ChargeFilter` typeDefs
+> ahead of the SQL and spent one release accepted-but-ignored. They now have real predicates and are
+> exposed through the MCP charge tools. This document records how they behave; the outstanding items
+> are in [Still open](#still-open).
 
-This document collects the work needed to make them real. It is a follow-up task, not part of the
-redesign PR.
+| Field                       | Type        | Positive twin         | Predicate                                 |
+| --------------------------- | ----------- | --------------------- | ----------------------------------------- |
+| `excludedBusinesses`        | `[UUID!]`   | `byBusinesses`        | `business_array` non-overlap              |
+| `excludedFinancialAccounts` | `[UUID!]`   | `byFinancialAccounts` | `account_array` non-overlap               |
+| `excludedTags`              | `[String!]` | `byTags`              | `tags` non-overlap                        |
+| `excludedFreeText`          | `String`    | `freeText`            | not present in the `excluded_matches` CTE |
 
-| Field                       | Type        | Positive twin         |
-| --------------------------- | ----------- | --------------------- |
-| `excludedBusinesses`        | `[UUID!]`   | `byBusinesses`        |
-| `excludedFinancialAccounts` | `[UUID!]`   | `byFinancialAccounts` |
-| `excludedTags`              | `[String!]` | `byTags`              |
-| `excludedFreeText`          | `String`    | `freeText`            |
+## How it works
 
-Schema location:
-[`packages/server/src/modules/charges/typeDefs/charges.graphql.ts`](../../packages/server/src/modules/charges/typeDefs/charges.graphql.ts)
-(base `input ChargeFilter`).
+`getChargesByFilters`
+([`charges.provider.ts`](../../packages/server/src/modules/charges/providers/charges.provider.ts))
+already aggregates each charge's businesses, tags and accounts into arrays before the closing
+`WHERE`, so the three entity exclusions are array **non**-overlap rather than the `NOT EXISTS` this
+document originally called for:
 
-## Current user-visible behaviour
+```sql
+AND ($isExcludedTags = 0 OR NOT COALESCE(ec.tags && $excludedTags, FALSE))
+```
 
-The UI ships the exclude controls fully enabled — a per-option `+`/`−` flip on Financial Entities,
-Financial Accounts and Tags, and a Contains/Excludes toggle on free text. Choosing "exclude" today
-produces an **unfiltered** result with no indication that the constraint was dropped. This was a
-deliberate call when the redesign shipped; it is the main reason to prioritise this work.
+The `COALESCE` matters. Those arrays come from `LEFT JOIN`s, and `NULL && array` is `NULL`, not
+`FALSE` — without it, every charge that has _no_ tags at all would be dropped from a tag-exclusion
+query, which is the opposite of what the filter means.
 
-## What each field needs
+Because the arrays hold the charge's full set, this gives the right semantics directly: a charge is
+dropped when **any** of its businesses / tags / accounts appears in the exclusion list. (The concern
+about a plain `NOT IN` matching on a second joined row does not arise — there is no per-row join
+left at that point.)
 
-All four follow the same three-step shape:
+`excludedFreeText` is a set-membership test instead. `excluded_matches` mirrors the existing
+`search_matches` CTE — the same eight sources: charge description, transaction
+description/reference, document description/remarks/serial, transaction and document amounts, and
+counterparty names via transactions, creditor and debtor. Every branch requires the parameter to be
+`NOT NULL`, the inverse of `search_matches`, whose first branch deliberately passes every charge
+through when `$freeText` is `NULL`. `filtered_charges` then requires the charge not to be in that
+set.
 
-1. A new parameter on `ChargesProvider.getChargesByFilters`
-   ([`charges.provider.ts`](../../packages/server/src/modules/charges/providers/charges.provider.ts)).
-2. A SQL predicate, negating the same joins the positive twin already uses.
-3. One wiring line in `filtered-charges.helper.ts`, next to its twin — e.g.
-   `excludedBusinessIds: filters?.excludedBusinesses`.
+This also settles the NULL question the original draft raised: a charge whose columns are all `NULL`
+never enters `excluded_matches`, so **"does not mention X" keeps charges with no text at all** — no
+`COALESCE` needed, because the test is set membership rather than a negated `ILIKE`.
 
-### `excludedBusinesses` / `excludedFinancialAccounts`
-
-Both twins filter through a join against the charge's transactions/documents. The negation must be
-`NOT EXISTS` over that join rather than `NOT IN` over a joined column: with a plain `NOT IN`, a
-charge that touches both an excluded business and a non-excluded one still matches on the second
-row, so the exclusion silently fails to exclude. Semantics to implement: _drop the charge if any of
-its businesses/accounts is in the list._
-
-### `excludedTags`
-
-Same `NOT EXISTS` reasoning against the charge-tags join table. Note the schema types this as
-`[String!]` to mirror `byTags`, even though the values are tag ids — keep them consistent rather
-than "fixing" one side.
-
-### `excludedFreeText`
-
-`freeText` is a multi-column `ILIKE` across user description, transaction description/reference and
-document description/remarks/serial. Negating it needs care on two points:
-
-- **NULL safety.** `NOT (column ILIKE '%x%')` is `NULL`, not `TRUE`, when the column is `NULL`, so a
-  charge with no description would be dropped from an exclusion query rather than kept. Wrap each
-  column in `COALESCE(column, '')`.
-- **Decide the intent explicitly.** "Charges that do not mention X" should almost certainly include
-  charges with no text at all. Confirm and encode that, and cover it with a test.
-
-Apply the same `.trim().toLowerCase()` normalisation the positive twin uses.
+`excludedFreeText` gets the same thousands-separator stripping as `freeText`
+(`excludedFreeTextNumeric`), so excluding `1,234.56` also excludes `1234.56`.
 
 ## Precedence
 
-The tri-state UI cannot put one value in both the include and exclude list, but the API allows it.
-Specify and test **exclude wins** — it is the safer default, and it keeps the predicate order
-irrelevant.
+Include and exclude are separate predicates, `AND`ed. A value named in both lists is therefore
+**excluded** — exclude wins. The client's tri-state cannot produce that, but the API allows it and
+`allCharges` accepts it.
 
-## Tests
+## Editing note
 
-Extend
-[`all-charges-filters.test.ts`](../../packages/server/src/modules/charges/resolvers/__tests__/all-charges-filters.test.ts)
-with, per field: a charge that should be excluded, one that should survive, a charge matching both
-an included and an excluded value (the precedence case), and — for `excludedFreeText` — a charge
-with `NULL` description.
+pgTyped **silently truncates the generated parameter list at the first `--` comment inside the
+closing `WHERE` clause**, dropping every parameter after it. This surfaced while adding these
+predicates: an explanatory comment there cut `IGetChargesByFiltersParams` down to ten entries and
+took `tags`, `accountIds`, `sortColumn` and the rest with it. Comments inside CTEs are fine. Keep
+explanation for that clause in TypeScript, above the `sql` template.
 
-## Downstream
+## Coverage
 
-- **MCP.** The four fields are currently listed in `UNSUPPORTED_UPSTREAM_CHARGE_FILTER_FIELDS`
-  ([`packages/mcp-server/src/tools/charge-filters.ts`](../../packages/mcp-server/src/tools/charge-filters.ts)),
-  which keeps them out of the charge tools precisely because upstream ignores them. Remove each
-  field from that list as it gains a predicate, and expose it on `accounter_get_charges` /
-  `accounter_search_charges`. The `schema-contract` test enforces this both ways, so a field left in
-  the list after implementation is not silently forgotten.
-- **Client.** No client change is needed — the UI already sends the fields.
+- [`all-charges-filters.test.ts`](../../packages/server/src/modules/charges/resolvers/__tests__/all-charges-filters.test.ts)
+  — each field reaching its provider parameter, free-text normalisation, and independence from its
+  positive twin.
+- [`charge-filter-exclusions.test.ts`](../../packages/mcp-server/src/tools/__tests__/charge-filter-exclusions.test.ts)
+  — the MCP input shape and `buildChargeFilters` forwarding, including empty-array handling.
+- [`schema-contract.test.ts`](../../packages/mcp-server/src/tools/__tests__/schema-contract.test.ts)
+  — enforces, in both directions, that a `ChargeFilter` field is either exposed by the charge tools
+  or explicitly listed as unsupported.
 
-## Related
+## Still open
 
-`unbalanced` and `businessTrip` are in the same accepted-but-ignored category and have been for
-longer. If this work is picked up, they are worth resolving in the same pass — either implement them
-or remove them from the schema.
+- **No DB-level integration test.** The predicates are covered at the mapping layer only; the SQL
+  itself is exercised by hand. A DB-backed test per field — a charge that should be dropped, one
+  that should survive, one matching both lists, and a `NULL`-description charge for
+  `excludedFreeText` — belongs in the integration project.
+- **Query cost.** `excluded_matches` roughly doubles the trigram-scan surface of `search_matches`
+  when an exclusion is active. It is guarded so the CTE is empty and the `NOT EXISTS` short-circuits
+  when both text parameters are `NULL`, but the exclusion path has not been profiled against a large
+  charge table.
+- **`unbalanced` and `businessTrip`** remain accepted-but-ignored, and stay in
+  `UNSUPPORTED_UPSTREAM_CHARGE_FILTER_FIELDS`
+  ([`charge-filters.ts`](../../packages/mcp-server/src/tools/charge-filters.ts)). They are the same
+  class of problem this change fixed and are worth either implementing or dropping from the schema.

--- a/docs/charges-filters/backend-followup.md
+++ b/docs/charges-filters/backend-followup.md
@@ -48,6 +48,22 @@ never enters `excluded_matches`, so **"does not mention X" keeps charges with no
 `excludedFreeText` gets the same thousands-separator stripping as `freeText`
 (`excludedFreeTextNumeric`), so excluding `1,234.56` also excludes `1234.56`.
 
+## Empty search text
+
+An empty string is not `NULL` in SQL, so it survives the query's `IS NOT NULL` guards and degrades
+to `ILIKE '%%'`. As an exclusion that drops nearly every charge; as a positive filter it drops the
+opposite set — the charges whose description is `NULL`, since they fail an `ILIKE` every other row
+passes. A whitespace-only input trims to exactly that.
+
+`ChargesProvider.getChargesByFilters` normalizes both `freeText` and `excludedFreeText` to `NULL`
+when they are empty after trimming. That is deliberately at the provider rather than any one caller
+— several resolvers build these params independently. The GraphQL mapping layer and the MCP input
+schema reject it too, so it fails at the edge rather than silently becoming a no-op.
+
+The numeric variants (`freeTextNumeric`, `excludedFreeTextNumeric`) are only set when the term
+contains a digit: those branches compare against `amount::TEXT`, so a digit-free term cannot match
+one and only costs a scan.
+
 ## Precedence
 
 Include and exclude are separate predicates, `AND`ed. A value named in both lists is therefore

--- a/packages/mcp-server/src/tools/__tests__/charge-filter-exclusions.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/charge-filter-exclusions.test.ts
@@ -64,6 +64,19 @@ describe('charge filter exclusions', () => {
     expect(chargeFiltersInput.safeParse({ excludedFreeText: 'ab' }).success).toBe(true);
   });
 
+  /**
+   * `.min(2)` alone accepts "  ", which is truthy and so reaches the builder, then
+   * trims to an empty string downstream — where SQL reads it as `ILIKE '%%'`. The
+   * exclusion form of that drops nearly every charge, so it has to fail at the edge.
+   */
+  it('rejects whitespace-only search text on both sides', () => {
+    expect(chargeFiltersInput.safeParse({ excludedFreeText: '  ' }).success).toBe(false);
+    expect(chargeFiltersInput.safeParse({ excludedFreeText: '    ' }).success).toBe(false);
+    expect(chargeFiltersInput.safeParse({ freeText: '  ' }).success).toBe(false);
+    // still fine with surrounding whitespace around real content
+    expect(chargeFiltersInput.safeParse({ excludedFreeText: ' ab ' }).success).toBe(true);
+  });
+
   // The shared array helper preprocesses `[]` to absent, so an empty exclusion never
   // becomes a predicate. Exercised through parse-then-build, which is the real path:
   // `[]` is truthy, so the builder alone would forward it (true of the positive

--- a/packages/mcp-server/src/tools/__tests__/charge-filter-exclusions.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/charge-filter-exclusions.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { buildChargeFilters, chargeFiltersInput } from '../charge-filters.js';
+
+/**
+ * The `excluded*` predicates reach the model through the shared charge-filter shape.
+ * They spent a release in `UNSUPPORTED_UPSTREAM_CHARGE_FILTER_FIELDS` because upstream
+ * accepted and ignored them; now that the SQL exists they are exposed, and the two
+ * halves that could silently regress are the zod shape accepting them and
+ * `buildChargeFilters` forwarding them.
+ */
+const SCOPE = ['owner-1'] as const;
+
+describe('charge filter exclusions', () => {
+  it('accepts the excluded predicates on the shared input shape', () => {
+    const parsed = chargeFiltersInput.safeParse({
+      excludedBusinesses: ['biz-2'],
+      excludedFinancialAccounts: ['account-2'],
+      excludedTags: ['tag-2'],
+      excludedFreeText: 'refund',
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('forwards each exclusion to the upstream filter', () => {
+    const filters = buildChargeFilters(
+      {
+        excludedBusinesses: ['biz-2'],
+        excludedFinancialAccounts: ['account-2'],
+        excludedTags: ['tag-2'],
+        excludedFreeText: 'refund',
+      },
+      SCOPE,
+    );
+    expect(filters).toMatchObject({
+      excludedBusinesses: ['biz-2'],
+      excludedFinancialAccounts: ['account-2'],
+      excludedTags: ['tag-2'],
+      excludedFreeText: 'refund',
+    });
+  });
+
+  it('carries include and exclude sides together for "mentions X but not Y"', () => {
+    const filters = buildChargeFilters(
+      { freeText: 'invoice', excludedFreeText: 'refund', byTags: ['a'], excludedTags: ['b'] },
+      SCOPE,
+    );
+    expect(filters.freeText).toBe('invoice');
+    expect(filters.excludedFreeText).toBe('refund');
+    expect(filters.byTags).toEqual(['a']);
+    expect(filters.excludedTags).toEqual(['b']);
+  });
+
+  it('omits the exclusion keys entirely when unused', () => {
+    const filters = buildChargeFilters({ byTags: ['a'] }, SCOPE);
+    expect(filters).not.toHaveProperty('excludedBusinesses');
+    expect(filters).not.toHaveProperty('excludedFinancialAccounts');
+    expect(filters).not.toHaveProperty('excludedTags');
+    expect(filters).not.toHaveProperty('excludedFreeText');
+  });
+
+  // Same floor as `freeText` — a single character is a near-match-everything scan.
+  it('holds excluded free text to the same minimum length as freeText', () => {
+    expect(chargeFiltersInput.safeParse({ excludedFreeText: 'a' }).success).toBe(false);
+    expect(chargeFiltersInput.safeParse({ excludedFreeText: 'ab' }).success).toBe(true);
+  });
+
+  // The shared array helper preprocesses `[]` to absent, so an empty exclusion never
+  // becomes a predicate. Exercised through parse-then-build, which is the real path:
+  // `[]` is truthy, so the builder alone would forward it (true of the positive
+  // twins too — zod is what normalizes it away).
+  it('treats an empty exclusion array as an omitted predicate', () => {
+    const parsed = chargeFiltersInput.parse({ excludedTags: [], excludedBusinesses: [] });
+    expect(parsed.excludedTags).toBeUndefined();
+    expect(parsed.excludedBusinesses).toBeUndefined();
+
+    const filters = buildChargeFilters(parsed, SCOPE);
+    expect(filters).not.toHaveProperty('excludedTags');
+    expect(filters).not.toHaveProperty('excludedBusinesses');
+  });
+});

--- a/packages/mcp-server/src/tools/charge-filters.ts
+++ b/packages/mcp-server/src/tools/charge-filters.ts
@@ -22,27 +22,15 @@ import { TIMELESS_DATE } from './dates.js';
  * them and then ignores them.
  *
  * `allCharges` forwards its filter to `ChargesProvider.getChargesByFilters`, and
- * these are never passed on — there is no SQL predicate behind them at
+ * these two are never passed on — there is no SQL predicate behind them at
  * all (the client's charges screen sends `unbalanced` and it does nothing
  * either). A filter that silently matches everything is worse than an absent
  * one for a model: it asks for "only unbalanced charges", gets the whole table,
  * and has no way to tell. They stay out until upstream implements them; the
  * schema-contract test uses this list, so it fails loudly if the set of
  * unimplemented fields changes.
- *
- * The four `excluded*` fields were added to the schema alongside the charges
- * filter redesign so the client could send them, with the resolver work
- * deliberately deferred — see `docs/charges-filters/backend-followup.md`.
- * Remove them from this list as each one gains a SQL predicate.
  */
-export const UNSUPPORTED_UPSTREAM_CHARGE_FILTER_FIELDS = [
-  'businessTrip',
-  'unbalanced',
-  'excludedBusinesses',
-  'excludedFinancialAccounts',
-  'excludedTags',
-  'excludedFreeText',
-] as const;
+export const UNSUPPORTED_UPSTREAM_CHARGE_FILTER_FIELDS = ['businessTrip', 'unbalanced'] as const;
 
 export const CHARGE_FILTER_IDS_CAP = 300;
 export const CHARGE_FILTER_TAGS_CAP = 50;
@@ -143,6 +131,33 @@ export const CHARGE_FILTER_SHAPE = {
   byTags: optionalNonEmptyStringArray(CHARGE_FILTER_TAGS_CAP)
     .optional()
     .describe('Include only charges carrying these tags.'),
+  excludedBusinesses: optionalNonEmptyStringArray(CHARGE_FILTER_IDS_CAP)
+    .optional()
+    .describe(
+      'Drop charges involving any of these businesses as the counterparty. Applied after the ' +
+        'include lists, so a business named in both is excluded.',
+    ),
+  excludedFinancialAccounts: optionalNonEmptyStringArray(CHARGE_FILTER_IDS_CAP)
+    .optional()
+    .describe(
+      'Drop charges with any transaction in these financial accounts. Applied after the include ' +
+        'lists, so an account named in both is excluded.',
+    ),
+  excludedFreeText: z
+    .string()
+    .min(2)
+    .max(CHARGE_FILTER_TEXT_MAX)
+    .optional()
+    .describe(
+      'Drop charges matching this text across the same fields as `freeText`. Charges with no text ' +
+        'at all are kept. Combine with `freeText` for "mentions X but not Y".',
+    ),
+  excludedTags: optionalNonEmptyStringArray(CHARGE_FILTER_TAGS_CAP)
+    .optional()
+    .describe(
+      'Drop charges carrying any of these tags. Applied after the include lists, so a tag named ' +
+        'in both is excluded.',
+    ),
   chargesType: z
     .enum(['ALL', 'INCOME', 'EXPENSE'])
     .optional()
@@ -264,6 +279,12 @@ export function buildChargeFilters(
   if (input.byChargeTypes) filters.byChargeTypes = [...input.byChargeTypes];
   if (input.byTags) filters.byTags = [...input.byTags];
   if (input.chargesType) filters.chargesType = input.chargesType;
+  if (input.excludedBusinesses) filters.excludedBusinesses = [...input.excludedBusinesses];
+  if (input.excludedFinancialAccounts) {
+    filters.excludedFinancialAccounts = [...input.excludedFinancialAccounts];
+  }
+  if (input.excludedFreeText) filters.excludedFreeText = input.excludedFreeText;
+  if (input.excludedTags) filters.excludedTags = [...input.excludedTags];
   if (input.freeText) filters.freeText = input.freeText;
   if (input.fromAnyDate) filters.fromAnyDate = input.fromAnyDate;
   if (input.fromDate) filters.fromDate = input.fromDate;

--- a/packages/mcp-server/src/tools/charge-filters.ts
+++ b/packages/mcp-server/src/tools/charge-filters.ts
@@ -70,6 +70,19 @@ export function optionalNonEmptyStringArray(max: number) {
   );
 }
 
+/**
+ * A free-text predicate. `.min(2)` alone accepts "  ", which is truthy and so gets
+ * forwarded, then trims to an empty string downstream — where SQL reads it as
+ * `ILIKE '%%'` and it matches everything. The refine holds the floor after trimming.
+ */
+function searchText(max: number) {
+  return z
+    .string()
+    .min(2)
+    .max(max)
+    .refine(value => value.trim().length >= 2, 'must contain at least 2 non-whitespace characters');
+}
+
 /** Same empty-array-means-absent treatment, for a fixed enum vocabulary. */
 function optionalNonEmptyEnumArray<const T extends readonly [string, ...string[]]>(values: T) {
   return z.preprocess(
@@ -143,10 +156,7 @@ export const CHARGE_FILTER_SHAPE = {
       'Drop charges with any transaction in these financial accounts. Applied after the include ' +
         'lists, so an account named in both is excluded.',
     ),
-  excludedFreeText: z
-    .string()
-    .min(2)
-    .max(CHARGE_FILTER_TEXT_MAX)
+  excludedFreeText: searchText(CHARGE_FILTER_TEXT_MAX)
     .optional()
     .describe(
       'Drop charges matching this text across the same fields as `freeText`. Charges with no text ' +
@@ -162,10 +172,7 @@ export const CHARGE_FILTER_SHAPE = {
     .enum(['ALL', 'INCOME', 'EXPENSE'])
     .optional()
     .describe('Restrict to income or expense charges (ALL for both).'),
-  freeText: z
-    .string()
-    .min(2)
-    .max(CHARGE_FILTER_TEXT_MAX)
+  freeText: searchText(CHARGE_FILTER_TEXT_MAX)
     .optional()
     .describe(
       'Free-text search across the charge: user description, transaction description/reference, and ' +

--- a/packages/server/src/modules/charges/helpers/filtered-charges.helper.ts
+++ b/packages/server/src/modules/charges/helpers/filtered-charges.helper.ts
@@ -95,6 +95,12 @@ export async function fetchFilteredCharges(
       withoutTags: filters?.withoutTags,
       freeText: filters?.freeText?.trim().toLowerCase(),
       tags: filters?.byTags,
+      // Exclusions. A value present in both an include and its exclude list is
+      // dropped: the predicates are ANDed, so exclude wins.
+      excludedBusinessIds: filters?.excludedBusinesses,
+      excludedAccountIds: filters?.excludedFinancialAccounts,
+      excludedTags: filters?.excludedTags,
+      excludedFreeText: filters?.excludedFreeText?.trim().toLowerCase(),
       accountantStatuses: filters?.accountantStatus as accountant_statusArray | undefined,
     })
     .catch(error => {

--- a/packages/server/src/modules/charges/helpers/filtered-charges.helper.ts
+++ b/packages/server/src/modules/charges/helpers/filtered-charges.helper.ts
@@ -93,14 +93,17 @@ export async function fetchFilteredCharges(
       withoutTransactions: filters?.withoutTransactions,
       withoutLedger: filters?.withoutLedger,
       withoutTags: filters?.withoutTags,
-      freeText: filters?.freeText?.trim().toLowerCase(),
+      // `|| undefined` so a whitespace-only value never leaves the mapping layer as
+      // an empty string, which SQL would read as ILIKE '%%'. The provider normalizes
+      // again as the authoritative guard.
+      freeText: filters?.freeText?.trim().toLowerCase() || undefined,
       tags: filters?.byTags,
       // Exclusions. A value present in both an include and its exclude list is
       // dropped: the predicates are ANDed, so exclude wins.
       excludedBusinessIds: filters?.excludedBusinesses,
       excludedAccountIds: filters?.excludedFinancialAccounts,
       excludedTags: filters?.excludedTags,
-      excludedFreeText: filters?.excludedFreeText?.trim().toLowerCase(),
+      excludedFreeText: filters?.excludedFreeText?.trim().toLowerCase() || undefined,
       accountantStatuses: filters?.accountantStatus as accountant_statusArray | undefined,
     })
     .catch(error => {

--- a/packages/server/src/modules/charges/providers/__tests__/search-text-normalization.test.ts
+++ b/packages/server/src/modules/charges/providers/__tests__/search-text-normalization.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeSearchText, toNumericSearchText } from '../charges.provider.js';
+
+/**
+ * These two guard the SQL boundary. Several resolvers build `getChargesByFilters`
+ * params independently, so the provider — not any one caller — is where a search
+ * string has to be made safe.
+ */
+describe('normalizeSearchText', () => {
+  /**
+   * The bug this exists for: an empty string is not NULL, so it passes the query's
+   * `IS NOT NULL` guards and degrades to `ILIKE '%%'`. As an exclusion that drops
+   * nearly every charge; as a positive filter it drops the charges whose description
+   * is NULL, since they fail the ILIKE that every other row passes.
+   */
+  it('collapses whitespace-only text to null', () => {
+    expect(normalizeSearchText('   ')).toBeNull();
+    expect(normalizeSearchText('\t\n ')).toBeNull();
+    expect(normalizeSearchText('')).toBeNull();
+  });
+
+  it('passes null and undefined through', () => {
+    expect(normalizeSearchText(null)).toBeNull();
+    expect(normalizeSearchText(undefined)).toBeNull();
+  });
+
+  it('trims and lowercases real content', () => {
+    expect(normalizeSearchText('  Coffee ')).toBe('coffee');
+    expect(normalizeSearchText('REFUND')).toBe('refund');
+  });
+});
+
+describe('toNumericSearchText', () => {
+  // The amount branches compare against `amount::TEXT`, so a term with no digit
+  // cannot match one and only costs a scan on both the search and exclusion paths.
+  it('is null for text with no digits', () => {
+    expect(toNumericSearchText('coffee')).toBeNull();
+    expect(toNumericSearchText('..')).toBeNull();
+    expect(toNumericSearchText(null)).toBeNull();
+  });
+
+  it('strips thousands separators so 1,234.56 matches the stored 1234.56', () => {
+    expect(toNumericSearchText('1,234.56')).toBe('1234.56');
+    expect(toNumericSearchText('1234.56')).toBe('1234.56');
+  });
+
+  it('keeps mixed text that contains a digit, since it may match an amount', () => {
+    expect(toNumericSearchText('-1')).toBe('-1');
+    expect(toNumericSearchText('invoice 42')).toBe('invoice 42');
+  });
+});

--- a/packages/server/src/modules/charges/providers/charges.provider.ts
+++ b/packages/server/src/modules/charges/providers/charges.provider.ts
@@ -173,6 +173,29 @@ const generateCharge = sql<IGenerateChargeQuery>`
 `;
 
 /**
+ * Collapses a search string that is empty once trimmed to `null`.
+ *
+ * An empty string is not `NULL` in SQL, so it survives the `IS NOT NULL` guards and
+ * degrades to `ILIKE '%%'`, which matches every non-null column. On the exclusion side
+ * that drops nearly every charge; on the positive side it drops the opposite set --
+ * charges whose description is `NULL` -- because they fail the `ILIKE` the others pass.
+ * Either way the caller meant "no text predicate", so normalize it away.
+ */
+export function normalizeSearchText(text?: string | null | void): string | null {
+  const trimmed = text?.trim().toLowerCase();
+  return trimmed || null;
+}
+
+/**
+ * The amount-matching branches compare against `amount::TEXT`, so a search term with
+ * no digit in it cannot match one and only costs a scan. Thousands separators are
+ * stripped so both "1,234.56" and "1234.56" match the plain stored value.
+ */
+export function toNumericSearchText(text: string | null): string | null {
+  return text && /\d/.test(text) ? text.replaceAll(',', '') : null;
+}
+
+/**
  * Note for editors: pgTyped silently truncates the generated parameter list at the
  * first `--` comment inside the closing WHERE clause, dropping every parameter after
  * it. Keep explanatory comments in TypeScript rather than in that clause.
@@ -1321,6 +1344,8 @@ export class ChargesProvider {
     const isExcludedAccountIds = !!params?.excludedAccountIds?.filter(Boolean).length;
     // A value in both an include and its exclude list is dropped: the predicates are
     // ANDed in SQL, so exclude wins.
+    const freeText = normalizeSearchText(params.freeText);
+    const excludedFreeText = normalizeSearchText(params.excludedFreeText);
 
     const defaults = {
       asc: false,
@@ -1361,12 +1386,12 @@ export class ChargesProvider {
       withoutLedger: params.withoutLedger ?? false,
       withoutTags: params.withoutTags ?? false,
       accountantStatuses: isAccountantStatuses ? params.accountantStatuses! : null,
-      // strip thousands separators so amount searches match the plain value stored in the DB
-      freeTextNumeric: params.freeText ? params.freeText.replaceAll(',', '') : null,
-      excludedFreeText: params.excludedFreeText ?? null,
-      excludedFreeTextNumeric: params.excludedFreeText
-        ? params.excludedFreeText.replaceAll(',', '')
-        : null,
+      // Normalized here rather than at the callers: this is the single chokepoint in
+      // front of the SQL, and several resolvers build these params independently.
+      freeText,
+      freeTextNumeric: toNumericSearchText(freeText),
+      excludedFreeText,
+      excludedFreeTextNumeric: toNumericSearchText(excludedFreeText),
     };
     return getChargesByFilters.run(fullParams, this.db).then(charges => {
       // The enriched rows are supersets of the plain charge rows — prime the

--- a/packages/server/src/modules/charges/providers/charges.provider.ts
+++ b/packages/server/src/modules/charges/providers/charges.provider.ts
@@ -172,6 +172,19 @@ const generateCharge = sql<IGenerateChargeQuery>`
   RETURNING *;
 `;
 
+/**
+ * Note for editors: pgTyped silently truncates the generated parameter list at the
+ * first `--` comment inside the closing WHERE clause, dropping every parameter after
+ * it. Keep explanatory comments in TypeScript rather than in that clause.
+ *
+ * The `excluded*` filters are array NON-overlap against the per-charge aggregates
+ * (`business_array`, `tags`, `account_array`), so a charge is dropped when *any* of
+ * its businesses / tags / accounts appears in the exclusion list. Each is wrapped in
+ * COALESCE because those arrays come from LEFT JOINs and `NULL && array` is NULL,
+ * which would otherwise drop the charges that have none of the excluded thing.
+ * `excludedFreeText` works the other way round, as an `excluded_matches` CTE the
+ * charge must not appear in.
+ */
 const getChargesByFilters = sql<IGetChargesByFiltersQuery>`
   WITH search_matches AS (
     -- Strategy: Identify IDs via Trigram indexes before doing any heavy math
@@ -228,6 +241,60 @@ const getChargesByFilters = sql<IGetChargesByFiltersQuery>`
     WHERE ($freeText::TEXT IS NOT NULL
            AND fe.name ILIKE '%' || $freeText || '%')
   ),
+  excluded_matches AS (
+    -- Mirror of search_matches for the negative side. Every branch requires the
+    -- param to be NOT NULL, so with no exclusion the set is empty and nothing is
+    -- dropped -- the opposite of search_matches, whose first branch passes every
+    -- charge through when $freeText is NULL.
+    -- A charge whose columns are all NULL simply never enters this set, so
+    -- "does not mention X" keeps charges with no text at all.
+    SELECT id FROM accounter_schema.charges
+    WHERE ($excludedFreeText::TEXT IS NOT NULL
+           AND user_description ILIKE '%' || $excludedFreeText || '%'
+    )
+    UNION
+    SELECT charge_id FROM accounter_schema.transactions
+    WHERE ($excludedFreeText::TEXT IS NOT NULL
+           AND (source_description ILIKE '%' || $excludedFreeText || '%'
+                OR source_reference ILIKE '%' || $excludedFreeText || '%')
+    )
+    UNION
+    SELECT charge_id FROM accounter_schema.documents
+    WHERE ($excludedFreeText::TEXT IS NOT NULL
+           AND (description ILIKE '%' || $excludedFreeText || '%'
+                OR remarks ILIKE '%' || $excludedFreeText || '%'
+                OR serial_number ILIKE '%' || $excludedFreeText || '%')
+    )
+    UNION
+    SELECT charge_id FROM accounter_schema.transactions
+    WHERE ($excludedFreeTextNumeric::TEXT IS NOT NULL
+           AND (amount::TEXT ILIKE '%' || $excludedFreeTextNumeric || '%'
+                OR ABS(amount)::TEXT ILIKE '%' || $excludedFreeTextNumeric || '%')
+    )
+    UNION
+    SELECT charge_id FROM accounter_schema.documents
+    WHERE ($excludedFreeTextNumeric::TEXT IS NOT NULL
+           AND (total_amount::TEXT ILIKE '%' || $excludedFreeTextNumeric || '%'
+                OR ABS(total_amount)::TEXT ILIKE '%' || $excludedFreeTextNumeric || '%'
+                OR vat_amount::TEXT ILIKE '%' || $excludedFreeTextNumeric || '%'
+                OR ABS(vat_amount)::TEXT ILIKE '%' || $excludedFreeTextNumeric || '%')
+    )
+    UNION
+    SELECT t.charge_id FROM accounter_schema.transactions t
+    JOIN accounter_schema.financial_entities fe ON fe.id = t.business_id
+    WHERE ($excludedFreeText::TEXT IS NOT NULL
+           AND fe.name ILIKE '%' || $excludedFreeText || '%')
+    UNION
+    SELECT d.charge_id FROM accounter_schema.documents d
+    JOIN accounter_schema.financial_entities fe ON fe.id = d.creditor_id
+    WHERE ($excludedFreeText::TEXT IS NOT NULL
+           AND fe.name ILIKE '%' || $excludedFreeText || '%')
+    UNION
+    SELECT d.charge_id FROM accounter_schema.documents d
+    JOIN accounter_schema.financial_entities fe ON fe.id = d.debtor_id
+    WHERE ($excludedFreeText::TEXT IS NOT NULL
+           AND fe.name ILIKE '%' || $excludedFreeText || '%')
+  ),
   filtered_charges AS MATERIALIZED (
     -- This is our "source of truth" for the rest of the query
     SELECT c.*
@@ -235,6 +302,10 @@ const getChargesByFilters = sql<IGetChargesByFiltersQuery>`
     INNER JOIN search_matches sm ON c.id = sm.id 
     WHERE ($isIDs = 0 OR c.id IN $$IDs)
       AND ($isOwnerIds = 0 OR c.owner_id IN $$ownerIds)
+      AND (
+        ($excludedFreeText::TEXT IS NULL AND $excludedFreeTextNumeric::TEXT IS NULL)
+        OR NOT EXISTS (SELECT 1 FROM excluded_matches em WHERE em.id = c.id)
+      )
   ),
   years_of_relevance AS (
     SELECT cs.charge_id,
@@ -736,6 +807,7 @@ const getChargesByFilters = sql<IGetChargesByFiltersQuery>`
   FROM enriched_charges ec
   WHERE
   ($isBusinessIds = 0 OR ec.business_array && $businessIds)
+  AND ($isExcludedBusinessIds = 0 OR NOT COALESCE(ec.business_array && $excludedBusinessIds, FALSE))
   AND ($fromDate ::TEXT IS NULL OR COALESCE(ec.documents_min_date, ec.transactions_min_event_date)::TEXT::DATE >= date_trunc('day', $fromDate ::DATE))
   AND ($fromAnyDate ::TEXT IS NULL OR GREATEST(ec.documents_max_date, ec.transactions_max_event_date, ec.transactions_max_debit_date, ec.ledger_max_invoice_date, ec.ledger_max_value_date)::TEXT::DATE >= date_trunc('day', $fromAnyDate ::DATE))
   AND ($toDate ::TEXT IS NULL OR COALESCE(ec.documents_max_date, ec.transactions_max_event_date)::TEXT::DATE <= date_trunc('day', $toDate ::DATE))
@@ -750,9 +822,11 @@ const getChargesByFilters = sql<IGetChargesByFiltersQuery>`
   AND ($withoutLedger = FALSE OR COALESCE(ec.ledger_count, 0) = 0)
   AND ($isAccountantStatuses = 0 OR ec.accountant_status = ANY ($accountantStatuses::accounter_schema.accountant_status[]))
   AND ($isTags = 0 OR ec.tags && $tags)
+  AND ($isExcludedTags = 0 OR NOT COALESCE(ec.tags && $excludedTags, FALSE))
   AND ($withoutTags = FALSE OR COALESCE(array_length(ec.tags, 1), 0) = 0)
   AND ($isBusinessTripIds = 0 OR ec.business_trip_id = ANY ($businessTripIds::uuid[]))
   AND ($isAccountIds = 0 OR ec.account_array && $accountIds::uuid[])
+  AND ($isExcludedAccountIds = 0 OR NOT COALESCE(ec.account_array && $excludedAccountIds::uuid[], FALSE))
   AND ($withMissingCounterparty = FALSE OR COALESCE(ec.missing_counterparty_transactions, false) = true OR COALESCE(ec.missing_counterparty_documents, false) = true)
   ORDER BY
   CASE WHEN $asc = true AND $sortColumn = 'event_date' THEN (COALESCE(ec.transactions_min_debit_date, ec.transactions_min_event_date, ec.documents_min_date, ec.ledger_min_value_date, ec.ledger_min_invoice_date), COALESCE(ec.documents_min_date, ec.transactions_min_event_date), ec.id) END ASC,
@@ -1105,6 +1179,13 @@ type IGetAdjustedChargesByFiltersParams = Optional<
     | 'isAccountIds'
     | 'accountIds'
     | 'freeTextNumeric'
+    | 'isExcludedBusinessIds'
+    | 'excludedBusinessIds'
+    | 'isExcludedTags'
+    | 'excludedTags'
+    | 'isExcludedAccountIds'
+    | 'excludedAccountIds'
+    | 'excludedFreeTextNumeric'
   >,
   'ownerIds' | 'IDs' | 'asc' | 'sortColumn' | 'toDate' | 'fromDate'
 > & {
@@ -1114,6 +1195,9 @@ type IGetAdjustedChargesByFiltersParams = Optional<
   businessIds?: readonly string[] | null;
   businessTripIds?: readonly string[] | null;
   accountIds?: readonly string[] | null;
+  excludedBusinessIds?: readonly string[] | null;
+  excludedTags?: readonly string[] | null;
+  excludedAccountIds?: readonly string[] | null;
 };
 
 const deleteChargesByIds = sql<IDeleteChargesByIdsQuery>`
@@ -1232,6 +1316,11 @@ export class ChargesProvider {
     const isAccountantStatuses = !!params?.accountantStatuses?.length;
     const isBusinessTripIds = !!params?.businessTripIds?.filter(Boolean).length;
     const isAccountIds = !!params?.accountIds?.filter(Boolean).length;
+    const isExcludedBusinessIds = !!params?.excludedBusinessIds?.filter(Boolean).length;
+    const isExcludedTags = !!params?.excludedTags?.length;
+    const isExcludedAccountIds = !!params?.excludedAccountIds?.filter(Boolean).length;
+    // A value in both an include and its exclude list is dropped: the predicates are
+    // ANDed in SQL, so exclude wins.
 
     const defaults = {
       asc: false,
@@ -1247,6 +1336,9 @@ export class ChargesProvider {
       isAccountantStatuses: isAccountantStatuses ? 1 : 0,
       isBusinessTripIds: isBusinessTripIds ? 1 : 0,
       isAccountIds: isAccountIds ? 1 : 0,
+      isExcludedBusinessIds: isExcludedBusinessIds ? 1 : 0,
+      isExcludedTags: isExcludedTags ? 1 : 0,
+      isExcludedAccountIds: isExcludedAccountIds ? 1 : 0,
       ...params,
       fromDate: params.fromDate ?? null,
       toDate: params.toDate ?? null,
@@ -1256,6 +1348,9 @@ export class ChargesProvider {
       tags: isTags ? (params.tags! as string[]) : null,
       businessTripIds: isBusinessTripIds ? (params.businessTripIds! as string[]) : null,
       accountIds: isAccountIds ? (params.accountIds! as string[]) : null,
+      excludedBusinessIds: isExcludedBusinessIds ? (params.excludedBusinessIds! as string[]) : null,
+      excludedTags: isExcludedTags ? (params.excludedTags! as string[]) : null,
+      excludedAccountIds: isExcludedAccountIds ? (params.excludedAccountIds! as string[]) : null,
       withMissingCounterparty: params.withMissingCounterparty ?? false,
       chargeType: params.chargeType ?? 'ALL',
       withoutInvoice: params.withoutInvoice ?? false,
@@ -1268,6 +1363,10 @@ export class ChargesProvider {
       accountantStatuses: isAccountantStatuses ? params.accountantStatuses! : null,
       // strip thousands separators so amount searches match the plain value stored in the DB
       freeTextNumeric: params.freeText ? params.freeText.replaceAll(',', '') : null,
+      excludedFreeText: params.excludedFreeText ?? null,
+      excludedFreeTextNumeric: params.excludedFreeText
+        ? params.excludedFreeText.replaceAll(',', '')
+        : null,
     };
     return getChargesByFilters.run(fullParams, this.db).then(charges => {
       // The enriched rows are supersets of the plain charge rows — prime the

--- a/packages/server/src/modules/charges/resolvers/__tests__/all-charges-filters.test.ts
+++ b/packages/server/src/modules/charges/resolvers/__tests__/all-charges-filters.test.ts
@@ -106,4 +106,62 @@ describe('Query.allCharges filter forwarding', () => {
     expect(params.tags).toEqual(['tag-1']);
     expect(params.withoutTags).toBeUndefined();
   });
+
+  /**
+   * The exclusion half of the filter. These shipped in the schema ahead of the SQL
+   * and were accepted-but-ignored for a release; the mapping is the exact place
+   * that silence lived, so each one is pinned here.
+   */
+  describe('exclusions', () => {
+    it('forwards the excluded entity lists onto their provider parameters', async () => {
+      const params = await paramsFor({
+        excludedBusinesses: ['biz-2'],
+        excludedFinancialAccounts: ['account-2'],
+        excludedTags: ['tag-2'],
+      });
+      expect(params).toMatchObject({
+        excludedBusinessIds: ['biz-2'],
+        excludedAccountIds: ['account-2'],
+        excludedTags: ['tag-2'],
+      });
+    });
+
+    it('normalizes excluded free text the same way as freeText', async () => {
+      const params = await paramsFor({ excludedFreeText: '  Refund  ' });
+      expect(params.excludedFreeText).toBe('refund');
+    });
+
+    // Include and exclude are separate predicates, ANDed in SQL — neither side may
+    // leak into the other's parameter, or "X but not Y" silently becomes one of them.
+    it('keeps each exclusion independent of its positive twin', async () => {
+      const params = await paramsFor({
+        byBusinesses: ['biz-1'],
+        excludedBusinesses: ['biz-2'],
+        byTags: ['tag-1'],
+        excludedTags: ['tag-2'],
+        byFinancialAccounts: ['account-1'],
+        excludedFinancialAccounts: ['account-2'],
+        freeText: 'invoice',
+        excludedFreeText: 'refund',
+      });
+      expect(params).toMatchObject({
+        businessIds: ['biz-1'],
+        excludedBusinessIds: ['biz-2'],
+        tags: ['tag-1'],
+        excludedTags: ['tag-2'],
+        accountIds: ['account-1'],
+        excludedAccountIds: ['account-2'],
+        freeText: 'invoice',
+        excludedFreeText: 'refund',
+      });
+    });
+
+    it('leaves the exclusion parameters unset when the filter omits them', async () => {
+      const params = await paramsFor({ byBusinesses: ['biz-1'] });
+      expect(params.excludedBusinessIds).toBeUndefined();
+      expect(params.excludedAccountIds).toBeUndefined();
+      expect(params.excludedTags).toBeUndefined();
+      expect(params.excludedFreeText).toBeUndefined();
+    });
+  });
 });

--- a/packages/server/src/modules/charges/resolvers/__tests__/all-charges-filters.test.ts
+++ b/packages/server/src/modules/charges/resolvers/__tests__/all-charges-filters.test.ts
@@ -156,6 +156,18 @@ describe('Query.allCharges filter forwarding', () => {
       });
     });
 
+    /**
+     * A whitespace-only value trims to an empty string, which is not NULL in SQL and
+     * so degrades to `ILIKE '%%'`. On the exclusion side that would drop nearly every
+     * charge; on the positive side it drops charges whose description is NULL. Both
+     * sides must read it as "no text predicate".
+     */
+    it('treats whitespace-only text as no predicate on both sides', async () => {
+      const params = await paramsFor({ freeText: '   ', excludedFreeText: '  ' });
+      expect(params.freeText).toBeUndefined();
+      expect(params.excludedFreeText).toBeUndefined();
+    });
+
     it('leaves the exclusion parameters unset when the filter omits them', async () => {
       const params = await paramsFor({ byBusinesses: ['biz-1'] });
       expect(params.excludedBusinessIds).toBeUndefined();


### PR DESCRIPTION
Stacked on #4289. Implements the deferred backend work from `docs/charges-filters/backend-followup.md`.

`excludedBusinesses`, `excludedFinancialAccounts`, `excludedTags` and `excludedFreeText` were added to the schema in #4289 so the client could send them, with the SQL deliberately deferred. Until now `allCharges` accepted all four and ignored them — picking "exclude" in the filter modal returned an unfiltered result with no indication the constraint had been dropped. They now have real predicates, and the exclude UI shipped in #4289 does what it says.

## The entity exclusions

The follow-up doc called for `NOT EXISTS`, but the query turned out not to need it. `getChargesByFilters` already aggregates each charge's businesses, tags and accounts into arrays before its closing `WHERE`, so exclusion is array **non**-overlap:

```sql
AND ($isExcludedTags = 0 OR NOT COALESCE(ec.tags && $excludedTags, FALSE))
```

Because the array holds the charge's full set, this gives the intended semantics directly — drop the charge when *any* of its businesses / tags / accounts is listed. The doc's worry about a plain `NOT IN` matching on a second joined row doesn't arise; there's no per-row join left at that point.

The `COALESCE` is load-bearing. Those arrays come from `LEFT JOIN`s, and `NULL && array` is `NULL`, not `FALSE` — without it, a tag exclusion would have dropped **every charge that has no tags at all**, which is the exact opposite of the filter's meaning.

## `excludedFreeText`

A set-membership test rather than a negated `ILIKE`. A new `excluded_matches` CTE mirrors the existing `search_matches` across the same eight sources — charge description, transaction description/reference, document description/remarks/serial, transaction and document amounts, and counterparty names via transactions, creditor and debtor — and `filtered_charges` requires the charge not to appear in it. Every branch requires the parameter to be non-null, the inverse of `search_matches`, whose first branch deliberately passes every charge through when `$freeText` is null.

This also dissolves the NULL-safety question the doc raised: a charge whose columns are all `NULL` never enters the set, so **"does not mention X" keeps charges with no text at all** — no `COALESCE` needed, because nothing is negating an `ILIKE`. Thousands separators are stripped as they are for `freeText`, so excluding `1,234.56` also excludes `1234.56`.

## Precedence

Include and exclude are separate predicates, `AND`ed, so a value named in both lists is **excluded**. The client's tri-state can't produce that, but the API allows it, and there's a test pinning that neither side leaks into the other's parameter.

## MCP

All four come off `UNSUPPORTED_UPSTREAM_CHARGE_FILTER_FIELDS` and are exposed on `accounter_get_charges` and `accounter_search_charges` — "mentions X but not Y" and "everything except these accounts" are expressible by a model for the first time. `unbalanced` and `businessTrip` stay on the list; they're still accepted-but-ignored.

## One hazard worth knowing about

**pgTyped silently truncates the generated parameter list at the first `--` comment inside the closing `WHERE` clause.** An explanatory comment placed there cut `IGetChargesByFiltersParams` from 30-odd entries down to ten, taking `tags`, `accountIds` and `sortColumn` with it. It's caught by `tsc` rather than being a silent runtime bug — the `fullParams` literal fails excess-property checking — but it's an easy hour to lose. Comments inside CTEs are fine. There's now a note above the `sql` template and in the doc.

## Verification

`yarn generate`, both `@accounter/server` and `@accounter/mcp-server` build clean, `yarn lint` (0 errors on changed files), `yarn test` — **3752 passing**, up 10.

**Not covered:** there's no DB-level test of the predicates. The 10 new tests pin the mapping layer — each field reaching its provider parameter, free-text normalisation, independence from its positive twin, and the MCP input/builder — but the SQL itself is only exercised by hand. A DB-backed test per field (dropped charge, surviving charge, both-lists charge, NULL-description charge) belongs in the integration project; it's listed under "Still open" in the doc. The query cost of `excluded_matches` also hasn't been profiled against a large charge table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
