### PR TITLE
feat(client): public landing page at the site root

### DIFF
--- a/.changeset/tidy-jars-shave.md
+++ b/.changeset/tidy-jars-shave.md
@@ -6,8 +6,11 @@ Add a public landing page at `/`.
 
 Logged-out visitors now get a static marketing page describing what Accounter does — how data is
 collected and matched, the feature set, the integrations, the Israeli compliance formats and the MCP
-connector — with "Sign in" and "Request access" buttons in the header. Anyone with a session is
-redirected into the app instead.
+connector — with a "Log in" button that goes straight to Auth0 for returning users and a
+"Request access" button for leads. Anyone with a session is redirected into the app instead.
+
+The Auth0 redirect itself moved into a shared `useLogin` hook, so the landing page and the login
+screen ask for the same audience, scopes and callback URL.
 
 The route tree changed to make room for it: the protected subtree is now a pathless layout route, so
 `/` belongs to the landing page, and `ROUTES.APP_HOME` (`/charges`) is the new destination for

--- a/.changeset/tidy-jars-shave.md
+++ b/.changeset/tidy-jars-shave.md
@@ -6,7 +6,7 @@ Add a public landing page at `/`.
 
 Logged-out visitors now get a static marketing page describing what Accounter does — how data is
 collected and matched, the feature set, the integrations, the Israeli compliance formats and the MCP
-connector — with a "Request access" call to action in the header. Anyone with a session is
+connector — with "Sign in" and "Request access" buttons in the header. Anyone with a session is
 redirected into the app instead.
 
 The route tree changed to make room for it: the protected subtree is now a pathless layout route, so

--- a/.changeset/tidy-jars-shave.md
+++ b/.changeset/tidy-jars-shave.md
@@ -1,0 +1,15 @@
+---
+'@accounter/client': minor
+---
+
+Add a public landing page at `/`.
+
+Logged-out visitors now get a static marketing page describing what Accounter does — how data is
+collected and matched, the feature set, the integrations, the Israeli compliance formats and the MCP
+connector — with a "Request access" call to action in the header. Anyone with a session is
+redirected into the app instead.
+
+The route tree changed to make room for it: the protected subtree is now a pathless layout route, so
+`/` belongs to the landing page, and `ROUTES.APP_HOME` (`/charges`) is the new destination for
+everything that means "send the user into the app" — post-login, post-invitation, the error
+boundary's home links and the dashboard logo.

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -5,6 +5,18 @@
     <link rel="icon" href="/icons/accounter-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Accounter</title>
+    <meta
+      name="description"
+      content="Accounter brings bank, card, crypto and payroll activity together, matches every transaction to the document that explains it, keeps a double-entry ledger, and generates the files the Israeli Tax Authority expects."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Accounter — Manage your taxes." />
+    <meta
+      property="og:description"
+      content="One system for financial operations and Israeli tax compliance: automated data collection, transaction-to-invoice matching, a double-entry ledger, and VAT, PCN874, SHAAM 6111 and uniform-format exports."
+    />
+    <meta property="og:image" content="/icons/accounter-logo.svg" />
+    <meta name="twitter:card" content="summary" />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/client/src/components/__tests__/landing-route.test.ts
+++ b/packages/client/src/components/__tests__/landing-route.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LandingRoute } from '../../router/guards/auth-guards.js';
+import { ROUTES } from '../../router/routes.js';
+
+const { useAuth0Mock, hasStoredAuth0SessionMock } = vi.hoisted(() => ({
+  useAuth0Mock: vi.fn(),
+  hasStoredAuth0SessionMock: vi.fn(),
+}));
+
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: useAuth0Mock,
+}));
+
+vi.mock('../../lib/auth0-session.js', () => ({
+  hasStoredAuth0Session: hasStoredAuth0SessionMock,
+}));
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type AuthState = {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+};
+
+async function renderRoot(authState: AuthState, hasStoredSession = false) {
+  useAuth0Mock.mockReturnValue(authState);
+  hasStoredAuth0SessionMock.mockReturnValue(hasStoredSession);
+
+  const router = createMemoryRouter(
+    [
+      {
+        path: ROUTES.HOME,
+        element: React.createElement(
+          LandingRoute,
+          null,
+          React.createElement('div', null, 'Landing Page'),
+        ),
+      },
+      {
+        path: ROUTES.APP_HOME,
+        element: React.createElement('div', null, 'Charges Page'),
+      },
+    ],
+    { initialEntries: [ROUTES.HOME] },
+  );
+
+  const container = document.createElement('div');
+  document.body.append(container);
+
+  let root: Root | null = null;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(React.createElement(RouterProvider, { router }));
+    await Promise.resolve();
+  });
+
+  const html = container.innerHTML;
+
+  const cleanup = async () => {
+    await act(async () => {
+      root?.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+  };
+
+  return { html, router, cleanup };
+}
+
+describe('LandingRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the landing page to an unauthenticated visitor', async () => {
+    const { html, router, cleanup } = await renderRoot({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+
+    expect(router.state.location.pathname).toBe(ROUTES.HOME);
+    expect(html).toContain('Landing Page');
+    await cleanup();
+  });
+
+  it('sends an authenticated user into the app', async () => {
+    const { html, router, cleanup } = await renderRoot({
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    expect(router.state.location.pathname).toBe(ROUTES.APP_HOME);
+    expect(html).not.toContain('Landing Page');
+    await cleanup();
+  });
+
+  it('paints immediately while Auth0 loads when there is no cached session', async () => {
+    const { html, router, cleanup } = await renderRoot(
+      { isAuthenticated: false, isLoading: true },
+      false,
+    );
+
+    // A first-time visitor must not wait on an Auth0 round trip to read the page.
+    expect(html).toContain('Landing Page');
+    expect(router.state.location.pathname).toBe(ROUTES.HOME);
+    await cleanup();
+  });
+
+  it('holds the landing page back while a cached session resolves', async () => {
+    const { html, cleanup } = await renderRoot({ isAuthenticated: false, isLoading: true }, true);
+
+    // A redirect into the app is coming, so showing marketing copy first would flash.
+    expect(html).not.toContain('Landing Page');
+    await cleanup();
+  });
+});

--- a/packages/client/src/components/__tests__/protected-route.test.ts
+++ b/packages/client/src/components/__tests__/protected-route.test.ts
@@ -109,7 +109,7 @@ async function renderPublicPath(pathname: string, authState: AuthState) {
         ),
       },
       {
-        path: ROUTES.HOME,
+        path: ROUTES.APP_HOME,
         element: React.createElement('div', null, 'Home Page'),
       },
     ],
@@ -255,7 +255,7 @@ describe('PublicOnlyGuard', () => {
       isLoading: false,
     });
 
-    expect(router.state.location.pathname).toBe(ROUTES.HOME);
+    expect(router.state.location.pathname).toBe(ROUTES.APP_HOME);
     await cleanup();
   });
 

--- a/packages/client/src/components/admin-settings/auth-management/index.tsx
+++ b/packages/client/src/components/admin-settings/auth-management/index.tsx
@@ -16,7 +16,7 @@ export function AuthManagement(): ReactElement {
   // The backend independently enforces business_owner authorization, but we
   // also guard the route client-side to avoid rendering it for other users.
   if (!adminBusinessId || adminBusinessId !== businessId) {
-    return <Navigate to={ROUTES.HOME} replace />;
+    return <Navigate to={ROUTES.APP_HOME} replace />;
   }
 
   return (

--- a/packages/client/src/components/error-boundary.tsx
+++ b/packages/client/src/components/error-boundary.tsx
@@ -24,7 +24,7 @@ export function ErrorBoundary(): ReactElement {
             statusCode={404}
           >
             <div className="flex gap-4">
-              <Link to={ROUTES.HOME}>
+              <Link to={ROUTES.APP_HOME}>
                 <Button variant="default">
                   <Home className="mr-2 h-4 w-4" />
                   Go Home
@@ -59,7 +59,7 @@ export function ErrorBoundary(): ReactElement {
             description="You don't have permission to access this resource."
             statusCode={403}
           >
-            <Link to={ROUTES.HOME}>
+            <Link to={ROUTES.APP_HOME}>
               <Button variant="default">
                 <Home className="mr-2 h-4 w-4" />
                 Go Home
@@ -81,7 +81,7 @@ export function ErrorBoundary(): ReactElement {
                 <RefreshCw className="mr-2 h-4 w-4" />
                 Reload Page
               </Button>
-              <Link to={ROUTES.HOME}>
+              <Link to={ROUTES.APP_HOME}>
                 <Button variant="outline">
                   <Home className="mr-2 h-4 w-4" />
                   Go Home
@@ -99,7 +99,7 @@ export function ErrorBoundary(): ReactElement {
             description={error.statusText || 'An unexpected error occurred'}
             statusCode={error.status}
           >
-            <Link to={ROUTES.HOME}>
+            <Link to={ROUTES.APP_HOME}>
               <Button variant="default">
                 <Home className="mr-2 h-4 w-4" />
                 Go Home
@@ -138,7 +138,7 @@ export function ErrorBoundary(): ReactElement {
           <RefreshCw className="mr-2 h-4 w-4" />
           Reload Page
         </Button>
-        <Link to={ROUTES.HOME}>
+        <Link to={ROUTES.APP_HOME}>
           <Button variant="outline">
             <Home className="mr-2 h-4 w-4" />
             Go Home

--- a/packages/client/src/components/error-boundary.tsx
+++ b/packages/client/src/components/error-boundary.tsx
@@ -24,7 +24,7 @@ export function ErrorBoundary(): ReactElement {
             statusCode={404}
           >
             <div className="flex gap-4">
-              <Link to={ROUTES.APP_HOME}>
+              <Link to={ROUTES.HOME}>
                 <Button variant="default">
                   <Home className="mr-2 h-4 w-4" />
                   Go Home
@@ -59,7 +59,7 @@ export function ErrorBoundary(): ReactElement {
             description="You don't have permission to access this resource."
             statusCode={403}
           >
-            <Link to={ROUTES.APP_HOME}>
+            <Link to={ROUTES.HOME}>
               <Button variant="default">
                 <Home className="mr-2 h-4 w-4" />
                 Go Home
@@ -81,7 +81,7 @@ export function ErrorBoundary(): ReactElement {
                 <RefreshCw className="mr-2 h-4 w-4" />
                 Reload Page
               </Button>
-              <Link to={ROUTES.APP_HOME}>
+              <Link to={ROUTES.HOME}>
                 <Button variant="outline">
                   <Home className="mr-2 h-4 w-4" />
                   Go Home
@@ -99,7 +99,7 @@ export function ErrorBoundary(): ReactElement {
             description={error.statusText || 'An unexpected error occurred'}
             statusCode={error.status}
           >
-            <Link to={ROUTES.APP_HOME}>
+            <Link to={ROUTES.HOME}>
               <Button variant="default">
                 <Home className="mr-2 h-4 w-4" />
                 Go Home
@@ -138,7 +138,7 @@ export function ErrorBoundary(): ReactElement {
           <RefreshCw className="mr-2 h-4 w-4" />
           Reload Page
         </Button>
-        <Link to={ROUTES.APP_HOME}>
+        <Link to={ROUTES.HOME}>
           <Button variant="outline">
             <Home className="mr-2 h-4 w-4" />
             Go Home

--- a/packages/client/src/components/landing/index.tsx
+++ b/packages/client/src/components/landing/index.tsx
@@ -1,0 +1,44 @@
+import { useEffect, type ReactElement } from 'react';
+import { LandingAssistant } from './landing-assistant.js';
+import { LandingCompliance } from './landing-compliance.js';
+import { LandingFeatures } from './landing-features.js';
+import { LandingFooter } from './landing-footer.js';
+import { LandingHero } from './landing-hero.js';
+import { LandingHowItWorks } from './landing-how-it-works.js';
+import { LandingIntegrations } from './landing-integrations.js';
+import { LandingNav } from './landing-nav.js';
+
+/**
+ * Public marketing page served at `/` to visitors without a session.
+ *
+ * Static by design: no GraphQL, no loaders, no viewer lookup. `LandingRoute`
+ * decides whether this renders at all, so nothing here needs to know about auth
+ * beyond the request-access link.
+ */
+export function LandingPage(): ReactElement {
+  // The app shell locks scrolling on `.dashboard` screens via `h-screen overflow-hidden`,
+  // and MUI's CssBaseline leaves whatever the previous route set. Make sure a
+  // full-page document scrolls normally when this route takes over.
+  useEffect(() => {
+    const { overflow } = document.body.style;
+    document.body.style.overflow = 'auto';
+    return () => {
+      document.body.style.overflow = overflow;
+    };
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-white antialiased">
+      <LandingNav />
+      <main>
+        <LandingHero />
+        <LandingHowItWorks />
+        <LandingFeatures />
+        <LandingIntegrations />
+        <LandingCompliance />
+        <LandingAssistant />
+      </main>
+      <LandingFooter />
+    </div>
+  );
+}

--- a/packages/client/src/components/landing/landing-assistant.tsx
+++ b/packages/client/src/components/landing/landing-assistant.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react';
+import { Bot, ShieldCheck } from 'lucide-react';
+import { MCP_TOOLS, MCP_URL } from './landing-content.js';
+import { LandingSectionHeading } from './landing-section-heading.js';
+
+export function LandingAssistant(): ReactElement {
+  return (
+    <section className="border-b border-gray-200 bg-white">
+      <div className="mx-auto grid w-full max-w-6xl gap-12 px-4 py-20 sm:px-6 lg:grid-cols-2 lg:items-center">
+        <div>
+          <LandingSectionHeading
+            eyebrow="AI connector"
+            title="Ask Claude about your books"
+            description="Accounter ships a hosted MCP connector, so you can put questions to your own financial data in plain language instead of building a report to answer them."
+          />
+
+          <div className="mt-8 space-y-4">
+            <p className="flex items-start gap-3 text-sm text-gray-600">
+              <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-gray-500" aria-hidden="true" />
+              <span>
+                Read-only by design, authenticated with your own account, and narrowed to the
+                businesses you are a member of.
+              </span>
+            </p>
+            <p className="flex items-start gap-3 text-sm text-gray-600">
+              <Bot className="mt-0.5 h-5 w-5 shrink-0 text-gray-500" aria-hidden="true" />
+              <span>
+                Connect it at{' '}
+                <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-950">
+                  {MCP_URL.replace('https://', '')}
+                </code>{' '}
+                once you have an account.
+              </span>
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-gray-200 bg-gray-50 p-6">
+          <p className="text-sm font-semibold text-gray-950">What it can look at</p>
+          <ul className="mt-4 flex flex-wrap gap-2">
+            {MCP_TOOLS.map(tool => (
+              <li
+                key={tool}
+                className="rounded-full border border-gray-200 bg-white px-3 py-1 text-xs text-gray-600"
+              >
+                {tool}
+              </li>
+            ))}
+          </ul>
+          <p className="mt-6 border-t border-gray-200 pt-4 text-sm text-gray-600">
+            &ldquo;Which clients still owe me for work invoiced last quarter, and what does that do
+            to this month&rsquo;s VAT?&rdquo;
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/client/src/components/landing/landing-compliance.tsx
+++ b/packages/client/src/components/landing/landing-compliance.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from 'react';
+import { COMPLIANCE_ITEMS } from './landing-content.js';
+import { LandingSectionHeading } from './landing-section-heading.js';
+
+export function LandingCompliance(): ReactElement {
+  return (
+    <section id="compliance" className="border-b border-gray-200 bg-gray-50">
+      <div className="mx-auto w-full max-w-6xl px-4 py-20 sm:px-6">
+        <LandingSectionHeading
+          eyebrow="Israeli compliance"
+          title="The formats the Tax Authority expects, generated from your ledger"
+          description="The file generators are open source and independently tested — they parse and validate their own output, not just write it."
+        />
+
+        <dl className="mt-12 grid gap-x-8 gap-y-8 sm:grid-cols-2">
+          {COMPLIANCE_ITEMS.map(item => (
+            <div key={item.title} className="border-l-2 border-gray-300 pl-5">
+              <dt className="text-base font-semibold text-gray-950">{item.title}</dt>
+              <dd className="mt-1.5 text-sm text-gray-600">{item.description}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/packages/client/src/components/landing/landing-content.ts
+++ b/packages/client/src/components/landing/landing-content.ts
@@ -62,7 +62,7 @@ export const STEPS: Step[] = [
   {
     title: 'Connect',
     description:
-      'Bank accounts, credit cards, crypto exchanges and payroll providers are pulled in automatically. Invoices arrive by forwarding them to your own @accounter.tax inbox, from Google Drive, or straight from Green Invoice.',
+      'Bank accounts, credit cards, crypto exchanges, brokerage accounts and payroll providers are pulled in automatically. Invoices arrive by forwarding them to your own @accounter.tax inbox, from a shared drive, or straight from your invoicing provider.',
   },
   {
     title: 'Match',
@@ -166,6 +166,8 @@ export type IntegrationGroup = {
   icon: LucideIcon;
   title: string;
   items: string[];
+  /** Renders a trailing "and more" so a sampled list does not read as the full set. */
+  andMore?: boolean;
 };
 
 export const INTEGRATION_GROUPS: IntegrationGroup[] = [
@@ -174,13 +176,14 @@ export const INTEGRATION_GROUPS: IntegrationGroup[] = [
     title: 'Israeli banks and cards',
     items: [
       'Bank Hapoalim',
+      'Bank Leumi',
       'Bank Discount',
-      'Bank Otsar Ha-Hayal',
       'Isracard',
       'American Express',
       'CAL',
       'Max',
     ],
+    andMore: true,
   },
   {
     icon: Bitcoin,
@@ -196,6 +199,7 @@ export const INTEGRATION_GROUPS: IntegrationGroup[] = [
     icon: ReceiptText,
     title: 'Invoicing and accounting',
     items: ['Green Invoice (two-way)', 'Hashavshevet', 'Payper'],
+    andMore: true,
   },
   {
     icon: BadgeDollarSign,
@@ -209,7 +213,7 @@ export const INTEGRATION_GROUPS: IntegrationGroup[] = [
       'Per-tenant @accounter.tax inbox',
       'Google Drive',
       'AI reading of scanned invoices',
-      'Cloudinary file storage',
+      'Cloud file storage',
     ],
   },
   {
@@ -239,13 +243,14 @@ export const COMPLIANCE_ITEMS: ComplianceItem[] = [
       'The annual tax report — generated, parsed and validated, with correct Hebrew encoding.',
   },
   {
-    title: 'Uniform format (מבנה אחיד)',
+    title: 'Uniform format (קובץ אחיד)',
     description:
-      'INI.TXT and BKMVDATA.TXT per SHAAM spec 1.31, down to field widths, padding and line endings.',
+      'INI.TXT and BKMVDATA.TXT per SHAAM spec 1.31, compatible with the leading accounting providers.',
   },
   {
     title: 'Monthly VAT',
-    description: 'A reviewable monthly VAT report built from the same ledger, not a side workbook.',
+    description:
+      'A reviewable monthly VAT report built from the same documents, not a side workbook.',
   },
   {
     title: 'Corporate tax',
@@ -280,8 +285,9 @@ export const HERO_PILLARS: Pillar[] = [
   },
   {
     icon: Scale,
-    title: 'A ledger that holds',
-    description: 'Double-entry records, regenerated on demand and checked for imbalance.',
+    title: 'A ledger that writes itself',
+    description:
+      'Double-entry records generated for you, regenerated on demand and checked for imbalance.',
   },
   {
     icon: FileCheck2,
@@ -297,10 +303,14 @@ export type PipelineStage = {
 };
 
 export const PIPELINE_STAGES: PipelineStage[] = [
-  { icon: Landmark, label: 'Transactions', caption: 'banks · cards · crypto · payroll' },
+  {
+    icon: Landmark,
+    label: 'Transactions',
+    caption: 'banks · cards · crypto · securities · deposits · payroll',
+  },
   { icon: Files, label: 'Documents', caption: 'invoices · receipts · email · drive' },
-  { icon: Receipt, label: 'Charge', caption: 'matched and categorised' },
-  { icon: Calculator, label: 'Ledger', caption: 'double-entry, validated' },
+  { icon: Receipt, label: 'Charge', caption: 'auto-matched and categorised' },
+  { icon: Calculator, label: 'Ledger', caption: 'auto-generated, validated' },
   { icon: HandCoins, label: 'Tax files', caption: 'VAT · PCN874 · 6111 · uniform' },
 ];
 

--- a/packages/client/src/components/landing/landing-content.ts
+++ b/packages/client/src/components/landing/landing-content.ts
@@ -1,0 +1,321 @@
+import {
+  ArrowLeftRight,
+  BadgeDollarSign,
+  Banknote,
+  BarChartBig,
+  Bitcoin,
+  BookOpenCheck,
+  Calculator,
+  CandlestickChart,
+  FileCheck2,
+  FilePen,
+  Files,
+  HandCoins,
+  Landmark,
+  ListChecks,
+  Mail,
+  PlaneTakeoff,
+  Puzzle,
+  Receipt,
+  ReceiptText,
+  Scale,
+  ScanText,
+  Tags,
+  type LucideIcon,
+} from 'lucide-react';
+
+/**
+ * Copy for the public landing page, kept out of the JSX so wording can be edited
+ * without touching layout. Nothing here is fetched — the page is static by design.
+ */
+
+/**
+ * Accounter is invitation-only (see `screens/welcome.tsx`), so this is the only
+ * way in for a visitor without an account. `accounter.tax` already runs
+ * Cloudflare Email Routing for the per-tenant ingestion aliases, so an alias on
+ * the same zone is the cheapest destination to keep working.
+ */
+export const REQUEST_ACCESS_URL = 'mailto:hello@accounter.tax';
+
+export const GITHUB_URL = 'https://github.com/Urigo/accounter-fullstack';
+
+export const MCP_URL = 'https://mcp.accounter.tax';
+
+export type LandingSection = {
+  id: string;
+  label: string;
+};
+
+export const NAV_SECTIONS: LandingSection[] = [
+  { id: 'how-it-works', label: 'How it works' },
+  { id: 'features', label: 'Features' },
+  { id: 'integrations', label: 'Integrations' },
+  { id: 'compliance', label: 'Compliance' },
+];
+
+export type Step = {
+  title: string;
+  description: string;
+};
+
+export const STEPS: Step[] = [
+  {
+    title: 'Connect',
+    description:
+      'Bank accounts, credit cards, crypto exchanges and payroll providers are pulled in automatically. Invoices arrive by forwarding them to your own @accounter.tax inbox, from Google Drive, or straight from Green Invoice.',
+  },
+  {
+    title: 'Match',
+    description:
+      'Every transaction is paired with the document that explains it. Scanned paperwork is read by AI, the counterparty business is identified, and confident pairs are matched for you — the rest land on a short review queue.',
+  },
+  {
+    title: 'Post',
+    description:
+      'Matched charges generate double-entry ledger records with the right tax category, sort code, VAT split and exchange rate. Records are re-derivable, validated for imbalance, and lockable once a period is closed.',
+  },
+  {
+    title: 'File',
+    description:
+      'Monthly VAT, PCN874, SHAAM 6111 and the full uniform-format export (INI.TXT + BKMVDATA.TXT) are generated from the same ledger you have been reviewing all year — not rebuilt from scratch each spring.',
+  },
+];
+
+export type Feature = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+};
+
+export const FEATURES: Feature[] = [
+  {
+    icon: Receipt,
+    title: 'Charges',
+    description:
+      'The unit that ties a transaction, its supporting document and its ledger records together. Filter, search and drill into every one of them.',
+  },
+  {
+    icon: Puzzle,
+    title: 'Charge matching',
+    description:
+      'Scored, assisted matching between transactions and documents, with a dedicated review screen for everything the matcher was not sure about.',
+  },
+  {
+    icon: BookOpenCheck,
+    title: 'Ledger validation',
+    description:
+      'Surfaces charges whose ledger would change if regenerated, plus businesses whose balance does not add up — before an accountant finds them.',
+  },
+  {
+    icon: ReceiptText,
+    title: 'Reports',
+    description:
+      'Trial balance, profit and loss, tax, depreciation, annual revenue, yearly ledger, transaction balance — and a dynamic report builder you can save as a template.',
+  },
+  {
+    icon: Files,
+    title: 'Documents',
+    description:
+      'Invoices, receipts, credit invoices and proformas in one place, linked to the charges they justify and stored with the original file.',
+  },
+  {
+    icon: FilePen,
+    title: 'Issue invoices',
+    description:
+      'Issue single or recurring documents through Green Invoice, preview the PDF, and email it to the client without leaving Accounter.',
+  },
+  {
+    icon: PlaneTakeoff,
+    title: 'Business trips',
+    description:
+      'Flights, accommodation, car rental, per-attendee expenses and employee reimbursements, with the Israeli travel and subsistence tax variables applied.',
+  },
+  {
+    icon: BadgeDollarSign,
+    title: 'Salaries',
+    description:
+      'Payroll charges with employees, pension and study funds, and recovery pay reconciled against what actually left the bank.',
+  },
+  {
+    icon: CandlestickChart,
+    title: 'Securities',
+    description:
+      'Foreign securities holdings and executions tracked alongside everything else, valued in your reporting currency.',
+  },
+  {
+    icon: ArrowLeftRight,
+    title: 'Business ledger',
+    description:
+      'A running ledger per counterparty, plus contracts, bank deposits, tax categories and the sort codes behind your chart of accounts.',
+  },
+  {
+    icon: ListChecks,
+    title: 'Annual audit workflow',
+    description:
+      'A guided year-end pass — opening balances through to the saved report template — so closing the books is a checklist, not an archaeology project.',
+  },
+  {
+    icon: BarChartBig,
+    title: 'Charts and tags',
+    description:
+      'Monthly income and expense charts, and a tagging system for slicing activity the way your business actually thinks about it.',
+  },
+];
+
+export type IntegrationGroup = {
+  icon: LucideIcon;
+  title: string;
+  items: string[];
+};
+
+export const INTEGRATION_GROUPS: IntegrationGroup[] = [
+  {
+    icon: Landmark,
+    title: 'Israeli banks and cards',
+    items: [
+      'Bank Hapoalim',
+      'Bank Discount',
+      'Bank Otsar Ha-Hayal',
+      'Isracard',
+      'American Express',
+      'CAL',
+      'Max',
+    ],
+  },
+  {
+    icon: Bitcoin,
+    title: 'Crypto and trading',
+    items: [
+      'Kraken ledgers and trades',
+      'Etherscan wallets and ERC-20 transfers',
+      'Etana statement import',
+      'CoinMarketCap pricing',
+    ],
+  },
+  {
+    icon: ReceiptText,
+    title: 'Invoicing and accounting',
+    items: ['Green Invoice (two-way)', 'Hashavshevet', 'Payper'],
+  },
+  {
+    icon: BadgeDollarSign,
+    title: 'Payroll and contractors',
+    items: ['Deel contracts and invoices', 'Payroll file ingestion'],
+  },
+  {
+    icon: Mail,
+    title: 'Documents in',
+    items: [
+      'Per-tenant @accounter.tax inbox',
+      'Google Drive',
+      'AI reading of scanned invoices',
+      'Cloudinary file storage',
+    ],
+  },
+  {
+    icon: Banknote,
+    title: 'Rates and government',
+    items: [
+      'Bank of Israel exchange rates',
+      'Israeli VAT portal (misim.gov.il)',
+      'Multi-currency revaluation',
+    ],
+  },
+];
+
+export type ComplianceItem = {
+  title: string;
+  description: string;
+};
+
+export const COMPLIANCE_ITEMS: ComplianceItem[] = [
+  {
+    title: 'PCN874',
+    description: 'The periodic VAT report file, generated in the format the Tax Authority expects.',
+  },
+  {
+    title: 'SHAAM 6111',
+    description:
+      'The annual tax report — generated, parsed and validated, with correct Hebrew encoding.',
+  },
+  {
+    title: 'Uniform format (מבנה אחיד)',
+    description:
+      'INI.TXT and BKMVDATA.TXT per SHAAM spec 1.31, down to field widths, padding and line endings.',
+  },
+  {
+    title: 'Monthly VAT',
+    description: 'A reviewable monthly VAT report built from the same ledger, not a side workbook.',
+  },
+  {
+    title: 'Corporate tax',
+    description:
+      'Corporate tax reporting plus a ruling-compliance report for businesses operating under a tax ruling.',
+  },
+  {
+    title: 'Depreciation',
+    description: 'Depreciation categories and schedules maintained across years.',
+  },
+  {
+    title: 'Dividends and withholding',
+    description: 'Dividend charges and withholding tax tracked on every charge that needs it.',
+  },
+  {
+    title: 'Accountant approval',
+    description: 'An explicit approval step so you and your accountant agree on what is final.',
+  },
+];
+
+export type Pillar = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+};
+
+export const HERO_PILLARS: Pillar[] = [
+  {
+    icon: ScanText,
+    title: 'Nothing typed twice',
+    description: 'Transactions and documents arrive on their own and find each other.',
+  },
+  {
+    icon: Scale,
+    title: 'A ledger that holds',
+    description: 'Double-entry records, regenerated on demand and checked for imbalance.',
+  },
+  {
+    icon: FileCheck2,
+    title: 'Files the authority accepts',
+    description: 'VAT, 6111 and uniform-format exports straight out of your own books.',
+  },
+];
+
+export type PipelineStage = {
+  icon: LucideIcon;
+  label: string;
+  caption: string;
+};
+
+export const PIPELINE_STAGES: PipelineStage[] = [
+  { icon: Landmark, label: 'Transactions', caption: 'banks · cards · crypto · payroll' },
+  { icon: Files, label: 'Documents', caption: 'invoices · receipts · email · drive' },
+  { icon: Receipt, label: 'Charge', caption: 'matched and categorised' },
+  { icon: Calculator, label: 'Ledger', caption: 'double-entry, validated' },
+  { icon: HandCoins, label: 'Tax files', caption: 'VAT · PCN874 · 6111 · uniform' },
+];
+
+export const MCP_TOOLS: string[] = [
+  'search charges',
+  'get transactions',
+  'get documents',
+  'get ledger records',
+  'balance report',
+  'list businesses',
+  'list tags',
+  'get contracts',
+];
+
+export const FOOTER_TAGS: { icon: LucideIcon; label: string }[] = [
+  { icon: Tags, label: 'Multi-business by default' },
+  { icon: Calculator, label: 'Built with accountants in the loop' },
+];

--- a/packages/client/src/components/landing/landing-features.tsx
+++ b/packages/client/src/components/landing/landing-features.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from 'react';
+import { FEATURES } from './landing-content.js';
+import { LandingSectionHeading } from './landing-section-heading.js';
+
+export function LandingFeatures(): ReactElement {
+  return (
+    <section id="features" className="border-b border-gray-200 bg-gray-50">
+      <div className="mx-auto w-full max-w-6xl px-4 py-20 sm:px-6">
+        <LandingSectionHeading
+          eyebrow="Features"
+          title="Everything the business actually does, in one place"
+          description="Accounter is not a reporting layer bolted onto someone else's books. The day-to-day work and the year-end filing happen against the same data."
+        />
+
+        <div className="mt-12 grid gap-px overflow-hidden rounded-xl border border-gray-200 bg-gray-200 sm:grid-cols-2 lg:grid-cols-3">
+          {FEATURES.map(feature => (
+            <article key={feature.title} className="bg-white p-6">
+              <feature.icon className="h-6 w-6 text-gray-500" aria-hidden="true" />
+              <h3 className="mt-4 text-base font-semibold text-gray-950">{feature.title}</h3>
+              <p className="mt-2 text-sm text-gray-600">{feature.description}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/client/src/components/landing/landing-footer.tsx
+++ b/packages/client/src/components/landing/landing-footer.tsx
@@ -1,0 +1,55 @@
+import type { ReactElement } from 'react';
+import { ArrowRight } from 'lucide-react';
+import { Button } from '../ui/button.js';
+import { FOOTER_TAGS, GITHUB_URL, REQUEST_ACCESS_URL } from './landing-content.js';
+
+export function LandingFooter(): ReactElement {
+  return (
+    <footer className="bg-gray-950 text-gray-300">
+      <div className="mx-auto w-full max-w-6xl px-4 py-20 sm:px-6">
+        <div className="max-w-2xl">
+          <h2 className="text-3xl font-bold tracking-tight text-balance text-white sm:text-4xl">
+            Accounter is invitation-only
+          </h2>
+          <p className="mt-4 text-lg text-pretty text-gray-400">
+            Tell us about your business and we will set up a workspace for you and your accountant.
+          </p>
+          <Button asChild size="lg" variant="secondary" className="mt-8">
+            <a href={REQUEST_ACCESS_URL}>
+              Request access
+              <ArrowRight />
+            </a>
+          </Button>
+        </div>
+
+        <ul className="mt-14 flex flex-wrap gap-x-8 gap-y-3">
+          {FOOTER_TAGS.map(tag => (
+            <li key={tag.label} className="flex items-center gap-2 text-sm text-gray-400">
+              <tag.icon className="h-4 w-4" aria-hidden="true" />
+              {tag.label}
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-14 flex flex-col gap-4 border-t border-gray-800 pt-8 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2">
+            <img src="/icons/accounter-logo.svg" alt="" className="h-6 w-6 invert" />
+            <span className="text-sm font-semibold text-white">Accounter</span>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm text-gray-400">
+            <a
+              href={GITHUB_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="transition-colors hover:text-white"
+            >
+              Source on GitHub
+            </a>
+            <span>MIT licensed</span>
+            <span>Built by The Guild</span>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/packages/client/src/components/landing/landing-hero.tsx
+++ b/packages/client/src/components/landing/landing-hero.tsx
@@ -1,0 +1,85 @@
+import { Fragment, type ReactElement } from 'react';
+import { ArrowRight, ChevronRight } from 'lucide-react';
+import { Button } from '../ui/button.js';
+import { HERO_PILLARS, PIPELINE_STAGES, REQUEST_ACCESS_URL } from './landing-content.js';
+
+export function LandingHero(): ReactElement {
+  return (
+    <section id="top" className="border-b border-gray-200 bg-gray-50">
+      <div className="mx-auto w-full max-w-6xl px-4 py-20 sm:px-6 lg:py-28">
+        <div className="max-w-3xl">
+          <p className="text-sm font-medium tracking-wide text-gray-500 uppercase">
+            Financial operations and Israeli tax compliance
+          </p>
+          <h1 className="mt-4 text-4xl font-bold tracking-tight text-balance text-gray-950 sm:text-5xl lg:text-6xl">
+            Manage your taxes.
+          </h1>
+          <p className="mt-6 text-lg text-pretty text-gray-600 sm:text-xl">
+            Accounter is one system for every shekel that moves through your business. It pulls in
+            bank, card, crypto and payroll activity, matches each transaction to the invoice that
+            explains it, keeps a double-entry ledger you can trust, and generates the exact files
+            the Israeli Tax Authority asks for.
+          </p>
+
+          <div className="mt-8 flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+            <Button asChild size="lg">
+              <a href={REQUEST_ACCESS_URL}>
+                Request access
+                <ArrowRight />
+              </a>
+            </Button>
+            <Button asChild variant="ghost" size="lg">
+              <a href="#how-it-works">
+                See how it works
+                <ChevronRight />
+              </a>
+            </Button>
+          </div>
+
+          <p className="mt-4 text-sm text-gray-500">Invitation-only. Open source, MIT licensed.</p>
+        </div>
+
+        <Pipeline />
+
+        <dl className="mt-12 grid gap-8 sm:grid-cols-3">
+          {HERO_PILLARS.map(pillar => (
+            <div key={pillar.title}>
+              <dt className="flex items-center gap-2 text-base font-semibold text-gray-950">
+                <pillar.icon className="h-5 w-5 text-gray-500" aria-hidden="true" />
+                {pillar.title}
+              </dt>
+              <dd className="mt-2 text-sm text-gray-600">{pillar.description}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * The product in one picture: two kinds of raw input converge on a charge, which
+ * becomes ledger records, which become the files that get filed.
+ */
+function Pipeline(): ReactElement {
+  return (
+    <div className="mt-14 overflow-x-auto rounded-xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
+      <ol className="flex min-w-max items-stretch gap-2">
+        {PIPELINE_STAGES.map((stage, index) => (
+          <Fragment key={stage.label}>
+            {index > 0 && (
+              <li aria-hidden="true" className="flex items-center">
+                <ChevronRight className="h-5 w-5 text-gray-300" />
+              </li>
+            )}
+            <li className="flex w-40 flex-col gap-2 rounded-lg bg-gray-50 p-4">
+              <stage.icon className="h-5 w-5 text-gray-500" aria-hidden="true" />
+              <span className="text-sm font-semibold text-gray-950">{stage.label}</span>
+              <span className="text-xs text-gray-500">{stage.caption}</span>
+            </li>
+          </Fragment>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/packages/client/src/components/landing/landing-hero.tsx
+++ b/packages/client/src/components/landing/landing-hero.tsx
@@ -15,10 +15,11 @@ export function LandingHero(): ReactElement {
             Manage your taxes.
           </h1>
           <p className="mt-6 text-lg text-pretty text-gray-600 sm:text-xl">
-            Accounter is one system for every shekel that moves through your business. It pulls in
-            bank, card, crypto and payroll activity, matches each transaction to the invoice that
-            explains it, keeps a double-entry ledger you can trust, and generates the exact files
-            the Israeli Tax Authority asks for.
+            Accounter is one system for every shekel that moves through your business — bank, card,
+            crypto, securities, deposits and payroll. It collects the activity on its own,
+            auto-matches every transaction to the document that explains it, generates the
+            double-entry ledger from those matches, and produces the exact files the Israeli Tax
+            Authority asks for. Your job is to review it, not to type it.
           </p>
 
           <div className="mt-8 flex flex-col items-start gap-3 sm:flex-row sm:items-center">

--- a/packages/client/src/components/landing/landing-how-it-works.tsx
+++ b/packages/client/src/components/landing/landing-how-it-works.tsx
@@ -1,0 +1,29 @@
+import type { ReactElement } from 'react';
+import { STEPS } from './landing-content.js';
+import { LandingSectionHeading } from './landing-section-heading.js';
+
+export function LandingHowItWorks(): ReactElement {
+  return (
+    <section id="how-it-works" className="border-b border-gray-200 bg-white">
+      <div className="mx-auto w-full max-w-6xl px-4 py-20 sm:px-6">
+        <LandingSectionHeading
+          eyebrow="How it works"
+          title="From a bank feed to a filed report, without the spreadsheet in the middle"
+          description="The same four steps run all year. Nothing is saved up for the last week before a deadline."
+        />
+
+        <ol className="mt-12 grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+          {STEPS.map((step, index) => (
+            <li key={step.title} className="border-t-2 border-gray-950 pt-5">
+              <span className="text-sm font-semibold text-gray-400 tabular-nums">
+                {String(index + 1).padStart(2, '0')}
+              </span>
+              <h3 className="mt-2 text-lg font-semibold text-gray-950">{step.title}</h3>
+              <p className="mt-2 text-sm text-gray-600">{step.description}</p>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/packages/client/src/components/landing/landing-integrations.tsx
+++ b/packages/client/src/components/landing/landing-integrations.tsx
@@ -26,6 +26,7 @@ export function LandingIntegrations(): ReactElement {
                     {item}
                   </li>
                 ))}
+                {group.andMore ? <li className="text-sm text-gray-400">…and more</li> : null}
               </ul>
             </div>
           ))}

--- a/packages/client/src/components/landing/landing-integrations.tsx
+++ b/packages/client/src/components/landing/landing-integrations.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement } from 'react';
+import { Lock } from 'lucide-react';
+import { INTEGRATION_GROUPS } from './landing-content.js';
+import { LandingSectionHeading } from './landing-section-heading.js';
+
+export function LandingIntegrations(): ReactElement {
+  return (
+    <section id="integrations" className="border-b border-gray-200 bg-white">
+      <div className="mx-auto w-full max-w-6xl px-4 py-20 sm:px-6">
+        <LandingSectionHeading
+          eyebrow="Integrations"
+          title="Your data arrives on its own"
+          description="Israeli banks and card issuers, crypto exchanges, invoicing platforms and payroll providers are read directly. What is left over, you forward by email."
+        />
+
+        <div className="mt-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {INTEGRATION_GROUPS.map(group => (
+            <div key={group.title} className="rounded-xl border border-gray-200 p-6">
+              <div className="flex items-center gap-2">
+                <group.icon className="h-5 w-5 text-gray-500" aria-hidden="true" />
+                <h3 className="text-base font-semibold text-gray-950">{group.title}</h3>
+              </div>
+              <ul className="mt-4 space-y-2">
+                {group.items.map(item => (
+                  <li key={item} className="text-sm text-gray-600">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 flex items-start gap-3 rounded-xl bg-gray-50 p-6">
+          <Lock className="mt-0.5 h-5 w-5 shrink-0 text-gray-500" aria-hidden="true" />
+          <p className="text-sm text-gray-600">
+            <span className="font-semibold text-gray-950">Your bank credentials stay yours.</span>{' '}
+            Scraping runs from a local app against an encrypted vault on your own machine — the
+            credentials never reach the server.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/client/src/components/landing/landing-nav.tsx
+++ b/packages/client/src/components/landing/landing-nav.tsx
@@ -1,10 +1,11 @@
 import type { ReactElement } from 'react';
-import { Link } from 'react-router-dom';
-import { ROUTES } from '../../router/routes.js';
+import { useLogin } from '../../hooks/use-login.js';
 import { Button } from '../ui/button.js';
 import { NAV_SECTIONS, REQUEST_ACCESS_URL } from './landing-content.js';
 
 export function LandingNav(): ReactElement {
+  const login = useLogin();
+
   return (
     <header className="sticky top-0 z-30 border-b border-gray-200 bg-white/85 backdrop-blur-sm">
       <nav
@@ -31,13 +32,12 @@ export function LandingNav(): ReactElement {
 
         <div className="flex items-center gap-1 sm:gap-2">
           {/*
-            Routed to the existing login screen rather than calling
-            loginWithRedirect here: that screen already owns returnTo, the
-            reauth flow and Auth0 error messaging, and this page is meant to
-            stay free of auth logic.
+            Straight to Auth0, not to /login. An existing user arriving on a new
+            device already knows who they are; the login screen would only be a
+            page with one button on it.
           */}
-          <Button asChild variant="ghost">
-            <Link to={ROUTES.LOGIN}>Sign in</Link>
+          <Button variant="ghost" onClick={() => void login()}>
+            Log in
           </Button>
           <Button asChild>
             <a href={REQUEST_ACCESS_URL}>Request access</a>

--- a/packages/client/src/components/landing/landing-nav.tsx
+++ b/packages/client/src/components/landing/landing-nav.tsx
@@ -1,0 +1,36 @@
+import type { ReactElement } from 'react';
+import { Button } from '../ui/button.js';
+import { NAV_SECTIONS, REQUEST_ACCESS_URL } from './landing-content.js';
+
+export function LandingNav(): ReactElement {
+  return (
+    <header className="sticky top-0 z-30 border-b border-gray-200 bg-white/85 backdrop-blur-sm">
+      <nav
+        aria-label="Main"
+        className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between gap-4 px-4 sm:px-6"
+      >
+        <a href="#top" className="flex items-center gap-2">
+          <img src="/icons/accounter-logo.svg" alt="" className="h-7 w-7" />
+          <span className="text-lg font-semibold tracking-tight text-gray-950">Accounter</span>
+        </a>
+
+        <ul className="hidden items-center gap-7 md:flex">
+          {NAV_SECTIONS.map(section => (
+            <li key={section.id}>
+              <a
+                href={`#${section.id}`}
+                className="text-sm text-gray-600 transition-colors hover:text-gray-950"
+              >
+                {section.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+
+        <Button asChild>
+          <a href={REQUEST_ACCESS_URL}>Request access</a>
+        </Button>
+      </nav>
+    </header>
+  );
+}

--- a/packages/client/src/components/landing/landing-nav.tsx
+++ b/packages/client/src/components/landing/landing-nav.tsx
@@ -1,4 +1,6 @@
 import type { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+import { ROUTES } from '../../router/routes.js';
 import { Button } from '../ui/button.js';
 import { NAV_SECTIONS, REQUEST_ACCESS_URL } from './landing-content.js';
 
@@ -27,9 +29,20 @@ export function LandingNav(): ReactElement {
           ))}
         </ul>
 
-        <Button asChild>
-          <a href={REQUEST_ACCESS_URL}>Request access</a>
-        </Button>
+        <div className="flex items-center gap-1 sm:gap-2">
+          {/*
+            Routed to the existing login screen rather than calling
+            loginWithRedirect here: that screen already owns returnTo, the
+            reauth flow and Auth0 error messaging, and this page is meant to
+            stay free of auth logic.
+          */}
+          <Button asChild variant="ghost">
+            <Link to={ROUTES.LOGIN}>Sign in</Link>
+          </Button>
+          <Button asChild>
+            <a href={REQUEST_ACCESS_URL}>Request access</a>
+          </Button>
+        </div>
       </nav>
     </header>
   );

--- a/packages/client/src/components/landing/landing-section-heading.tsx
+++ b/packages/client/src/components/landing/landing-section-heading.tsx
@@ -1,0 +1,23 @@
+import type { ReactElement } from 'react';
+
+type LandingSectionHeadingProps = {
+  eyebrow: string;
+  title: string;
+  description?: string;
+};
+
+export function LandingSectionHeading({
+  eyebrow,
+  title,
+  description,
+}: LandingSectionHeadingProps): ReactElement {
+  return (
+    <div className="max-w-3xl">
+      <p className="text-sm font-medium tracking-wide text-gray-500 uppercase">{eyebrow}</p>
+      <h2 className="mt-3 text-3xl font-bold tracking-tight text-balance text-gray-950 sm:text-4xl">
+        {title}
+      </h2>
+      {description ? <p className="mt-4 text-lg text-pretty text-gray-600">{description}</p> : null}
+    </div>
+  );
+}

--- a/packages/client/src/components/layout/header.tsx
+++ b/packages/client/src/components/layout/header.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'react';
 import { Link, useResolvedPath } from 'react-router-dom';
 import { cn } from '../../lib/utils.js';
+import { ROUTES } from '../../router/routes.js';
 import { MobileSidebar } from './mobile-sidebar.js';
 import { sidelinks } from './sidelinks.js';
 import { UserNav } from './user-nav.js';
@@ -19,7 +20,7 @@ export function Header(): JSX.Element {
     <div className="supports-backdrop-blur:bg-white/60 fixed left-0 right-0 top-0 z-20 border-b bg-white/95 backdrop-blur-sm">
       <nav className="flex h-14 items-center justify-between px-4">
         <div className="hidden lg:block">
-          <Link to="/">
+          <Link to={ROUTES.APP_HOME}>
             <img src="../../../icons/logo.svg" alt="Guild Logo" className="w-[64px] h-[64px]" />
           </Link>
         </div>

--- a/packages/client/src/components/login-page.tsx
+++ b/packages/client/src/components/login-page.tsx
@@ -15,7 +15,7 @@ export function LoginPage(): ReactElement {
   const returnTo =
     (location.state as { returnTo?: string } | null)?.returnTo ??
     (isReauthFlow ? sessionStorage.getItem('auth:invitationReturnTo') : null) ??
-    ROUTES.HOME;
+    ROUTES.APP_HOME;
   const errorParam = searchParams.get('error');
 
   const authError = errorParam

--- a/packages/client/src/components/login-page.tsx
+++ b/packages/client/src/components/login-page.tsx
@@ -1,13 +1,15 @@
 import { useEffect, type ReactElement } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
+import { useLogin } from '../hooks/use-login.js';
 import { AUTH0_ERROR_MESSAGES } from '../lib/auth0-errors.js';
 import { clearStoredAuth0Session } from '../lib/auth0-session.js';
 import { ROUTES } from '../router/routes.js';
 import { Button } from './ui/button.js';
 
 export function LoginPage(): ReactElement {
-  const { loginWithRedirect, isAuthenticated, isLoading } = useAuth0();
+  const { isAuthenticated, isLoading } = useAuth0();
+  const login = useLogin();
   const navigate = useNavigate();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
@@ -54,21 +56,7 @@ export function LoginPage(): ReactElement {
           </div>
 
           <Button
-            onClick={() => {
-              // Avoid overwriting an existing returnTo set earlier in the reauth flow.
-              if (!isReauthFlow || !sessionStorage.getItem('auth:returnTo')) {
-                sessionStorage.setItem('auth:returnTo', returnTo);
-              }
-              return loginWithRedirect({
-                authorizationParams: {
-                  audience: import.meta.env.VITE_AUTH0_AUDIENCE,
-                  scope: 'openid profile email offline_access',
-                  ...(isReauthFlow ? { prompt: 'login' } : {}),
-                  redirect_uri: `${window.location.origin}${ROUTES.AUTH_CALLBACK}`,
-                },
-                appState: { returnTo },
-              });
-            }}
+            onClick={() => login({ returnTo, isReauth: isReauthFlow })}
             className="w-full font-semibold"
             disabled={isLoading}
           >

--- a/packages/client/src/components/screens/__tests__/accept-invitation.test.tsx
+++ b/packages/client/src/components/screens/__tests__/accept-invitation.test.tsx
@@ -192,7 +192,7 @@ describe('AcceptInvitationPage', () => {
     });
 
     expect(acceptInvitationMock).toHaveBeenCalledWith('invite-token-123');
-    expect(navigateMock).toHaveBeenCalledWith(ROUTES.HOME, { replace: true });
+    expect(navigateMock).toHaveBeenCalledWith(ROUTES.APP_HOME, { replace: true });
 
     await cleanup();
   });

--- a/packages/client/src/components/screens/__tests__/welcome.test.ts
+++ b/packages/client/src/components/screens/__tests__/welcome.test.ts
@@ -43,7 +43,7 @@ async function renderWelcome(
   const router = createMemoryRouter(
     [
       { path: ROUTES.WELCOME, element: React.createElement(WelcomePage) },
-      { path: ROUTES.HOME, element: React.createElement('div', null, 'Home Page') },
+      { path: ROUTES.APP_HOME, element: React.createElement('div', null, 'Home Page') },
       { path: ROUTES.LOGIN, element: React.createElement('div', null, 'Login Page') },
     ],
     { initialEntries: [ROUTES.WELCOME] },
@@ -143,7 +143,7 @@ describe('WelcomePage', () => {
       viewer: { email: 'member@example.com', emailVerified: true, status: 'ACTIVE' },
     });
 
-    expect(router.state.location.pathname).toBe(ROUTES.HOME);
+    expect(router.state.location.pathname).toBe(ROUTES.APP_HOME);
     await cleanup();
   });
 });

--- a/packages/client/src/components/screens/accept-invitation.tsx
+++ b/packages/client/src/components/screens/accept-invitation.tsx
@@ -73,7 +73,7 @@ export function AcceptInvitationPage(): ReactElement {
   const handleAccept = async () => {
     const success = await acceptInvitation(token);
     if (success?.success) {
-      navigate(ROUTES.HOME, { replace: true });
+      navigate(ROUTES.APP_HOME, { replace: true });
     }
   };
 

--- a/packages/client/src/components/screens/auth-callback.tsx
+++ b/packages/client/src/components/screens/auth-callback.tsx
@@ -136,7 +136,10 @@ export function AuthCallbackPage(): ReactElement {
         const invitationReturnTo = sessionStorage.getItem('auth:invitationReturnTo');
         const savedReturnTo = sessionStorage.getItem('auth:returnTo');
         const returnTo =
-          invitationReturnTo ?? callbackResult.appState?.returnTo ?? savedReturnTo ?? ROUTES.HOME;
+          invitationReturnTo ??
+          callbackResult.appState?.returnTo ??
+          savedReturnTo ??
+          ROUTES.APP_HOME;
 
         callbackResolvedReturnToBySearch.set(callbackSearch, returnTo);
         sessionStorage.setItem('auth:lastResolvedReturnTo', returnTo);
@@ -185,7 +188,7 @@ export function AuthCallbackPage(): ReactElement {
                     scope: 'openid profile email offline_access',
                     redirect_uri: `${redirectUriOrigin}${ROUTES.AUTH_CALLBACK}`,
                   },
-                  appState: { returnTo: savedReturnTo ?? ROUTES.HOME },
+                  appState: { returnTo: savedReturnTo ?? ROUTES.APP_HOME },
                 });
               }}
             >

--- a/packages/client/src/components/screens/welcome.tsx
+++ b/packages/client/src/components/screens/welcome.tsx
@@ -30,7 +30,7 @@ export function WelcomePage(): ReactElement {
   // send an already-active viewer back to the app rather than stranding them.
   useEffect(() => {
     if (viewer?.status === 'ACTIVE') {
-      navigate(ROUTES.HOME, { replace: true });
+      navigate(ROUTES.APP_HOME, { replace: true });
     }
   }, [viewer?.status, navigate]);
 

--- a/packages/client/src/hooks/__tests__/use-login.test.ts
+++ b/packages/client/src/hooks/__tests__/use-login.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLogin } from '../use-login.js';
+import { ROUTES } from '../../router/routes.js';
+
+const { useAuth0Mock, loginWithRedirectMock } = vi.hoisted(() => ({
+  useAuth0Mock: vi.fn(),
+  loginWithRedirectMock: vi.fn(),
+}));
+
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: useAuth0Mock,
+}));
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type HarnessOptions = Parameters<ReturnType<typeof useLogin>>[0];
+
+async function clickLogin(options?: HarnessOptions) {
+  function LoginHarness(): React.ReactElement {
+    const login = useLogin();
+
+    return React.createElement('button', { onClick: () => void login(options) }, 'Log in');
+  }
+
+  const container = document.createElement('div');
+  document.body.append(container);
+
+  let root: Root | null = null;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(React.createElement(LoginHarness));
+    await Promise.resolve();
+  });
+
+  await act(async () => {
+    container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+  });
+
+  const cleanup = async () => {
+    await act(async () => {
+      root?.unmount();
+      await Promise.resolve();
+    });
+    container.remove();
+  };
+
+  return { cleanup };
+}
+
+describe('useLogin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+
+    loginWithRedirectMock.mockResolvedValue(undefined);
+    useAuth0Mock.mockReturnValue({ loginWithRedirect: loginWithRedirectMock });
+  });
+
+  it('sends the browser to Auth0 aimed at the app by default', async () => {
+    const { cleanup } = await clickLogin();
+
+    expect(loginWithRedirectMock).toHaveBeenCalledTimes(1);
+    const [call] = loginWithRedirectMock.mock.calls[0];
+    expect(call.appState).toEqual({ returnTo: ROUTES.APP_HOME });
+    expect(call.authorizationParams.redirect_uri).toBe(
+      `${window.location.origin}${ROUTES.AUTH_CALLBACK}`,
+    );
+    expect(call.authorizationParams.scope).toBe('openid profile email offline_access');
+    // Not a re-prompt: an existing browser session should be reused silently.
+    expect(call.authorizationParams.prompt).toBeUndefined();
+    expect(sessionStorage.getItem('auth:returnTo')).toBe(ROUTES.APP_HOME);
+
+    await cleanup();
+  });
+
+  it('honours an explicit returnTo', async () => {
+    const { cleanup } = await clickLogin({ returnTo: ROUTES.REPORTS.VAT_MONTHLY });
+
+    const [call] = loginWithRedirectMock.mock.calls[0];
+    expect(call.appState).toEqual({ returnTo: ROUTES.REPORTS.VAT_MONTHLY });
+    expect(sessionStorage.getItem('auth:returnTo')).toBe(ROUTES.REPORTS.VAT_MONTHLY);
+
+    await cleanup();
+  });
+
+  it('forces a re-prompt on reauth', async () => {
+    const { cleanup } = await clickLogin({ isReauth: true });
+
+    const [call] = loginWithRedirectMock.mock.calls[0];
+    expect(call.authorizationParams.prompt).toBe('login');
+
+    await cleanup();
+  });
+
+  it('keeps a returnTo an earlier reauth step already stored', async () => {
+    sessionStorage.setItem('auth:returnTo', ROUTES.DOCUMENTS.ALL);
+
+    const { cleanup } = await clickLogin({ returnTo: ROUTES.APP_HOME, isReauth: true });
+
+    expect(sessionStorage.getItem('auth:returnTo')).toBe(ROUTES.DOCUMENTS.ALL);
+
+    await cleanup();
+  });
+});

--- a/packages/client/src/hooks/use-login.ts
+++ b/packages/client/src/hooks/use-login.ts
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import { ROUTES } from '../router/routes.js';
+
+/** Scopes the interactive login must request; `offline_access` buys silent renewal later. */
+const LOGIN_SCOPE = 'openid profile email offline_access';
+
+type LoginOptions = {
+  /** Where to land once the callback resolves. Defaults to the app's first screen. */
+  returnTo?: string;
+  /**
+   * Forces Auth0 to re-prompt even when it still reports a browser session, and
+   * keeps any `returnTo` a previous step already stored.
+   */
+  isReauth?: boolean;
+};
+
+/**
+ * Sends the browser to Auth0 Universal Login.
+ *
+ * Shared so that every entry point — the landing page's Log in button, the
+ * login screen, a session that expired mid-use — asks for the same audience,
+ * scopes and callback URL. Getting one of those wrong is the kind of bug that
+ * only shows up as a silent-renewal failure days later.
+ */
+export function useLogin(): (options?: LoginOptions) => Promise<void> {
+  const { loginWithRedirect } = useAuth0();
+
+  return useCallback(
+    ({ returnTo = ROUTES.APP_HOME, isReauth = false }: LoginOptions = {}) => {
+      // Do not overwrite a returnTo an earlier step in the reauth flow stored.
+      if (!isReauth || !sessionStorage.getItem('auth:returnTo')) {
+        sessionStorage.setItem('auth:returnTo', returnTo);
+      }
+
+      return loginWithRedirect({
+        authorizationParams: {
+          audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+          scope: LOGIN_SCOPE,
+          ...(isReauth ? { prompt: 'login' } : {}),
+          redirect_uri: `${window.location.origin}${ROUTES.AUTH_CALLBACK}`,
+        },
+        appState: { returnTo },
+      });
+    },
+    [loginWithRedirect],
+  );
+}

--- a/packages/client/src/lib/__tests__/auth0-session.test.ts
+++ b/packages/client/src/lib/__tests__/auth0-session.test.ts
@@ -50,4 +50,28 @@ describe('auth0-session utilities', () => {
     expect(getStoredAuth0AccessToken()).toBeNull();
     expect(hasStoredAuth0Session()).toBe(false);
   });
+  it('reports no session when the browser blocks storage access', () => {
+    // Private windows and "block all cookies" make the accessor itself throw.
+    // LandingRoute calls this during render, so a throw here would take the
+    // public landing page down for the visitors it exists to serve.
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+
+    expect(() => getStoredAuth0AccessToken()).not.toThrow();
+    expect(getStoredAuth0AccessToken()).toBeNull();
+    expect(hasStoredAuth0Session()).toBe(false);
+
+    getItem.mockRestore();
+  });
+
+  it('reports no session when enumerating storage throws', () => {
+    const length = vi.spyOn(Storage.prototype, 'length', 'get').mockImplementation(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+
+    expect(hasStoredAuth0Session()).toBe(false);
+
+    length.mockRestore();
+  });
 });

--- a/packages/client/src/lib/auth0-session.ts
+++ b/packages/client/src/lib/auth0-session.ts
@@ -30,31 +30,39 @@ export function getStoredAuth0AccessToken(): string | null {
     return null;
   }
 
-  const exactCacheKey = `@@auth0spajs@@::${clientId}::${audience}::${AUTH0_SCOPE}`;
-  const exactValue = localStorage.getItem(exactCacheKey);
-  if (exactValue) {
-    const token = parseAuth0CacheEntry(exactValue);
-    if (token) {
-      return token;
-    }
-  }
-
-  const prefix = buildAuth0CachePrefix(clientId, audience);
-  for (let index = 0; index < localStorage.length; index += 1) {
-    const key = localStorage.key(index);
-    if (!key?.startsWith(prefix)) {
-      continue;
+  // Reading localStorage throws outright where the browser blocks site data
+  // (private windows, "block all cookies"). A browser that cannot hold a cache
+  // has no cached session, so answer that rather than propagating: callers use
+  // this during render, where a throw would take the page down.
+  try {
+    const exactCacheKey = `@@auth0spajs@@::${clientId}::${audience}::${AUTH0_SCOPE}`;
+    const exactValue = localStorage.getItem(exactCacheKey);
+    if (exactValue) {
+      const token = parseAuth0CacheEntry(exactValue);
+      if (token) {
+        return token;
+      }
     }
 
-    const rawValue = localStorage.getItem(key);
-    if (!rawValue) {
-      continue;
-    }
+    const prefix = buildAuth0CachePrefix(clientId, audience);
+    for (let index = 0; index < localStorage.length; index += 1) {
+      const key = localStorage.key(index);
+      if (!key?.startsWith(prefix)) {
+        continue;
+      }
 
-    const token = parseAuth0CacheEntry(rawValue);
-    if (token) {
-      return token;
+      const rawValue = localStorage.getItem(key);
+      if (!rawValue) {
+        continue;
+      }
+
+      const token = parseAuth0CacheEntry(rawValue);
+      if (token) {
+        return token;
+      }
     }
+  } catch {
+    return null;
   }
 
   return null;

--- a/packages/client/src/router/config.tsx
+++ b/packages/client/src/router/config.tsx
@@ -2,7 +2,7 @@ import { lazy, Suspense, type ReactElement } from 'react';
 import type { RouteObject } from 'react-router-dom';
 import { ErrorBoundary } from '../components/error-boundary.js';
 import { PageSkeleton, ReportSkeleton, TableSkeleton } from '../components/layout/page-skeleton.js';
-import { ProtectedRoute, PublicOnlyGuard } from './guards/auth-guards.js';
+import { LandingRoute, ProtectedRoute, PublicOnlyGuard } from './guards/auth-guards.js';
 import { DashboardLayoutRoute } from './layouts/dashboard-layout.js';
 import { RootLayout } from './layouts/root-layout.js';
 import { businessLoader, chargeLoader } from './loaders/index.js';
@@ -213,6 +213,11 @@ const WelcomePage = lazy(() =>
   import('../components/screens/welcome.js').then(m => ({ default: m.WelcomePage })),
 );
 
+// Public landing page
+const LandingPage = lazy(() =>
+  import('../components/landing/index.js').then(m => ({ default: m.LandingPage })),
+);
+
 /**
  * Helper to wrap components with Suspense
  */
@@ -238,6 +243,16 @@ export const routes: RouteObject[] = [
     element: <RootLayout />,
     errorElement: <ErrorBoundary />,
     children: [
+      // Public landing page. Owns `/` for logged-out visitors; `LandingRoute`
+      // sends anyone with a session on to ROUTES.APP_HOME instead.
+      // No handle.title on purpose: DocumentTitle then leaves the plain "Accounter".
+      {
+        index: true,
+        element: (
+          <LandingRoute>{withSuspense(LandingPage, <div className="min-h-screen" />)}</LandingRoute>
+        ),
+      },
+
       // Public routes (login, error pages)
       {
         path: ROUTES.LOGIN,
@@ -270,9 +285,10 @@ export const routes: RouteObject[] = [
         },
       },
 
-      // Protected routes (require authentication)
+      // Protected routes (require authentication).
+      // Pathless layout route: `/` itself belongs to the landing page above, and
+      // the relative child paths below still resolve against the root.
       {
-        path: '/',
         element: (
           <ProtectedRoute>
             <DashboardLayoutRoute />
@@ -280,16 +296,6 @@ export const routes: RouteObject[] = [
         ),
         errorElement: <ErrorBoundary />,
         children: [
-          // Home / Charges (default)
-          {
-            index: true,
-            element: withSuspense(AllCharges, <TableSkeleton />),
-            handle: {
-              title: 'All Charges',
-              breadcrumb: 'Charges',
-            },
-          },
-
           // Charges section
           {
             path: 'charges',

--- a/packages/client/src/router/guards/auth-guards.tsx
+++ b/packages/client/src/router/guards/auth-guards.tsx
@@ -3,6 +3,7 @@ import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 import { PageSkeleton } from '../../components/layout/page-skeleton.js';
 import { useViewer } from '../../hooks/use-viewer.js';
+import { hasStoredAuth0Session } from '../../lib/auth0-session.js';
 import { ROUTES } from '../routes.js';
 
 type GuardProps = {
@@ -69,6 +70,39 @@ export function OnboardingGuard({ children }: GuardProps): ReactElement {
   return children;
 }
 
+/**
+ * Owns the site root, which serves two audiences.
+ *
+ * A visitor without a session gets the public landing page; anyone already
+ * signed in is sent straight into the app. Unlike the other guards this one
+ * does not hold the render back on `isLoading` by default — the landing page is
+ * the first thing a stranger ever sees, and making them wait on an Auth0 round
+ * trip to read marketing copy is the wrong trade. A cached session is the one
+ * case worth waiting for: it means a redirect is coming, so painting the
+ * marketing page first would only be a flash.
+ */
+export function LandingRoute({ children }: GuardProps): ReactElement {
+  if (isDevAuthEnabled) {
+    return <Navigate to={ROUTES.APP_HOME} replace />;
+  }
+
+  return <Auth0LandingRoute>{children}</Auth0LandingRoute>;
+}
+
+function Auth0LandingRoute({ children }: GuardProps): ReactElement {
+  const { isAuthenticated, isLoading } = useAuth0();
+
+  if (isLoading) {
+    return hasStoredAuth0Session() ? <PageSkeleton /> : children;
+  }
+
+  if (isAuthenticated) {
+    return <Navigate to={ROUTES.APP_HOME} replace />;
+  }
+
+  return children;
+}
+
 export function PublicOnlyGuard({ children }: GuardProps): ReactElement {
   if (isDevAuthEnabled) {
     return children;
@@ -94,7 +128,7 @@ function Auth0PublicOnlyGuard({ children }: GuardProps): ReactElement {
     if (invitationReturnTo) {
       sessionStorage.removeItem('auth:invitationReturnTo');
     }
-    return <Navigate to={invitationReturnTo ?? ROUTES.HOME} replace />;
+    return <Navigate to={invitationReturnTo ?? ROUTES.APP_HOME} replace />;
   }
 
   return children;

--- a/packages/client/src/router/routes.ts
+++ b/packages/client/src/router/routes.ts
@@ -65,7 +65,14 @@ function getTrialBalanceReportHref(filter?: TrialBalanceReportFilters | null): s
 }
 
 export const ROUTES = {
+  /** Public landing page. Logged-out visitors land here; see `LandingRoute`. */
   HOME: '/',
+  /**
+   * First screen inside the app shell. `HOME` is the marketing page now, so
+   * anything that means "send the user into the app" points here instead.
+   * Keep in sync with `CHARGES.ROOT`.
+   */
+  APP_HOME: '/charges',
   LOGIN: '/login',
   AUTH_CALLBACK: '/auth/callback',
   WELCOME: '/welcome',


### PR DESCRIPTION
Accounter had no public face: `/` was the app's index route inside
`ProtectedRoute`, so a logged-out visitor got a skeleton and a redirect
to a bare sign-in form. Nobody who had not already been invited could
learn what the product does.

`/` is now a static marketing page for visitors without a session —
how data is collected and matched, the feature set, the integrations,
the Israeli compliance formats and the MCP connector — with a
"Request access" call to action in the header and footer. It fetches
nothing: no GraphQL, no loaders, no viewer lookup.

To make room for it the protected subtree becomes a pathless layout
route, leaving `/` to the new index route. `LandingRoute` decides what
renders there: the page for a visitor, a redirect to the app for anyone
signed in. It deliberately does not block on Auth0's `isLoading` unless
a cached session exists — a stranger should not wait on a token round
trip to read marketing copy, and a cached session is the only case where
painting the page first would just be a flash.

`ROUTES.HOME` now means the landing page, so everything that meant
"send the user into the app" points at the new `ROUTES.APP_HOME`
(`/charges`): post-login, post-invitation, the error boundary's home
links and the dashboard logo.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012qHVSUqNbMx16QQfamUE8E