### PR TITLE
feat(mcp-server): log the `initialize` handshake

### DIFF
--- a/.changeset/mcp-log-initialize-handshake.md
+++ b/.changeset/mcp-log-initialize-handshake.md
@@ -1,0 +1,44 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Log the MCP `initialize` handshake, so a client changing underneath this connector is visible.
+
+The connector recently went blind — every tool returned its summary line and no rows — because rows
+lived only in `structuredContent`, a field a client may ignore, and the client's handling of it
+changed. Establishing that took a rollback test plus reading Claude Desktop's own log directory,
+because this server records **nothing** about who connects: `initialize` never read `request.params`
+and never logged. The one hop with no trace was the one that mattered.
+
+Every `initialize` now emits one structured line tagged `event: "mcp_initialize"`, joining
+`tool_call` as the second selectable event. It carries `clientName` / `clientVersion` (the fields
+that date a client-side change), `requestedProtocolVersion` vs `servedProtocolVersion`, a
+`protocolVersionMismatch` boolean, `clientCapabilities` (names only — the values are unbounded and
+caller-supplied), and the usual `userId` / `correlationId` so a session can be joined across both
+events.
+
+Three decisions are load-bearing:
+
+- **Logged from `dispatchMcpRequest`, not from the `case 'initialize'` that builds the response.**
+  `handleRpcRequest` is the pure, env-free half and takes only the request — it has neither the
+  caller nor the correlation id. Delegating to it afterwards keeps the response built in exactly one
+  place, so the two cannot drift. The sync `handleMcpBody` path has no production call sites and
+  stays silent, which leaves its existing test of the pure response shape untouched.
+- **`describeInitializeParams` is total.** `params` is `unknown` off the wire and validated only as
+  a non-null object *or array*, so every field is narrowed there and anything unexpected degrades to
+  `null`/`[]`. A malformed handshake must still produce a line: a client sending something this
+  server cannot parse is precisely the event worth seeing, and an exception there would lose it.
+- **Caller-derived fields are spread beneath the canonical ones**, matching the `tool_call` line.
+  Without that, `clientInfo` would be an authenticated way to attribute a call to a different
+  `userId`. Client strings are also clipped before reaching the log.
+
+Deliberately excluded: a `labeledTotals` counter keyed by client version. `/metrics` is
+unauthenticated while calling a tool requires a token — already flagged as worth closing — and
+client identity is a fingerprint of the deployment, so it belongs in the log (durable, access-
+controlled by the platform) rather than on a public endpoint. Worth revisiting once `/metrics` is
+gated.
+
+Also deliberately excluded: protocol-version *negotiation*. The server keeps answering `2025-06-18`
+unconditionally; this only records what was asked. Changing what the server advertises is a live
+behavioural change to a connector that has just broken once, and it should be decided against a
+logged mismatch rather than a guess — which is what `protocolVersionMismatch` now provides.

--- a/.changeset/mcp-log-initialize-handshake.md
+++ b/.changeset/mcp-log-initialize-handshake.md
@@ -40,5 +40,5 @@ gated.
 
 Also deliberately excluded: protocol-version *negotiation*. The server keeps answering `2025-06-18`
 unconditionally; this only records what was asked. Changing what the server advertises is a live
-behavioural change to a connector that has just broken once, and it should be decided against a
+behavioral change to a connector that has just broken once, and it should be decided against a
 logged mismatch rather than a guess — which is what `protocolVersionMismatch` now provides.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -346,6 +346,27 @@ A snapshot is exposed at `GET /metrics`:
 curl http://localhost:3100/metrics
 ```
 
+### Handshake logging
+
+Every `initialize` emits one structured line tagged `event: "mcp_initialize"`, carrying
+`clientName`, `clientVersion`, `requestedProtocolVersion`, `servedProtocolVersion`,
+`protocolVersionMismatch`, `clientCapabilities` (names only) and the usual `userId` /
+`correlationId`.
+
+This exists because a client's handling of tool results changed underneath this connector once and
+the server had no record of it — the change had to be reconstructed from the _client's_ own logs.
+`clientInfo` is what dates such a change, and `protocolVersionMismatch` is the one field worth
+alerting on.
+
+The line is emitted from `dispatchMcpRequest`, not from the `case 'initialize'` that builds the
+response: `handleRpcRequest` is the pure, env-free half and receives neither the caller nor the
+correlation id. `describeInitializeParams` does the parsing and is deliberately total — `params` is
+`unknown` off the wire, so a malformed handshake still produces a line rather than an exception. A
+client sending something the server cannot parse is precisely the event worth seeing. Caller-derived
+fields are merged _beneath_ the canonical ones, so a client cannot attribute its call to another
+user by putting `userId` in `clientInfo`, and `clientInfo` strings are clipped before they reach the
+log.
+
 ### Usage logging
 
 Operational telemetry answers "is it healthy"; usage telemetry answers "what are callers trying to
@@ -376,8 +397,9 @@ from stale charge ids becomes visible. This line is the complement to the `audit
 write already emits _before_ its handler runs: the audit line names the records, this one says what
 applied. Neither carries document content, filenames, or URLs.
 
-See [`docs/operations-runbook.md`](./docs/operations-runbook.md) §3.1 for the full field reference
-and the `jq` extraction recipes (most-requested terms, missing terms, tool popularity).
+See [`docs/operations-runbook.md`](./docs/operations-runbook.md) §3.1 (handshake) and §3.2 (tool
+calls) for the full field references and the `jq` extraction recipes (client versions,
+most-requested terms, missing terms, tool popularity).
 
 ### Tracing (OpenTelemetry → Grafana Tempo)
 

--- a/packages/mcp-server/docs/operations-runbook.md
+++ b/packages/mcp-server/docs/operations-runbook.md
@@ -102,7 +102,27 @@ Useful queries (adapt to your log backend):
 - **Unexpected tool errors**: `message == "unexpected error during tool execution"` (carries `tool`,
   `correlationId`, and the sanitized error) — these map to `INTERNAL_ERROR` for callers.
 
-### 3.1 Tool-call usage logs (`event: "tool_call"`)
+### 3.1 Handshake logs (`event: "mcp_initialize"`)
+
+Every `initialize` emits one line. This is the only record of _which client_ is talking to the
+connector — a remote client's handling of tool results can change without anything in this repo
+changing, and when that happened once, dating it required the client's own local logs.
+
+| Field                      | Meaning                                                                                                                          |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `clientName`               | `clientInfo.name` as the client reported it, clipped. `null` if it sent none.                                                    |
+| `clientVersion`            | `clientInfo.version`, clipped. **The field that dates a client-side behaviour change.**                                          |
+| `requestedProtocolVersion` | The MCP revision the client asked for. `null` if absent.                                                                         |
+| `servedProtocolVersion`    | What this server answered — currently unconditional.                                                                             |
+| `protocolVersionMismatch`  | Client asked for a revision this server does not implement. The one field worth alerting on. `false` when nothing was requested. |
+| `clientCapabilities`       | Capability _names_ only, sorted. Values are unbounded and caller-supplied.                                                       |
+| `userId` / `correlationId` | Same meaning as on `tool_call`, so a session can be joined across both events.                                                   |
+
+Caller-derived fields are merged beneath the canonical ones, so `clientName` and friends can never
+overwrite `userId`, `correlationId`, or `event`. A handshake the server cannot parse still logs a
+line, with the unparseable fields `null`.
+
+### 3.2 Tool-call usage logs (`event: "tool_call"`)
 
 Every completed tool call emits exactly one line with `event: "tool_call"` — including calls
 rejected by validation, policy, or the rate limiter, which never reach a handler. This is the only
@@ -179,6 +199,18 @@ jq -r 'select(.event=="tool_call" and .updatedChargeCount != null
 # Tool popularity and error rate
 jq -r 'select(.event=="tool_call") | "\(.tool)\t\(.outcome)"' logs.jsonl \
   | sort | uniq -c | sort -rn
+
+# Client versions seen, in order — the query that dates a client-side change
+jq -r 'select(.event=="mcp_initialize")
+  | [.timestamp, .clientName, .clientVersion] | @tsv' logs.jsonl
+
+# Distinct client + protocol revision pairs: what is connecting, and with what
+jq -r 'select(.event=="mcp_initialize")
+  | [.clientName, .clientVersion, .requestedProtocolVersion] | @tsv' logs.jsonl | sort -u
+
+# Clients asking for a protocol revision this server does not serve
+jq -r 'select(.event=="mcp_initialize" and .protocolVersionMismatch)
+  | [.timestamp, .clientName, .requestedProtocolVersion, .servedProtocolVersion] | @tsv' logs.jsonl
 ```
 
 ## 4. Incident playbooks

--- a/packages/mcp-server/docs/operations-runbook.md
+++ b/packages/mcp-server/docs/operations-runbook.md
@@ -111,7 +111,7 @@ changing, and when that happened once, dating it required the client's own local
 | Field                      | Meaning                                                                                                                          |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `clientName`               | `clientInfo.name` as the client reported it, clipped. `null` if it sent none.                                                    |
-| `clientVersion`            | `clientInfo.version`, clipped. **The field that dates a client-side behavior change.**                                          |
+| `clientVersion`            | `clientInfo.version`, clipped. **The field that dates a client-side behavior change.**                                           |
 | `requestedProtocolVersion` | The MCP revision the client asked for. `null` if absent.                                                                         |
 | `servedProtocolVersion`    | What this server answered — currently unconditional.                                                                             |
 | `protocolVersionMismatch`  | Client asked for a revision this server does not implement. The one field worth alerting on. `false` when nothing was requested. |

--- a/packages/mcp-server/docs/operations-runbook.md
+++ b/packages/mcp-server/docs/operations-runbook.md
@@ -111,7 +111,7 @@ changing, and when that happened once, dating it required the client's own local
 | Field                      | Meaning                                                                                                                          |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `clientName`               | `clientInfo.name` as the client reported it, clipped. `null` if it sent none.                                                    |
-| `clientVersion`            | `clientInfo.version`, clipped. **The field that dates a client-side behaviour change.**                                          |
+| `clientVersion`            | `clientInfo.version`, clipped. **The field that dates a client-side behavior change.**                                          |
 | `requestedProtocolVersion` | The MCP revision the client asked for. `null` if absent.                                                                         |
 | `servedProtocolVersion`    | What this server answered — currently unconditional.                                                                             |
 | `protocolVersionMismatch`  | Client asked for a revision this server does not implement. The one field worth alerting on. `false` when nothing was requested. |

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -5,7 +5,14 @@ import { buildAuthContext } from '../../auth/identity.js';
 import { TokenVerificationError } from '../../auth/token.js';
 import { verifyAccessToken } from '../../auth/verifier.js';
 import { getMetrics, resetMetrics } from '../../observability/metrics.js';
-import { dispatchMcpRequest, handleMcpBody, MCP_PROTOCOL_VERSION, mcpHttpHandler } from '../handler.js';
+import {
+  describeInitializeParams,
+  dispatchMcpRequest,
+  handleMcpBody,
+  MCP_INITIALIZE_EVENT,
+  MCP_PROTOCOL_VERSION,
+  mcpHttpHandler,
+} from '../handler.js';
 import type { JsonRpcErrorResponse, JsonRpcSuccess } from '../jsonrpc.js';
 import { JsonRpcErrorCode } from '../jsonrpc.js';
 import { SMOKE_TOOL_NAME } from '../tools.js';
@@ -402,5 +409,188 @@ describe('hasBearerToken', () => {
     expect(hasBearerToken(mockReq('', {}))).toBe(false);
     expect(hasBearerToken(mockReq('', { authorization: 'Bearer ' }))).toBe(false);
     expect(hasBearerToken(mockReq('', { authorization: 'Basic xyz' }))).toBe(false);
+  });
+});
+
+describe('describeInitializeParams', () => {
+  /**
+   * `params` arrives as `unknown` and is validated only as a non-null object or
+   * array, so every one of these shapes is reachable from the wire. A malformed
+   * handshake still has to produce a line — a client sending something this
+   * server cannot parse is exactly the event worth seeing.
+   */
+  it('reads a well-formed handshake', () => {
+    expect(
+      describeInitializeParams({
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: { roots: { listChanged: true }, sampling: {} },
+        clientInfo: { name: 'claude-ai', version: '1.37937.1' },
+      }),
+    ).toEqual({
+      clientName: 'claude-ai',
+      clientVersion: '1.37937.1',
+      requestedProtocolVersion: MCP_PROTOCOL_VERSION,
+      servedProtocolVersion: MCP_PROTOCOL_VERSION,
+      protocolVersionMismatch: false,
+      clientCapabilities: ['roots', 'sampling'],
+    });
+  });
+
+  it('flags a client asking for a revision this server does not implement', () => {
+    const described = describeInitializeParams({ protocolVersion: '2099-01-01' });
+
+    expect(described.requestedProtocolVersion).toBe('2099-01-01');
+    expect(described.servedProtocolVersion).toBe(MCP_PROTOCOL_VERSION);
+    expect(described.protocolVersionMismatch).toBe(true);
+  });
+
+  // Absent is not mismatched — nothing was asked for, so there is nothing to
+  // disagree with. Flagging it would make every bare handshake look like a
+  // version conflict.
+  it('does not flag a mismatch when no version was requested', () => {
+    expect(describeInitializeParams({}).protocolVersionMismatch).toBe(false);
+    expect(describeInitializeParams({}).requestedProtocolVersion).toBeNull();
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'initialize'],
+    ['an array', [1, 2, 3]],
+    ['a number', 42],
+  ])('degrades to nulls for params that are %s', (_label, params) => {
+    expect(describeInitializeParams(params)).toEqual({
+      clientName: null,
+      clientVersion: null,
+      requestedProtocolVersion: null,
+      servedProtocolVersion: MCP_PROTOCOL_VERSION,
+      protocolVersionMismatch: false,
+      clientCapabilities: [],
+    });
+  });
+
+  it.each([
+    ['clientInfo is a string', { clientInfo: 'claude' }],
+    ['clientInfo is an array', { clientInfo: ['claude'] }],
+    ['clientInfo is null', { clientInfo: null }],
+    ['name is not a string', { clientInfo: { name: 7, version: {} } }],
+    ['name is empty', { clientInfo: { name: '', version: '' } }],
+  ])('tolerates a clientInfo where %s', (_label, params) => {
+    const described = describeInitializeParams(params);
+
+    expect(described.clientName).toBeNull();
+    expect(described.clientVersion).toBeNull();
+  });
+
+  it('clips an over-long client identifier', () => {
+    const described = describeInitializeParams({
+      clientInfo: { name: 'n'.repeat(500), version: 'v'.repeat(500) },
+    });
+
+    expect(described.clientName!.length).toBeLessThanOrEqual(61);
+    expect(described.clientName!.endsWith('…')).toBe(true);
+    expect(described.clientVersion!.length).toBeLessThanOrEqual(61);
+  });
+
+  // Deterministic ordering is what makes "the client started declaring a new
+  // capability" visible by diffing two lines.
+  it('reports capability names only, sorted', () => {
+    expect(
+      describeInitializeParams({ capabilities: { sampling: {}, elicitation: {}, roots: {} } })
+        .clientCapabilities,
+    ).toEqual(['elicitation', 'roots', 'sampling']);
+  });
+});
+
+describe('initialize handshake logging', () => {
+  const auth = buildAuthContext(PRINCIPAL, []);
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Scoped restore rather than `vi.restoreAllMocks()`, which would also drop
+    // the module-level verifier/upstream mocks this file relies on.
+    logSpy.mockRestore();
+  });
+
+  function handshakeLines(): Record<string, unknown>[] {
+    return logSpy.mock.calls
+      .map(call => JSON.parse(String(call[0])) as Record<string, unknown>)
+      .filter(entry => entry.event === MCP_INITIALIZE_EVENT);
+  }
+
+  async function initialize(params?: unknown) {
+    return dispatchMcpRequest(
+      { jsonrpc: '2.0', id: 1, method: 'initialize', ...(params !== undefined && { params }) },
+      { auth, correlationId: 'corr-1', allowlist: [], writeToolsEnabled: false },
+    );
+  }
+
+  it('emits exactly one line naming the client and the negotiated versions', async () => {
+    await initialize({
+      protocolVersion: MCP_PROTOCOL_VERSION,
+      capabilities: { roots: {} },
+      clientInfo: { name: 'claude-ai', version: '1.37937.1' },
+    });
+
+    const lines = handshakeLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      event: MCP_INITIALIZE_EVENT,
+      message: 'mcp initialize',
+      clientName: 'claude-ai',
+      clientVersion: '1.37937.1',
+      requestedProtocolVersion: MCP_PROTOCOL_VERSION,
+      servedProtocolVersion: MCP_PROTOCOL_VERSION,
+      protocolVersionMismatch: false,
+      clientCapabilities: ['roots'],
+      userId: auth.userId,
+      correlationId: 'corr-1',
+    });
+  });
+
+  it('still logs a handshake it could not parse', async () => {
+    await initialize('not-an-object');
+
+    expect(handshakeLines()).toHaveLength(1);
+    expect(handshakeLines()[0]).toMatchObject({ clientName: null, protocolVersionMismatch: false });
+  });
+
+  // The canonical fields are spread last precisely so a client cannot overwrite
+  // them; without that, `clientInfo` is an attacker-controlled way to attribute
+  // a call to someone else.
+  it('a client cannot overwrite the canonical fields', async () => {
+    await initialize({
+      clientInfo: { name: 'claude-ai', version: '1' },
+      userId: 'somebody-else',
+      event: 'tool_call',
+      correlationId: 'forged',
+    });
+
+    expect(handshakeLines()[0]).toMatchObject({
+      event: MCP_INITIALIZE_EVENT,
+      userId: auth.userId,
+      correlationId: 'corr-1',
+    });
+  });
+
+  it('leaves the initialize response untouched', async () => {
+    const res = (await initialize({ clientInfo: { name: 'claude-ai' } })) as JsonRpcSuccess;
+    const result = res.result as Record<string, unknown>;
+
+    expect(result.protocolVersion).toBe(MCP_PROTOCOL_VERSION);
+    expect(result.capabilities).toEqual({ tools: { listChanged: false } });
+  });
+
+  // The sync entry point has no caller and no correlation id to log, and no
+  // production call sites — so it stays silent, and its existing coverage of the
+  // pure response shape is unaffected.
+  it('does not log on the sync handleMcpBody path', () => {
+    handleMcpBody(rpc('initialize'));
+
+    expect(handshakeLines()).toHaveLength(0);
   });
 });

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -9,6 +9,7 @@ import {
   describeInitializeParams,
   dispatchMcpRequest,
   handleMcpBody,
+  MAX_CLIENT_LABEL_LENGTH,
   MCP_INITIALIZE_EVENT,
   MCP_PROTOCOL_VERSION,
   mcpHttpHandler,
@@ -414,10 +415,16 @@ describe('hasBearerToken', () => {
 
 describe('describeInitializeParams', () => {
   /**
-   * `params` arrives as `unknown` and is validated only as a non-null object or
-   * array, so every one of these shapes is reachable from the wire. A malformed
-   * handshake still has to produce a line — a client sending something this
-   * server cannot parse is exactly the event worth seeing.
+   * Not all of these are reachable through `parseMcpBody` today —
+   * `asJsonRpcRequest` rejects a primitive or null `params` before dispatch, so
+   * over the wire this narrows to object, array, or absent.
+   *
+   * The helper is total anyway, for two reasons: `params` is typed `unknown`, so
+   * the compiler offers no guarantee here; and the parser's validation is
+   * exactly the kind of upstream promise that quietly stops holding. A
+   * malformed handshake has to produce a line rather than an exception — a
+   * client sending something this server cannot parse is the event most worth
+   * seeing, and throwing would lose it.
    */
   it('reads a well-formed handshake', () => {
     expect(
@@ -482,14 +489,25 @@ describe('describeInitializeParams', () => {
     expect(described.clientVersion).toBeNull();
   });
 
-  it('clips an over-long client identifier', () => {
+  // The ellipsis counts towards the cap, so the emitted string never exceeds
+  // MAX_CLIENT_LABEL_LENGTH. Asserted against the constant rather than a literal
+  // so raising the cap cannot silently loosen the guarantee.
+  it('clips an over-long client identifier to a hard cap', () => {
     const described = describeInitializeParams({
       clientInfo: { name: 'n'.repeat(500), version: 'v'.repeat(500) },
     });
 
-    expect(described.clientName!.length).toBeLessThanOrEqual(61);
+    expect(described.clientName).toHaveLength(MAX_CLIENT_LABEL_LENGTH);
     expect(described.clientName!.endsWith('…')).toBe(true);
-    expect(described.clientVersion!.length).toBeLessThanOrEqual(61);
+    expect(described.clientVersion).toHaveLength(MAX_CLIENT_LABEL_LENGTH);
+  });
+
+  it('leaves an identifier exactly at the cap untouched', () => {
+    const exact = 'n'.repeat(MAX_CLIENT_LABEL_LENGTH);
+    const described = describeInitializeParams({ clientInfo: { name: exact } });
+
+    expect(described.clientName).toBe(exact);
+    expect(described.clientName!.endsWith('…')).toBe(false);
   });
 
   // Deterministic ordering is what makes "the client started declaring a new
@@ -552,6 +570,9 @@ describe('initialize handshake logging', () => {
     });
   });
 
+  // Reaches `dispatchMcpRequest` directly, bypassing the parser that would
+  // reject this shape — the point is that the log line survives a `params` the
+  // helper cannot read, whatever route delivered it.
   it('still logs a handshake it could not parse', async () => {
     await initialize('not-an-object');
 

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -51,6 +51,23 @@ import { listedTools, runSmokeTool, SMOKE_TOOL_NAME } from './tools.js';
 /** MCP protocol revision this server implements. */
 export const MCP_PROTOCOL_VERSION = '2025-06-18';
 
+/**
+ * `event` discriminator on the handshake log line, so `initialize` can be
+ * selected out of the log stream without matching on free-text messages —
+ * the same contract as `TOOL_CALL_EVENT` in `tools/execute.ts`.
+ */
+export const MCP_INITIALIZE_EVENT = 'mcp_initialize';
+
+/**
+ * Length cap on a logged client identifier.
+ *
+ * `clientInfo.name` and `clientInfo.version` are caller-supplied strings off the
+ * wire with no schema behind them, so they are clipped before reaching the log.
+ * Mirrors `MAX_MISS_LABEL_LENGTH` in `tools/terminology.ts`, which caps the
+ * other caller-derived text this server records.
+ */
+const MAX_CLIENT_LABEL_LENGTH = 60;
+
 export const MCP_SERVER_INFO = {
   name: SERVICE_NAME,
   version: getServiceVersion(),
@@ -58,6 +75,64 @@ export const MCP_SERVER_INFO = {
 
 /** Max accepted request body size (bounded input, per spec §9.1). */
 export const MAX_MCP_BODY_BYTES = 1_000_000;
+
+/** Narrow an unknown value to a plain object, or `{}` — never throws. */
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+/** Clip a caller-supplied identifier for the log, or `null` when absent. */
+function clipClientLabel(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length === 0) {
+    return null;
+  }
+  return value.length <= MAX_CLIENT_LABEL_LENGTH
+    ? value
+    : `${value.slice(0, MAX_CLIENT_LABEL_LENGTH)}\u2026`;
+}
+
+/** What a client told us about itself during `initialize`. */
+export interface InitializeHandshake {
+  clientName: string | null;
+  clientVersion: string | null;
+  requestedProtocolVersion: string | null;
+  servedProtocolVersion: string;
+  /** The client asked for a revision this server does not implement. */
+  protocolVersionMismatch: boolean;
+  /** Capability *names* only — the values are unbounded and caller-supplied. */
+  clientCapabilities: string[];
+}
+
+/**
+ * Describe an `initialize` request for the log.
+ *
+ * Pure, and deliberately total: `params` is `unknown` off the wire and is
+ * validated only as a non-null object *or array* (`jsonrpc.ts`), so every field
+ * is narrowed here and anything unexpected degrades to `null`/`[]` rather than
+ * throwing. A malformed handshake must still be recorded — a client sending
+ * something this server cannot parse is precisely the event worth seeing.
+ *
+ * An absent `protocolVersion` is not a mismatch: nothing was asked for.
+ */
+export function describeInitializeParams(params: unknown): InitializeHandshake {
+  const record = asRecord(params);
+  const requestedProtocolVersion = clipClientLabel(record.protocolVersion);
+  const clientInfo = asRecord(record.clientInfo);
+
+  return {
+    clientName: clipClientLabel(clientInfo.name),
+    clientVersion: clipClientLabel(clientInfo.version),
+    requestedProtocolVersion,
+    servedProtocolVersion: MCP_PROTOCOL_VERSION,
+    protocolVersionMismatch:
+      requestedProtocolVersion !== null && requestedProtocolVersion !== MCP_PROTOCOL_VERSION,
+    // Sorted so the same handshake always logs the same line, which makes a
+    // change in what the client declares visible by diffing.
+    clientCapabilities: Object.keys(asRecord(record.capabilities)).sort(),
+  };
+}
 
 /**
  * Dispatch a single JSON-RPC request to its MCP method handler. Returns the
@@ -192,6 +267,29 @@ export async function dispatchMcpRequest(
     return null;
   }
   const id = request.id ?? null;
+
+  // Record the handshake, then let `handleRpcRequest` build the response.
+  //
+  // It is logged here rather than in that function's `case 'initialize'` for two
+  // reasons: `handleRpcRequest` is the pure, env-free half and takes only the
+  // request, so it has neither the caller nor the correlation id to log; and
+  // keeping the response in one place means the two cannot drift.
+  //
+  // This is the one hop that was never recorded, which is why a client changing
+  // its handling of tool results underneath this server had to be reconstructed
+  // from the *client's* own logs. `clientInfo` is what dates such a change.
+  if (request.method === 'initialize') {
+    // Caller-derived fields spread first so the canonical ones below always win
+    // a name collision — cf. the `tool_call` line in `tools/execute.ts`. A
+    // client cannot misreport who it is by putting `userId` in `clientInfo`.
+    log('info', 'mcp initialize', {
+      ...describeInitializeParams(request.params),
+      event: MCP_INITIALIZE_EVENT,
+      userId: context.auth.userId,
+      correlationId: context.correlationId,
+    });
+    return handleRpcRequest(request);
+  }
 
   // Exposure controls: `MCP_TOOL_ALLOWLIST` (empty ⇒ every tool; non-empty ⇒
   // only the named subset) and `MCP_ENABLE_WRITE_TOOLS` (off ⇒ no mutating

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -59,14 +59,17 @@ export const MCP_PROTOCOL_VERSION = '2025-06-18';
 export const MCP_INITIALIZE_EVENT = 'mcp_initialize';
 
 /**
- * Length cap on a logged client identifier.
+ * Hard cap on the length of a logged client identifier, ellipsis included.
  *
  * `clientInfo.name` and `clientInfo.version` are caller-supplied strings off the
  * wire with no schema behind them, so they are clipped before reaching the log.
- * Mirrors `MAX_MISS_LABEL_LENGTH` in `tools/terminology.ts`, which caps the
- * other caller-derived text this server records.
+ * Same motivation as `MAX_MISS_LABEL_LENGTH` in `tools/terminology.ts`, but
+ * deliberately a different number: that one bounds a `/metrics` label, where
+ * the constraint is a readable snapshot, while this bounds a log field and only
+ * needs to stop an unbounded string. A real client identifier
+ * (`claude-ai` / `1.37937.1`) is nowhere near either limit.
  */
-const MAX_CLIENT_LABEL_LENGTH = 60;
+export const MAX_CLIENT_LABEL_LENGTH = 60;
 
 export const MCP_SERVER_INFO = {
   name: SERVICE_NAME,
@@ -83,14 +86,20 @@ function asRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
-/** Clip a caller-supplied identifier for the log, or `null` when absent. */
+/**
+ * Clip a caller-supplied identifier for the log, or `null` when absent.
+ *
+ * The ellipsis counts towards the cap, so the result is never longer than
+ * {@link MAX_CLIENT_LABEL_LENGTH} — a cap that its own truncation marker can
+ * push past is not a cap.
+ */
 function clipClientLabel(value: unknown): string | null {
   if (typeof value !== 'string' || value.length === 0) {
     return null;
   }
   return value.length <= MAX_CLIENT_LABEL_LENGTH
     ? value
-    : `${value.slice(0, MAX_CLIENT_LABEL_LENGTH)}\u2026`;
+    : `${value.slice(0, MAX_CLIENT_LABEL_LENGTH - 1)}\u2026`;
 }
 
 /** What a client told us about itself during `initialize`. */


### PR DESCRIPTION
## Why

The connector went blind between Aug 18 and Aug 26 — every tool returned its summary line and no
rows. #4295 fixes the cause (rows lived only in `structuredContent`, a field a client may ignore).

This PR addresses the *second* problem that incident exposed: **the server had no idea the client
had changed.**

Establishing that it *was* the client took a rollback test — checking out `e31e8066`, the commit
that demonstrably worked on Aug 18 including a successful tag write, and running it today reproduces
the failure exactly. Same commit, same server, opposite outcome. Confirming it then meant reading
Claude Desktop's own log directory:

| Date | Log file | Event vocabulary | Outcome |
| --- | --- | --- | --- |
| Aug 10 | `main.log` | `Making remote MCP tool call: accounter_get_charges` → `Remote tool call succeeded` | rows arrived |
| Aug 26 | `claude.ai-web.log` | `[MCP] tool_approval_gate {"toolName":"Accounter:accounter_search_charges",…}` | rows missing |

None of that should have required someone's `~/Library/Logs`. `initialize` (`handler.ts`) never read
`request.params` and never logged, so there was no record of the client's name, its version, the
protocol revision it asked for, or the capabilities it declared. The connector already logs every
tool call and every auth failure — the handshake was the one hop with no trace.

## What

Every `initialize` emits one structured line tagged `event: "mcp_initialize"`, joining `tool_call`
as the second selectable event:

| Field | Why |
| --- | --- |
| `clientName`, `clientVersion` | the fields that date a client-side behaviour change |
| `requestedProtocolVersion` / `servedProtocolVersion` | what was asked vs what we answered |
| `protocolVersionMismatch` | the one field worth alerting on |
| `clientCapabilities` | names only, sorted — values are unbounded and caller-supplied |
| `userId`, `correlationId` | matches `tool_call`, so a session joins across both events |

## Three decisions worth reviewing

**Logged from `dispatchMcpRequest`, not from the `case 'initialize'` that builds the response.**
`handleRpcRequest` is the pure, env-free half and takes only the request — it has neither the caller
nor the correlation id to log. Delegating to it afterwards keeps the response built in exactly one
place, so the two cannot drift. The sync `handleMcpBody` path has no production call sites and stays
silent, which conveniently leaves its existing test of the pure response shape untouched (there's a
test asserting that silence).

**`describeInitializeParams` is total.** `params` is `unknown` off the wire and validated only as a
non-null object *or array*, so every field is narrowed there and anything unexpected degrades to
`null`/`[]`. A malformed handshake must still produce a line — a client sending something the server
cannot parse is precisely the event worth seeing, and an exception would lose it. Covered with
`params` as `null`, a string, an array, a number, and a `clientInfo` that is variously a string, an
array, `null`, or has non-string fields.

**Caller-derived fields are spread beneath the canonical ones**, matching the `tool_call` line.
Without it, `clientInfo` would be an authenticated way to attribute a call to a different `userId` —
there's a test for that specifically. Client strings are clipped before reaching the log.

## Deliberately excluded

- **A `labeledTotals` counter keyed by client version.** `/metrics` is unauthenticated while calling
  a tool requires a token — already flagged in the runbook as worth closing — and client identity is
  a fingerprint of the deployment. It belongs in the log rather than on a public endpoint. Worth
  revisiting once `/metrics` is gated.
- **Protocol-version negotiation.** The server keeps answering `2025-06-18` unconditionally; this
  only records what was asked. Changing what the server advertises is a live behavioural change to a
  connector that has just broken once, and should be decided against a logged mismatch rather than a
  guess — which is what `protocolVersionMismatch` now provides.

## Verification

- 785 tests pass (53 files), 14 of them new; typecheck, eslint and prettier clean
- The `initialize` response is unchanged — asserted directly; this adds a log line, not a new
  response
- Docs: README gains a "Handshake logging" section; runbook gains §3.1 with the field reference and
  `jq` recipes (the cross-reference from README was renumbered to match)

Note the first real run will answer something this investigation could not: which protocol revision
Claude Desktop `1.37937.1` actually negotiates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)