### PR TITLE
docs: correct the MCP tool count from nineteen to seventeen

### DIFF
--- a/.changeset/mcp-mirror-payload-into-content.md
+++ b/.changeset/mcp-mirror-payload-into-content.md
@@ -27,7 +27,7 @@ became visible when the assumption underneath it changed.
 still leads — a cheap orientation line before the payload — followed by the serialized JSON, with
 `structuredContent` kept as-is for hosts that consume it directly. Deliberately one function rather
 than a per-tool convention: the failure mode being fixed is exactly the kind that drifts back one
-tool at a time. No tool handler changed; all nineteen already route through those three functions.
+tool at a time. No tool handler changed; all seventeen already route through those three functions.
 
 Two things this restores that were less obvious than the missing rows:
 


### PR DESCRIPTION
#4295's changeset says "all nineteen already route through those three functions". The registry holds
**seventeen** — 15 read-only + 2 write (`registry-instance.ts`).

Nineteen came from counting `shapeListResult` call sites rather than tools: there are 16, because
`terminology.ts` calls it twice (index and full mode) and `lookups.ts` three times.

The changeset is still unreleased, so correcting it now means the number reaches the changelog right.
Nothing about the fix it describes changes — the shared shaper genuinely does cover every tool, which
was the substantive claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)