### PR TITLE
refactor(mcp-server): collapse the three hand-written money shapes onto one

### DIFF
--- a/.changeset/mcp-single-money-shape.md
+++ b/.changeset/mcp-single-money-shape.md
@@ -1,0 +1,26 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Collapse the three hand-written money shapes onto one.
+
+`normalizeAmount` in `tools/entity-shapes.ts` is meant to be the single definition of how money
+appears in a tool result, but the same `raw -> value` mapping had been rewritten by hand in
+`search_charges` (`charges.ts`) and `balance_report` (`reports.ts`). Three copies, nothing keeping
+them in step — drift that had already started rather than a hypothetical one.
+
+Both now call `normalizeAmount`. The emitted JSON is unchanged: same keys, same values, same order.
+The only type-level change is that a balance-report row's `amount` is now `NormalizedAmount | null`
+rather than non-nullable. That is the safe direction — the value is never null in practice, and a
+shape that permits more than it emits cannot violate a schema, which matters if these rows ever get
+a declared `outputSchema`.
+
+Pinned by a contract test in `entity-shapes.test.ts` that asserts the key set against the tools'
+real output rather than by grepping the source, so a fourth copy that happens to be correct today
+still has to stay correct. Verified it bites: reintroducing the mapping with `amount` in place of
+`value` fails with `expected [ 'amount', 'currency', 'formatted' ] to deeply equal [ 'currency',
+'formatted', 'value' ]`.
+
+Context: this is groundwork from the blind-connector postmortem. Any future `outputSchema` has to be
+generated from a single source to be truthful, and the money shape was the clearest place where that
+single source had already been lost.

--- a/packages/mcp-server/src/tools/__tests__/entity-shapes.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/entity-shapes.test.ts
@@ -1,7 +1,36 @@
-import { describe, expect, it } from 'vitest';
-import {
-  chargeTypeFromTypename,
-} from '../entity-shapes.js';
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { searchChargesTool } from '../charges.js';
+import { chargeTypeFromTypename, normalizeAmount } from '../entity-shapes.js';
+import { executeRegisteredTool } from '../execute.js';
+import { balanceReportTool } from '../reports.js';
+
+const PRINCIPAL: AuthPrincipal = {
+  subject: 'user-1',
+  issuer: 'https://tenant.auth0.com/',
+  audience: 'aud',
+  scopes: [],
+  email: null,
+  expiresAt: undefined,
+  claims: { sub: 'user-1' },
+};
+
+function authContext(): McpAuthContext {
+  return buildAuthContext(PRINCIPAL, [{ memberBusinessId: 'b1', roleId: 'accountant' }]);
+}
+
+function clientReturning(data: unknown) {
+  const fetchImpl = vi.fn(
+    async () => ({ ok: true, status: 200, json: async () => ({ data }) }) as unknown as Response,
+  );
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
 
 /**
  * Unit coverage for the derived fields the detail tools expose: local-currency
@@ -25,5 +54,85 @@ describe('chargeTypeFromTypename', () => {
   it('returns null for an absent or unrecognized typename', () => {
     expect(chargeTypeFromTypename(undefined)).toBeNull();
     expect(chargeTypeFromTypename('SomeFutureCharge')).toBeNull();
+  });
+});
+
+describe('one money shape, across every tool that emits money', () => {
+  /**
+   * `normalizeAmount` is the single definition of the money shape, but it had
+   * been hand-rewritten in `search_charges` and `balance_report` — three copies
+   * of the same `raw -> value` mapping with nothing keeping them in step. That
+   * is drift that had already started, not a hypothetical.
+   *
+   * Asserted against the tools' real output rather than by grepping the source,
+   * so a fourth copy that happens to be correct today still has to stay correct.
+   */
+  const MONEY_KEYS = ['value', 'formatted', 'currency'];
+
+  it('normalizeAmount defines exactly the expected keys', () => {
+    const amount = normalizeAmount({ raw: -180, formatted: '-180.00', currency: 'ILS' });
+
+    expect(Object.keys(amount!).sort()).toEqual([...MONEY_KEYS].sort());
+    expect(amount).toEqual({ value: -180, formatted: '-180.00', currency: 'ILS' });
+  });
+
+  it('maps a missing amount to null rather than an empty object', () => {
+    expect(normalizeAmount(null)).toBeNull();
+    expect(normalizeAmount(undefined)).toBeNull();
+  });
+
+  it('search_charges emits the shared shape', async () => {
+    const result = await executeRegisteredTool({
+      tool: searchChargesTool,
+      rawArgs: {},
+      auth: authContext(),
+      correlationId: 'c',
+      authorization: 'Bearer t',
+      client: clientReturning({
+        allCharges: {
+          nodes: [
+            {
+              id: 'c1',
+              ownerId: 'b1',
+              userDescription: 'x',
+              owner: { id: 'b1', name: 'Acme' },
+              totalAmount: { raw: -180, formatted: '-180.00', currency: 'ILS' },
+              minEventDate: '2026-03-11',
+            },
+          ],
+          pageInfo: { totalPages: 1, totalRecords: 1, currentPage: 1, pageSize: 10 },
+        },
+      }),
+    });
+
+    const [charge] = (result.structuredContent as { charges: Array<{ amount: object }> }).charges;
+    expect(Object.keys(charge!.amount).sort()).toEqual([...MONEY_KEYS].sort());
+    expect(charge!.amount).toEqual({ value: -180, formatted: '-180.00', currency: 'ILS' });
+  });
+
+  it('balance_report emits the shared shape', async () => {
+    const result = await executeRegisteredTool({
+      tool: balanceReportTool,
+      rawArgs: { memberBusinessId: 'b1', fromDate: '2026-01-01', toDate: '2026-03-01' },
+      auth: authContext(),
+      correlationId: 'c',
+      authorization: 'Bearer t',
+      client: clientReturning({
+        transactionsForBalanceReport: [
+          {
+            id: 't1',
+            chargeId: 'c1',
+            date: '2026-01-05',
+            isFee: false,
+            description: 'x',
+            amount: { raw: 10, formatted: '10.00', currency: 'ILS' },
+          },
+        ],
+      }),
+    });
+
+    const [row] = (result.structuredContent as { rows: Array<{ amount: object }> }).rows;
+    expect(Object.keys(row!.amount).sort()).toEqual([...MONEY_KEYS].sort());
+    expect(row!.amount).toEqual({ value: 10, formatted: '10.00', currency: 'ILS' });
   });
 });

--- a/packages/mcp-server/src/tools/__tests__/entity-shapes.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/entity-shapes.test.ts
@@ -67,12 +67,16 @@ describe('one money shape, across every tool that emits money', () => {
    * Asserted against the tools' real output rather than by grepping the source,
    * so a fourth copy that happens to be correct today still has to stay correct.
    */
+  // Declared in emission order, and compared in order: the mirrored `content`
+  // block is `JSON.stringify(structuredContent)`, so key order is a real
+  // property of what the model reads, not just an implementation detail. The
+  // changeset claims the emitted JSON is unchanged — this is what backs it.
   const MONEY_KEYS = ['value', 'formatted', 'currency'];
 
   it('normalizeAmount defines exactly the expected keys', () => {
     const amount = normalizeAmount({ raw: -180, formatted: '-180.00', currency: 'ILS' });
 
-    expect(Object.keys(amount!).sort()).toEqual([...MONEY_KEYS].sort());
+    expect(Object.keys(amount!)).toEqual(MONEY_KEYS);
     expect(amount).toEqual({ value: -180, formatted: '-180.00', currency: 'ILS' });
   });
 
@@ -106,7 +110,7 @@ describe('one money shape, across every tool that emits money', () => {
     });
 
     const [charge] = (result.structuredContent as { charges: Array<{ amount: object }> }).charges;
-    expect(Object.keys(charge!.amount).sort()).toEqual([...MONEY_KEYS].sort());
+    expect(Object.keys(charge!.amount)).toEqual(MONEY_KEYS);
     expect(charge!.amount).toEqual({ value: -180, formatted: '-180.00', currency: 'ILS' });
   });
 
@@ -132,7 +136,7 @@ describe('one money shape, across every tool that emits money', () => {
     });
 
     const [row] = (result.structuredContent as { rows: Array<{ amount: object }> }).rows;
-    expect(Object.keys(row!.amount).sort()).toEqual([...MONEY_KEYS].sort());
+    expect(Object.keys(row!.amount)).toEqual(MONEY_KEYS);
     expect(row!.amount).toEqual({ value: 10, formatted: '10.00', currency: 'ILS' });
   });
 });

--- a/packages/mcp-server/src/tools/charges.ts
+++ b/packages/mcp-server/src/tools/charges.ts
@@ -6,7 +6,7 @@ import {
   type ChargeFiltersInput,
 } from './charge-filters.js';
 import { DAY_MS, parseCalendarDate, TIMELESS_DATE } from './dates.js';
-import { chargeTypeFromTypename } from './entity-shapes.js';
+import { chargeTypeFromTypename, normalizeAmount, type NormalizedAmount } from './entity-shapes.js';
 import { ToolInputError } from './execute.js';
 import { shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
@@ -143,7 +143,7 @@ export interface NormalizedCharge {
   /** Owning business, so multi-business results can be grouped by the model. */
   ownerId: string | null;
   ownerName: string | null;
-  amount: { value: number; formatted: string; currency: string } | null;
+  amount: NormalizedAmount | null;
   date: string | null;
 }
 
@@ -267,13 +267,7 @@ function normalizeCharge(charge: RawCharge): NormalizedCharge {
     // Optional chaining: fixtures predating owner selection omit the field.
     ownerId: charge.ownerId,
     ownerName: charge.owner?.name ?? null,
-    amount: charge.totalAmount
-      ? {
-          value: charge.totalAmount.raw,
-          formatted: charge.totalAmount.formatted,
-          currency: charge.totalAmount.currency,
-        }
-      : null,
+    amount: normalizeAmount(charge.totalAmount),
     date: charge.minEventDate,
   };
 }

--- a/packages/mcp-server/src/tools/entity-shapes.ts
+++ b/packages/mcp-server/src/tools/entity-shapes.ts
@@ -1,6 +1,11 @@
 /**
- * Shared normalizers for the by-id detail tools (`get_charges`,
- * `get_transactions`, `get_documents`).
+ * Shared normalizers for tool row shapes.
+ *
+ * Originally scoped to the by-id detail tools (`get_charges`,
+ * `get_transactions`, `get_documents`), now also the single definition of the
+ * money shape — `normalizeAmount` is used by `search_charges` and
+ * `balance_report` too. It had been hand-rewritten in both, which is drift
+ * waiting to happen: three copies of `raw -> value` that nothing keeps in step.
  *
  * The GraphQL field selections are intentionally *not* shared as interpolated
  * fragment strings — graphql-codegen plucks operations from plain

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { McpBalanceReportQuery, McpBalanceReportQueryVariables } from '../gql/index.js';
 import { DAY_MS, parseCalendarDate, TIMELESS_DATE } from './dates.js';
+import { normalizeAmount } from './entity-shapes.js';
 import { ToolInputError } from './execute.js';
 import { shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
@@ -110,11 +111,7 @@ async function handler(
     date: row.date,
     isFee: row.isFee,
     description: row.description,
-    amount: {
-      value: row.amount.raw,
-      formatted: row.amount.formatted,
-      currency: row.amount.currency,
-    },
+    amount: normalizeAmount(row.amount),
   }));
 
   return shapeListResult({


### PR DESCRIPTION
Groundwork from the blind-connector postmortem, and worth landing on its own merit.

## The problem

`normalizeAmount` (`tools/entity-shapes.ts`) is meant to be the single definition of how money
appears in a tool result. The same `raw -> value` mapping had been rewritten by hand in two more
places:

- `charges.ts` — `search_charges` re-inlined both the type (`{ value: number; formatted: string; currency: string }`) and the mapping
- `reports.ts` — `balance_report` built the object literal inline

Three copies, nothing keeping them in step. This is drift that had **already started**, not a
hypothetical: the shared `NormalizedAmount` existed the whole time and neither call site used it.

## The change

Both call `normalizeAmount`. The emitted JSON is unchanged — same keys, same values, same order.

One type-level change: a balance-report row's `amount` is now `NormalizedAmount | null` rather than
non-nullable. That is the safe direction. The value is never null in practice, and a shape that
permits more than it emits cannot violate a declared schema — which matters if these rows ever get an
`outputSchema`, where "servers **MUST** provide structured results that conform".

`entity-shapes.ts`'s header claimed it was scoped to "the by-id detail tools"; it now says what it
actually owns.

## Pinned against recurrence

A contract test asserts the key set against the tools' **real output** rather than by grepping the
source, so a fourth copy that happens to be correct today still has to stay correct.

Verified it bites — reintroducing the mapping with `amount` in place of `value`:

```
AssertionError: expected [ 'amount', 'currency', 'formatted' ]
                to deeply equal [ 'currency', 'formatted', 'value' ]
```

## Why now

From the postmortem's follow-up work. Any future `outputSchema` has to be generated from a single
source to be truthful, and the money shape was the clearest place where that single source had
already been lost. Fixing it is a prerequisite, and it stands alone regardless of whether we adopt
output schemas.

## Verification

817 tests pass (54 files), typecheck / eslint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)