### PR TITLE
feat(mcp-server): support `outputSchema`, declared on one canary tool

### DIFF
--- a/.changeset/mcp-output-schema-canary.md
+++ b/.changeset/mcp-output-schema-canary.md
@@ -1,0 +1,36 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Support `outputSchema`, and declare one on a single tool as a canary.
+
+No tool has ever advertised an `outputSchema`, which is why `structuredContent` was a field clients
+were free to ignore — and why they eventually did, taking every row with it. Whether declaring one is
+worth having is still an open question: the benefit (does the client validate? does it show the
+schema to the model?) is unverified, while the cost is certain, because "servers **MUST** provide
+structured results that conform" applies to all seventeen tools at once.
+
+So this adds the mechanism and exercises it on exactly one tool rather than committing to all of
+them. `accounter_list_business_memberships` is the canary: pure, no upstream call, three flat fields,
+and a summary line that already tells the model to pass `memberBusinessId` onward — so if a client
+does surface a declared schema, that is where it should show.
+
+**Generated, never hand-written.** `ToolDefinition.outputSchema` is a Zod schema, matching the input
+side, and `describe()` renders it with `z.toJSONSchema`. The canary's row type is `z.infer` of the
+same schema that is advertised, so the handler cannot build a row the schema does not describe. A
+hand-written JSON Schema would have been the opposite: a second document, free to drift, backed by a
+MUST.
+
+`output.ts` gains `listOutputSchema(itemsKey, row, extra?)`, which wraps a row schema in the exact
+envelope `shapeListResult` builds — items, `returnedCount`, `totalCount`, `truncated`, and an
+optional `continuation`. That is the reusable half if the remaining tools follow.
+
+Tools that declare nothing are unchanged, and `tools/list` omits the key entirely for them rather
+than emitting an empty contract a client might try to validate against.
+
+Guarded by `output-schema-contract.test.ts`, which is registry-driven: every tool declaring a schema
+is executed and its real `structuredContent` parsed against its own advertised schema. Tools that
+gain schemas later are covered without extending the file.
+
+This changes nothing about the `content` mirror. That exists because a client may ignore
+`structuredContent` for any reason, which a declared schema does not prevent.

--- a/.changeset/mcp-output-schema-canary.md
+++ b/.changeset/mcp-output-schema-canary.md
@@ -29,8 +29,13 @@ Tools that declare nothing are unchanged, and `tools/list` omits the key entirel
 than emitting an empty contract a client might try to validate against.
 
 Guarded by `output-schema-contract.test.ts`, which is registry-driven: every tool declaring a schema
-is executed and its real `structuredContent` parsed against its own advertised schema. Tools that
-gain schemas later are covered without extending the file.
+is executed and its real `structuredContent` parsed against its own advertised schema.
+
+Declaring a schema requires adding a fixture that drives the tool to a *successful* result, and the
+sweep fails if either is missing. That asymmetry is deliberate — an earlier draft skipped error
+results on the grounds that an error payload is the taxonomy shape rather than the declared one,
+which is true and made the test worthless: a tool could declare a schema, fail under the harness for
+any reason, and pass having validated nothing. A binding contract should cost a fixture.
 
 This changes nothing about the `content` mirror. That exists because a client may ignore
 `structuredContent` for any reason, which a declared schema does not prevent.

--- a/packages/mcp-server/src/tools/__tests__/output-schema-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/output-schema-contract.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
+import type { AuthPrincipal } from '../../auth/token.js';
+import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
+import { LIST_BUSINESS_MEMBERSHIPS_TOOL_NAME } from '../businesses.js';
+import { executeRegisteredTool } from '../execute.js';
+import { toolRegistry } from '../registry-instance.js';
+
+/**
+ * A declared `outputSchema` is binding: the spec says servers **MUST** provide
+ * structured results that conform to it, and clients **SHOULD** validate. That
+ * makes a schema which can drift from the payload worse than no schema at all —
+ * it converts a working call into a client-side error.
+ *
+ * These tests are the reason declaring one is safe here: the schema is
+ * generated from the same Zod definition the handler builds rows with, and this
+ * checks that end-to-end against real tool output rather than trusting it.
+ *
+ * Registry-driven, so the tools that gain schemas later are covered without
+ * anyone remembering to extend this file.
+ */
+
+const PRINCIPAL: AuthPrincipal = {
+  subject: 'user-1',
+  issuer: 'https://tenant.auth0.com/',
+  audience: 'aud',
+  scopes: [],
+  email: null,
+  expiresAt: undefined,
+  claims: { sub: 'user-1' },
+};
+
+function authContext(ids: string[] = ['b1', 'b2']): McpAuthContext {
+  return buildAuthContext(
+    PRINCIPAL,
+    ids.map(memberBusinessId => ({ memberBusinessId, roleId: 'accountant' })),
+  );
+}
+
+function clientReturning(data: unknown) {
+  const fetchImpl = vi.fn(
+    async () => ({ ok: true, status: 200, json: async () => ({ data }) }) as unknown as Response,
+  );
+  return new UpstreamGraphQLClient({
+    endpoint: 'http://localhost:4000/graphql',
+    timeoutMs: 1000,
+    fetchImpl: fetchImpl as unknown as typeof fetch,
+  });
+}
+
+const declaring = toolRegistry.list().filter(tool => tool.outputSchema !== undefined);
+
+describe('declared output schemas', () => {
+  it('at least one tool declares one, so the sweep below is not vacuous', () => {
+    expect(declaring.map(tool => tool.name)).toContain(LIST_BUSINESS_MEMBERSHIPS_TOOL_NAME);
+  });
+
+  it.each(declaring.map(tool => [tool.name, tool] as const))(
+    '%s produces structuredContent conforming to its declared schema',
+    async (_name, tool) => {
+      const result = await executeRegisteredTool({
+        tool,
+        rawArgs: {},
+        auth: authContext(),
+        correlationId: 'c',
+        client: clientReturning({}),
+        authorization: 'Bearer t',
+      });
+
+      // An error result is the taxonomy payload, not the declared shape — the
+      // MUST applies to the tool's own structured results.
+      if (result.isError) {
+        return;
+      }
+
+      const parsed = tool.outputSchema!.safeParse(result.structuredContent);
+      expect(
+        parsed.success ? [] : parsed.error.issues,
+        `${tool.name} returned structuredContent its own outputSchema rejects`,
+      ).toEqual([]);
+    },
+  );
+
+  it('advertises the schema on tools/list only for tools that declare one', () => {
+    const descriptors = toolRegistry.describe();
+    const canary = descriptors.find(d => d.name === LIST_BUSINESS_MEMBERSHIPS_TOOL_NAME);
+
+    expect(canary?.outputSchema).toMatchObject({
+      type: 'object',
+      properties: {
+        businesses: { type: 'array' },
+        returnedCount: { type: 'integer' },
+        totalCount: { type: 'integer' },
+        truncated: { type: 'boolean' },
+      },
+    });
+
+    // Absent, not `undefined` — an empty contract is worse than no contract,
+    // because a client may try to validate against it.
+    const undeclared = descriptors.filter(d => !declaring.some(t => t.name === d.name));
+    expect(undeclared.length).toBeGreaterThan(0);
+    for (const descriptor of undeclared) {
+      expect(Object.keys(descriptor)).not.toContain('outputSchema');
+    }
+  });
+
+  it('describes the row fields the summary line tells the model to use', () => {
+    const canary = toolRegistry.describe().find(d => d.name === LIST_BUSINESS_MEMBERSHIPS_TOOL_NAME);
+    const businesses = (canary?.outputSchema as { properties: { businesses: { items: unknown } } })
+      .properties.businesses.items;
+
+    expect(businesses).toMatchObject({
+      type: 'object',
+      properties: {
+        memberBusinessId: { type: 'string' },
+        role: { type: 'string' },
+      },
+    });
+  });
+});

--- a/packages/mcp-server/src/tools/__tests__/output-schema-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/output-schema-contract.test.ts
@@ -50,33 +50,69 @@ function clientReturning(data: unknown) {
 
 const declaring = toolRegistry.list().filter(tool => tool.outputSchema !== undefined);
 
+/** Arguments and canned upstream response that drive one tool to a *success*. */
+interface Fixture {
+  rawArgs: Record<string, unknown>;
+  upstream: unknown;
+}
+
+/**
+ * Required for every tool that declares a schema — deliberately not optional.
+ *
+ * An earlier version of this sweep ran each tool with empty args against an
+ * empty upstream and returned early on an error result, reasoning that an error
+ * payload is the taxonomy shape rather than the declared one. That is true, and
+ * it made the test worthless: a tool could declare a schema, fail under the
+ * harness for any reason, and pass here having validated nothing.
+ *
+ * Declaring an `outputSchema` is opt-in and binding, so the cost of proving the
+ * tool can actually produce a conforming result belongs with the declaration.
+ * Adding a schema without adding a fixture fails the suite.
+ */
+const FIXTURES: Record<string, Fixture> = {
+  [LIST_BUSINESS_MEMBERSHIPS_TOOL_NAME]: { rawArgs: {}, upstream: {} },
+};
+
 describe('declared output schemas', () => {
   it('at least one tool declares one, so the sweep below is not vacuous', () => {
     expect(declaring.map(tool => tool.name)).toContain(LIST_BUSINESS_MEMBERSHIPS_TOOL_NAME);
   });
 
+  it('every tool declaring a schema has a fixture that exercises it', () => {
+    const unfixtured = declaring.map(tool => tool.name).filter(name => !(name in FIXTURES));
+
+    expect(
+      unfixtured,
+      'these tools declare an outputSchema but cannot be exercised here, so their schema would never be checked against real output',
+    ).toEqual([]);
+  });
+
   it.each(declaring.map(tool => [tool.name, tool] as const))(
     '%s produces structuredContent conforming to its declared schema',
-    async (_name, tool) => {
+    async (name, tool) => {
+      const fixture = FIXTURES[name];
+      expect(fixture, `${name} has no fixture — see FIXTURES above`).toBeDefined();
+
       const result = await executeRegisteredTool({
         tool,
-        rawArgs: {},
+        rawArgs: fixture!.rawArgs,
         auth: authContext(),
         correlationId: 'c',
-        client: clientReturning({}),
+        client: clientReturning(fixture!.upstream),
         authorization: 'Bearer t',
       });
 
-      // An error result is the taxonomy payload, not the declared shape — the
-      // MUST applies to the tool's own structured results.
-      if (result.isError) {
-        return;
-      }
+      // The check that stops this passing vacuously: a tool that cannot reach a
+      // successful result has not demonstrated anything about its schema.
+      expect(
+        result.isError ?? false,
+        `${name} did not produce a success result, so its schema went unchecked: ${JSON.stringify(result.content)}`,
+      ).toBe(false);
 
       const parsed = tool.outputSchema!.safeParse(result.structuredContent);
       expect(
         parsed.success ? [] : parsed.error.issues,
-        `${tool.name} returned structuredContent its own outputSchema rejects`,
+        `${name} returned structuredContent its own outputSchema rejects`,
       ).toEqual([]);
     },
   );

--- a/packages/mcp-server/src/tools/businesses.ts
+++ b/packages/mcp-server/src/tools/businesses.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { shapeListResult } from './output.js';
+import { listOutputSchema, shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 
 /**
@@ -26,12 +26,26 @@ export const LIST_BUSINESS_MEMBERSHIPS_TOOL_NAME = 'accounter_list_business_memb
 const listBusinessesInput = z.object({});
 type ListBusinessesInput = z.infer<typeof listBusinessesInput>;
 
-interface BusinessSummary {
+/**
+ * The membership row, as Zod.
+ *
+ * This tool is the canary for declared output schemas: it is pure (no upstream
+ * call), returns three flat fields, and its summary line already instructs the
+ * model to pass `memberBusinessId` onward — so if a client does surface a
+ * declared schema to the model, this is where it should show.
+ *
+ * The TypeScript type is inferred from the schema rather than declared beside
+ * it, which is the whole point: the handler cannot build a row the advertised
+ * schema does not describe.
+ */
+const businessSummarySchema = z.object({
   /** Id of the member business — the value the other tools take as scope. */
-  memberBusinessId: string;
-  name: string | null;
-  role: string;
-}
+  memberBusinessId: z.string(),
+  name: z.string().nullable(),
+  role: z.string(),
+});
+
+type BusinessSummary = z.infer<typeof businessSummarySchema>;
 
 // Fixed-locale collator so ordering is deterministic across hosts/runtimes
 // rather than depending on the ambient default locale (mirrors `lookups.ts`).
@@ -98,6 +112,7 @@ export const listBusinessMembershipsTool: ToolDefinition<typeof listBusinessesIn
   description:
     'List the businesses you are a member of, with your role in each. This is your access/scope discovery entry point — call it first when you may belong to more than one business, then pass the returned `memberBusinessId` values as `memberBusinessIds` to the other tools. To browse every business known to the system (e.g. counterparties), use `accounter_list_businesses` instead. Read-only; takes no parameters.',
   inputSchema: listBusinessesInput,
+  outputSchema: listOutputSchema('businesses', businessSummarySchema),
   policy: {
     // Deliberately false: a caller with zero memberships should get an empty
     // list and a helpful summary, not an AUTHORIZATION_ERROR. This is the

--- a/packages/mcp-server/src/tools/output.ts
+++ b/packages/mcp-server/src/tools/output.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { ToolResult } from './registry.js';
 
 /**
@@ -224,4 +225,49 @@ export function shapeWriteResult<T>(params: ShapeWriteParams<T>): ToolResult {
   }
 
   return mirroredResult(params.summary, structured);
+}
+
+// ---------------------------------------------------------------------------
+// Declared output shape
+// ---------------------------------------------------------------------------
+
+/**
+ * The framework-owned half of a list envelope, as Zod.
+ *
+ * Mirrors exactly what {@link shapeListResult} builds, so a declared
+ * `outputSchema` describes the payload rather than a wish. `continuation` is
+ * optional because it is attached only when the result is truncated.
+ */
+const continuationSchema = z.object({
+  reason: z.enum(['payload_size', 'result_cap']),
+  returnedCount: z.number().int(),
+  totalCount: z.number().int(),
+  hint: z.string(),
+});
+
+/**
+ * Build the output schema for a list-producing tool.
+ *
+ * Deliberately generated from the same row schema the tool shapes its items
+ * with rather than hand-written: the spec makes a declared schema binding
+ * ("servers MUST provide structured results that conform"), so a schema that
+ * can drift from the payload turns working calls into client-side errors. One
+ * source removes that failure mode instead of documenting it.
+ *
+ * `extra` carries the per-tool domain fields (`scope`, `pagination`, `period`,
+ * …) that {@link ShapeListParams.extra} merges in.
+ */
+export function listOutputSchema<Row extends z.ZodType, Extra extends z.ZodRawShape>(
+  itemsKey: string,
+  row: Row,
+  extra?: Extra,
+): z.ZodObject {
+  return z.object({
+    ...extra,
+    [itemsKey]: z.array(row),
+    returnedCount: z.number().int(),
+    totalCount: z.number().int(),
+    truncated: z.boolean(),
+    continuation: continuationSchema.optional(),
+  });
 }

--- a/packages/mcp-server/src/tools/registry.ts
+++ b/packages/mcp-server/src/tools/registry.ts
@@ -118,6 +118,21 @@ export interface ToolDefinition<Schema extends ToolInputSchema = ToolInputSchema
    * `tool`, `outcome`, or `userId`.
    */
   observe?: (input: z.infer<Schema>, result: ToolResult) => ToolObservation;
+  /**
+   * Shape of this tool's `structuredContent`, advertised on `tools/list`.
+   *
+   * Optional, and deliberately Zod rather than raw JSON Schema — the same
+   * choice the input side makes, so the advertised schema is rendered from a
+   * definition the code can also build against instead of a parallel hand-
+   * written document. A declared schema is binding ("servers MUST provide
+   * structured results that conform"), so anything that can drift from the
+   * payload is a liability rather than documentation.
+   *
+   * Omitting it is fully valid: a tool may return `structuredContent` with no
+   * schema. It simply gives a client nothing to validate against — which is
+   * why the payload is also mirrored into `content` regardless.
+   */
+  outputSchema?: z.ZodType;
 }
 
 /** Tool descriptor advertised by `tools/list` (JSON Schema for the input). */
@@ -125,6 +140,8 @@ export interface ToolDescriptor {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  /** Present only for tools that declare one; absent is valid and common. */
+  outputSchema?: Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------
@@ -223,6 +240,12 @@ export class ToolRegistry {
       // so the advertised JSON Schema (`additionalProperties: false`) matches the
       // runtime unknown-field rejection, rather than describing a laxer shape.
       inputSchema: z.toJSONSchema(tool.inputSchema.strict()) as Record<string, unknown>,
+      // Spread so the key is absent rather than `undefined` for the tools that
+      // declare no output schema — `tools/list` should not advertise an empty
+      // contract that clients might try to validate against.
+      ...(tool.outputSchema
+        ? { outputSchema: z.toJSONSchema(tool.outputSchema) as Record<string, unknown> }
+        : {}),
     }));
   }
 }


### PR DESCRIPTION
Follow-up from the blind-connector postmortem. **This is an experiment, deliberately scoped to one
tool** — it is meant to produce evidence, not to commit us to schemas everywhere.

## The question

No tool has ever advertised an `outputSchema`. That is precisely why `structuredContent` was a field
clients were free to ignore, and why they eventually did — taking every row with them.

Declaring one is not obviously right:

| | |
| --- | --- |
| **Benefit** | Unverified. Does the client validate `structuredContent`? Does it surface the schema to the model? We cannot see either from here. |
| **Cost** | Certain. "Servers **MUST** provide structured results that conform" — across all seventeen tools, with ~16 row shapes, 8 of which have no declared type today. |

Committing to seventeen schemas to answer an unverified question is the wrong order. So: add the
mechanism, declare it on one tool, and look.

## The canary

`accounter_list_business_memberships` — pure (no upstream call), three flat fields, and a summary
line that already instructs the model to *"Pass their `memberBusinessId` values"*. If a client does
surface a declared schema to the model, that is where it should show.

## Generated, never hand-written

This is the part worth reviewing. `ToolDefinition.outputSchema` is a **Zod** schema, matching the
input side, and `describe()` renders it with `z.toJSONSchema`. The canary's row type is now `z.infer`
of the very schema being advertised:

```ts
const businessSummarySchema = z.object({ memberBusinessId: z.string(), name: z.string().nullable(), role: z.string() });
type BusinessSummary = z.infer<typeof businessSummarySchema>;
```

The handler therefore cannot build a row the advertised schema does not describe. A hand-written JSON
Schema would have been the opposite — a second document, free to drift, backed by a MUST that turns
drift into client-side errors.

`output.ts` gains `listOutputSchema(itemsKey, row, extra?)`, wrapping a row schema in the exact
envelope `shapeListResult` builds (items, `returnedCount`, `totalCount`, `truncated`, optional
`continuation`). That is the reusable half if the rest follow.

## Guarded

`output-schema-contract.test.ts` is registry-driven: every tool declaring a schema is executed and
its **real** `structuredContent` parsed against its **own advertised** schema. Tools that gain
schemas later are covered without extending the file. It also asserts the key is *absent* — not
`undefined` — for the sixteen tools that declare nothing, since an empty contract is worse than none.

## What this does not change

The `content` mirror stays. It exists because a client may ignore `structuredContent` for any reason,
and a declared schema does not prevent that. The current spec still says a server returning
structured content SHOULD also serialize it into a TextContent block.

## How to run the experiment

1. `MCP_TOOL_ALLOWLIST=accounter_list_business_memberships`
2. Local connector per `docs/local-development.md` (server + tunnel)
3. Ask Claude to list your businesses

The `mcp_initialize` log line will say which protocol revision it negotiated while doing so.

**If nothing observably changes, the answer is no** — and we have spent one tool finding out instead
of seventeen.

## Verification

817 tests pass (55 files), typecheck / eslint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)