### PR TITLE
docs(mcp-server): document each tool's result in its description

### DIFF
--- a/.changeset/mcp-tool-descriptions.md
+++ b/.changeset/mcp-tool-descriptions.md
@@ -1,0 +1,48 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Document each tool's result in its description, since that is the only channel that reaches the
+model.
+
+Two things were measured on Claude Desktop after the blind-connector incident, and both are now
+recorded in `docs/connector-gaps-and-decisions.md`:
+
+1. The model is shown **neither** `structuredContent` nor a declared `outputSchema`. The first
+   caused the incident; the second was established by declaring a schema on one canary tool and
+   asking. After ruling out a cached `tools/list` with a marker string, the model enumerated the
+   loaded definition as name, description, input schema — "There is no output schema."
+2. Desktop **defers tool definitions**. Until the model loads one, it sees roughly the first
+   sentence of the description.
+
+Asked what a tool returns, the model reconstructed the shape from *sibling* descriptions and then
+named precisely what it could not know: whether rows sit under `businesses` or `memberships`, and
+whether there is a `scope` echo. That is the gap this closes.
+
+- **`resultEnvelopeDescription(itemsKey)`** and **`writeResultDescription(itemsKey)`** live in
+  `output.ts` next to the functions that build those envelopes, so the prose and the shape cannot
+  drift apart. Same idiom as `SCOPE_DESCRIPTION_SUFFIX`: one shared clause, so the model learns the
+  envelope once rather than in fifteen phrasings. No description previously mentioned
+  `returnedCount`, `totalCount`, `truncated`, `continuation` or `itemsOmitted` at all.
+- **Both write tools** documented nothing about their result. A model that has just changed data
+  could not tell what confirmation to expect — including that `itemsOmitted` means the write
+  *applied* and only the echo was dropped, which reads like a failure if you have not been told.
+- **`accounter_list_business_memberships` is front-loaded.** Its scope-discovery instruction — call
+  it first, pass the returned ids onward — was sentence two and did not arrive under deferred
+  loading. It is now part of sentence one, which is the only sentence guaranteed to be read.
+- **`accounter_list_tags` and `accounter_list_tax_categories`** named no output fields; they now name
+  their actual keys, including `namePath` and `sortCode`.
+- **Prose replaced by literal keys** where the two diverged: "file/image links" are `fileUrl` /
+  `imageUrl`, and "total, VAT, withholding" are `totalAmount` / `vat` / `withholdingTax`. A
+  near-miss name is worse than no name, because it reads authoritative.
+
+Deliberately surgical rather than a rewrite. Most of these descriptions are carefully built — the
+securities and upload ones especially — and the measured gap was narrow: where rows live, what the
+envelope carries, and a handful of prose-versus-key mismatches.
+
+Guarded by `description-contract.test.ts`: every list tool must name its own `itemsKey` and the four
+envelope fields, every write tool must name its items key plus `ok` / `action` / `itemsOmitted`, a
+first sentence has to carry more than a restatement of the tool's name, and no description may
+contain a line break, a doubled space, or stray outer whitespace. That last check exists because
+this changeset's own first draft shipped `\n` escapes into three descriptions — invisible in a diff,
+verbatim to the model.

--- a/packages/mcp-server/docs/connector-gaps-and-decisions.md
+++ b/packages/mcp-server/docs/connector-gaps-and-decisions.md
@@ -187,6 +187,51 @@ what scopes them in production. So a lookup by ISIN sees every tenant's securiti
 on a whole result set's size assumes exclusive access to the database. Use synthetic per-suite ISINs
 and assert on your own fixtures' buckets, not on totals.
 
+### Claude Desktop shows the model neither `structuredContent` nor `outputSchema` (2026-08-27, decided)
+
+Settled by experiment after the blind-connector incident, so it is not re-litigated: **the tool
+description is the only channel that reaches the model.** Two independent measurements, on Claude
+Desktop with a locally-tunnelled connector.
+
+**`structuredContent`.** Established by the incident itself. Rows lived only in that field, and when
+the client stopped surfacing it every tool returned its summary line with nothing behind it. Fixed
+by mirroring the payload into `content` (#4295).
+
+**`outputSchema`.** Declared on one canary tool (`accounter_list_business_memberships`) purely to
+find out, since the cost of adopting it — "servers MUST provide structured results that conform",
+across every tool — is certain while the benefit was not.
+
+- First probe was inconclusive in an instructive way: the tool came back as a **deferred**
+  definition, so the model had a one-line summary and no schema at all. It correctly declined to
+  guess field names.
+- The canary changed _only_ `outputSchema` — description and `inputSchema` byte-identical — so a
+  cached `tools/list` would look exactly like a client that strips the field. Ruled out by adding a
+  marker string to the description, restarting, and **reconnecting the connector** to force a fresh
+  listing. A new conversation is not enough; the listing is cached per connection.
+- Second probe was decisive: the model reported the marker (listing fresh) and enumerated the loaded
+  definition as name, description, input schema — "There is no output schema."
+
+Since model comprehension was the entire upside — validation is the _risk_, not the benefit —
+declaring schemas for a field the model never sees buys nothing. The canary PR was closed rather
+than merged; none of its parts stand alone once the schema is dropped.
+
+**Known limit.** This establishes that Desktop does not show `outputSchema` _to the model_. It does
+**not** establish whether the host validates `structuredContent` against a declared one. Moot while
+we declare none, and the first thing to re-check if that changes.
+
+**Second finding, from the same probes: Desktop defers tool definitions.** Until the model chooses
+to load one, it sees roughly the first sentence of the description. Our scope-discovery instruction
+— "call it first … pass the returned `memberBusinessId` values as `memberBusinessIds`" — is sentence
+two, and did not arrive until the definition was explicitly loaded. Sentence one carries
+disproportionate weight.
+
+**The general lesson:** a tool's description is load-bearing in a way its schemas are not. Asked
+what a tool returns, the model reconstructed the shape from _sibling_ descriptions — `list_tags`,
+`list_tax_categories` and `list_clients` all saying to call this tool "to discover ids" — inferred
+an id, a role and a name, then named exactly what it could not know: whether rows sit under
+`businesses` or `memberships`, and whether there is a `scope` echo. Anything the model needs about a
+result has to be in prose, in the description, ideally in its first sentence.
+
 ## Open decisions
 
 1. **Audience strategy.** Accept the shared `https://api.accounter.com` audience for MCP and GraphQL

--- a/packages/mcp-server/src/tools/__tests__/description-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/description-contract.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { toolRegistry } from '../registry-instance.js';
+
+/**
+ * The tool description is the only channel that reaches the model.
+ *
+ * Claude Desktop shows it neither `structuredContent` nor a declared
+ * `outputSchema` — both measured, see `docs/connector-gaps-and-decisions.md`.
+ * Asked what a tool returns, the model could infer that rows existed and could
+ * not determine what they were keyed under. Anything it needs about a result
+ * has to be written in prose.
+ *
+ * These are mechanical guards on that prose. They cannot judge whether a
+ * description is *good*; they check the two properties that are objectively
+ * checkable and were objectively missing.
+ */
+
+/** Every tool that shapes rows into the shared list envelope, and its key. */
+const LIST_TOOLS: ReadonlyArray<readonly [tool: string, itemsKey: string]> = [
+  ['accounter_list_business_memberships', 'businesses'],
+  ['accounter_explain_terminology', 'terms'],
+  ['accounter_search_charges', 'charges'],
+  ['accounter_get_charges', 'charges'],
+  ['accounter_get_transactions', 'transactions'],
+  ['accounter_get_documents', 'documents'],
+  ['accounter_get_ledger_records', 'ledgerRecords'],
+  ['accounter_list_clients', 'clients'],
+  ['accounter_get_contracts', 'contracts'],
+  ['accounter_list_security_holdings', 'holdings'],
+  ['accounter_get_security_executions', 'executions'],
+  ['accounter_list_tags', 'tags'],
+  ['accounter_list_tax_categories', 'taxCategories'],
+  ['accounter_list_businesses', 'businesses'],
+  ['accounter_balance_report', 'rows'],
+];
+
+function describedBy(name: string): string {
+  const tool = toolRegistry.list().find(t => t.name === name);
+  expect(tool, `${name} is not registered`).toBeDefined();
+  return tool!.description;
+}
+
+describe('tool descriptions are well-formed', () => {
+  /**
+   * A description is assembled by concatenating string literals, which makes it
+   * easy to leave a stray `\n` escape or a doubled space at a join. Both reach
+   * the model verbatim and both are invisible in a diff — this was written
+   * after doing exactly that.
+   */
+  it.each(toolRegistry.list().map(tool => [tool.name, tool.description] as const))(
+    '%s is one clean line',
+    (name, description) => {
+      expect(description, `${name} contains a line break`).not.toMatch(/[\n\r]/);
+      expect(description, `${name} contains a doubled space`).not.toMatch(/ {2}/);
+      expect(description.trim(), `${name} has stray outer whitespace`).toBe(description);
+    },
+  );
+});
+
+describe('tool descriptions document their own result', () => {
+  it('covers every list-producing tool in the registry', () => {
+    // A tool added later must be added here too, or its description goes
+    // unchecked — which is exactly how the gap this fixes came about.
+    const listed = new Set(LIST_TOOLS.map(([name]) => name));
+    const writeTools = toolRegistry
+      .list()
+      .filter(tool => tool.policy.mutating)
+      .map(tool => tool.name);
+    const unaccounted = toolRegistry
+      .list()
+      .map(tool => tool.name)
+      .filter(name => !listed.has(name) && !writeTools.includes(name));
+
+    expect(unaccounted, 'these tools are neither listed above nor write tools').toEqual([]);
+  });
+
+  it.each(LIST_TOOLS)('%s names the key its rows arrive under (`%s`)', (name, itemsKey) => {
+    expect(
+      describedBy(name),
+      `${name} never tells the model its rows are under \`${itemsKey}\` — it cannot find them`,
+    ).toContain(`\`${itemsKey}\``);
+  });
+
+  it.each(LIST_TOOLS)('%s documents the result envelope', (name, _itemsKey) => {
+    const description = describedBy(name);
+
+    // Emitted by `resultEnvelopeDescription`, so this also catches a tool that
+    // hand-rolls the sentence and drifts from what the envelope really carries.
+    for (const field of ['returnedCount', 'totalCount', 'truncated', 'continuation']) {
+      expect(description, `${name} does not document \`${field}\``).toContain(`\`${field}\``);
+    }
+  });
+
+  /**
+   * The write tools shape a different envelope, and documented nothing about it
+   * — a model that has just changed data could not tell from the description
+   * what confirmation to expect, including that `itemsOmitted` means the write
+   * applied and only the echo was dropped.
+   */
+  it.each([
+    ['accounter_update_charges_tags', 'charges'],
+    ['accounter_upload_documents', 'results'],
+  ])('%s documents its write result (`%s`)', (name, itemsKey) => {
+    const description = describedBy(name);
+
+    for (const field of [itemsKey, 'ok', 'action', 'itemsOmitted']) {
+      expect(description, `${name} does not document \`${field}\``).toContain(`\`${field}\``);
+    }
+  });
+
+  /**
+   * Deferred loading means the model sees roughly the first sentence until it
+   * chooses to load the full definition. A first sentence that only restates
+   * the tool's own name spends that budget on nothing.
+   */
+  it.each(LIST_TOOLS)('%s says what it returns in its first sentence', (name, _itemsKey) => {
+    const [first = ''] = describedBy(name).split(/(?<=\.)\s/);
+
+    expect(first.length, `${name}'s first sentence is too thin to decide on`).toBeGreaterThan(40);
+  });
+});

--- a/packages/mcp-server/src/tools/businesses.ts
+++ b/packages/mcp-server/src/tools/businesses.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { shapeListResult } from './output.js';
+import { resultEnvelopeDescription, shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 
 /**
@@ -96,7 +96,9 @@ function handler(_input: ListBusinessesInput, context: ToolExecutionContext): To
 export const listBusinessMembershipsTool: ToolDefinition<typeof listBusinessesInput> = {
   name: LIST_BUSINESS_MEMBERSHIPS_TOOL_NAME,
   description:
-    'List the businesses you are a member of, with your role in each. This is your access/scope discovery entry point — call it first when you may belong to more than one business, then pass the returned `memberBusinessId` values as `memberBusinessIds` to the other tools. To browse every business known to the system (e.g. counterparties), use `accounter_list_businesses` instead. Read-only; takes no parameters.',
+    'List the businesses you are a member of and your role in each — your access-scope discovery entry point: call it first when you may belong to more than one business, then pass the returned `memberBusinessId` values as `memberBusinessIds` to the other tools. Each row is `{ memberBusinessId, name, role }`, sorted by name. ' +
+    resultEnvelopeDescription('businesses') +
+    ' To browse every business known to the system (e.g. counterparties), use `accounter_list_businesses` instead. Read-only; takes no parameters.',
   inputSchema: listBusinessesInput,
   policy: {
     // Deliberately false: a caller with zero memberships should get an empty

--- a/packages/mcp-server/src/tools/charge-details.ts
+++ b/packages/mcp-server/src/tools/charge-details.ts
@@ -23,7 +23,7 @@ import {
   type RawDocument,
   type RawTransaction,
 } from './entity-shapes.js';
-import { shapeListResult } from './output.js';
+import { resultEnvelopeDescription, shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
@@ -610,7 +610,9 @@ async function handler(input: GetChargesInput, context: ToolExecutionContext): P
 export const getChargesTool: ToolDefinition<typeof getChargesInput> = {
   name: GET_CHARGES_TOOL_NAME,
   description:
-    'Fetch charges by id and/or by filters (all ChargeFilter fields), with full detail: owner, counterparty, amounts (total, VAT, withholding), dates, tags, metadata counts and `chargeType`. Linked transactions and documents are opt-in via `includeTransactions` / `includeDocuments`, and for a foreign-securities charge the security traded and the portfolio executions behind it are opt-in via `includeSecurities` (each reporting a `securityBusinessId` that accounter_list_security_holdings and accounter_get_security_executions accept). Read-only. ' +
+    'Fetch charges by id and/or by filters (all ChargeFilter fields), with full detail: owner, counterparty, amounts (`totalAmount`, `vat`, `withholdingTax`), a nested `dates` object, `tags`, `metadata` counts and `chargeType`. Linked transactions and documents are opt-in via `includeTransactions` / `includeDocuments`, and for a foreign-securities charge the security traded and the portfolio executions behind it are opt-in via `includeSecurities` (each reporting a `securityBusinessId` that accounter_list_security_holdings and accounter_get_security_executions accept). Read-only. ' +
+    resultEnvelopeDescription('charges') +
+    ' ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: getChargesInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/charges.ts
+++ b/packages/mcp-server/src/tools/charges.ts
@@ -8,7 +8,7 @@ import {
 import { DAY_MS, parseCalendarDate, TIMELESS_DATE } from './dates.js';
 import { chargeTypeFromTypename, normalizeAmount, type NormalizedAmount } from './entity-shapes.js';
 import { ToolInputError } from './execute.js';
-import { shapeListResult } from './output.js';
+import { resultEnvelopeDescription, shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
@@ -325,6 +325,8 @@ export const searchChargesTool: ToolDefinition<typeof searchChargesInput> = {
   name: SEARCH_CHARGES_TOOL_NAME,
   description:
     'Search and browse accounting charges within your authorized businesses. Supports every ChargeFilter predicate — date ranges (overlap via `fromDate`/`toDate`, containment via `fromMainDate`/`toMainDate`), tags, free text, income/expense, charge types, counterparties, business trips, accountant status, ordering, and the missing-document/transaction/ledger flags — with bounded pagination. Each row carries `chargeType`, so money moving between your own accounts can be excluded without inspecting descriptions. Read-only. ' +
+    resultEnvelopeDescription('charges') +
+    ' ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: searchChargesInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/clients.ts
+++ b/packages/mcp-server/src/tools/clients.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { McpListClientsQuery } from '../gql/index.js';
-import { shapeListResult } from './output.js';
+import { resultEnvelopeDescription, shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
@@ -233,6 +233,8 @@ export const listClientsTool: ToolDefinition<typeof listClientsInput> = {
     'resolve a client by name before asking about its contracts. `generatedDocumentType` is the ' +
     "client-level default only — what actually gets issued is the contract's own `documentType`. " +
     'Read-only. ' +
+    resultEnvelopeDescription('clients') +
+    ' ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: listClientsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/contracts.ts
+++ b/packages/mcp-server/src/tools/contracts.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { McpGetContractsQuery, McpGetContractsQueryVariables } from '../gql/index.js';
 import { normalizeAmount, type NormalizedAmount } from './entity-shapes.js';
-import { shapeListResult } from './output.js';
+import { resultEnvelopeDescription, shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
@@ -183,6 +183,8 @@ export const getContractsTool: ToolDefinition<typeof getContractsInput> = {
   name: GET_CONTRACTS_TOOL_NAME,
   description:
     'List client billing contracts within your authorized businesses. Filter by client, by contract id, and by active state; `memberBusinessIds` narrows to specific owning (admin) businesses, since a contract is always owned by one of yours. Each row reports its `ownerId`. Read-only. ' +
+    resultEnvelopeDescription('contracts') +
+    ' ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: getContractsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/document-details.ts
+++ b/packages/mcp-server/src/tools/document-details.ts
@@ -7,7 +7,7 @@ import type {
 } from '../gql/index.js';
 import { TIMELESS_DATE } from './dates.js';
 import { MAX_DETAIL_IDS, normalizeDocument, type RawDocument } from './entity-shapes.js';
-import { shapeListResult } from './output.js';
+import { resultEnvelopeDescription, shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
@@ -326,7 +326,9 @@ async function handler(
 export const getDocumentsTool: ToolDefinition<typeof getDocumentsInput> = {
   name: GET_DOCUMENTS_TOOL_NAME,
   description:
-    'Fetch documents (invoices, receipts, credit invoices, …) either by id or by filters (owners, charge ids, date range, type, unmatched/missing-info flags, and free-text), with type, serial number, date, amount, VAT, creditor/debtor, file/image links, and the owning business (`ownerId`). Read-only. ' +
+    'Fetch documents (invoices, receipts, credit invoices, …) either by id or by filters (owners, charge ids, date range, type, unmatched/missing-info flags, and free-text), with type, serial number, date, amount, VAT, creditor/debtor, the `fileUrl`/`imageUrl` links, and the owning business (`ownerId`). Read-only. ' +
+    resultEnvelopeDescription('documents') +
+    ' ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: getDocumentsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/documents-write.ts
+++ b/packages/mcp-server/src/tools/documents-write.ts
@@ -5,7 +5,7 @@ import type {
   McpBatchUploadDocumentsMutation,
 } from '../gql/index.js';
 import type { UploadFile } from '../upstream/graphql-client.js';
-import { shapeWriteResult } from './output.js';
+import { shapeWriteResult, writeResultDescription } from './output.js';
 import type {
   ToolDefinition,
   ToolExecutionContext,
@@ -465,6 +465,9 @@ export const uploadDocumentsTool: ToolDefinition<typeof uploadDocumentsInput> = 
     'because that content travels as tool arguments and both costs enormous output and risks ' +
     'corrupting the file. Never re-encode or downscale a financial document to make it fit — use ' +
     '`documentUrls` instead. ' +
+    'Each result is positional and carries `status` (`uploaded` or `failed`) with either `documentId` and `documentType` or a `message`, keyed by `url` or `filename` depending on which input you used; `uploadedCount` and `failedCount` summarise them, so a partial failure is visible rather than collapsed. ' +
+    writeResultDescription('results') +
+    ' ' +
     WRITE_SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: uploadDocumentsInput,
   policy: {

--- a/packages/mcp-server/src/tools/ledger.ts
+++ b/packages/mcp-server/src/tools/ledger.ts
@@ -3,7 +3,7 @@ import type { McpGetLedgerRecordsQuery, McpGetLedgerRecordsQueryVariables } from
 import { DAY_MS, parseCalendarDate, TIMELESS_DATE } from './dates.js';
 import { normalizeAmount, normalizeEntity, type NormalizedAmount } from './entity-shapes.js';
 import { ToolInputError } from './execute.js';
-import { shapeListResult } from './output.js';
+import { resultEnvelopeDescription, shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
@@ -338,6 +338,8 @@ export const getLedgerRecordsTool: ToolDefinition<typeof getLedgerRecordsInput> 
   name: GET_LEDGER_RECORDS_TOOL_NAME,
   description:
     'Search double-entry ledger records within your authorized businesses. Filter by invoice date, value date, or either; by the financial entity in any of the debit/credit account slots; and by charge id. Each row reports its `ownerId` and `chargeId`. Read-only. ' +
+    resultEnvelopeDescription('ledgerRecords') +
+    ' ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: getLedgerRecordsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/lookups.ts
+++ b/packages/mcp-server/src/tools/lookups.ts
@@ -4,7 +4,7 @@ import type {
   McpListTagsQuery,
   McpListTaxCategoriesQuery,
 } from '../gql/index.js';
-import { shapeListResult } from './output.js';
+import { resultEnvelopeDescription, shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
@@ -109,7 +109,9 @@ async function listTagsHandler(
 export const listTagsTool: ToolDefinition<typeof listTagsInput> = {
   name: LIST_TAGS_TOOL_NAME,
   description:
-    'List the tags available for categorizing charges, optionally filtered by name. Read-only. ' +
+    "List the tags available for categorizing charges, optionally filtered by name. Each row is `{ id, name, ownerId, namePath }`, where `namePath` is the tag's ancestry for nested tags. " +
+    resultEnvelopeDescription('tags') +
+    ' ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: listTagsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },
@@ -178,7 +180,9 @@ async function listTaxCategoriesHandler(
 export const listTaxCategoriesTool: ToolDefinition<typeof listTaxCategoriesInput> = {
   name: LIST_TAX_CATEGORIES_TOOL_NAME,
   description:
-    'List tax categories (id, name, IRS code, active flag), optionally filtered by name or active status. Read-only. ' +
+    'List tax categories, optionally filtered by name or active status. Each row is `{ id, name, ownerId, irsCode, isActive, sortCode }`. ' +
+    resultEnvelopeDescription('taxCategories') +
+    ' ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: listTaxCategoriesInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },
@@ -358,6 +362,8 @@ export const listBusinessesTool: ToolDefinition<typeof listBusinessesInput> = {
   name: LIST_BUSINESSES_TOOL_NAME,
   description:
     'List the full business directory (id, name, ownerId, active flag, and whether the business is a client) — every business visible to you, not just the ones you are a member of — optionally filtered by name, active status, or client status, with `limit`/`page` pagination over the name-ordered directory. For your own memberships and roles use `accounter_list_business_memberships`; for client emails and integrations use `accounter_list_clients`, whose ids are these same business ids. Read-only. ' +
+    resultEnvelopeDescription('businesses') +
+    ' ' +
     DIRECTORY_SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: listBusinessesInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/output.ts
+++ b/packages/mcp-server/src/tools/output.ts
@@ -14,6 +14,47 @@ import type { ToolResult } from './registry.js';
  * echo is dropped when the payload guard trips.
  */
 
+/**
+ * Describe the shared list envelope, for a tool's description text.
+ *
+ * Lives next to {@link shapeListResult} deliberately: this is the prose
+ * counterpart of the object that function builds, and the two drift the moment
+ * they live apart.
+ *
+ * It exists because the description is the *only* channel that reaches the
+ * model. Claude Desktop shows it neither `structuredContent` nor a declared
+ * `outputSchema` (see `docs/connector-gaps-and-decisions.md`), so anything the
+ * model needs to know about a result has to be written in prose — asked what a
+ * tool returned, it could infer that rows existed but not what they were keyed
+ * under.
+ *
+ * Same idiom as `SCOPE_DESCRIPTION_SUFFIX`: one shared clause so the model
+ * learns the envelope once instead of a different phrasing per tool.
+ */
+export function resultEnvelopeDescription(itemsKey: string): string {
+  return (
+    `Rows come back under \`${itemsKey}\`, alongside \`returnedCount\`, \`totalCount\` and ` +
+    '`truncated`; when not everything fit, a `continuation` hint says why and what to narrow.'
+  );
+}
+
+/**
+ * Describe the shared write envelope, for a write tool's description text.
+ *
+ * The counterpart of {@link resultEnvelopeDescription}, and it matters more:
+ * neither write tool documents its result at all today, so a model that has
+ * just changed data cannot tell from the description what confirmation to
+ * expect — including that `itemsOmitted` means the write *applied* and only the
+ * echo was dropped, which reads like a failure if you have not been told.
+ */
+export function writeResultDescription(itemsKey: string): string {
+  return (
+    `The result reports \`ok\`, \`action\` and per-item outcomes under \`${itemsKey}\`; if that ` +
+    'echo is too large it is replaced by `itemsOmitted`, which means the write applied in full and ' +
+    'only the echo was dropped.'
+  );
+}
+
 /** Max serialized size of a tool result's structured content, in bytes. */
 export const MAX_TOOL_RESULT_BYTES = 60_000;
 

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -3,7 +3,7 @@ import type { McpBalanceReportQuery, McpBalanceReportQueryVariables } from '../g
 import { DAY_MS, parseCalendarDate, TIMELESS_DATE } from './dates.js';
 import { normalizeAmount } from './entity-shapes.js';
 import { ToolInputError } from './execute.js';
-import { shapeListResult } from './output.js';
+import { resultEnvelopeDescription, shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 import { SINGLE_BUSINESS_SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
@@ -135,6 +135,8 @@ export const balanceReportTool: ToolDefinition<typeof balanceReportInput> = {
   name: BALANCE_REPORT_TOOL_NAME,
   description:
     'Generate a read-only balance report (transactions) for one of your businesses over a bounded date range. Every row carries the owning business as `ownerId`. Requires business owner or accountant role. ' +
+    resultEnvelopeDescription('rows') +
+    ' ' +
     SINGLE_BUSINESS_SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: balanceReportInput,
   policy: {

--- a/packages/mcp-server/src/tools/securities.ts
+++ b/packages/mcp-server/src/tools/securities.ts
@@ -3,7 +3,7 @@ import { ToolInputError } from '../errors/taxonomy.js';
 import type { McpGetSecurityExecutionsQuery, McpListSecurityHoldingsQuery } from '../gql/index.js';
 import { parseCalendarDate, TIMELESS_DATE } from './dates.js';
 import { normalizeAmount } from './entity-shapes.js';
-import { shapeListResult } from './output.js';
+import { resultEnvelopeDescription, shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
@@ -301,6 +301,8 @@ export const listSecurityHoldingsTool: ToolDefinition<typeof listSecurityHolding
     "Amounts are in each security's own trade currency and are never converted: use the response's `byCurrency` subtotals rather than adding rows up, and never sum quantities or average costs. " +
     'Every response carries a `caveats` array stating the limits of the derivation. ' +
     'Set `includeClosed` to also see securities traded but no longer held. Use accounter_get_security_executions for the trades behind a row. Read-only. ' +
+    resultEnvelopeDescription('holdings') +
+    ' ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: listSecurityHoldingsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },
@@ -580,6 +582,8 @@ export const getSecurityExecutionsTool: ToolDefinition<typeof getSecurityExecuti
     "Amounts are in each security's own trade currency and are never converted, so do not add rows from different securities together. " +
     'Set `includeCharges` to also get the charge each trade cash movement landed on; that requires naming the securities, because the pairing is computed over a security whole history rather than a page. ' +
     'If a call fails with an upstream error naming an unknown trade type, the bank has used a label the server does not yet translate - that is a data bug worth reporting, not something to retry; passing explicit `tradeTypes` filters such rows out and works around it. Read-only. ' +
+    resultEnvelopeDescription('executions') +
+    ' ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: getSecurityExecutionsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },

--- a/packages/mcp-server/src/tools/tags-write.ts
+++ b/packages/mcp-server/src/tools/tags-write.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { ToolInputError } from '../errors/taxonomy.js';
 import type { McpBatchUpdateChargesTagsMutation } from '../gql/index.js';
 import { UpstreamError } from '../upstream/graphql-client.js';
-import { shapeWriteResult } from './output.js';
+import { shapeWriteResult, writeResultDescription } from './output.js';
 import type {
   ToolDefinition,
   ToolExecutionContext,
@@ -164,6 +164,9 @@ export const updateChargesTagsTool: ToolDefinition<typeof updateChargesTagsInput
     'tags already on a charge and not listed in `removeTagIds` stay. Removals are applied before ' +
     'additions, so a tag id passed in BOTH lists ends up added. Adding a tag a charge already has ' +
     'does nothing. ' +
+    'Each row echoes `{ id, tags }` for the charge as it now stands, alongside `updatedCount`, `requestedCount`, `addedTagIds` and `removedTagIds`. ' +
+    writeResultDescription('charges') +
+    ' ' +
     WRITE_SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: updateChargesTagsInput,
   policy: {

--- a/packages/mcp-server/src/tools/terminology.ts
+++ b/packages/mcp-server/src/tools/terminology.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { shapeListResult } from './output.js';
+import { resultEnvelopeDescription, shapeListResult } from './output.js';
 import type {
   LabeledCounter,
   ToolDefinition,
@@ -352,7 +352,8 @@ export const explainTerminologyTool: ToolDefinition<typeof explainTerminologyInp
     'the counterparty; `INTERNAL`/`CONVERSION` charges are money moving between your own accounts and ' +
     'double-count in spend totals). Call it with no arguments for a one-line index of every term, then ' +
     'pass `terms` to define specific ones or `topics` to read a whole area. Reference content only: ' +
-    'static, read-only, no business data, and callable before you know which businesses you can access.',
+    'static, read-only, no business data, and callable before you know which businesses you can access. ' +
+    resultEnvelopeDescription('terms'),
   inputSchema: explainTerminologyInput,
   policy: {
     // Deliberately unscoped and `public`: the content is static reference text

--- a/packages/mcp-server/src/tools/transaction-details.ts
+++ b/packages/mcp-server/src/tools/transaction-details.ts
@@ -8,7 +8,7 @@ import type {
 import { UpstreamError } from '../upstream/graphql-client.js';
 import { TIMELESS_DATE } from './dates.js';
 import { MAX_DETAIL_IDS, normalizeTransaction, type RawTransaction } from './entity-shapes.js';
-import { shapeListResult } from './output.js';
+import { resultEnvelopeDescription, shapeListResult } from './output.js';
 import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registry.js';
 import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
@@ -295,6 +295,8 @@ export const getTransactionsTool: ToolDefinition<typeof getTransactionsInput> = 
   name: GET_TRANSACTIONS_TOOL_NAME,
   description:
     'Fetch bank/card transactions either by id or by filters (owners, charge ids, date ranges, counterparties, missing-info flags, and free-text), with amount, dates, direction, counterparty, account, and the owning business (`ownerId`). Read-only. ' +
+    resultEnvelopeDescription('transactions') +
+    ' ' +
     SCOPE_DESCRIPTION_SUFFIX,
   inputSchema: getTransactionsInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },


### PR DESCRIPTION
Closes out the investigation that started with the blind connector. #4303 asked whether
`outputSchema` was worth adopting; the answer was no, and this is where the value went instead.

## What was measured

Two properties of Claude Desktop, both established by experiment rather than assumed:

1. **The model is shown neither `structuredContent` nor a declared `outputSchema`.** The first caused
   the August incident. The second was tested by declaring a schema on one canary tool and asking —
   and after ruling out a cached `tools/list` with a marker string, the model enumerated the loaded
   definition as name, description, input schema: *"There is no output schema."*
2. **Desktop defers tool definitions.** Until the model chooses to load one, it sees roughly the
   first sentence of the description.

Together: **the description is the only channel that reaches the model.**

The probe made the gap concrete. Asked what a tool returns, the model reconstructed the shape from
*sibling* descriptions — `list_tags`, `list_tax_categories` and `list_clients` all saying to call
this tool "to discover ids" — correctly inferred an id, a role and a name, and then named exactly
what it could not know:

> whether rows are wrapped in a `businesses` or `memberships` array, and whether there's a `scope`
> echo like the other tools have — none of that is determinable without an actual call

## What changed

**Shared clauses, next to the code that builds the shape.** `resultEnvelopeDescription(itemsKey)`
and `writeResultDescription(itemsKey)` live in `output.ts` beside `shapeListResult` /
`shapeWriteResult`, so the prose and the object cannot drift apart. Same idiom as
`SCOPE_DESCRIPTION_SUFFIX` — one clause, so the model learns the envelope once instead of in fifteen
phrasings. No description previously mentioned `returnedCount`, `totalCount`, `truncated`,
`continuation` or `itemsOmitted` at all.

**Both write tools documented nothing about their result.** A model that has just changed data could
not tell what confirmation to expect — including that `itemsOmitted` means the write *applied* and
only the echo was dropped, which reads like a failure if you have not been told.

**`accounter_list_business_memberships` is front-loaded.** Its scope-discovery instruction — call it
first, pass the returned ids onward — was sentence two and demonstrably did not arrive under
deferred loading. It is now in sentence one, the only sentence guaranteed to be read. This is the
tool the entire multi-business scoping design routes through.

**Thin descriptions filled in.** `list_tags` and `list_tax_categories` named no output fields; they
now name their real keys, `namePath` and `sortCode` included.

**Prose replaced by literal keys where they diverged.** "file/image links" are `fileUrl` /
`imageUrl`; "total, VAT, withholding" are `totalAmount` / `vat` / `withholdingTax`. A near-miss name
is worse than no name — it reads authoritative.

**Deliberately surgical.** Most of these descriptions are carefully built, the securities and upload
ones especially, and the measured gap was narrow. This is not a rewrite.

## Also here

The `outputSchema` decision and its evidence are recorded in
`docs/connector-gaps-and-decisions.md` under "Recorded findings", including the known limit: we
established Desktop does not show the schema *to the model*, not whether it *validates*
`structuredContent` against one. Moot while we declare none; first thing to re-check if that changes.

## Guarded

`description-contract.test.ts` — every list tool must name its own `itemsKey` and the four envelope
fields; every write tool its items key plus `ok` / `action` / `itemsOmitted`; a first sentence must
carry more than a restatement of the tool's name; a new tool must be accounted for or the suite
fails.

Plus a well-formedness check — no line breaks, doubled spaces, or stray outer whitespace. That one
exists because this change's **own first draft** shipped `\n` escapes into three descriptions.
Invisible in a diff, verbatim to the model. Verified the guards bite by removing the envelope clause
from `list_tags`, which fails with *"never tells the model its rows are under `tags` — it cannot find
them"*.

## Verification

882 tests pass (55 files), typecheck / eslint / prettier clean. Sample rendered output checked
end-to-end for three tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)