### PR TITLE
feat(client): add copy ID, unlink and delete to documents actions menu

### DIFF
--- a/.changeset/documents-actions-menu-destructive-items.md
+++ b/.changeset/documents-actions-menu-destructive-items.md
@@ -1,0 +1,8 @@
+---
+'@accounter/client': patch
+---
+
+Add "Copy Document ID", "Unlink Document" and "Delete Document" to the documents table's actions
+menu, so the table offers the same actions as the edit-document modal's top bar. Unlink is disabled
+for a document that is not linked to a charge, and both destructive actions keep their confirmation
+dialog and the charge-deleted handling.

--- a/packages/client/src/components/common/buttons/delete-document-button.tsx
+++ b/packages/client/src/components/common/buttons/delete-document-button.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import type { Dispatch, ReactElement, SetStateAction } from 'react';
 import { Trash } from 'lucide-react';
 import { useDeleteDocument } from '../../../hooks/use-delete-document.js';
 import { Button } from '../../ui/button.js';
@@ -14,6 +14,13 @@ interface Props {
    * deleted id, which would leave a stale "shadow charge" on screen.
    */
   onChargeDeleted?: (chargeId: string) => void;
+  /**
+   * Drive the confirmation from outside instead of from the built-in icon trigger. Hosts that
+   * already have their own trigger (the documents table's actions menu, for instance) pass both
+   * and no trigger button is rendered.
+   */
+  open?: boolean;
+  setOpen?: Dispatch<SetStateAction<boolean>>;
 }
 
 export function DeleteDocumentButton({
@@ -21,6 +28,8 @@ export function DeleteDocumentButton({
   onChange,
   onDone,
   onChargeDeleted,
+  open,
+  setOpen,
 }: Props): ReactElement {
   const { deleteDocument } = useDeleteDocument();
 
@@ -43,10 +52,17 @@ export function DeleteDocumentButton({
   }
 
   return (
-    <ConfirmationModal onConfirm={onDelete} title="Are you sure you want to delete this document?">
-      <Button variant="ghost" size="icon" className="size-7.5 text-red-500">
-        <Trash className="size-5" />
-      </Button>
+    <ConfirmationModal
+      onConfirm={onDelete}
+      title="Are you sure you want to delete this document?"
+      open={open}
+      setOpen={setOpen}
+    >
+      {setOpen ? undefined : (
+        <Button variant="ghost" size="icon" className="size-7.5 text-red-500">
+          <Trash className="size-5" />
+        </Button>
+      )}
     </ConfirmationModal>
   );
 }

--- a/packages/client/src/components/common/buttons/unlink-document-button.tsx
+++ b/packages/client/src/components/common/buttons/unlink-document-button.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement } from 'react';
+import { type Dispatch, type ReactElement, type SetStateAction } from 'react';
 import { Unlink } from 'lucide-react';
 import { EMPTY_UUID } from '../../../helpers/index.js';
 import { useUpdateDocument } from '../../../hooks/use-update-document.js';
@@ -15,6 +15,13 @@ interface Props {
    * which would leave a stale "shadow charge" on screen.
    */
   onChargeDeleted?: (chargeId: string) => void;
+  /**
+   * Drive the confirmation from outside instead of from the built-in icon trigger. Hosts that
+   * already have their own trigger (the documents table's actions menu, for instance) pass both
+   * and no trigger button is rendered.
+   */
+  open?: boolean;
+  setOpen?: Dispatch<SetStateAction<boolean>>;
 }
 
 export function UnlinkDocumentButton({
@@ -22,6 +29,8 @@ export function UnlinkDocumentButton({
   onChange,
   onDone,
   onChargeDeleted,
+  open,
+  setOpen,
 }: Props): ReactElement {
   const { updateDocument } = useUpdateDocument();
 
@@ -48,10 +57,14 @@ export function UnlinkDocumentButton({
     <ConfirmationModal
       onConfirm={onUnlink}
       title="Are you sure you want to unlink this document from the charge?"
+      open={open}
+      setOpen={setOpen}
     >
-      <Button variant="ghost" size="icon" className="size-7.5">
-        <Unlink className="size-5" />
-      </Button>
+      {setOpen ? undefined : (
+        <Button variant="ghost" size="icon" className="size-7.5">
+          <Unlink className="size-5" />
+        </Button>
+      )}
     </ConfirmationModal>
   );
 }

--- a/packages/client/src/components/documents-table/columns.tsx
+++ b/packages/client/src/components/documents-table/columns.tsx
@@ -83,6 +83,8 @@ import { DocumentActionsMenu } from './document-actions-menu.js';
 export type DocumentsTableRowType = TableDocumentsRowFieldsFragment & {
   onUpdate: () => void;
   editDocument: () => void;
+  /** Called when removing the document emptied its charge and the server deleted the charge too. */
+  onChargeDeleted?: (chargeId: string) => void;
 };
 
 export interface DocumentsTableColumnsOptions {

--- a/packages/client/src/components/documents-table/document-actions-menu.tsx
+++ b/packages/client/src/components/documents-table/document-actions-menu.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState, type ReactElement } from 'react';
 import {
   CircleX,
+  Copy,
   Edit,
   ExternalLink,
   File,
@@ -8,12 +9,20 @@ import {
   Link as LinkIcon,
   ListPlus,
   MoreVertical,
+  Trash,
+  Unlink,
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { ROUTES } from '@/router/routes.js';
 import { DocumentType } from '../../gql/graphql.js';
 import { writeToClipboard } from '../../helpers/index.js';
-import { CloseDocumentButton, DocumentImageDrawer, PreviewDocumentModal } from '../common/index.js';
+import {
+  CloseDocumentButton,
+  DeleteDocumentButton,
+  DocumentImageDrawer,
+  PreviewDocumentModal,
+  UnlinkDocumentButton,
+} from '../common/index.js';
 import { Button } from '../ui/button.js';
 import {
   DropdownMenu,
@@ -48,6 +57,8 @@ export function DocumentActionsMenu({
   const [imageOpen, setImageOpen] = useState(false);
   const [closeDocumentOpen, setCloseDocumentOpen] = useState(false);
   const [issueDocumentOpen, setIssueDocumentOpen] = useState(false);
+  const [unlinkOpen, setUnlinkOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
   const chargeId = document.charge?.id;
   const fileHref = toHref(document.file);
@@ -59,6 +70,10 @@ export function DocumentActionsMenu({
       writeToClipboard(`${window.location.origin}${ROUTES.CHARGES.DETAIL(chargeId)}`);
     }
   }, [chargeId]);
+
+  const onCopyDocumentId = useCallback((): void => {
+    writeToClipboard(document.id);
+  }, [document.id]);
 
   return (
     <>
@@ -83,6 +98,10 @@ export function DocumentActionsMenu({
           <DropdownMenuItem onSelect={document.editDocument}>
             <Edit className="size-4" />
             Edit Document
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={onCopyDocumentId}>
+            <Copy className="size-4" />
+            Copy Document ID
           </DropdownMenuItem>
 
           <DropdownMenuSeparator />
@@ -139,6 +158,17 @@ export function DocumentActionsMenu({
               </DropdownMenuItem>
             </>
           )}
+
+          <DropdownMenuSeparator />
+
+          <DropdownMenuItem disabled={!chargeId} onSelect={() => setUnlinkOpen(true)}>
+            <Unlink className="size-4" />
+            Unlink Document
+          </DropdownMenuItem>
+          <DropdownMenuItem variant="destructive" onSelect={() => setDeleteOpen(true)}>
+            <Trash className="size-4" />
+            Delete Document
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -146,6 +176,21 @@ export function DocumentActionsMenu({
         src={document.image}
         opened={imageOpen}
         onClose={(): void => setImageOpen(false)}
+      />
+
+      <UnlinkDocumentButton
+        documentId={document.id}
+        onChange={document.onUpdate}
+        onChargeDeleted={document.onChargeDeleted}
+        open={unlinkOpen}
+        setOpen={setUnlinkOpen}
+      />
+      <DeleteDocumentButton
+        documentId={document.id}
+        onChange={document.onUpdate}
+        onChargeDeleted={document.onChargeDeleted}
+        open={deleteOpen}
+        setOpen={setDeleteOpen}
       />
 
       {isOpenIssuedDocument && (

--- a/packages/client/src/components/documents-table/index.tsx
+++ b/packages/client/src/components/documents-table/index.tsx
@@ -26,6 +26,7 @@ export const DocumentsTable = ({
   const { table, editDocumentId, closeEditDocument } = useDocumentsTable({
     documentsProps,
     onChange,
+    onChargeDeleted,
     columnIds,
     withChargeLink,
   });

--- a/packages/client/src/components/documents-table/use-documents-table.ts
+++ b/packages/client/src/components/documents-table/use-documents-table.ts
@@ -12,6 +12,8 @@ import { getDocumentsTableColumns, type DocumentsTableRowType } from './columns.
 type UseDocumentsTableOptions = {
   documentsProps: FragmentType<typeof TableDocumentsRowFieldsFragmentDoc>[];
   onChange?: () => void;
+  /** Called when removing a document emptied its charge and the server deleted the charge too. */
+  onChargeDeleted?: (chargeId: string) => void;
   /** Restrict the table to these column ids, in the shared columns' order. Defaults to all of them. */
   columnIds?: string[];
   /** Include the actions-menu items that navigate to the document's charge. */
@@ -28,6 +30,7 @@ type UseDocumentsTableOptions = {
 export function useDocumentsTable({
   documentsProps,
   onChange,
+  onChargeDeleted,
   columnIds,
   withChargeLink = false,
 }: UseDocumentsTableOptions) {
@@ -80,8 +83,9 @@ export function useDocumentsTable({
         ...document,
         editDocument: (): void => setEditDocumentId(document.id),
         onUpdate: onChange ?? ((): void => {}),
+        onChargeDeleted,
       })),
-    [documents, onChange],
+    [documents, onChange, onChargeDeleted],
   );
 
   const tableColumns = useMemo(() => {


### PR DESCRIPTION
The documents table's actions menu offered only the edit / file / charge items, while the edit-document modal's top bar also had **copy ID**, **unlink** and **delete**. This brings those three into the menu so the table stands on its own.

## Changes

- **`document-actions-menu.tsx`** — `Copy Document ID` under the *Document* section (next to `Edit Document`), and `Unlink Document` / `Delete Document` in a destructive group at the bottom of the menu. Unlink is disabled when the document is not linked to a charge; delete uses the menu item's `destructive` variant.
- **`delete-document-button.tsx` / `unlink-document-button.tsx`** — accept an optional controlled `open` / `setOpen` pair. When given, the built-in icon trigger is not rendered and the host drives the confirmation, so the mutation, confirmation dialog and charge-deleted handling stay in one place rather than being duplicated in the menu.
- **`columns.tsx` / `use-documents-table.ts` / `index.tsx`** — thread `onChargeDeleted` from `DocumentsTable` through `useDocumentsTable` onto each row, so removing the last document of a charge drops the charge (as the edit modal already did) instead of refetching a deleted id.

A changeset is included (`@accounter/client`, patch).

## Validation

- `yarn generate` + `tsc --noEmit` on `@accounter/client` — clean
- `yarn lint` — 0 errors
- `yarn prettier:check` — clean
- `yarn test` — 3853 passed; the single failure (`packages/migrations/src/__tests__/rls-all-tables.test.ts`) is pre-existing and only fails here because the DB env vars are not set in this environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_015jxJRVcb4Hf1TXkckTfDhU)_