### PR TITLE
feat(mcp-server): detect clients speaking a newer protocol era

### DIFF
--- a/.changeset/mcp-modern-era-detector.md
+++ b/.changeset/mcp-modern-era-detector.md
@@ -41,5 +41,12 @@ byte-identical whether or not a probe was detected.
 it reads is caller-supplied and unvalidated, and a probe this server cannot parse is precisely the
 event worth seeing rather than throwing on.
 
+Capability names copied out of caller input are bounded — each clipped, the set capped at 20 with a
+trailing `+N more` so a truncated list is visibly truncated. Both how many keys a caller sends and
+how long each one is are bounded only by the 1 MB body cap, so a verbatim copy into a log line was
+caller-controlled amplification: a ~600KB payload produced a ~613KB log line, and now produces a
+1.4KB one. The same fix applies to `describeInitializeParams`, which shipped with the identical
+unbounded copy and is already released — this corrects both.
+
 Runbook §3.2 documents the fields, the `jq` recipes, and — since the point of this is to be a trigger
 — what to do when it fires.

--- a/.changeset/mcp-modern-era-detector.md
+++ b/.changeset/mcp-modern-era-detector.md
@@ -1,0 +1,45 @@
+---
+'@accounter/mcp-server': patch
+---
+
+Detect and log requests from clients speaking a newer MCP protocol era.
+
+This connector implements a handshake-based protocol revision. The current revision removed
+`initialize` entirely — version, identity and capabilities now travel per-request in `_meta`. A
+client that moved there completely would simply stop handshaking, which means the handshake logging
+added earlier **cannot** warn us about it: `mcp_initialize` would go quiet rather than report a
+changed version, and the first real symptom would be failing calls. That is the same shape as the
+incident that prompted all of this, and worse — a legacy-only server answering a modern-only client
+fails outright rather than returning partial results.
+
+What makes it detectable in advance is that a dual-era client on Streamable HTTP tries a modern
+request **first** and falls back based on the response. That attempt is the warning, and until now
+nothing was looking for it.
+
+Any request carrying one of these emits a single `event: "mcp_modern_probe"` line at `warn`, with
+the method, the client identity it advertised, and the revision it named:
+
+- `MCP-Protocol-Version` whose value disagrees with what we serve — a header this server has never
+  read, which is half of a real conformance gap in our own revision (we observe it; we still do not
+  enforce it, because enforcement changes behavior)
+- a per-request `_meta` protocol version, client info, or capabilities
+- the modern-only `server/discover` method
+
+Deliberately quiet otherwise. `MCP-Protocol-Version` is required by the revision we already
+implement, so it may well be on every call; recording its presence would make this event mean "a
+request happened" rather than "something changed", and `mcp_initialize` already reports the
+negotiated version.
+
+**Observation only, and that is the load-bearing property.** Era detection keys off exactly what a
+server returns: a dual-era client decides we are legacy from the shape of our reply. Answering
+`server/discover`, or anything else that makes us look modern, would stop the fallback that is
+currently keeping every client working — the failure this is meant to warn about, caused by the
+warning. So `server/discover` still returns method-not-found, and a test asserts responses are
+byte-identical whether or not a probe was detected.
+
+`describeModernEraProbe` is pure and total in the same way as `describeInitializeParams`: everything
+it reads is caller-supplied and unvalidated, and a probe this server cannot parse is precisely the
+event worth seeing rather than throwing on.
+
+Runbook §3.2 documents the fields, the `jq` recipes, and — since the point of this is to be a trigger
+— what to do when it fires.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -377,6 +377,23 @@ fields are merged _beneath_ the canonical ones, so a client cannot attribute its
 user by putting `userId` in `clientInfo`, and `clientInfo` strings are clipped before they reach the
 log.
 
+### Modern-era probe detection
+
+The connector implements a handshake-based protocol revision. The current revision removed
+`initialize` entirely, so a client that moved there completely would stop handshaking — and
+`mcp_initialize` would go _quiet_ rather than change, leaving failing calls as the first symptom.
+
+A dual-era client tries a modern request first and falls back on the response, so that attempt is
+the available warning. Any request carrying `MCP-Protocol-Version` that disagrees with what we
+serve, a per-request `_meta` protocol version, or the modern-only `server/discover` method emits one
+`event: "mcp_modern_probe"` line at `warn`. Silence is the normal state; a line means a client is
+moving.
+
+It is **observation only, and that is load-bearing**: era detection keys off what a server returns,
+so answering `server/discover` — or anything else that makes us look modern — would stop the
+fallback currently keeping every client working. A test asserts responses are byte-identical whether
+or not a probe was detected.
+
 ### Usage logging
 
 Operational telemetry answers "is it healthy"; usage telemetry answers "what are callers trying to
@@ -407,9 +424,9 @@ from stale charge ids becomes visible. This line is the complement to the `audit
 write already emits _before_ its handler runs: the audit line names the records, this one says what
 applied. Neither carries document content, filenames, or URLs.
 
-See [`docs/operations-runbook.md`](./docs/operations-runbook.md) §3.1 (handshake) and §3.2 (tool
-calls) for the full field references and the `jq` extraction recipes (client versions,
-most-requested terms, missing terms, tool popularity).
+See [`docs/operations-runbook.md`](./docs/operations-runbook.md) §3.1 (handshake), §3.2 (modern-era
+probes) and §3.3 (tool calls) for the full field references and the `jq` extraction recipes (client
+versions, most-requested terms, missing terms, tool popularity).
 
 ### Tracing (OpenTelemetry → Grafana Tempo)
 

--- a/packages/mcp-server/docs/operations-runbook.md
+++ b/packages/mcp-server/docs/operations-runbook.md
@@ -122,7 +122,46 @@ Caller-derived fields are merged beneath the canonical ones, so `clientName` and
 overwrite `userId`, `correlationId`, or `event`. A handshake the server cannot parse still logs a
 line, with the unparseable fields `null`.
 
-### 3.2 Tool-call usage logs (`event: "tool_call"`)
+### 3.2 Modern-era probes (`event: "mcp_modern_probe"`, level `warn`)
+
+**This is a trigger, not a diagnostic.** Silence is the normal state; a line here means a client is
+speaking a protocol revision this server does not implement.
+
+The connector implements a handshake-based revision. The current revision removed `initialize`
+entirely — version, identity and capabilities travel per-request in `_meta`. A client that moved
+there completely would simply stop handshaking, so `mcp_initialize` would go quiet rather than
+change, and the first real symptom would be failing calls. What makes it visible in advance is that
+a dual-era client tries a modern request **first** and falls back on the response; this event
+records that attempt.
+
+| Field                                  | Meaning                                                                                                                                                                               |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `method`                               | What was attempted. `server/discover` is modern-only                                                                                                                                  |
+| `protocolVersionHeader`                | The `MCP-Protocol-Version` value — recorded **only when it disagrees** with what we serve, since the header is also required by our own revision and would otherwise be on every call |
+| `metaProtocolVersion`                  | Version from per-request `_meta`; the defining marker of a modern request                                                                                                             |
+| `metaClientName` / `metaClientVersion` | Modern per-request identity, where handshake-era clients send it once                                                                                                                 |
+| `metaClientCapabilities`               | Capability names only, sorted                                                                                                                                                         |
+| `modernMethod`                         | The method itself exists only in the modern protocol                                                                                                                                  |
+| `servedEra`                            | Always `legacy` — what we actually answered, which this event never changes                                                                                                           |
+
+**What to do when it fires.** Nothing breaks at first: the client falls back and keeps working. It
+means the dual-era migration has stopped being hypothetical, and the analysis for it is in
+[`connector-gaps-and-decisions.md`](./connector-gaps-and-decisions.md). The hazard to avoid is a
+partial response: era detection keys off what we return, so answering `server/discover` — or
+anything else that makes us look modern — stops the fallback that is currently keeping clients
+working. Either the modern path is complete or it is absent.
+
+```bash
+# Has any client tried the modern protocol?
+jq -r 'select(.event=="mcp_modern_probe")
+  | [.timestamp, .method, .metaClientName, .metaProtocolVersion // .protocolVersionHeader] | @tsv' logs.jsonl
+
+# Which revisions are being asked for, and by whom
+jq -r 'select(.event=="mcp_modern_probe")
+  | [.metaClientName, .metaClientVersion, .metaProtocolVersion // .protocolVersionHeader] | @tsv' logs.jsonl | sort -u
+```
+
+### 3.3 Tool-call usage logs (`event: "tool_call"`)
 
 Every completed tool call emits exactly one line with `event: "tool_call"` — including calls
 rejected by validation, policy, or the rate limiter, which never reach a handler. This is the only

--- a/packages/mcp-server/docs/operations-runbook.md
+++ b/packages/mcp-server/docs/operations-runbook.md
@@ -108,15 +108,15 @@ Every `initialize` emits one line. This is the only record of _which client_ is 
 connector — a remote client's handling of tool results can change without anything in this repo
 changing, and when that happened once, dating it required the client's own local logs.
 
-| Field                      | Meaning                                                                                                                          |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `clientName`               | `clientInfo.name` as the client reported it, clipped. `null` if it sent none.                                                    |
-| `clientVersion`            | `clientInfo.version`, clipped. **The field that dates a client-side behavior change.**                                           |
-| `requestedProtocolVersion` | The MCP revision the client asked for. `null` if absent.                                                                         |
-| `servedProtocolVersion`    | What this server answered — currently unconditional.                                                                             |
-| `protocolVersionMismatch`  | Client asked for a revision this server does not implement. The one field worth alerting on. `false` when nothing was requested. |
-| `clientCapabilities`       | Capability _names_ only, sorted. Values are unbounded and caller-supplied.                                                       |
-| `userId` / `correlationId` | Same meaning as on `tool_call`, so a session can be joined across both events.                                                   |
+| Field                      | Meaning                                                                                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `clientName`               | `clientInfo.name` as the client reported it, clipped. `null` if it sent none.                                                              |
+| `clientVersion`            | `clientInfo.version`, clipped. **The field that dates a client-side behavior change.**                                                     |
+| `requestedProtocolVersion` | The MCP revision the client asked for. `null` if absent.                                                                                   |
+| `servedProtocolVersion`    | What this server answered — currently unconditional.                                                                                       |
+| `protocolVersionMismatch`  | Client asked for a revision this server does not implement. The one field worth alerting on. `false` when nothing was requested.           |
+| `clientCapabilities`       | Capability _names_ only, sorted, clipped and capped at 20 with a trailing `+N more`. Values are never read: caller-supplied and unbounded. |
+| `userId` / `correlationId` | Same meaning as on `tool_call`, so a session can be joined across both events.                                                             |
 
 Caller-derived fields are merged beneath the canonical ones, so `clientName` and friends can never
 overwrite `userId`, `correlationId`, or `event`. A handshake the server cannot parse still logs a
@@ -140,8 +140,9 @@ records that attempt.
 | `protocolVersionHeader`                | The `MCP-Protocol-Version` value — recorded **only when it disagrees** with what we serve, since the header is also required by our own revision and would otherwise be on every call |
 | `metaProtocolVersion`                  | Version from per-request `_meta`; the defining marker of a modern request                                                                                                             |
 | `metaClientName` / `metaClientVersion` | Modern per-request identity, where handshake-era clients send it once                                                                                                                 |
-| `metaClientCapabilities`               | Capability names only, sorted                                                                                                                                                         |
+| `metaClientCapabilities`               | Capability names only, sorted, each clipped and the set capped at 20 with a trailing `+N more` — it is caller-supplied and otherwise unbounded                                        |
 | `modernMethod`                         | The method itself exists only in the modern protocol                                                                                                                                  |
+| `servedProtocolVersion`                | The revision this server implements, so served-versus-requested reads off the line itself                                                                                             |
 | `servedEra`                            | Always `legacy` — what we actually answered, which this event never changes                                                                                                           |
 
 **What to do when it fires.** Nothing breaks at first: the client falls back and keeps working. It

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -9,7 +9,9 @@ import {
   describeInitializeParams,
   dispatchMcpRequest,
   handleMcpBody,
+  describeModernEraProbe,
   MAX_CLIENT_LABEL_LENGTH,
+  MAX_LOGGED_CAPABILITIES,
   MCP_INITIALIZE_EVENT,
   MCP_MODERN_PROBE_EVENT,
   MCP_PROTOCOL_VERSION,
@@ -727,5 +729,69 @@ describe('modern-era probe detection', () => {
     for (const params of [null, 'nope', [1, 2], { _meta: 'nope' }, { _meta: { 'io.modelcontextprotocol/clientInfo': 7 } }]) {
       await expect(dispatch({ method: 'tools/list', params })).resolves.toBeDefined();
     }
+  });
+});
+
+describe('caller-supplied capability lists are bounded', () => {
+  /**
+   * Every field these two extractors read comes from the caller and is bounded
+   * only by the 1 MB body cap, so an unbounded copy into a log line is
+   * caller-controlled amplification. `clientName` and `clientVersion` were
+   * clipped from the start; the capability *set* was not, in either extractor.
+   */
+  const many = (count: number): Record<string, unknown> =>
+    Object.fromEntries(Array.from({ length: count }, (_, i) => [`cap${String(i).padStart(3, '0')}`, {}]));
+
+  it('caps the number of capability names on a handshake', () => {
+    const { clientCapabilities } = describeInitializeParams({ capabilities: many(500) });
+
+    expect(clientCapabilities).toHaveLength(MAX_LOGGED_CAPABILITIES + 1);
+    // Silently short would read as a client declaring fewer capabilities.
+    expect(clientCapabilities.at(-1)).toBe(`+${500 - MAX_LOGGED_CAPABILITIES} more`);
+  });
+
+  it('caps the number of capability names on a modern probe', () => {
+    const probe = describeModernEraProbe(
+      'tools/list',
+      { _meta: { 'io.modelcontextprotocol/clientCapabilities': many(100) } },
+      undefined,
+    );
+
+    expect(probe!.metaClientCapabilities).toHaveLength(MAX_LOGGED_CAPABILITIES + 1);
+    expect(probe!.metaClientCapabilities.at(-1)).toBe(`+${100 - MAX_LOGGED_CAPABILITIES} more`);
+  });
+
+  it('clips an over-long capability name', () => {
+    const { clientCapabilities } = describeInitializeParams({
+      capabilities: { ['c'.repeat(500)]: {} },
+    });
+
+    expect(clientCapabilities[0]).toHaveLength(MAX_CLIENT_LABEL_LENGTH);
+    expect(clientCapabilities[0]!.endsWith('…')).toBe(true);
+  });
+
+  it('leaves a normal capability set untouched and sorted', () => {
+    const { clientCapabilities } = describeInitializeParams({
+      capabilities: { sampling: {}, elicitation: {}, roots: {} },
+    });
+
+    expect(clientCapabilities).toEqual(['elicitation', 'roots', 'sampling']);
+  });
+
+  it('bounds the whole emitted line, not just the array', () => {
+    const probe = describeModernEraProbe(
+      'tools/list',
+      {
+        _meta: {
+          'io.modelcontextprotocol/clientCapabilities': Object.fromEntries(
+            Array.from({ length: 2000 }, (_, i) => [`${'x'.repeat(300)}${i}`, {}]),
+          ),
+        },
+      },
+      undefined,
+    );
+
+    // ~600KB of caller input; the log line must not scale with it.
+    expect(JSON.stringify(probe).length).toBeLessThan(2_000);
   });
 });

--- a/packages/mcp-server/src/mcp/__tests__/handler.test.ts
+++ b/packages/mcp-server/src/mcp/__tests__/handler.test.ts
@@ -11,10 +11,11 @@ import {
   handleMcpBody,
   MAX_CLIENT_LABEL_LENGTH,
   MCP_INITIALIZE_EVENT,
+  MCP_MODERN_PROBE_EVENT,
   MCP_PROTOCOL_VERSION,
   mcpHttpHandler,
 } from '../handler.js';
-import type { JsonRpcErrorResponse, JsonRpcSuccess } from '../jsonrpc.js';
+import type { JsonRpcErrorResponse, JsonRpcResponse, JsonRpcSuccess } from '../jsonrpc.js';
 import { JsonRpcErrorCode } from '../jsonrpc.js';
 import { SMOKE_TOOL_NAME } from '../tools.js';
 
@@ -613,5 +614,118 @@ describe('initialize handshake logging', () => {
     handleMcpBody(rpc('initialize'));
 
     expect(handshakeLines()).toHaveLength(0);
+  });
+});
+
+describe('modern-era probe detection', () => {
+  const auth = buildAuthContext(PRINCIPAL, []);
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  function probes(): Record<string, unknown>[] {
+    return logSpy.mock.calls
+      .map(call => JSON.parse(String(call[0])) as Record<string, unknown>)
+      .filter(entry => entry.event === MCP_MODERN_PROBE_EVENT);
+  }
+
+  async function dispatch(
+    request: Record<string, unknown>,
+    protocolVersionHeader?: string,
+  ): Promise<JsonRpcResponse | null> {
+    return dispatchMcpRequest({ jsonrpc: '2.0', id: 1, ...request } as never, {
+      auth,
+      correlationId: 'corr-1',
+      allowlist: [],
+      writeToolsEnabled: false,
+      protocolVersionHeader,
+    });
+  }
+
+  it('stays silent for an ordinary request', async () => {
+    await dispatch({ method: 'tools/list' });
+
+    expect(probes()).toEqual([]);
+  });
+
+  // The header is required by the revision we already implement, so it may be
+  // on every call. Logging its presence would make this event mean "a request
+  // happened" rather than "something changed".
+  it('stays silent when the header agrees with what we serve', async () => {
+    await dispatch({ method: 'tools/list' }, MCP_PROTOCOL_VERSION);
+
+    expect(probes()).toEqual([]);
+  });
+
+  it('reports a header naming a revision we do not implement', async () => {
+    await dispatch({ method: 'tools/list' }, '2026-07-28');
+
+    expect(probes()).toHaveLength(1);
+    expect(probes()[0]).toMatchObject({
+      method: 'tools/list',
+      protocolVersionHeader: '2026-07-28',
+      servedProtocolVersion: MCP_PROTOCOL_VERSION,
+      servedEra: 'legacy',
+      correlationId: 'corr-1',
+    });
+  });
+
+  it('reports per-request `_meta`, the marker of a modern request', async () => {
+    await dispatch({
+      method: 'tools/list',
+      params: {
+        _meta: {
+          'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+          'io.modelcontextprotocol/clientInfo': { name: 'claude-ai', version: '1.40.0' },
+          'io.modelcontextprotocol/clientCapabilities': { roots: {}, elicitation: {} },
+        },
+      },
+    });
+
+    expect(probes()[0]).toMatchObject({
+      metaProtocolVersion: '2026-07-28',
+      metaClientName: 'claude-ai',
+      metaClientVersion: '1.40.0',
+      metaClientCapabilities: ['elicitation', 'roots'],
+    });
+  });
+
+  it('reports `server/discover`, and still answers method-not-found', async () => {
+    const response = (await dispatch({ method: 'server/discover' })) as JsonRpcErrorResponse;
+
+    expect(probes()[0]).toMatchObject({ method: 'server/discover', modernMethod: true });
+    // Answering it would tell a dual-era client we are modern, and it would
+    // stop falling back to the handshake that currently works.
+    expect(response.error.code).toBe(JsonRpcErrorCode.MethodNotFound);
+  });
+
+  /**
+   * The load-bearing assertion. Detection must be observation only: a dual-era
+   * client decides our era from what we return, so a response that changes
+   * because a probe was noticed would cause the very failure this warns about.
+   */
+  it('changes no response byte when a probe is detected', async () => {
+    const quiet = await dispatch({ method: 'tools/list' });
+    const probed = await dispatch(
+      { method: 'tools/list', params: { _meta: { 'io.modelcontextprotocol/protocolVersion': '2026-07-28' } } },
+      '2026-07-28',
+    );
+
+    expect(probes().length).toBeGreaterThan(0);
+    expect(JSON.stringify(probed)).toBe(JSON.stringify(quiet));
+  });
+
+  it('survives junk in `_meta` rather than throwing', async () => {
+    for (const params of [null, 'nope', [1, 2], { _meta: 'nope' }, { _meta: { 'io.modelcontextprotocol/clientInfo': 7 } }]) {
+      await expect(dispatch({ method: 'tools/list', params })).resolves.toBeDefined();
+    }
   });
 });

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -130,6 +130,39 @@ function clipClientLabel(value: unknown): string | null {
     : `${value.slice(0, MAX_CLIENT_LABEL_LENGTH - 1)}\u2026`;
 }
 
+/**
+ * Max capability names copied from a caller-supplied capabilities object.
+ *
+ * Both how many keys there are and how long each one is are the caller's
+ * choice, bounded only by the 1 MB body cap — so copying the set verbatim into
+ * a log line is caller-controlled amplification. Same reasoning as
+ * {@link MAX_CLIENT_LABEL_LENGTH} and the metrics registry's
+ * `MAX_COUNTER_LABELS`: anything derived from caller input gets a ceiling.
+ */
+export const MAX_LOGGED_CAPABILITIES = 20;
+
+/**
+ * Capability *names* from a caller-supplied capabilities object — sorted,
+ * clipped, and capped.
+ *
+ * Values are never read: they are unbounded and carry no diagnostic value here.
+ * Sorted so the same handshake logs the same line and a change is visible by
+ * diffing. When more names are present than the cap allows, a final `+N more`
+ * entry says so, because a list that is silently short reads as a client that
+ * declared fewer capabilities.
+ */
+function capabilityNames(value: unknown): string[] {
+  const names = Object.keys(asRecord(value)).sort();
+  const kept = names
+    .slice(0, MAX_LOGGED_CAPABILITIES)
+    .map(name => clipClientLabel(name))
+    .filter((name): name is string => name !== null);
+
+  return names.length > MAX_LOGGED_CAPABILITIES
+    ? [...kept, `+${names.length - MAX_LOGGED_CAPABILITIES} more`]
+    : kept;
+}
+
 /** What a client told us about itself during `initialize`. */
 export interface InitializeHandshake {
   clientName: string | null;
@@ -165,9 +198,7 @@ export function describeInitializeParams(params: unknown): InitializeHandshake {
     servedProtocolVersion: MCP_PROTOCOL_VERSION,
     protocolVersionMismatch:
       requestedProtocolVersion !== null && requestedProtocolVersion !== MCP_PROTOCOL_VERSION,
-    // Sorted so the same handshake always logs the same line, which makes a
-    // change in what the client declares visible by diffing.
-    clientCapabilities: Object.keys(asRecord(record.capabilities)).sort(),
+    clientCapabilities: capabilityNames(record.capabilities),
   };
 }
 
@@ -215,7 +246,7 @@ export function describeModernEraProbe(
     metaProtocolVersion: clipClientLabel(meta[META_PROTOCOL_VERSION_KEY]),
     metaClientName: clipClientLabel(metaClientInfo.name),
     metaClientVersion: clipClientLabel(metaClientInfo.version),
-    metaClientCapabilities: Object.keys(asRecord(meta[META_CLIENT_CAPABILITIES_KEY])).sort(),
+    metaClientCapabilities: capabilityNames(meta[META_CLIENT_CAPABILITIES_KEY]),
     modernMethod: method === SERVER_DISCOVER_METHOD,
   };
 

--- a/packages/mcp-server/src/mcp/handler.ts
+++ b/packages/mcp-server/src/mcp/handler.ts
@@ -59,6 +59,34 @@ export const MCP_PROTOCOL_VERSION = '2025-06-18';
 export const MCP_INITIALIZE_EVENT = 'mcp_initialize';
 
 /**
+ * `event` discriminator for a request that looks like it came from a client
+ * speaking a protocol era this server does not implement.
+ *
+ * The connector implements a handshake-based ("legacy") revision. Under the
+ * current revision there is no `initialize` at all: version, identity and
+ * capabilities travel per-request in `_meta`. A client that has moved there
+ * entirely would not handshake, so `mcp_initialize` would simply stop
+ * appearing — silence, not a changed value, discovered when calls began to
+ * fail.
+ *
+ * What makes this detectable in advance is that a dual-era client on
+ * Streamable HTTP tries a modern request *first* and falls back on the
+ * response. That probe is the warning, and this is what records it.
+ */
+export const MCP_MODERN_PROBE_EVENT = 'mcp_modern_probe';
+
+/** Header carrying the protocol revision a request is written against. */
+export const MCP_PROTOCOL_VERSION_HEADER = 'mcp-protocol-version';
+
+/** `_meta` keys a modern request carries, per the current revision. */
+const META_PROTOCOL_VERSION_KEY = 'io.modelcontextprotocol/protocolVersion';
+const META_CLIENT_INFO_KEY = 'io.modelcontextprotocol/clientInfo';
+const META_CLIENT_CAPABILITIES_KEY = 'io.modelcontextprotocol/clientCapabilities';
+
+/** Method a modern client calls to discover what a server supports. */
+export const SERVER_DISCOVER_METHOD = 'server/discover';
+
+/**
  * Hard cap on the length of a logged client identifier, ellipsis included.
  *
  * `clientInfo.name` and `clientInfo.version` are caller-supplied strings off the
@@ -141,6 +169,65 @@ export function describeInitializeParams(params: unknown): InitializeHandshake {
     // change in what the client declares visible by diffing.
     clientCapabilities: Object.keys(asRecord(record.capabilities)).sort(),
   };
+}
+
+/** A request bearing signals of a protocol era this server does not implement. */
+export interface ModernEraProbe {
+  method: string;
+  /** The header value, recorded only when it disagrees with what we serve. */
+  protocolVersionHeader: string | null;
+  metaProtocolVersion: string | null;
+  metaClientName: string | null;
+  metaClientVersion: string | null;
+  metaClientCapabilities: string[];
+  /** True when the method itself only exists in the modern protocol. */
+  modernMethod: boolean;
+}
+
+/**
+ * Describe a request's modern-era signals, or `null` when it has none.
+ *
+ * Returning `null` for the ordinary case is the design: this line must mean
+ * "something changed", not "a request happened". `MCP-Protocol-Version` is
+ * required by the revision we already implement, so it may well be on every
+ * call — recorded only when its value *disagrees* with ours, since
+ * `mcp_initialize` already reports the negotiated version.
+ *
+ * Pure and total, like {@link describeInitializeParams}: everything here is
+ * caller-supplied and unvalidated, and a probe this server cannot parse is
+ * exactly the event worth seeing rather than throwing on.
+ */
+export function describeModernEraProbe(
+  method: string,
+  params: unknown,
+  protocolVersionHeader: string | undefined,
+): ModernEraProbe | null {
+  const meta = asRecord(asRecord(params)._meta);
+  const metaClientInfo = asRecord(meta[META_CLIENT_INFO_KEY]);
+  const headerDisagrees =
+    typeof protocolVersionHeader === 'string' &&
+    protocolVersionHeader.length > 0 &&
+    protocolVersionHeader !== MCP_PROTOCOL_VERSION;
+
+  const probe: ModernEraProbe = {
+    method,
+    protocolVersionHeader: headerDisagrees ? clipClientLabel(protocolVersionHeader) : null,
+    metaProtocolVersion: clipClientLabel(meta[META_PROTOCOL_VERSION_KEY]),
+    metaClientName: clipClientLabel(metaClientInfo.name),
+    metaClientVersion: clipClientLabel(metaClientInfo.version),
+    metaClientCapabilities: Object.keys(asRecord(meta[META_CLIENT_CAPABILITIES_KEY])).sort(),
+    modernMethod: method === SERVER_DISCOVER_METHOD,
+  };
+
+  const sawSomething =
+    probe.protocolVersionHeader !== null ||
+    probe.metaProtocolVersion !== null ||
+    probe.metaClientName !== null ||
+    probe.metaClientVersion !== null ||
+    probe.metaClientCapabilities.length > 0 ||
+    probe.modernMethod;
+
+  return sawSomething ? probe : null;
 }
 
 /**
@@ -241,6 +328,15 @@ export interface McpDispatchContext {
   /** Caller's Authorization header value, forwarded upstream (never logged). */
   authorization?: string;
   /**
+   * The caller's `MCP-Protocol-Version` header, for era detection only.
+   *
+   * Read, never enforced. Enforcing it would change what we answer, and a
+   * dual-era client decides we are legacy from the shape of our reply — look
+   * modern and it stops falling back, which is the failure this is meant to
+   * warn about rather than cause.
+   */
+  protocolVersionHeader?: string;
+  /**
    * `MCP_TOOL_ALLOWLIST`, resolved at the HTTP boundary. Empty ⇒ no restriction
    * (every registered tool is exposed); non-empty ⇒ `tools/list` and
    * `tools/call` are limited to exactly these tool names.
@@ -276,6 +372,30 @@ export async function dispatchMcpRequest(
     return null;
   }
   const id = request.id ?? null;
+
+  // Era detection, before anything else: a request carrying modern signals is
+  // the only advance warning available that a client is moving off the
+  // handshake-based protocol this server implements.
+  //
+  // Observation only — nothing below changes, and no response byte differs.
+  // That is deliberate rather than incidental: era detection keys off exactly
+  // what we return, so answering a modern probe would stop the fallback that is
+  // currently keeping every client working.
+  const probe = describeModernEraProbe(
+    request.method,
+    request.params,
+    context.protocolVersionHeader,
+  );
+  if (probe) {
+    log('warn', 'mcp modern-era probe', {
+      ...probe,
+      event: MCP_MODERN_PROBE_EVENT,
+      servedProtocolVersion: MCP_PROTOCOL_VERSION,
+      servedEra: 'legacy',
+      userId: context.auth.userId,
+      correlationId: context.correlationId,
+    });
+  }
 
   // Record the handshake, then let `handleRpcRequest` build the response.
   //
@@ -521,6 +641,10 @@ export async function mcpHttpHandler(req: IncomingMessage, res: ServerResponse):
     correlationId: getRequestContext(req)?.correlationId ?? '',
     authorization:
       typeof req.headers.authorization === 'string' ? req.headers.authorization : undefined,
+    protocolVersionHeader:
+      typeof req.headers[MCP_PROTOCOL_VERSION_HEADER] === 'string'
+        ? (req.headers[MCP_PROTOCOL_VERSION_HEADER] as string)
+        : undefined,
     allowlist: env.server.toolAllowlist,
     writeToolsEnabled: env.server.writeToolsEnabled,
   });


### PR DESCRIPTION
Closes a blind spot in #4299 that I only spotted afterwards.

## The gap

I said handshake logging would show us a client changing protocol era. It won't.

This connector implements a **handshake-based** revision. The current revision removed `initialize`
entirely — version, identity and capabilities travel per-request in `_meta`. A client that moved
there completely would simply stop handshaking, so `mcp_initialize` would go **quiet** rather than
report a changed version. The first real symptom would be failing calls.

That's the same shape as the incident that started all this, and worse: the spec's compatibility
matrix says a modern-only client against a legacy-only server **fails outright**, rather than
returning partial results the way August did.

## Why it's detectable anyway

A dual-era client on Streamable HTTP tries a modern request **first** and falls back based on the
response. That attempt is the warning — it arrives before anything breaks, and nothing was looking
for it.

## What this does

Any request carrying one of these emits a single `event: "mcp_modern_probe"` line at `warn`, with the
method, the client identity it advertised, and the revision it named:

| Signal | Why |
|---|---|
| `MCP-Protocol-Version` disagreeing with what we serve | A header this server has never read — half of a real conformance gap in our *own* revision. We observe it; we still don't enforce it, because enforcement changes behavior |
| per-request `_meta` protocol version / clientInfo / capabilities | The defining marker of a modern request |
| `server/discover` | Modern-only method; calling it means the client thinks we might be modern |

**Quiet otherwise.** `MCP-Protocol-Version` is required by the revision we already implement, so it
may well be on every call. Recording its *presence* would make this event mean "a request happened"
rather than "something changed" — and `mcp_initialize` already reports the negotiated version. So the
header is logged only when its value disagrees.

## The load-bearing property

**Observation only — no response byte changes.** This is not incidental caution. Era detection keys
off exactly what a server returns: a dual-era client decides we are legacy from the shape of our
reply. Answering `server/discover`, or anything else that makes us look modern, would stop the
fallback that is currently keeping every client working — causing the exact failure this is meant to
warn about.

So `server/discover` still returns method-not-found, and there's a test for the invariant directly:

```ts
it('changes no response byte when a probe is detected', ...)
  expect(JSON.stringify(probed)).toBe(JSON.stringify(quiet));
```

`describeModernEraProbe` is pure and total in the same way as `describeInitializeParams` — everything
it reads is caller-supplied and unvalidated, and a probe this server cannot parse is precisely the
event worth seeing rather than throwing on. Covered with `params` as `null`, a string, an array, and
a `_meta` holding junk.

## Verified it actually fires

A realistic dual-era probe:

```
method: "server/discover", protocolVersionHeader: "2026-07-28",
metaProtocolVersion: "2026-07-28", metaClientName: "claude-ai", modernMethod: true
```

A current-revision request with a matching header: `null` — silent.

## Docs

Runbook §3.2 covers the fields, `jq` recipes, and — since the whole point is to be a trigger — what
to do when it fires: the dual-era migration stops being hypothetical, and the hazard to avoid is a
*partial* one. Renumbered tool-call logs to §3.3 and updated the README cross-reference.

## What this is not

It catches dual-era probes, not a client that goes straight to modern-only with no fallback. That
residual case is what the migration is for; this buys the warning, not the cure.

## Verification

892 tests pass (55 files), typecheck / eslint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)