### PR TITLE
fix(server): sum credit entity 2 in getLedgerBalanceToDate

### DIFF
--- a/.changeset/ledger-balance-to-date-credit-entity2.md
+++ b/.changeset/ledger-balance-to-date-credit-entity2.md
@@ -1,0 +1,19 @@
+---
+'@accounter/server': patch
+---
+
+Fix opening balances in the yearly ledger report missing every credit-side entity-2 amount.
+
+`getLedgerBalanceToDate` unions the four entity slots of a ledger record into one
+`(entity_id, amount, invoice_date)` stream and sums it. Two of the four branches were byte-identical
+— `credit_entity1, credit_local_amount1, invoice_date` appeared twice — so `credit_entity2` /
+`credit_local_amount2` was never read at all, while both debit slots were. Any record crediting a
+second entity (the common shape for a split credit) contributed nothing for that entity, and the
+opening balance `yearlyLedgerReport` carries into the year was silently wrong for it. The duplicated
+branch did not double-count, because `UNION` deduplicated it against its twin.
+
+The second branch now selects `credit_entity2, credit_local_amount2`, and all three set operations
+are `UNION ALL`. `UNION` deduplicates across the whole stream, not just the accidental duplicate:
+two genuine movements that happen to share an entity, a local amount and an invoice date — the same
+fee posted twice in a day, two identical monthly lines — collapsed into one, understating the
+balance. `UNION ALL` keeps every row, which is what a sum over ledger sides needs.

--- a/packages/server/src/modules/ledger/providers/ledger.provider.ts
+++ b/packages/server/src/modules/ledger/providers/ledger.provider.ts
@@ -83,16 +83,20 @@ const getLedgerRecordsByFilters = sql<IGetLedgerRecordsByFiltersQuery>`
     ORDER BY invoice_date, value_date, id
     LIMIT $limit;`;
 
+-- Every one of the four entity slots contributes to the balance, so all four are
+-- summed. UNION ALL rather than UNION: two ledger sides that happen to share an
+-- entity, amount and date are two real movements, and deduplicating them would
+-- drop one of them from the sum.
 const getLedgerBalanceToDate = sql<IGetLedgerBalanceToDateQuery>`
     WITH grouped_entities AS (SELECT credit_entity1 AS entity_id, credit_local_amount1 AS amount, invoice_date
                               FROM accounter_schema.ledger_records
-                              UNION
-                              SELECT credit_entity1, credit_local_amount1, invoice_date
+                              UNION ALL
+                              SELECT credit_entity2, credit_local_amount2, invoice_date
                               FROM accounter_schema.ledger_records
-                              UNION
+                              UNION ALL
                               SELECT debit_entity1, debit_local_amount1 * -1, invoice_date
                               FROM accounter_schema.ledger_records
-                              UNION
+                              UNION ALL
                               SELECT debit_entity2, debit_local_amount2 * -1, invoice_date
                               FROM accounter_schema.ledger_records)
     SELECT entity_id, sum(amount)

--- a/packages/server/src/modules/ledger/providers/ledger.provider.ts
+++ b/packages/server/src/modules/ledger/providers/ledger.provider.ts
@@ -83,10 +83,10 @@ const getLedgerRecordsByFilters = sql<IGetLedgerRecordsByFiltersQuery>`
     ORDER BY invoice_date, value_date, id
     LIMIT $limit;`;
 
--- Every one of the four entity slots contributes to the balance, so all four are
--- summed. UNION ALL rather than UNION: two ledger sides that happen to share an
--- entity, amount and date are two real movements, and deduplicating them would
--- drop one of them from the sum.
+// Every one of the four entity slots contributes to the balance, so all four are
+// summed. UNION ALL rather than UNION: two ledger sides that happen to share an
+// entity, amount and date are two real movements, and deduplicating them would
+// drop one of them from the sum.
 const getLedgerBalanceToDate = sql<IGetLedgerBalanceToDateQuery>`
     WITH grouped_entities AS (SELECT credit_entity1 AS entity_id, credit_local_amount1 AS amount, invoice_date
                               FROM accounter_schema.ledger_records


### PR DESCRIPTION
## What

`getLedgerBalanceToDate` (`packages/server/src/modules/ledger/providers/ledger.provider.ts`) unions the four entity slots of a ledger record into one `(entity_id, amount, invoice_date)` stream and sums it per entity. Two of the four branches were byte-identical:

```sql
SELECT credit_entity1 AS entity_id, credit_local_amount1 AS amount, invoice_date ...
UNION
SELECT credit_entity1,            credit_local_amount1,            invoice_date ...
```

So `credit_entity2` / `credit_local_amount2` was never read at all, while both `debit_entity1` and `debit_entity2` were. Any record crediting a second entity contributed nothing for that entity, and the opening balance `yearlyLedgerReport` carries into the year was silently wrong for it. The duplicated branch did not double-count, because `UNION` deduplicated it against its twin — which is the only reason the bug stayed invisible.

## Changes

- Second branch now selects `credit_entity2, credit_local_amount2`.
- All three set operations are `UNION ALL`. `UNION` deduplicates across the whole stream, not just the accidental duplicate: two genuine movements sharing an entity, a local amount and an invoice date — the same fee posted twice in a day, two identical monthly lines — collapsed into one, understating the balance. A sum over ledger sides needs every row.
- Changeset (`@accounter/server`: patch).

## Impact

Opening balances in the yearly ledger report change for any entity that appears in a `credit_entity2` slot, and for entities with duplicate-looking movements. These are corrections — the previous numbers were wrong.

The result shape (`entity_id`, `sum`) is unchanged, so no pgtyped regeneration is needed. Tenant scoping is unaffected: this query relies on RLS via `TenantAwareDBClient`, as before.

## Not in this PR

`getLedgerRecordsByFinancialEntityIds`, twenty lines above, has the same class of typo — it tests `credit_entity1 IN $$financialEntityIds` twice and never tests `credit_entity2`. Left out to keep this PR focused; worth a follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WHwz8x7p7rungo9Tu1hE4Y)_