### PR TITLE
fix(server): correlate unmatched documents filter with outer documents.charge_id

### DIFF
--- a/.changeset/documents-unmatched-filter-correlation.md
+++ b/.changeset/documents-unmatched-filter-correlation.md
@@ -1,0 +1,10 @@
+---
+'@accounter/server': patch
+---
+
+Fix the documents `unmatched` filter losing its outer correlation. In
+`getDocumentsByExtendedFilters`, the `NOT EXISTS` subquery compared `t.charge_id = charge_id`, where
+the unqualified column resolved to the subquery's own `transactions.charge_id` instead of the outer
+`documents.charge_id`. The predicate therefore collapsed to "no transaction anywhere has a non-null
+charge_id", so the filter returned no documents as soon as any transaction was matched to a charge.
+The comparison is now qualified as `t.charge_id = documents.charge_id`.

--- a/packages/server/src/modules/documents/providers/documents.provider.ts
+++ b/packages/server/src/modules/documents/providers/documents.provider.ts
@@ -251,7 +251,7 @@ const getDocumentsByExtendedFilters = sql<IGetDocumentsByExtendedFiltersQuery>`
     AND ($isUnmatched = 0 OR NOT EXISTS (
       SELECT 1
       FROM accounter_schema.transactions t
-      WHERE t.charge_id = charge_id
+      WHERE t.charge_id = documents.charge_id
     ))
     AND ($freeText::TEXT IS NULL OR (
       serial_number ILIKE '%' || $freeText || '%'


### PR DESCRIPTION
## Problem

In `getDocumentsByExtendedFilters` (`packages/server/src/modules/documents/providers/documents.provider.ts`), the `$isUnmatched` filter used:

```sql
NOT EXISTS (
  SELECT 1
  FROM accounter_schema.transactions t
  WHERE t.charge_id = charge_id
)
```

The unqualified `charge_id` resolves to the subquery's own `t.charge_id`, not the outer `documents.charge_id`, so the correlation was lost. The predicate degenerated to `t.charge_id = t.charge_id`, i.e. "no transaction anywhere has a non-null charge_id" — the filter returned zero documents as soon as any transaction was matched to a charge.

## Fix

Qualify the comparison as `t.charge_id = documents.charge_id`, matching the qualified style already used by the `$freeText` counterparty subqueries a few lines below. Documents with a `NULL` `charge_id` still count as unmatched, since the equality is never true for them.

## Notes

- One-line SQL change plus a patch changeset for `@accounter/server`.
- `yarn lint` / `yarn prettier:check` could not run in this environment (no `node_modules` state file); CI will cover them.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Q6yHdD7tzSXmdijWvedUQ)_