### PR TITLE
Refresh approved charges in similar-charges dialog

### DIFF
--- a/.changeset/similar-charges-refresh-approved-rows.md
+++ b/.changeset/similar-charges-refresh-approved-rows.md
@@ -1,0 +1,24 @@
+---
+'@accounter/client': patch
+---
+
+Refresh every charge a batch update touched, not just the one that was acted on.
+
+Approving suggestions in the similar-charges dialog applies one charge's tags or description to a
+whole set of other charges. The charge the user acted on refreshed correctly — its cell calls the
+row's `onChange` as soon as the mutation lands — but the other approved charges did not, so any of
+them that were rows in the same table kept showing their pre-approval tags and description until the
+page was reloaded.
+
+Nothing could refresh them: a row's refetch is reachable only through its own `row.original.onChange`
+or through the rows currently selected in the table, and the dialog has charge ids, not rows. The
+charges table now carries a charge-id → refresh registry that each row publishes into, and
+`useBatchUpdateCharges` refreshes whichever of the charges the server reports as updated are on
+screen. Ids that aren't rendered are skipped, so callers don't need to know what the table is
+showing, and the hook is a no-op outside one.
+
+This also covers the by-business variant of the dialog, and closes the standing TODO on
+`useBatchUpdateCharges` about updating local data after a change.
+
+One limitation: the registry is per table, so a screen rendering two charges tables refreshes rows
+in the table the dialog was opened from, not the other one.

--- a/packages/client/src/components/charges/__tests__/charges-table-refetch.test.tsx
+++ b/packages/client/src/components/charges/__tests__/charges-table-refetch.test.tsx
@@ -43,11 +43,17 @@ function makeCharge(overrides: Record<string, unknown> = {}) {
 }
 
 /** Builds an urql client backed by a scripted, request-recording fetch. */
-function makeClient(operations: string[], responses: Record<string, () => unknown>): Client {
+function makeClient(
+  operations: string[],
+  responses: Record<string, (variables: Record<string, unknown>) => unknown>,
+): Client {
   const mockFetch = (async (_url: string, init: RequestInit) => {
-    const body = JSON.parse(String(init.body)) as { operationName: string };
+    const body = JSON.parse(String(init.body)) as {
+      operationName: string;
+      variables?: Record<string, unknown>;
+    };
     operations.push(body.operationName);
-    const data = (responses[body.operationName] ?? (() => ({})))();
+    const data = (responses[body.operationName] ?? (() => ({})))(body.variables ?? {});
     const payload = JSON.stringify({ data });
     return {
       status: 200,
@@ -90,13 +96,13 @@ describe('charges table row refetch', () => {
     }
   }
 
-  async function renderTable(client: Client, charge: ChargeFixture): Promise<void> {
+  async function renderTable(client: Client, ...charges: ChargeFixture[]): Promise<void> {
     await act(async () => {
       root.render(
         <MemoryRouter>
           <Provider value={client}>
-            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw fixture stands in for the masked fragment */}
-            <ChargesTable data={[charge as any]} />
+            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw fixtures stand in for the masked fragments */}
+            <ChargesTable data={charges as any} />
           </Provider>
         </MemoryRouter>,
       );
@@ -202,5 +208,170 @@ describe('charges table row refetch', () => {
     await click(remaining[0]);
     expect(refetchCount).toBe(2);
     expect(confirmButtons()).toHaveLength(0);
+  });
+
+  /** The similar-charges dialog renders through a portal on `document.body`, not into `container`. */
+  function dialog(): HTMLElement | null {
+    return document.body.querySelector<HTMLElement>('[role="dialog"]');
+  }
+
+  function buttonByText(scope: ParentNode, text: string): HTMLElement | undefined {
+    return [...scope.querySelectorAll<HTMLElement>('button')].find(
+      element => element.textContent?.trim() === text,
+    );
+  }
+
+  it('refreshes the other charges a similar-charges approval updated', async () => {
+    const operations: string[] = [];
+    const refetched: string[] = [];
+    // Flipped by the batch mutation: until then the refetch answers with the pre-approval charge,
+    // exactly as the server would.
+    let approved = false;
+
+    const client = makeClient(operations, {
+      UpdateCharge: () => ({
+        updateCharge: { __typename: 'UpdateChargeSuccessfulResult', charge: { id: 'charge-1' } },
+      }),
+      // `charge-2` is a row in the table *and* a similar charge — the case that used to go stale.
+      SimilarCharges: () => ({
+        similarCharges: [
+          {
+            id: 'charge-2',
+            __typename: 'CommonCharge',
+            counterparty: { name: 'Acme', id: 'business-1' },
+            minEventDate: '2024-01-02',
+            minDebitDate: null,
+            minDocumentsDate: null,
+            totalAmount: { raw: -50, formatted: '-50 ILS' },
+            vat: { raw: -7, formatted: '-7 ILS' },
+            userDescription: null,
+            tags: [],
+            taxCategory: { id: 'tax-1', name: 'Expenses' },
+            metadata: {
+              transactionsCount: 1,
+              documentsCount: 0,
+              ledgerCount: 0,
+              miscExpensesCount: 0,
+            },
+          },
+        ],
+      }),
+      BatchUpdateCharges: () => {
+        approved = true;
+        return {
+          batchUpdateCharges: {
+            __typename: 'BatchUpdateChargesSuccessfulResult',
+            charges: [{ id: 'charge-2' }],
+          },
+        };
+      },
+      RefetchChargeForChargesTable: variables => {
+        const chargeId = String(variables.chargeId);
+        refetched.push(chargeId);
+        if (chargeId === 'charge-1') {
+          return { charge: makeCharge({ userDescription: 'Confirmed description' }) };
+        }
+        return {
+          charge: makeCharge({
+            id: 'charge-2',
+            userDescription: approved ? 'Confirmed description' : 'Stale description',
+          }),
+        };
+      },
+    });
+
+    await renderTable(
+      client,
+      makeCharge({
+        validationData: { missingInfo: ['DESCRIPTION'] },
+        missingInfoSuggestions: { description: 'Suggested description', tags: [] },
+      }),
+      makeCharge({ id: 'charge-2', userDescription: 'Stale description' }),
+    );
+
+    // Confirming charge-1's suggestion refreshes its own row and opens the similar-charges dialog.
+    await click(confirmButtons()[0]);
+    expect(container.textContent).toContain('Confirmed description');
+    expect(container.textContent).toContain('Stale description');
+
+    const modal = dialog();
+    expect(modal).not.toBeNull();
+
+    // The header checkbox selects every charge the dialog is offering — here, just charge-2.
+    const selectAll = modal!.querySelector<HTMLElement>('[role="checkbox"]');
+    expect(selectAll).not.toBeNull();
+    await click(selectAll!);
+
+    const approve = buttonByText(modal!, 'Approve selected');
+    expect(approve).toBeDefined();
+    await click(approve!);
+
+    expect(operations).toContain('BatchUpdateCharges');
+    // The approval only ever touched charge-2, so that is the row that had to be refreshed.
+    expect(refetched.filter(id => id === 'charge-2')).not.toHaveLength(0);
+    expect(container.textContent).not.toContain('Stale description');
+  });
+
+  it('leaves charges that are not in the table alone', async () => {
+    const operations: string[] = [];
+    const refetched: string[] = [];
+
+    const client = makeClient(operations, {
+      UpdateCharge: () => ({
+        updateCharge: { __typename: 'UpdateChargeSuccessfulResult', charge: { id: 'charge-1' } },
+      }),
+      SimilarCharges: () => ({
+        similarCharges: [
+          {
+            id: 'charge-elsewhere',
+            __typename: 'CommonCharge',
+            counterparty: { name: 'Acme', id: 'business-1' },
+            minEventDate: '2024-01-02',
+            minDebitDate: null,
+            minDocumentsDate: null,
+            totalAmount: { raw: -50, formatted: '-50 ILS' },
+            vat: { raw: -7, formatted: '-7 ILS' },
+            userDescription: null,
+            tags: [],
+            taxCategory: { id: 'tax-1', name: 'Expenses' },
+            metadata: {
+              transactionsCount: 1,
+              documentsCount: 0,
+              ledgerCount: 0,
+              miscExpensesCount: 0,
+            },
+          },
+        ],
+      }),
+      BatchUpdateCharges: () => ({
+        batchUpdateCharges: {
+          __typename: 'BatchUpdateChargesSuccessfulResult',
+          charges: [{ id: 'charge-elsewhere' }],
+        },
+      }),
+      RefetchChargeForChargesTable: variables => {
+        refetched.push(String(variables.chargeId));
+        return { charge: makeCharge({ userDescription: 'Confirmed description' }) };
+      },
+    });
+
+    await renderTable(
+      client,
+      makeCharge({
+        validationData: { missingInfo: ['DESCRIPTION'] },
+        missingInfoSuggestions: { description: 'Suggested description', tags: [] },
+      }),
+    );
+
+    await click(confirmButtons()[0]);
+
+    const modal = dialog();
+    expect(modal).not.toBeNull();
+    await click(modal!.querySelector<HTMLElement>('[role="checkbox"]')!);
+    await click(buttonByText(modal!, 'Approve selected')!);
+
+    expect(operations).toContain('BatchUpdateCharges');
+    // Only charge-1's own post-mutation refresh; the approved charge isn't rendered anywhere.
+    expect(refetched).not.toContain('charge-elsewhere');
   });
 });

--- a/packages/client/src/components/charges/charges-row.tsx
+++ b/packages/client/src/components/charges/charges-row.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/gql/graphql.js';
 import { getFragmentData } from '@/gql/index.js';
 import type { TableFeaturesConfig } from '@/lib/table-features.js';
+import { useRegisterChargeRefresh } from '../../providers/charge-refresh.js';
 import { Card } from '../ui/card.js';
 import { TableCell, TableRow } from '../ui/table.js';
 import { ChargeExtendedInfo } from './charge-extended-info.js';
@@ -48,6 +49,11 @@ export const ChargeRow = ({ row, updateCharge, removeCharge }: Props): ReactElem
   const refetchCharge = useCallback((): void => {
     fetchCharge({ requestPolicy: 'network-only' });
   }, [fetchCharge]);
+
+  // Publish the same refetch under this charge's id, so a batch mutation elsewhere in the tree can
+  // refresh this row without holding a reference to it. `row.original` is swapped out on every
+  // refresh, but its id is stable, which is what the registry keys on.
+  useRegisterChargeRefresh(row.original.id, refetchCharge);
 
   const dropCharge = useCallback((): void => {
     removeCharge(row.original.id);

--- a/packages/client/src/components/charges/charges-table.tsx
+++ b/packages/client/src/components/charges/charges-table.tsx
@@ -19,6 +19,7 @@ import {
 import { getFragmentData, type FragmentType } from '../../gql/index.js';
 import type { ChargeType } from '../../helpers/index.js';
 import { useStableValue } from '../../hooks/use-stable-value.js';
+import { ChargeRefreshProvider } from '../../providers/charge-refresh.js';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table.js';
 import type { AmountProps } from './cells/amount.js';
 import type { BusinessTripProps } from './cells/business-trip.js';
@@ -391,55 +392,59 @@ export const ChargesTable = ({
   const exportIds = selectedIds.length > 0 ? selectedIds : chargeIds;
 
   return (
-    <BatchChargesExtendedInfoProvider chargeIds={chargeIds} active={isAllOpened}>
-      <div className="flex flex-col gap-2 w-full">
-        {showExport && (
-          <div className="flex justify-end">
-            <DownloadChargesCsv chargeIds={exportIds} />
-          </div>
-        )}
-        <div className="overflow-hidden rounded-md border w-full">
-          {/* Cells wrap (overriding the ui table's nowrap, and the nowrap of the sort
+    // Rows publish their refetch here, so a mutation that touched several charges at once can
+    // refresh whichever of them this table happens to be showing.
+    <ChargeRefreshProvider>
+      <BatchChargesExtendedInfoProvider chargeIds={chargeIds} active={isAllOpened}>
+        <div className="flex flex-col gap-2 w-full">
+          {showExport && (
+            <div className="flex justify-end">
+              <DownloadChargesCsv chargeIds={exportIds} />
+            </div>
+          )}
+          <div className="overflow-hidden rounded-md border w-full">
+            {/* Cells wrap (overriding the ui table's nowrap, and the nowrap of the sort
               buttons in the headers) so the table fits the viewport instead of forcing
               the page to scroll sideways. */}
-          <Table className="[&_th]:whitespace-normal [&_td]:whitespace-normal [&_th_button]:whitespace-normal">
-            <TableHeader>
-              {table.getHeaderGroups().map(headerGroup => (
-                <TableRow key={headerGroup.id}>
-                  {headerGroup.headers.map(header => (
-                    <TableHead key={header.id} colSpan={header.colSpan}>
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(header.column.columnDef.header, header.getContext())}
-                    </TableHead>
-                  ))}
-                  <TableHead />
-                </TableRow>
-              ))}
-            </TableHeader>
-            <TableBody>
-              {table.getRowModel().rows?.length ? (
-                table
-                  .getRowModel()
-                  .rows.map(row => (
-                    <ChargeRow
-                      key={row.id}
-                      row={row}
-                      updateCharge={updateCharge}
-                      removeCharge={removeCharge}
-                    />
-                  ))
-              ) : (
-                <TableRow>
-                  <TableCell colSpan={columns.length} className="h-24 text-center">
-                    No results.
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+            <Table className="[&_th]:whitespace-normal [&_td]:whitespace-normal [&_th_button]:whitespace-normal">
+              <TableHeader>
+                {table.getHeaderGroups().map(headerGroup => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map(header => (
+                      <TableHead key={header.id} colSpan={header.colSpan}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(header.column.columnDef.header, header.getContext())}
+                      </TableHead>
+                    ))}
+                    <TableHead />
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {table.getRowModel().rows?.length ? (
+                  table
+                    .getRowModel()
+                    .rows.map(row => (
+                      <ChargeRow
+                        key={row.id}
+                        row={row}
+                        updateCharge={updateCharge}
+                        removeCharge={removeCharge}
+                      />
+                    ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={columns.length} className="h-24 text-center">
+                      No results.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
         </div>
-      </div>
-    </BatchChargesExtendedInfoProvider>
+      </BatchChargesExtendedInfoProvider>
+    </ChargeRefreshProvider>
   );
 };

--- a/packages/client/src/hooks/use-batch-update-charges.ts
+++ b/packages/client/src/hooks/use-batch-update-charges.ts
@@ -7,6 +7,7 @@ import {
   type BatchUpdateChargesMutationVariables,
 } from '../gql/graphql.js';
 import { handleCommonErrors } from '../helpers/error-handling.js';
+import { useRefreshCharges } from '../providers/charge-refresh.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -41,9 +42,14 @@ const NOTIFICATION_ID = 'batchUpdateCharges';
 
 export const useBatchUpdateCharges = (): UseBatchUpdateCharges => {
   // TODO: add authentication
-  // TODO: add local data update method after change
 
   const [{ fetching }, mutate] = useMutation(BatchUpdateChargesDocument);
+  // A batch update, by definition, changes charges the caller isn't rendering an action for — the
+  // similar-charges dialog applies one charge's tags/description to a set of others. Any of those
+  // that are rows in a charges table would otherwise keep their pre-mutation values until a reload,
+  // so refresh them here rather than asking every caller to remember. A no-op outside a charges
+  // table, and for ids that aren't currently rendered.
+  const refreshCharges = useRefreshCharges();
   const batchUpdateCharges = useCallback(
     async (variables: BatchUpdateChargesMutationVariables) => {
       const chargeIds = Array.isArray(variables.chargeIds)
@@ -62,6 +68,8 @@ export const useBatchUpdateCharges = (): UseBatchUpdateCharges => {
             id: notificationId,
             description: `${chargeIds.length} charge${chargeIds.length > 1 ? 's' : ''} updated`,
           });
+          // The server's own list, not the requested ids — only these actually changed.
+          refreshCharges(data.batchUpdateCharges.charges.map(charge => charge.id));
           return data.batchUpdateCharges.charges;
         }
       } catch (e) {
@@ -75,7 +83,7 @@ export const useBatchUpdateCharges = (): UseBatchUpdateCharges => {
       }
       return void 0;
     },
-    [mutate],
+    [mutate, refreshCharges],
   );
 
   return {

--- a/packages/client/src/providers/__tests__/charge-refresh.test.tsx
+++ b/packages/client/src/providers/__tests__/charge-refresh.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ChargeRefreshProvider,
+  useRefreshCharges,
+  useRegisterChargeRefresh,
+} from '../charge-refresh.js';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/** Stands in for a `ChargeRow`: publishes a refresh handler for as long as it's mounted. */
+function Row({ chargeId, refresh }: { chargeId: string; refresh: () => void }): ReactElement {
+  useRegisterChargeRefresh(chargeId, refresh);
+  return <div />;
+}
+
+describe('charge refresh registry', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  /** Captured from inside the provider, the way a mutation hook would call it. */
+  let refreshCharges: (chargeIds: string[]) => void;
+
+  function Consumer(): ReactElement {
+    refreshCharges = useRefreshCharges();
+    return <div />;
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  async function render(node: ReactElement): Promise<void> {
+    await act(async () => {
+      root.render(node);
+    });
+  }
+
+  it('refreshes only the registered charges and ignores the rest', async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    await render(
+      <ChargeRefreshProvider>
+        <Consumer />
+        <Row chargeId="charge-1" refresh={first} />
+        <Row chargeId="charge-2" refresh={second} />
+      </ChargeRefreshProvider>,
+    );
+
+    // "charge-3" isn't rendered — callers pass whatever the mutation touched and expect the
+    // registry to sort out what's on screen.
+    await act(async () => refreshCharges(['charge-1', 'charge-3']));
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it('fires every registration for a charge rendered more than once', async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    await render(
+      <ChargeRefreshProvider>
+        <Consumer />
+        <Row chargeId="charge-1" refresh={first} />
+        <Row chargeId="charge-1" refresh={second} />
+      </ChargeRefreshProvider>,
+    );
+
+    await act(async () => refreshCharges(['charge-1']));
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops refreshing a charge once its row unmounts', async () => {
+    const refresh = vi.fn();
+
+    await render(
+      <ChargeRefreshProvider>
+        <Consumer />
+        <Row chargeId="charge-1" refresh={refresh} />
+      </ChargeRefreshProvider>,
+    );
+
+    await render(
+      <ChargeRefreshProvider>
+        <Consumer />
+      </ChargeRefreshProvider>,
+    );
+
+    await act(async () => refreshCharges(['charge-1']));
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('re-registers when a row hands over a new refresh handler', async () => {
+    const stale = vi.fn();
+    const fresh = vi.fn();
+
+    await render(
+      <ChargeRefreshProvider>
+        <Consumer />
+        <Row chargeId="charge-1" refresh={stale} />
+      </ChargeRefreshProvider>,
+    );
+
+    // A row's refetch identity tracks urql's `executeQuery`, so it can change between renders.
+    await render(
+      <ChargeRefreshProvider>
+        <Consumer />
+        <Row chargeId="charge-1" refresh={fresh} />
+      </ChargeRefreshProvider>,
+    );
+
+    await act(async () => refreshCharges(['charge-1']));
+
+    expect(stale).not.toHaveBeenCalled();
+    expect(fresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op outside a provider instead of throwing', async () => {
+    const refresh = vi.fn();
+
+    await render(
+      <>
+        <Consumer />
+        <Row chargeId="charge-1" refresh={refresh} />
+      </>,
+    );
+
+    await act(async () => refreshCharges(['charge-1']));
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/providers/charge-refresh.tsx
+++ b/packages/client/src/providers/charge-refresh.tsx
@@ -1,0 +1,101 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+
+// A charge-id → refresh registry for the charges table.
+//
+// Every `ChargeRow` already owns a network-only refetch of its own charge, threaded onto
+// `row.original.onChange` for the actions rendered inside that row. That covers the charge a user
+// acted on, but not the *other* charges a batch mutation touched — most visibly "Approve selected"
+// in the similar-charges dialog, which applies one charge's tags/description to N others that may
+// themselves be rows in the table behind the dialog.
+//
+// Those rows are unreachable from the mutation site: it has charge ids, not rows. The registry
+// closes that gap — each row publishes its refetch under its id, and anything holding a list of
+// mutated ids can refresh whichever of them happen to be on screen. Ids that aren't rendered are
+// silently skipped, so callers never need to know what the table is currently showing.
+
+interface ChargeRefreshContextValue {
+  /** Publishes a charge's refresh handler. Returns the matching unregister. */
+  register: (chargeId: string, refresh: () => void) => () => void;
+  /** Refreshes every one of these charges that is currently rendered; unknown ids are ignored. */
+  refreshCharges: (chargeIds: string[]) => void;
+}
+
+const ChargeRefreshContext = createContext<ChargeRefreshContextValue>({
+  register: () => () => void 0,
+  refreshCharges: () => void 0,
+});
+
+export function ChargeRefreshProvider({ children }: { children: ReactNode }): ReactElement {
+  // A ref, not state: registrations are a side channel between rows and mutation sites, and
+  // re-rendering the whole table whenever a row mounts would be pure cost. A `Set` per id keeps
+  // concurrent registrations for the same charge (a charge rendered twice, or React StrictMode's
+  // double-invoked effects) from clobbering one another.
+  const registry = useRef(new Map<string, Set<() => void>>());
+
+  const register = useCallback((chargeId: string, refresh: () => void) => {
+    const handlers = registry.current.get(chargeId) ?? new Set<() => void>();
+    handlers.add(refresh);
+    registry.current.set(chargeId, handlers);
+
+    return () => {
+      const current = registry.current.get(chargeId);
+      if (!current) {
+        return;
+      }
+      current.delete(refresh);
+      if (current.size === 0) {
+        registry.current.delete(chargeId);
+      }
+    };
+  }, []);
+
+  const refreshCharges = useCallback((chargeIds: string[]) => {
+    for (const chargeId of chargeIds) {
+      // Snapshot before iterating: a refresh handler can drop or replace registrations (a refetch
+      // that removes the row) while we're still walking the set.
+      const handlers = [...(registry.current.get(chargeId) ?? [])];
+      for (const refresh of handlers) {
+        refresh();
+      }
+    }
+  }, []);
+
+  // Both handlers close over the ref alone, so this value is stable for the provider's lifetime.
+  const value = useMemo<ChargeRefreshContextValue>(
+    () => ({ register, refreshCharges }),
+    [register, refreshCharges],
+  );
+
+  return <ChargeRefreshContext.Provider value={value}>{children}</ChargeRefreshContext.Provider>;
+}
+
+/**
+ * Publishes `refresh` as the way to reload `chargeId` for as long as the caller is mounted.
+ *
+ * `refresh` is a dependency on purpose: a row's refetch identity tracks urql's `executeQuery`, so
+ * re-registering when it changes is what keeps the registry from holding a stale handler.
+ */
+export function useRegisterChargeRefresh(chargeId: string, refresh: () => void): void {
+  const { register } = useContext(ChargeRefreshContext);
+
+  useEffect(() => register(chargeId, refresh), [register, chargeId, refresh]);
+}
+
+/**
+ * Returns a stable handler that reloads the given charges wherever they're rendered.
+ *
+ * Safe outside a `ChargeRefreshProvider` — the default context value makes it a no-op, so mutation
+ * hooks can call it unconditionally without caring whether a charges table is on screen.
+ */
+export function useRefreshCharges(): (chargeIds: string[]) => void {
+  return useContext(ChargeRefreshContext).refreshCharges;
+}

--- a/packages/client/src/providers/index.ts
+++ b/packages/client/src/providers/index.ts
@@ -2,3 +2,8 @@ export { UrqlProvider } from './urql.js';
 export { UserContext, UserProvider, type UserInfo } from './user-provider.js';
 export { FiltersContext } from './filters-context.js';
 export { PortalContainerContext, usePortalContainer } from './portal-container.js';
+export {
+  ChargeRefreshProvider,
+  useRefreshCharges,
+  useRegisterChargeRefresh,
+} from './charge-refresh.js';


### PR DESCRIPTION
## Summary

When approving suggestions in the similar-charges dialog, only the charge the user acted on would refresh. Other charges in the batch update would keep their pre-approval values until page reload if they were rows in the same table.

This change introduces a charge-id → refresh registry that allows mutations affecting multiple charges to refresh whichever of them are currently rendered, without needing to know which rows are on screen.

## Key Changes

- **New `ChargeRefreshProvider`** (`packages/client/src/providers/charge-refresh.tsx`): A context-based registry that tracks which charges are rendered and their refresh handlers. Each `ChargeRow` publishes its refetch under its charge id, and mutations can refresh any subset of those ids.

- **`useRegisterChargeRefresh` hook**: Called by `ChargeRow` to publish its refetch handler for the lifetime of the row's mount.

- **`useRefreshCharges` hook**: Called by `useBatchUpdateCharges` to refresh all charges the server reports as updated. Safe outside a provider (no-op), so mutation hooks don't need to know if a charges table is on screen.

- **Updated `useBatchUpdateCharges`**: Now calls `useRefreshCharges` with the ids returned by the batch mutation, refreshing any that are rendered in a charges table.

- **Wrapped `ChargesTable` in `ChargeRefreshProvider`**: Rows publish their refresh handlers into this provider, making them available to mutations.

- **Updated test helpers**: `makeClient` now passes variables to response handlers, and `renderTable` accepts multiple charges for testing scenarios with multiple rows.

## Implementation Details

- The registry uses a `Map<chargeId, Set<refreshHandler>>` to support the same charge rendered multiple times (or React StrictMode's double-invoked effects).
- Handlers are snapshotted before iteration to allow refresh handlers to modify registrations without breaking the loop.
- The registry is per-table, so a screen with two charges tables will only refresh rows in the table the dialog was opened from.
- Comprehensive test coverage in `charge-refresh.test.tsx` validates registration, unregistration, concurrent renders, and handler updates.

https://claude.ai/code/session_01CFgC1ZttaqhBUwAJs84tNV