### PR TITLE
chore(db): pin dev and CI Postgres to 18

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16-alpine
+        image: postgres:18-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ If you want to create new local database, run:
 yarn local:setup
 ```
 
+> **Note:** the local Postgres data directory lives in `docker/.accounter-dev/postgresql/db` and is
+> tied to the major version of the `postgres` image in `docker/docker-compose.dev.yml`. Whenever
+> that major version changes (e.g. 16 → 18), the server refuses to start against the old data
+> directory — delete `docker/.accounter-dev/postgresql/db` and re-run `yarn local:setup`. It is
+> dev-only data.
+
 In case you already have a database, you can set the database variables in your `.env` file, then
 run:
 
@@ -138,9 +144,8 @@ ALLOW_DEMO_SEED=1 yarn test:demo-seed
 
 Integration and demo-seed tests require:
 
-1. **PostgreSQL running**: Start with
-   `docker compose -f docker/docker-compose.dev.yml up -d postgres`
-2. **Migrations applied**: Run `yarn workspace @accounter/migrations migration:run`
+1. **PostgreSQL running**: Start with `docker compose -f docker/docker-compose.dev.yml up -d db`
+2. **Migrations applied**: Run `yarn workspace @accounter-helper/migrations migration:run`
 3. **Demo seed only**: Set `ALLOW_DEMO_SEED=1` environment variable
 
 If migrations are stale, demo-seed tests fail gracefully with instructions to run migrations.

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -14,10 +14,12 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: accounter
-      # postgres:18+ scopes PGDATA by major version (/var/lib/postgresql/18/docker) and
-      # declares its VOLUME at /var/lib/postgresql. Leave PGDATA unset and mount the
-      # parent: /var/lib/postgresql/data is a symlink in these images, so mounting
-      # over it fails at startup.
+      # postgres:18+ images scope PGDATA by major version
+      # (/var/lib/postgresql/<major>/docker) and declare their VOLUME at the parent
+      # /var/lib/postgresql. So: leave PGDATA unset and bind-mount /var/lib/postgresql,
+      # NOT /var/lib/postgresql/data -- the latter is a symlink in these images and
+      # mounting over it fails at startup. This holds for any future major bump; only
+      # the <major> segment of the on-disk path changes (today: db/18/docker).
     volumes:
       - ./.accounter-dev/postgresql/db:/var/lib/postgresql
     ports:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: "1.0"
 name: "accounter-dev"
 services:
   db:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     networks:
       - "stack"
     healthcheck:
@@ -14,9 +14,12 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: accounter
-      PGDATA: /var/lib/postgresql/data
+      # postgres:18+ scopes PGDATA by major version (/var/lib/postgresql/18/docker) and
+      # declares its VOLUME at /var/lib/postgresql. Leave PGDATA unset and mount the
+      # parent: /var/lib/postgresql/data is a symlink in these images, so mounting
+      # over it fails at startup.
     volumes:
-      - ./.accounter-dev/postgresql/db:/var/lib/postgresql/data
+      - ./.accounter-dev/postgresql/db:/var/lib/postgresql
     ports:
       - "5432:5432"
 


### PR DESCRIPTION
Production Postgres is moving from 16 to 18. Dev and CI are pinned independently of production, so they go first — leaving them on 16 means pgTyped checks query types, and tests check behavior, against a parser and planner production no longer runs.

**The SQL in this repo needs no changes to run on 18.** Every PG17/PG18 incompatibility from the upstream release notes was checked against the schema and the server's queries; the codebase avoids essentially all of them for structural reasons (no generated columns, no matviews, no partitioned/inherited tables, no `COPY FROM`, no monitoring-catalog reads in app code, no deferrable triggers). The full audit is in `docs/postgresql-v18-migration.md`.

## Changes

**`docker/docker-compose.dev.yml`** — the one change with a real trap. Bumped to `postgres:18-alpine`, dropped `PGDATA`, and moved the bind mount to the parent `/var/lib/postgresql`. The official `postgres:18` images scope `PGDATA` by major version (`/var/lib/postgresql/18/docker`) and declare their `VOLUME` at `/var/lib/postgresql`, which makes `/var/lib/postgresql/data` a **symlink**. A tag-only bump would mount over that symlink and the container would fail at startup — breaking every CI job that uses `.github/actions/setup` with `localDB`/`pgTyped`, since that action brings this exact compose file up.

**`.github/workflows/server-tests.yml`** — tag bump only. Service containers mount no volume.

**`README.md`** — note that the local data directory must be deleted when the major version changes, plus two commands in the test prerequisites that have never worked: the compose service is `db`, not `postgres`, and the migrations workspace is `@accounter-helper/migrations`, not `@accounter/migrations`.

## Action required for each developer

```sh
rm -rf docker/.accounter-dev/postgresql/db
yarn local:setup
```

An 18 server refuses to start against a 16 data directory regardless of the mount layout. It is dev-only data — nothing to preserve. CI is unaffected; the path is fresh every run.

## Verification

Ran locally against `postgres:18-alpine` (**18.6**), with the data directory landing correctly at `/var/lib/postgresql/18/docker`:

| Check | Result |
| --- | --- |
| `yarn setup` (`db:init` + codegen) | all **202** migrations apply cleanly |
| `yarn test` | 293 files, 3940 passed / 6 skipped |
| `yarn test:integration` | 340 files, 4435 passed / 8 skipped |
| `ALLOW_DEMO_SEED=1 yarn test:demo-seed` | 1 passed (seed + validate) |
| `rls-all-tables.test.ts` | 2 passed |
| `yarn lint` | 0 errors |
| `yarn prettier:check` | clean |

**pgTyped type drift: zero.** Generated files are gitignored, so `git diff` proves nothing here. Instead: a throwaway `postgres:16-alpine` (16.10) was stood up on port 5433, migrated, and codegen re-run against it. A hash over every `__generated__/*.types.ts` is `841666e6…` on both 18 and 16 — byte-identical.

The real CI signal on this PR is any workflow using `.github/actions/setup` with `localDB`/`pgTyped`, since that is the one that would fail on the PGDATA symlink.

## Scope

Part 1 of `docs/postgresql-v18-migration.md` only. Part 2 (the Render upgrade runbook: collation-provider check and `pg_trgm` reindex decision, `ALTER EXTENSION`, `ANALYZE`, re-asserting the RLS invariants) and Part 3 (`uuidv7()` PK defaults, `WITHOUT OVERLAPS` on `clients_contracts`, `NOT NULL NOT VALID`, skip-scan measurements) are separate PRs. No changeset: nothing under `packages/**` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
