### PR TITLE
perf(migrations): add GIN trigram index on financial_entities.name

### DIFF
--- a/.changeset/financial-entities-name-trigram-index.md
+++ b/.changeset/financial-entities-name-trigram-index.md
@@ -1,0 +1,16 @@
+---
+'@accounter/server': patch
+---
+
+Add a GIN trigram index on `accounter_schema.financial_entities.name`.
+
+The charge free-text filter matches counterparty names with a leading-wildcard `ILIKE '%…%'` in six
+branches of the `search_matches` / `excluded_matches` CTEs. The only index on that column was a
+plain btree (`financial_entities_name_index`), which cannot serve `'%…%'` patterns, so every one of
+those branches fell back to a sequential scan of `financial_entities` — the one hot search column
+the original `pg_trgm` work missed.
+
+The new `idx_financial_entities_name_trgm` is built with `CREATE INDEX CONCURRENTLY`, so it does not
+lock `financial_entities` against writes while it builds. The existing btree is kept: it still
+serves equality, prefix and ordering lookups. Query behaviour is unchanged — this is a pure index
+addition.

--- a/packages/migrations/src/actions/2026-08-31T11-00-00.index-financial-entity-names.ts
+++ b/packages/migrations/src/actions/2026-08-31T11-00-00.index-financial-entity-names.ts
@@ -1,6 +1,17 @@
 import { sql } from 'slonik';
 import { type MigrationExecutor } from '../pg-migrator.js';
 
+/**
+ * Add a GIN trigram index on accounter_schema.financial_entities.name.
+ *
+ * The charge free-text filter matches counterparty names with a leading-wildcard ILIKE
+ * in six branches of the search_matches / excluded_matches CTEs (charges.provider.ts).
+ * The pre-existing financial_entities_name_index is a plain btree, which cannot serve
+ * '%...%' patterns, so those branches fell back to a sequential scan. pg_trgm is already
+ * installed by 2026-03-23T12-00-00.index-search-strings.sql.
+ *
+ * The existing btree is kept: it still serves equality, prefix and ordering lookups.
+ */
 export default {
   name: '2026-08-31T11-00-00.index-financial-entity-names.sql',
   // CREATE INDEX CONCURRENTLY cannot run inside a transaction block, so this migration
@@ -8,13 +19,34 @@ export default {
   // an ACCESS EXCLUSIVE lock on financial_entities while production writes continue.
   noTransaction: true,
   run: async ({ connection }) => {
-    // financial_entities.name is searched with a leading-wildcard ILIKE from the charge
-    // free-text filter (search_matches / excluded_matches in charges.provider.ts). The
-    // pre-existing financial_entities_name_index is a plain btree, which cannot serve
-    // '%...%' patterns, so those branches fell back to a sequential scan. pg_trgm is
-    // already installed by 2026-03-23T12-00-00.index-search-strings.sql.
-    await connection.query(
-      sql.unsafe`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_financial_entities_name_trgm ON accounter_schema.financial_entities USING gin (name gin_trgm_ops)`,
-    );
+    // A CONCURRENTLY build that fails part-way (deadlock, cancelled statement, dropped
+    // connection) leaves the index behind with indisvalid = false. The planner ignores
+    // such an index, but IF NOT EXISTS below matches on name alone and would silently
+    // no-op on the retry -- recording this migration as applied while the index stays
+    // unusable. So drop an invalid leftover first. NOT indisvalid also covers the
+    // mirror case of a failed DROP INDEX CONCURRENTLY (indisvalid and indisready both
+    // false); either way the index has to be rebuilt.
+    const hasInvalidIndex = await connection.maybeOneFirst(sql.unsafe`
+      SELECT true
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'accounter_schema'
+        AND c.relname = 'idx_financial_entities_name_trgm'
+        AND NOT i.indisvalid
+    `);
+
+    // Conditional on purpose: an unconditional drop would tear down and rebuild a
+    // perfectly good index every time the migration history is replayed.
+    if (hasInvalidIndex === true) {
+      await connection.query(sql.unsafe`
+        DROP INDEX CONCURRENTLY IF EXISTS accounter_schema.idx_financial_entities_name_trgm
+      `);
+    }
+
+    await connection.query(sql.unsafe`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_financial_entities_name_trgm
+        ON accounter_schema.financial_entities USING gin (name gin_trgm_ops)
+    `);
   },
 } satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2026-08-31T11-00-00.index-financial-entity-names.ts
+++ b/packages/migrations/src/actions/2026-08-31T11-00-00.index-financial-entity-names.ts
@@ -1,0 +1,20 @@
+import { sql } from 'slonik';
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+export default {
+  name: '2026-08-31T11-00-00.index-financial-entity-names.sql',
+  // CREATE INDEX CONCURRENTLY cannot run inside a transaction block, so this migration
+  // opts out of the wrapping transaction. In exchange, building the index does not hold
+  // an ACCESS EXCLUSIVE lock on financial_entities while production writes continue.
+  noTransaction: true,
+  run: async ({ connection }) => {
+    // financial_entities.name is searched with a leading-wildcard ILIKE from the charge
+    // free-text filter (search_matches / excluded_matches in charges.provider.ts). The
+    // pre-existing financial_entities_name_index is a plain btree, which cannot serve
+    // '%...%' patterns, so those branches fell back to a sequential scan. pg_trgm is
+    // already installed by 2026-03-23T12-00-00.index-search-strings.sql.
+    await connection.query(
+      sql.unsafe`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_financial_entities_name_trgm ON accounter_schema.financial_entities USING gin (name gin_trgm_ops)`,
+    );
+  },
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -202,6 +202,7 @@ import migration_2026_08_14T10_00_00_poalim_securities_transactions_calendar_dat
 import migration_2026_08_20T10_00_00_add_security_businesses from './actions/2026-08-20T10-00-00.add-security-businesses.js';
 import migration_2026_08_23T10_00_00_rls_scope_securities_tables from './actions/2026-08-23T10-00-00.rls-scope-securities-tables.js';
 import migration_2026_08_31T10_00_00_add_tenant_scoped_date_indexes from './actions/2026-08-31T10-00-00.add-tenant-scoped-date-indexes.js';
+import migration_2026_08_31T11_00_00_index_financial_entity_names from './actions/2026-08-31T11-00-00.index-financial-entity-names.js';
 import { runMigrations } from './pg-migrator.js';
 
 export const MIGRATIONS = [
@@ -408,6 +409,7 @@ export const MIGRATIONS = [
   migration_2026_08_20T10_00_00_add_security_businesses,
   migration_2026_08_23T10_00_00_rls_scope_securities_tables,
   migration_2026_08_31T10_00_00_add_tenant_scoped_date_indexes,
+  migration_2026_08_31T11_00_00_index_financial_entity_names,
 ] as const;
 
 export const LATEST_MIGRATION_NAME = MIGRATIONS[MIGRATIONS.length - 1]?.name;


### PR DESCRIPTION
## Context

A review flagged that `financial_entities.name` is searched with a leading-wildcard `ILIKE '%…%'` but has no trigram index. I verified the claim — it holds on every checkable point:

- `packages/migrations/src/actions/2026-03-23T12-00-00.index-search-strings.ts` is the only file in the repo mentioning `pg_trgm`. It enables the extension and creates six GIN trigram indexes (`charges.user_description`, `transactions.source_description`, `transactions.source_reference`, `documents.description`, `documents.remarks`, `documents.serial_number`). `financial_entities.name` is not among them.
- The only index on that column is `financial_entities_name_index`, a plain non-unique **btree** from `2024-01-29T13-15-23.initial.ts:1193-1194`. A btree cannot serve `'%…%'`.
- All nine `ILIKE` sites the review cited are genuinely `accounter_schema.financial_entities.name` — not `businesses.name`, which was dropped from the subtype tables in `2024-02-26T11-01-45.centralize-financial-entities-shared-columns.ts`. `financial_entities` is a plain table (no `INHERITS`) sharing a PK with `businesses` / `tax_categories`, so a single index covers every counterparty-name search in the codebase.
- `pg_trgm` is already installed, so no extension work is needed.

## Changes

- New migration `packages/migrations/src/actions/2026-08-31T11-00-00.index-financial-entity-names.ts` creating `idx_financial_entities_name_trgm` — `USING gin (name gin_trgm_ops)`, name following the existing `idx_<table>_<col>_trgm` convention.
- Registered in `packages/migrations/src/run-pg-migrations.ts` (import + last entry of `MIGRATIONS`, which `LATEST_MIGRATION_NAME` derives from).
- Changeset: `patch` on `@accounter/server`, matching how the 2026-03-23 trigram work was recorded.

Built with `CREATE INDEX CONCURRENTLY` + `noTransaction: true`, following `2026-02-19T14-00-00.add-owner-id-indexes.ts` rather than the in-transaction style of the 2026-03-23 trigram migration — so it does not hold an `ACCESS EXCLUSIVE` lock on `financial_entities` while it builds. The existing btree is kept; it still serves equality, prefix and ordering lookups.

Pure index addition — no query or result-set changes.

### Invalid-index safety on retry

Per review feedback, the migration first probes `pg_index` for an *invalid* index of that name and `DROP INDEX CONCURRENTLY`s it before creating. Without that, a `CONCURRENTLY` build that fails part-way leaves the index with `indisvalid = false`; `IF NOT EXISTS` matches on name alone, so the retry would silently no-op and `runMigration` would record the migration as applied while the planner ignores the index. The drop is conditional on purpose — an unconditional drop-then-create would rebuild a healthy index on every replay of the migration history.

## One refinement to the review's framing

The index is only actually *usable* by six of the nine cited sites — the `search_matches` / `excluded_matches` CTE branches in `charges.provider.ts` (L250-265, L306-319). There `fe` is scanned as its own relation with `fe.name ILIKE …` as a base restriction, so the planner can use a bitmap index scan and drive the join from a small id set. That is the hot path the 2026-03-23 PR was built around — its own comment at `charges.provider.ts:213` reads *"Strategy: Identify IDs via Trigram indexes before doing any heavy math"*, while three of that CTE's eight branches were scanning an unindexed column.

The other three cannot use any index on that column, whatever we build:

- `transactions.provider.ts:87` — `fe.name ILIKE …` sits in an `OR` chain that also spans `t.*` columns across a `LEFT JOIN`. A cross-relation `OR` is a join filter; no index applies.
- `documents.provider.ts:269,273` — correlated `EXISTS (… WHERE fe.id = documents.creditor_id AND fe.name ILIKE …)`. The subplan already resolves to one row via the PK, so the `ILIKE` is a single-row filter.

Fixing those two query shapes is a behaviour-sensitive rewrite and is deliberately out of scope here — see follow-ups.

## Verification

Static checks all pass:

- `yarn migration:check-conflicts` → *OK: PR additions: 1, base additions since merge-base: 0*
- `tsc --noEmit` on the migrations package → clean
- `yarn eslint` and `yarn prettier --check` on the changed files → clean

**Not yet verified against a live database.** The sandbox has no Docker daemon and starting a local cluster was not permitted, so the following still needs a run on the dev stack before merge:

```bash
docker compose -f docker/docker-compose.dev.yml up -d --wait db
yarn workspace @accounter/migrations migration:run
```

```sql
\d+ accounter_schema.financial_entities   -- expect idx_financial_entities_name_trgm, gin

EXPLAIN (ANALYZE, BUFFERS)
SELECT t.charge_id FROM accounter_schema.transactions t
JOIN accounter_schema.financial_entities fe ON fe.id = t.business_id
WHERE fe.name ILIKE '%acme%';
```

Expect `Bitmap Index Scan on idx_financial_entities_name_trgm` rather than `Seq Scan on financial_entities`. Two things worth checking specifically, because either would silently negate the win:

1. **RLS interaction.** `financial_entities` has RLS enabled *and forced* (`2026-05-12T09-00-00.enable-rls-all-tables.ts:43`), predicate `owner_id = ANY (accounter_schema.get_current_business_scope())` (`2026-05-25T10-00-00.rls-multi-business-scope.ts:108`). Postgres will not promote a non-leakproof qual into an index condition below a security qual, and whether `texticlike` qualifies varies by server version. Run the `EXPLAIN` **as the application role with a business scope set**, not as superuser — a superuser gives a misleadingly good plan.
2. **Short terms.** GIN trigram cannot help patterns under 3 characters; use a ≥3-char term.

The retry-safety path is also reproducible on a live database: forge an invalid index (`CREATE INDEX …` then `UPDATE pg_index SET indisvalid = false WHERE indexrelid = 'accounter_schema.idx_financial_entities_name_trgm'::regclass`), delete the migration's row from `accounter_schema.migration`, re-run the migration, and confirm `indisvalid` comes back `true`. Before this change it stays `false` while the migration records as applied.

## Rebase note

Rebased onto `main` at e6d67f3. `main` had meanwhile added `2026-08-31T10-00-00.add-tenant-scoped-date-indexes.ts` (#4331) at the **same timestamp** as this migration, which conflicted in the `MIGRATIONS` array. Resolved by keeping both and renaming this one to `2026-08-31T11-00-00` so ordering is unambiguous — it is not yet merged, so the README rule against renaming merged migrations does not apply. The two are complementary: #4331 adds composite `(owner_id, <date>)` indexes for the now-sargable date filters; this one adds the trigram index for name search. Re-verified after the rebase that all nine `fe.name ILIKE` sites are unchanged and this is still the only trigram index on `financial_entities`.

## Follow-ups (not in this PR)

**F1. Restructure the `transactions` free-text predicate — highest value.** `transactions.provider.ts:80-93` is one `OR` chain mixing `t.*` columns with `fe.name` across a `LEFT JOIN`. Because a cross-relation `OR` is a join filter, **none** of those predicates can use an index — including `idx_trans_src_trgm` and `idx_trans_src_ref_trgm`, which already exist and are dead in this query. Every free-text transaction search is a full scan today. Fix: mirror the UNION-of-CTEs shape `charges.provider.ts:230-268` already uses — one single-relation `SELECT t.id FROM …` branch per column, then `INNER JOIN`. Keep the per-branch `$freeText IS NULL` guard, and preserve `LEFT JOIN` semantics (rows with `business_id IS NULL` must still match on their own columns).

**F2. Restructure the `documents` free-text predicate.** `documents.provider.ts:255-275`, same problem plus the correlated `EXISTS` subqueries. Rewriting to the CTE shape turns each into `SELECT d.id FROM documents d JOIN financial_entities fe ON fe.id = d.creditor_id WHERE fe.name ILIKE …`, which *does* hit the index this PR adds. Do F1 first; this is the same transformation applied twice (creditor + debtor).

**F3. Trigram indexes for `transactions.counter_account` and `transactions.origin_key`** (`transactions.provider.ts:85-86`) — also missed by the 2026-03-23 batch. **Do not add until F1 lands**: while the `OR` chain stands they would be dead indexes carrying write cost for no read benefit.

**F4. Confirm the existing six trigram indexes are actually used under RLS.** If the `EXPLAIN` above shows the new index skipped when run as the application role, then `idx_charges_desc_trgm`, `idx_docs_desc_trgm` and the rest are almost certainly skipped too, and the whole 2026-03-23 effort is inert in production. That would be a considerably bigger finding than the missing index.

**F5. The invalid-index retry trap is not unique to this migration.** `2026-02-19T14-00-00.add-owner-id-indexes.ts` (42 calls) and the newly merged `2026-08-31T10-00-00.add-tenant-scoped-date-indexes.ts` (4 calls) both use bare `CREATE INDEX CONCURRENTLY IF NOT EXISTS` and carry the same silent-no-op-on-retry behaviour fixed here. Both are merged, so `packages/migrations/README.md` rule 2 puts them out of scope for this PR. Worth either a repair migration that revalidates any invalid index, or a shared helper so future `CONCURRENTLY` migrations get this for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WccZoRRc6XCWuP7hemVLs4