### PR TITLE
fix(client): render cleared charges filters as cleared

### DIFF
--- a/.changeset/charges-filters-cleared-fields.md
+++ b/.changeset/charges-filters-cleared-fields.md
@@ -1,0 +1,30 @@
+---
+'@accounter/client': patch
+---
+
+Fix charges filter fields re-rendering the values they were just cleared of.
+
+Reported against the entities section: apply a filter with one or more financial entities, reopen
+the modal, remove every selected entity — and the picker repopulates with the entities that were
+just removed. Applying from there filtered *without* them, so the form was showing one thing and
+submitting another.
+
+`FormField` is shadcn's wrapper around react-hook-form's `Controller`, which resolves the rendered
+value as `get(_formValues, name, X)`, where `X` is the value the field held when it mounted and
+`get` falls back to `X` whenever the stored value is `undefined`. Every field in this modal clears
+itself to exactly that `undefined` — an empty array is not "unset": `JSON.stringify` keeps `[]`, so
+it would churn the URL and light up the trigger badge. Clearing a field therefore re-armed the
+fallback and re-rendered the value the modal opened with, while the form state — and so the applied
+filter — correctly held nothing. It only bit on a second visit, because on a first visit the
+mount-time value is empty too.
+
+The displayed value now comes from a new `useFilterValue` — `useWatch` with no `defaultValue`,
+which carries no such fallback — rather than from the controller. The form's `undefined`
+representation is unchanged, so `formValuesToFilter`, the active-filter counts and the URL encoding
+are untouched.
+
+The same fallback sat under every other field in the modal, all fixed here: financial accounts,
+tags, owners, business trips, charge types, accountant status, the two free-text inputs, both dates
+and the nine completeness switches. It also defeated **Reset** and **Clear all**, which call
+`form.reset()` and so write the same `undefined` — any field holding a value when the modal opened
+kept displaying it after the reset.

--- a/packages/client/src/components/charges/charges-filters/__tests__/cleared-filter-fields.test.tsx
+++ b/packages/client/src/components/charges/charges-filters/__tests__/cleared-filter-fields.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useForm, type UseFormReturn } from 'react-hook-form';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Form } from '../../../ui/form.js';
+import { buildEmptyFormValues } from '../constants.js';
+import { FreeTextField } from '../free-text-field.js';
+import { NegatableMultiSelectField } from '../negatable-multi-select-field.js';
+import type { ChargeFilterFormValues } from '../schema.js';
+import { CompletenessSection } from '../sections/completeness-section.js';
+import { DateRangeSection } from '../sections/date-range-section.js';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const OPTIONS = [
+  { value: 'biz-1', label: 'Business 1' },
+  { value: 'biz-2', label: 'Business 2' },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+let form: UseFormReturn<ChargeFilterFormValues>;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/**
+ * The bug only exists relative to a value the field already had: react-hook-form's
+ * controller falls back to whatever the field held when it mounted. So every case here
+ * opens the form on an applied filter, exactly as the modal does on a second visit.
+ */
+function renderWith(
+  values: Partial<ChargeFilterFormValues>,
+  body: (control: UseFormReturn<ChargeFilterFormValues>['control']) => ReactElement,
+): void {
+  function Harness(): ReactElement {
+    form = useForm<ChargeFilterFormValues>({
+      defaultValues: { ...buildEmptyFormValues(), ...values },
+    });
+    return <Form {...form}>{body(form.control)}</Form>;
+  }
+  act(() => root.render(<Harness />));
+}
+
+function renderEntities(values: Partial<ChargeFilterFormValues>): void {
+  renderWith(values, control => (
+    <NegatableMultiSelectField
+      control={control}
+      include="byBusinesses"
+      exclude="excludedBusinesses"
+      label="Financial Entities"
+      options={OPTIONS}
+      placeholder="All counterparties"
+    />
+  ));
+}
+
+const chipLabels = (): string[] =>
+  [...container.querySelectorAll('span.truncate')].map(node => node.textContent ?? '');
+
+function click(selector: string): void {
+  const target = container.querySelector(selector);
+  expect(target, `no element matching ${selector}`).not.toBeNull();
+  act(() => {
+    target!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+describe('clearing a filter that was applied when the form opened', () => {
+  it('empties the entities picker and the form state together', () => {
+    renderEntities({ byBusinesses: ['biz-1'] });
+    expect(chipLabels()).toEqual(['Business 1']);
+
+    click('button[aria-label="Remove Business 1"]');
+
+    // The regression: the picker used to re-render "Business 1" from the controller's
+    // mount-time fallback while the form state held nothing, so Apply sent an unfiltered
+    // query. Display and form state have to agree.
+    expect(chipLabels()).toEqual([]);
+    expect(container.textContent).toContain('All counterparties');
+    expect(form.getValues('byBusinesses')).toBeUndefined();
+  });
+
+  it('empties the exclude leg the same way', () => {
+    renderEntities({ excludedBusinesses: ['biz-2'] });
+    expect(chipLabels()).toEqual(['Business 2']);
+
+    click('button[aria-label="Remove Business 2"]');
+
+    expect(chipLabels()).toEqual([]);
+    expect(form.getValues('excludedBusinesses')).toBeUndefined();
+  });
+
+  it('keeps the values it did not clear', () => {
+    renderEntities({ byBusinesses: ['biz-1', 'biz-2'] });
+
+    click('button[aria-label="Remove Business 1"]');
+
+    expect(chipLabels()).toEqual(['Business 2']);
+    expect(form.getValues('byBusinesses')).toEqual(['biz-2']);
+  });
+
+  // "Clear all" and "Reset" both go through form.reset(), which writes the same
+  // `undefined` the controller falls back over.
+  it('empties the picker when the form is reset', () => {
+    renderEntities({ byBusinesses: ['biz-1'], excludedBusinesses: ['biz-2'] });
+    expect(chipLabels()).toEqual(['Business 1', 'Business 2']);
+
+    act(() => form.reset(buildEmptyFormValues()));
+
+    expect(chipLabels()).toEqual([]);
+    expect(container.textContent).toContain('All counterparties');
+  });
+
+  // Same fallback, non-array fields: these clear from the header chips, which call
+  // setValue(name, undefined).
+  it('empties the free text input', () => {
+    renderWith({ freeText: 'coffee' }, control => <FreeTextField control={control} />);
+    expect(container.querySelector<HTMLInputElement>('#charges-free-text')?.value).toBe('coffee');
+
+    act(() => form.setValue('freeText', undefined, { shouldDirty: true }));
+
+    expect(container.querySelector<HTMLInputElement>('#charges-free-text')?.value).toBe('');
+  });
+
+  it('empties a date input', () => {
+    renderWith({ fromAnyDate: '2026-01-01' }, control => <DateRangeSection control={control} />);
+    expect(container.querySelector<HTMLInputElement>('#from-any-date')?.value).toBe('2026-01-01');
+
+    act(() => form.setValue('fromAnyDate', undefined, { shouldDirty: true }));
+
+    expect(container.querySelector<HTMLInputElement>('#from-any-date')?.value).toBe('');
+  });
+
+  it('switches a completeness toggle back off', () => {
+    renderWith({ withoutInvoice: true }, control => <CompletenessSection control={control} />);
+    const toggle = (): Element | null => container.querySelector('[role="switch"]');
+    expect(toggle()?.getAttribute('aria-checked')).toBe('true');
+
+    act(() => form.setValue('withoutInvoice', undefined, { shouldDirty: true }));
+
+    expect(toggle()?.getAttribute('aria-checked')).toBe('false');
+  });
+});

--- a/packages/client/src/components/charges/charges-filters/free-text-field.tsx
+++ b/packages/client/src/components/charges/charges-filters/free-text-field.tsx
@@ -23,6 +23,9 @@ export function FreeTextField({
   const excludedFreeText = useWatch({ control, name: 'excludedFreeText' });
   const excluding = !!excludedFreeText;
   const activeField = excluding ? 'excludedFreeText' : 'freeText';
+  // Not `field.value`: clearing the input writes `undefined`, and the controller's own
+  // value falls back to whatever the field held when the modal opened.
+  const activeValue = excluding ? excludedFreeText : freeText;
 
   function flip(): void {
     const text = excluding ? excludedFreeText : freeText;
@@ -73,7 +76,7 @@ export function FreeTextField({
                 <Input
                   {...field}
                   id="charges-free-text"
-                  value={field.value ?? ''}
+                  value={activeValue ?? ''}
                   onChange={(event): void => field.onChange(event.target.value || undefined)}
                   placeholder={
                     excluding

--- a/packages/client/src/components/charges/charges-filters/negatable-multi-select-field.tsx
+++ b/packages/client/src/components/charges/charges-filters/negatable-multi-select-field.tsx
@@ -4,6 +4,7 @@ import type { NegatableMultiSelectOption } from '../../common/inputs/negatable-m
 import { NegatableMultiSelect } from '../../common/inputs/negatable-multi-select.js';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import type { ChargeFilterFormValues } from './schema.js';
+import { useFilterValue } from './use-filter-value.js';
 
 /** The include/exclude field pairs the schema supports. */
 type NegatableFieldPair =
@@ -24,10 +25,14 @@ type SharedProps = {
   disabled?: boolean;
 };
 
+/** Stable identity for the "nothing selected" case, so it isn't a fresh array per render. */
+const EMPTY_LIST: string[] = [];
+
 /**
  * An empty array is not the same as "unset": JSON.stringify keeps `[]` but drops
  * `undefined`, so a stray empty array churns the URL and makes an otherwise empty
- * filter look active.
+ * filter look active. `useFilterValue` is what keeps the cleared field rendering as
+ * cleared despite that — see the comment there.
  */
 const orUndefined = (values: string[]): string[] | undefined =>
   values.length > 0 ? values : undefined;
@@ -38,6 +43,9 @@ const orUndefined = (values: string[]): string[] | undefined =>
  * prop, which is invoked as a function rather than mounted as a component. The
  * include leg stays a `FormField` because that is what installs the context
  * `FormLabel` / `FormControl` / `FormMessage` depend on.
+ *
+ * Both legs render from `useFilterValue` rather than from the controller's own value,
+ * which falls back to whatever the field held when the modal opened.
  */
 export function NegatableMultiSelectField({
   control,
@@ -53,6 +61,8 @@ export function NegatableMultiSelectField({
   renderOption,
 }: NegatableFieldPair & SharedProps): ReactElement {
   const { field: excluded } = useController({ control, name: exclude });
+  const includedValue = useFilterValue(control, include) ?? EMPTY_LIST;
+  const excludedValue = useFilterValue(control, exclude) ?? EMPTY_LIST;
 
   return (
     <FormField
@@ -67,9 +77,9 @@ export function NegatableMultiSelectField({
               onBlur={field.onBlur}
               negatable
               options={options}
-              value={field.value ?? []}
+              value={includedValue}
               onValueChange={(next): void => field.onChange(orUndefined(next))}
-              excludedValue={excluded.value ?? []}
+              excludedValue={excludedValue}
               onExcludedChange={(next): void => excluded.onChange(orUndefined(next))}
               loading={loading}
               placeholder={placeholder}
@@ -101,6 +111,8 @@ export function MultiSelectField({
   renderOption,
   disabled,
 }: SharedProps & { name: PlainField }): ReactElement {
+  const value = useFilterValue(control, name) ?? EMPTY_LIST;
+
   return (
     <FormField
       control={control}
@@ -113,7 +125,7 @@ export function MultiSelectField({
               ref={field.ref}
               onBlur={field.onBlur}
               options={options}
-              value={field.value ?? []}
+              value={value}
               onValueChange={(next): void => field.onChange(orUndefined(next))}
               loading={loading}
               disabled={disabled}

--- a/packages/client/src/components/charges/charges-filters/sections/classification-section.tsx
+++ b/packages/client/src/components/charges/charges-filters/sections/classification-section.tsx
@@ -8,6 +8,7 @@ import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../
 import { chargesTypeFilterOptions, chargeTypeNameOptions } from '../constants.js';
 import { MultiSelectField } from '../negatable-multi-select-field.js';
 import type { ChargeFilterFormValues } from '../schema.js';
+import { useFilterValue } from '../use-filter-value.js';
 
 const ACCOUNTANT_STATUSES: AccountantStatus[] = [
   AccountantStatus.Approved,
@@ -15,11 +16,18 @@ const ACCOUNTANT_STATUSES: AccountantStatus[] = [
   AccountantStatus.Unapproved,
 ];
 
+/** Stable identity for the "nothing selected" case, so it isn't a fresh array per render. */
+const EMPTY_STATUSES: AccountantStatus[] = [];
+
 export function ClassificationSection({
   control,
 }: {
   control: Control<ChargeFilterFormValues>;
 }): ReactElement {
+  // Cleared to `undefined` below, which is exactly what makes the controller's own
+  // value fall back to whatever the field held when the modal opened.
+  const accountantStatus = useFilterValue(control, 'accountantStatus') ?? EMPTY_STATUSES;
+
   return (
     <>
       <FormField
@@ -73,7 +81,7 @@ export function ClassificationSection({
                 {ACCOUNTANT_STATUSES.map(status => {
                   const option = accountantApprovalOptions[status];
                   const ApprovalIcon = option.icon;
-                  const selected = (field.value ?? []).includes(status);
+                  const selected = accountantStatus.includes(status);
                   return (
                     <Button
                       key={status}
@@ -85,10 +93,9 @@ export function ClassificationSection({
                         selected ? 'border-primary bg-accent' : option.bgColor,
                       )}
                       onClick={(): void => {
-                        const current = field.value ?? [];
                         const next = selected
-                          ? current.filter(item => item !== status)
-                          : [...current, status];
+                          ? accountantStatus.filter(item => item !== status)
+                          : [...accountantStatus, status];
                         field.onChange(next.length > 0 ? next : undefined);
                       }}
                     >

--- a/packages/client/src/components/charges/charges-filters/sections/completeness-section.tsx
+++ b/packages/client/src/components/charges/charges-filters/sections/completeness-section.tsx
@@ -73,7 +73,7 @@ function ToggleRow({
             {/* Controlled, so form.reset() from Reset / Clear all moves the switch. */}
             <Switch
               checked={checked}
-              onCheckedChange={(checked): void => field.onChange(checked || undefined)}
+              onCheckedChange={(next): void => field.onChange(next || undefined)}
             />
           </FormControl>
         </FormItem>

--- a/packages/client/src/components/charges/charges-filters/sections/completeness-section.tsx
+++ b/packages/client/src/components/charges/charges-filters/sections/completeness-section.tsx
@@ -6,6 +6,7 @@ import { Switch } from '../../../ui/switch.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../ui/tooltip.js';
 import type { COMPLETENESS_KEYS } from '../counts.js';
 import type { ChargeFilterFormValues } from '../schema.js';
+import { useFilterValue } from '../use-filter-value.js';
 
 type ToggleKey = (typeof COMPLETENESS_KEYS)[number];
 type ToggleDef = { name: ToggleKey; label: string; tooltip?: string };
@@ -41,6 +42,10 @@ function ToggleRow({
   control: Control<ChargeFilterFormValues>;
   def: ToggleDef;
 }): ReactElement {
+  // Switching a toggle off writes `undefined`, which is exactly what makes the
+  // controller's own value fall back to the state the modal opened with.
+  const checked = useFilterValue(control, def.name) ?? false;
+
   return (
     <FormField
       control={control}
@@ -67,7 +72,7 @@ function ToggleRow({
           <FormControl>
             {/* Controlled, so form.reset() from Reset / Clear all moves the switch. */}
             <Switch
-              checked={field.value ?? false}
+              checked={checked}
               onCheckedChange={(checked): void => field.onChange(checked || undefined)}
             />
           </FormControl>

--- a/packages/client/src/components/charges/charges-filters/sections/date-range-section.tsx
+++ b/packages/client/src/components/charges/charges-filters/sections/date-range-section.tsx
@@ -6,6 +6,7 @@ import { Button } from '../../../ui/button.js';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../../ui/form.js';
 import { DATE_PRESETS } from '../constants.js';
 import type { ChargeFilterFormValues } from '../schema.js';
+import { useFilterValue } from '../use-filter-value.js';
 
 export function DateRangeSection({
   control,
@@ -13,6 +14,11 @@ export function DateRangeSection({
   control: Control<ChargeFilterFormValues>;
 }): ReactElement {
   const { setValue } = useFormContext<ChargeFilterFormValues>();
+  // Clearing a date — from the picker, the "No range" preset or a header chip — writes
+  // `undefined`, which is exactly what makes the controller's own value fall back to
+  // whatever the field held when the modal opened.
+  const fromAnyDate = useFilterValue(control, 'fromAnyDate') as TimelessDateString | undefined;
+  const toAnyDate = useFilterValue(control, 'toAnyDate') as TimelessDateString | undefined;
 
   return (
     <>
@@ -46,9 +52,9 @@ export function DateRangeSection({
               <FormControl>
                 <DatePickerInput
                   id="from-any-date"
-                  value={(field.value ?? undefined) as TimelessDateString | undefined}
+                  value={fromAnyDate}
                   onChange={(date): void => {
-                    if (date !== field.value) field.onChange(date ?? undefined);
+                    if (date !== fromAnyDate) field.onChange(date ?? undefined);
                   }}
                   aria-invalid={!!fieldState.error}
                 />
@@ -66,9 +72,9 @@ export function DateRangeSection({
               <FormControl>
                 <DatePickerInput
                   id="to-any-date"
-                  value={(field.value ?? undefined) as TimelessDateString | undefined}
+                  value={toAnyDate}
                   onChange={(date): void => {
-                    if (date !== field.value) field.onChange(date ?? undefined);
+                    if (date !== toAnyDate) field.onChange(date ?? undefined);
                   }}
                   aria-invalid={!!fieldState.error}
                 />

--- a/packages/client/src/components/charges/charges-filters/use-filter-value.ts
+++ b/packages/client/src/components/charges/charges-filters/use-filter-value.ts
@@ -1,0 +1,25 @@
+import { useWatch, type Control, type FieldPath, type FieldPathValue } from 'react-hook-form';
+import type { ChargeFilterFormValues } from './schema.js';
+
+/**
+ * The value a filter field should render.
+ *
+ * react-hook-form resolves a controller's value as `get(_formValues, name, X)`, where `X`
+ * is the value the field held when it mounted — and `get` falls back to `X` whenever the
+ * stored value is `undefined`. Every field in this modal clears itself to `undefined`
+ * (an empty array is not "unset": it would churn the URL and light up the trigger badge),
+ * so a field emptied inside a modal opened on an applied filter re-renders what the modal
+ * opened with, while the form state holds nothing — the input shows entities that Apply
+ * will not send. `useWatch` without a `defaultValue` carries no such fallback, so cleared
+ * renders as cleared. It is also what makes Reset and Clear all, which write the same
+ * `undefined`, visibly empty a field.
+ *
+ * Before the form mounts, `_getWatch` reads `_defaultValues` for a string name, so a
+ * filter that was already applied when the modal opened still paints on the first render.
+ */
+export function useFilterValue<TName extends FieldPath<ChargeFilterFormValues>>(
+  control: Control<ChargeFilterFormValues>,
+  name: TName,
+): FieldPathValue<ChargeFilterFormValues, TName> | undefined {
+  return useWatch({ control, name }) as FieldPathValue<ChargeFilterFormValues, TName> | undefined;
+}


### PR DESCRIPTION
## The bug

Reported against the entities section of the charges filter modal:

1. Apply a filter with one or more financial entities.
2. Reopen the filter modal.
3. Remove all selected entities.
4. The input repopulates with the entities that were just removed.

Applying from there filters *without* those entities — so the form shows one thing and submits
another.

## Root cause

`FormField` is shadcn's wrapper around react-hook-form's `Controller` → `useController`, which
resolves the rendered value as:

```ts
// useController.ts — the fallback is the value the field held when it mounted
const defaultValueMemo = get(control._formValues, name, get(control._defaultValues, name, defaultValue));
const value = useWatch({ control, name, defaultValue: defaultValueMemo });

// useWatch.ts — and it is frozen in a ref
const _defaultValue = React.useRef(defaultValue);

// get.ts — the fallback is used whenever the stored value is undefined
return isUndefined(result) ? defaultValue : result;
```

Every field in this modal deliberately clears itself to `undefined` (`orUndefined()`,
`next.length > 0 ? next : undefined`, `value || undefined`, `checked || undefined`) — an empty array
is not "unset": `JSON.stringify` keeps `[]`, so it would churn the URL and light up the trigger
badge. That `undefined` is exactly what re-arms the stale fallback:

- `_formValues.byBusinesses` really is `undefined` → `formValuesToFilter` sends nothing → the
  applied filter is correct.
- The picker re-renders the entities the modal opened with.

It only bites on a second visit, which is why steps 1–2 of the repro are required: on a first visit
the mount-time value is empty too.

The same fallback also defeated **Reset** and **Clear all**, which call `form.reset()` and write the
same `undefined` — any field that held a value when the modal opened kept displaying it after the
reset.

## The fix

A new `useFilterValue` (`useWatch` with no `defaultValue`, which carries no such fallback) supplies
the *displayed* value; the controller keeps `ref` / `onBlur` / `onChange`. Before the form mounts,
`_getWatch` reads `_defaultValues` for a string name, so a filter that was already applied when the
modal opened still paints correctly on the first render.

The form's `undefined` representation is unchanged, so `formValuesToFilter`, the active-filter
counts and the URL encoding are untouched. `active-filter-chips.tsx` needed no change — its
name-less `useWatch()` returns `_formValues` wholesale and was already honest.

Applied to every field carrying the same bug: financial entities, financial accounts, tags, owners,
business trips, charge types, accountant status, both free-text inputs, both dates and the nine
completeness switches.

## Tests

New `__tests__/cleared-filter-fields.test.tsx`, following the existing happy-dom + `createRoot`
harness. Each case opens the form on an applied filter — the bug is invisible from an empty form —
and asserts that the display and the form state agree after clearing. Verified to fail against the
pre-fix code:

```
× empties the entities picker and the form state together   expected [ 'Business 1' ] to deeply equal []
× empties the exclude leg the same way                      expected [ 'Business 2' ] to deeply equal []
× empties the picker when the form is reset                 expected [ 'Business 1', 'Business 2' ] to deeply equal []
× empties the free text input                               expected 'coffee' to be ''
× empties a date input                                      expected '2026-01-01' to be ''
× switches a completeness toggle back off                   expected 'true' to be 'false'
```

All seven pass after the fix (26 tests across the folder's three files).

## Verification

- `yarn vitest run --project unit packages/client/src/components/charges/charges-filters` — 3 files,
  26 tests passing
- `yarn tsc --noEmit -p packages/client` — clean
- `yarn eslint packages/client/src/components/charges/charges-filters` — clean
- `yarn prettier --check` on the changed files — clean

## Out of scope

The same `onChange(x || undefined)` pattern appears in other forms (`chart-filter.tsx`,
`modify-document-fields.tsx`, `charge-spread-input.tsx`, …). They only misbehave when a field is
cleared after mounting with a value — worth a follow-up sweep, not touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Card2PAypBYY6s5tDXwcSL)_