### PR TITLE
feat(migrations): refuse dev tooling against a non-local database

### DIFF
--- a/.changeset/local-db-guard.md
+++ b/.changeset/local-db-guard.md
@@ -1,0 +1,19 @@
+---
+'@accounter/server': patch
+---
+
+Refuse to run dev tooling against a non-local database by default.
+
+The repo root `.env` is shared by codegen, migrations, seeds and every DB-backed test, so a
+command that looks local is only as local as that file currently is — and it has historically
+defaulted to a deployed host. `scripts/vitest-global-setup.ts` runs before *every* vitest
+project (`--project unit` included) and writes reference data, and
+`packages/migrations/src/__tests__/rls-all-tables.test.ts` issues `CREATE DATABASE` and runs
+every migration into it.
+
+New `packages/migrations/src/local-db-guard.ts` centralises the check. The test harness
+(`test-db-config.ts`, which every DB-backed helper builds its pool from), the vitest global
+setup, the RLS suite and both seed scripts now **refuse** a non-local host unless
+`ALLOW_REMOTE_DB=1` is set for that command. `migration:run` **warns** loudly instead of
+failing, because production deploys may apply migrations during the build and that path is
+unconfirmed; set `ENFORCE_LOCAL_DB=1` to make it strict locally.

--- a/.env.template
+++ b/.env.template
@@ -6,9 +6,16 @@
 ; global setup writes reference data before any test runs.
 ;
 ; Credentials for a deployed database belong in a separate, explicitly named file (e.g.
-; .env.production, also git-ignored) that you pass deliberately -- never here. Tooling
-; refuses a non-local host unless you opt in per command with ALLOW_REMOTE_DB=1; see
-; packages/migrations/src/local-db-guard.ts.
+; .env.production, also git-ignored) that you pass deliberately -- never here.
+;
+; Guard behaviour is not uniform, so do not rely on it as a blanket block
+; (packages/migrations/src/local-db-guard.ts):
+;   - tests, the vitest global setup and the seed scripts REFUSE a non-local host outright,
+;     unless you opt in for that one command with ALLOW_REMOTE_DB=1
+;   - `migration:run` only WARNS and then proceeds, because production deploys may apply
+;     migrations during the build; set ENFORCE_LOCAL_DB=1 to make it refuse too
+;   - codegen (`yarn generate` / pgTyped) is NOT guarded at all -- it only reads, so it will
+;     silently introspect whatever host is set here
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_HOST=localhost
@@ -16,8 +23,8 @@ POSTGRES_PORT=5432
 POSTGRES_DB=accounter
 POSTGRES_SSL='0'
 
-; Set ENFORCE_LOCAL_DB=1 in your shell profile to make `migration:run` refuse a non-local
-; host outright instead of only warning.
+; Recommended: set this in your shell profile so `migration:run` refuses a non-local host
+; outright instead of only warning.
 # ENFORCE_LOCAL_DB=1
 
 ; seed (Part of the seed script)

--- a/.env.template
+++ b/.env.template
@@ -1,10 +1,24 @@
 ; Database variables
+;
+; KEEP THESE POINTED AT THE LOCAL DEV CONTAINER. This file is read by codegen, migrations,
+; seeds and every DB-backed test, so whatever is set here is what `yarn test`, `yarn
+; generate` and `migration:run` all target -- including `vitest --project unit`, whose
+; global setup writes reference data before any test runs.
+;
+; Credentials for a deployed database belong in a separate, explicitly named file (e.g.
+; .env.production, also git-ignored) that you pass deliberately -- never here. Tooling
+; refuses a non-local host unless you opt in per command with ALLOW_REMOTE_DB=1; see
+; packages/migrations/src/local-db-guard.ts.
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=accounter
 POSTGRES_SSL='0'
+
+; Set ENFORCE_LOCAL_DB=1 in your shell profile to make `migration:run` refuse a non-local
+; host outright instead of only warning.
+# ENFORCE_LOCAL_DB=1
 
 ; seed (Part of the seed script)
 # SEED_BANK_ACCOUNT_NUMBER=1234567890

--- a/packages/migrations/src/__tests__/local-db-guard.test.ts
+++ b/packages/migrations/src/__tests__/local-db-guard.test.ts
@@ -77,6 +77,48 @@ describe('describeDatabaseTarget', () => {
   it('marks an absent host explicitly', () => {
     expect(describeDatabaseTarget({ db: 'accounter' })).toBe('<default>/accounter');
   });
+
+  // The displayed value must match the value that was classified, or the message describes
+  // a different target than the one the guard judged.
+  it('shows the trimmed, unquoted host rather than the raw .env value', () => {
+    expect(describeDatabaseTarget({ host: "  'db.example.com'  " })).toBe('db.example.com');
+  });
+
+  it('applies the same trimming to port, user and database', () => {
+    expect(
+      describeDatabaseTarget({
+        host: ' "db.example.com" ',
+        port: " '5433' ",
+        db: "  'prod_db' ",
+        user: ' "prod_user" ',
+      }),
+    ).toBe('prod_user@db.example.com:5433/prod_db');
+  });
+
+  it('strips control characters so an ANSI escape cannot reach the terminal', () => {
+    const withEscape = describeDatabaseTarget({
+      host: 'db.example.com\u001B[31m',
+      user: 'user\u0000\u0007',
+      db: 'prod\u007F',
+    });
+
+    // The ESC byte is removed, which is what disarms the sequence; the remaining "[31m" is
+    // inert printable text and is deliberately left visible rather than silently rewritten.
+    expect(withEscape).toBe('user@db.example.com[31m/prod');
+    // eslint-disable-next-line no-control-regex -- asserting control characters are gone
+    expect(withEscape).not.toMatch(/[\u0000-\u001F\u007F-\u009F]/);
+  });
+
+  it('treats a host that is only quotes and whitespace as absent', () => {
+    expect(describeDatabaseTarget({ host: "  ''  " })).toBe('<default>');
+  });
+
+  it('truncates a pathologically long value instead of flooding the message', () => {
+    const long = 'a'.repeat(500);
+    const rendered = describeDatabaseTarget({ host: long });
+    expect(rendered.length).toBeLessThan(130);
+    expect(rendered.endsWith('…')).toBe(true);
+  });
 });
 
 describe('isRemoteDatabaseAllowed', () => {

--- a/packages/migrations/src/__tests__/local-db-guard.test.ts
+++ b/packages/migrations/src/__tests__/local-db-guard.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ALLOW_REMOTE_DB_ENV,
+  ENFORCE_LOCAL_DB_ENV,
+  assertLocalDatabase,
+  describeDatabaseTarget,
+  isLocalDatabaseHost,
+  isRemoteDatabaseAllowed,
+  warnIfRemoteDatabase,
+} from '../local-db-guard.js';
+
+const REMOTE = {
+  host: 'accounter2.postgres.database.azure.com',
+  port: 5432,
+  db: 'accounter_prod_db',
+  user: 'accounter_prod_user',
+};
+
+const LOCAL = { host: 'localhost', port: 5432, db: 'accounter', user: 'postgres' };
+
+describe('isLocalDatabaseHost', () => {
+  it.each([
+    'localhost',
+    'LOCALHOST',
+    '  localhost  ',
+    "'localhost'",
+    '"localhost"',
+    '127.0.0.1',
+    '127.1.2.3',
+    '::1',
+    '[::1]',
+    '0.0.0.0',
+    'db',
+    'host.docker.internal',
+    '/var/run/postgresql',
+  ])('treats %j as local', host => {
+    expect(isLocalDatabaseHost(host)).toBe(true);
+  });
+
+  it.each([
+    'accounter2.postgres.database.azure.com',
+    'db.example.com',
+    '10.0.0.5',
+    '192.168.1.10',
+    'localhost.evil.com',
+    'notlocalhost',
+  ])('treats %j as non-local', host => {
+    expect(isLocalDatabaseHost(host)).toBe(false);
+  });
+
+  it('treats an absent host as local, matching libpq defaults', () => {
+    // `pg` connects locally when no host is given, so calling this "remote" would be wrong.
+    expect(isLocalDatabaseHost(undefined)).toBe(true);
+    expect(isLocalDatabaseHost(null)).toBe(true);
+    expect(isLocalDatabaseHost('')).toBe(true);
+    expect(isLocalDatabaseHost('   ')).toBe(true);
+  });
+
+  it('does not treat a private LAN address as local', () => {
+    // A deployed database reachable on a VPN is still not the dev container.
+    expect(isLocalDatabaseHost('172.16.0.9')).toBe(false);
+  });
+});
+
+describe('describeDatabaseTarget', () => {
+  it('renders user, host, port and database', () => {
+    expect(describeDatabaseTarget(REMOTE)).toBe(
+      'accounter_prod_user@accounter2.postgres.database.azure.com:5432/accounter_prod_db',
+    );
+  });
+
+  it('never includes a password even when one is present on the object', () => {
+    const withSecret = { ...REMOTE, password: 'super-secret' } as never;
+    expect(describeDatabaseTarget(withSecret)).not.toContain('super-secret');
+  });
+
+  it('marks an absent host explicitly', () => {
+    expect(describeDatabaseTarget({ db: 'accounter' })).toBe('<default>/accounter');
+  });
+});
+
+describe('isRemoteDatabaseAllowed', () => {
+  it('requires exactly "1"', () => {
+    expect(isRemoteDatabaseAllowed({ [ALLOW_REMOTE_DB_ENV]: '1' })).toBe(true);
+    expect(isRemoteDatabaseAllowed({ [ALLOW_REMOTE_DB_ENV]: 'true' })).toBe(false);
+    expect(isRemoteDatabaseAllowed({ [ALLOW_REMOTE_DB_ENV]: '0' })).toBe(false);
+    expect(isRemoteDatabaseAllowed({})).toBe(false);
+  });
+});
+
+describe('assertLocalDatabase', () => {
+  it('passes for a local target', () => {
+    expect(() => assertLocalDatabase(LOCAL, 'the test harness', {})).not.toThrow();
+  });
+
+  it('throws for a non-local target', () => {
+    expect(() => assertLocalDatabase(REMOTE, 'the test harness', {})).toThrow(
+      /Refusing to run the test harness against a non-local database/,
+    );
+  });
+
+  it('names the offending host and the opt-in variable in the message', () => {
+    let message = '';
+    try {
+      assertLocalDatabase(REMOTE, 'the test harness', {});
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain('accounter2.postgres.database.azure.com');
+    expect(message).toContain(ALLOW_REMOTE_DB_ENV);
+    expect(message).toContain("grep '^POSTGRES' .env");
+  });
+
+  it('never leaks a password into the error message', () => {
+    let message = '';
+    try {
+      assertLocalDatabase({ ...REMOTE, password: 'super-secret' } as never, 'ctx', {});
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).not.toContain('super-secret');
+  });
+
+  it('allows a non-local target when explicitly opted in', () => {
+    expect(() =>
+      assertLocalDatabase(REMOTE, 'the RLS suite', { [ALLOW_REMOTE_DB_ENV]: '1' }),
+    ).not.toThrow();
+  });
+});
+
+describe('warnIfRemoteDatabase', () => {
+  it('stays silent for a local target', () => {
+    const logger = { warn: vi.fn() };
+    warnIfRemoteDatabase(LOCAL, 'migration:run', {}, logger);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns but does not throw for a non-local target by default', () => {
+    const logger = { warn: vi.fn() };
+    expect(() => warnIfRemoteDatabase(REMOTE, 'migration:run', {}, logger)).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledOnce();
+    expect(logger.warn.mock.calls[0]?.[0]).toContain(
+      'accounter2.postgres.database.azure.com',
+    );
+  });
+
+  it('throws instead of warning when ENFORCE_LOCAL_DB=1', () => {
+    const logger = { warn: vi.fn() };
+    expect(() =>
+      warnIfRemoteDatabase(REMOTE, 'migration:run', { [ENFORCE_LOCAL_DB_ENV]: '1' }, logger),
+    ).toThrow(/non-local database/);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when opted in, even with enforcement on', () => {
+    const logger = { warn: vi.fn() };
+    expect(() =>
+      warnIfRemoteDatabase(
+        REMOTE,
+        'migration:run',
+        { [ENFORCE_LOCAL_DB_ENV]: '1', [ALLOW_REMOTE_DB_ENV]: '1' },
+        logger,
+      ),
+    ).not.toThrow();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/migrations/src/__tests__/rls-all-tables.test.ts
+++ b/packages/migrations/src/__tests__/rls-all-tables.test.ts
@@ -1,6 +1,7 @@
 import { createPool, DatabasePool, sql } from 'slonik';
 import { createConnectionString } from '../connection-string.js';
 import { env } from '../environment.js';
+import { assertLocalDatabase } from '../local-db-guard.js';
 import { runPGMigrations } from '../run-pg-migrations.js';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import z from 'zod';
@@ -13,6 +14,12 @@ describe('RLS All Tables Migration', () => {
   let testPool: DatabasePool;
 
   beforeAll(async () => {
+    // This suite CREATEs and DROPs a database and runs every migration into it. Against a
+    // deployed server that is destructive, so refuse unless explicitly opted in. The
+    // postgres-18 runbook does opt in (ALLOW_REMOTE_DB=1) to re-assert RLS on an upgraded
+    // PITR-restored server -- that is the one intended non-local use.
+    assertLocalDatabase({ ...env.postgres }, 'the RLS all-tables migration suite');
+
     // 1. Connect to default DB
     const connectionString = createConnectionString({
       ...env.postgres,

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -2,9 +2,15 @@
 import { createPool } from 'slonik';
 import { createConnectionString } from './connection-string.js';
 import { env } from './environment.js';
+import { warnIfRemoteDatabase } from './local-db-guard.js';
 import { runPGMigrations } from './run-pg-migrations.js';
 
 async function migrations() {
+  // Warning rather than a hard stop: production deploys are believed to apply migrations
+  // during the build, but that is unconfirmed for the Azure production path, so refusing
+  // by default could break a deploy. Set ENFORCE_LOCAL_DB=1 locally for the strict form.
+  warnIfRemoteDatabase({ ...env.postgres }, 'migration:run');
+
   const slonik = await createPool(createConnectionString(env.postgres), {
     // 10 minute timeout per statement
     statementTimeout: 10 * 60 * 1000,

--- a/packages/migrations/src/local-db-guard.ts
+++ b/packages/migrations/src/local-db-guard.ts
@@ -47,15 +47,39 @@ const LOCAL_HOSTNAMES = new Set([
 ]);
 
 /**
- * Normalize a host the way a human would have typed it into `.env`: dotenv already strips
- * matching quotes, but a hand-edited value can still carry whitespace or stray quotes.
+ * Strip what a hand-edited `.env` tends to leave behind: dotenv already removes matching
+ * quotes, but a value typed by hand can still carry surrounding whitespace or stray quotes.
+ * Shared by classification and display so the two never disagree about what was read.
  */
-function normalizeHost(host: string): string {
-  return host
+function stripQuotesAndTrim(value: string): string {
+  return value
     .trim()
     .replace(/^['"]|['"]$/g, '')
-    .trim()
-    .toLowerCase();
+    .trim();
+}
+
+function normalizeHost(host: string): string {
+  return stripQuotesAndTrim(host).toLowerCase();
+}
+
+/** Upper bound on any single field rendered into a message. */
+const MAX_DISPLAY_LENGTH = 120;
+
+/**
+ * Render one connection field for human eyes, applying the same trimming used for
+ * classification so the message cannot describe a different value than the one judged.
+ *
+ * Also strips C0/C1 control characters. A stray byte in `.env` would otherwise be echoed
+ * verbatim into an error, and an ANSI escape sequence there would corrupt the terminal of
+ * whoever is reading it — the one place we can be sure a human is looking.
+ */
+function sanitizeForDisplay(value: string | number): string {
+  const text = stripQuotesAndTrim(String(value)).replace(
+    // eslint-disable-next-line no-control-regex -- stripping control characters is the point
+    /[\u0000-\u001F\u007F-\u009F]/g,
+    '',
+  );
+  return text.length > MAX_DISPLAY_LENGTH ? `${text.slice(0, MAX_DISPLAY_LENGTH)}…` : text;
 }
 
 /**
@@ -94,12 +118,23 @@ export function isLocalDatabaseHost(host: string | undefined | null): boolean {
   return false;
 }
 
-/** Human-readable target with the password omitted — safe to log or put in an error. */
+/**
+ * Human-readable target with the password omitted — safe to log or put in an error.
+ *
+ * Every field goes through `sanitizeForDisplay`, so a `.env` value carrying quotes,
+ * whitespace or control bytes is shown as the value that was actually classified rather
+ * than as raw input.
+ */
 export function describeDatabaseTarget(target: DatabaseTarget): string {
-  const host = target.host === undefined || target.host === '' ? '<default>' : target.host;
-  const port = target.port === undefined ? '' : `:${target.port}`;
-  const db = target.db === undefined || target.db === '' ? '' : `/${target.db}`;
-  const user = target.user === undefined || target.user === '' ? '' : `${target.user}@`;
+  const rawHost = target.host === undefined ? '' : sanitizeForDisplay(target.host);
+  const rawPort = target.port === undefined ? '' : sanitizeForDisplay(target.port);
+  const rawDb = target.db === undefined ? '' : sanitizeForDisplay(target.db);
+  const rawUser = target.user === undefined ? '' : sanitizeForDisplay(target.user);
+
+  const host = rawHost === '' ? '<default>' : rawHost;
+  const port = rawPort === '' ? '' : `:${rawPort}`;
+  const db = rawDb === '' ? '' : `/${rawDb}`;
+  const user = rawUser === '' ? '' : `${rawUser}@`;
   return `${user}${host}${port}${db}`;
 }
 

--- a/packages/migrations/src/local-db-guard.ts
+++ b/packages/migrations/src/local-db-guard.ts
@@ -1,0 +1,190 @@
+/**
+ * Guard against dev tooling connecting to a non-local Postgres.
+ *
+ * The repo root `.env` is what codegen, migrations, seeds and every DB-backed test read
+ * (`packages/server/src/__tests__/helpers/test-db-config.ts` loads `.env` / `../../.env`;
+ * `packages/migrations/src/environment.ts` does the same). When that file points at a
+ * deployed database — which is its historical default — commands that look local are not:
+ *
+ * - `scripts/vitest-global-setup.ts` runs before *every* vitest project, `--project unit`
+ *   included, and executes `seedCountries()` — a write.
+ * - `packages/migrations/src/__tests__/rls-all-tables.test.ts` issues `CREATE DATABASE`,
+ *   then runs every migration into it.
+ * - `scripts/seed.ts` and `scripts/seed-demo-data.ts` insert reference and fixture data.
+ *
+ * This module is the chokepoint that makes "am I about to touch a deployed database?"
+ * an explicit decision instead of an assumption about a file nobody re-read.
+ *
+ * Deliberately dependency-free (no dotenv, no zod, no side effects) so importing it from
+ * a test helper, a root script or a package entry point is always safe.
+ *
+ * **Known limitation:** this inspects the configured host only. A port-forward or SSH
+ * tunnel that presents a deployed database as `localhost` is indistinguishable from the
+ * dev container and will pass. The guard raises the floor; it is not a sandbox.
+ */
+
+/** Opt in to a non-local target for one command. Mirrors `ALLOW_DEMO_SEED`. */
+export const ALLOW_REMOTE_DB_ENV = 'ALLOW_REMOTE_DB';
+
+/** Upgrade the migration CLI's warning to a hard failure. See `assertLocalDatabase`. */
+export const ENFORCE_LOCAL_DB_ENV = 'ENFORCE_LOCAL_DB';
+
+export type DatabaseTarget = {
+  host?: string | undefined;
+  port?: number | string | undefined;
+  db?: string | undefined;
+  user?: string | undefined;
+};
+
+const LOCAL_HOSTNAMES = new Set([
+  'localhost',
+  '::1',
+  '0.0.0.0',
+  // Docker service name in docker/docker-compose.dev.yml, and the usual escape hatch
+  // for reaching the host from inside a container.
+  'db',
+  'host.docker.internal',
+]);
+
+/**
+ * Normalize a host the way a human would have typed it into `.env`: dotenv already strips
+ * matching quotes, but a hand-edited value can still carry whitespace or stray quotes.
+ */
+function normalizeHost(host: string): string {
+  return host
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * An absent host is treated as local: both `pg` and libpq default to a local connection
+ * when no host is given, so reporting it as remote would be inaccurate rather than safe.
+ */
+export function isLocalDatabaseHost(host: string | undefined | null): boolean {
+  if (host === undefined || host === null) {
+    return true;
+  }
+
+  const normalized = normalizeHost(host);
+  if (normalized === '') {
+    return true;
+  }
+
+  // A unix socket directory is by definition local.
+  if (normalized.startsWith('/')) {
+    return true;
+  }
+
+  if (LOCAL_HOSTNAMES.has(normalized)) {
+    return true;
+  }
+
+  // Whole IPv4 loopback range, not just 127.0.0.1.
+  if (/^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(normalized)) {
+    return true;
+  }
+
+  // Bracketed IPv6 loopback, e.g. [::1].
+  if (normalized === '[::1]') {
+    return true;
+  }
+
+  return false;
+}
+
+/** Human-readable target with the password omitted — safe to log or put in an error. */
+export function describeDatabaseTarget(target: DatabaseTarget): string {
+  const host = target.host === undefined || target.host === '' ? '<default>' : target.host;
+  const port = target.port === undefined ? '' : `:${target.port}`;
+  const db = target.db === undefined || target.db === '' ? '' : `/${target.db}`;
+  const user = target.user === undefined || target.user === '' ? '' : `${target.user}@`;
+  return `${user}${host}${port}${db}`;
+}
+
+export function isRemoteDatabaseAllowed(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[ALLOW_REMOTE_DB_ENV] === '1';
+}
+
+function buildMessage(target: DatabaseTarget, context: string): string {
+  return [
+    `Refusing to run ${context} against a non-local database: ${describeDatabaseTarget(target)}`,
+    '',
+    'The repo root .env is shared by codegen, migrations, seeds and all DB-backed tests, so a',
+    'command that looks local is only as local as that file currently is. Check it now:',
+    '',
+    "  grep '^POSTGRES' .env",
+    '',
+    'Then either point it at the dev container, or override for this command only:',
+    '',
+    '  POSTGRES_HOST=localhost POSTGRES_PORT=5432 POSTGRES_DB=accounter \\',
+    '    POSTGRES_USER=postgres POSTGRES_SSL=0 <your command>',
+    '',
+    `If you genuinely mean to target ${describeDatabaseTarget(target)}, opt in explicitly:`,
+    '',
+    `  ${ALLOW_REMOTE_DB_ENV}=1 <your command>`,
+  ].join('\n');
+}
+
+/**
+ * Throw unless the target is local or `ALLOW_REMOTE_DB=1` is set.
+ *
+ * Use this wherever a deployed database is never the intended target: the test harness and
+ * the seed scripts. `context` is quoted verbatim in the error, so name the actual command
+ * ("the vitest global setup", "scripts/seed.ts").
+ */
+export function assertLocalDatabase(
+  target: DatabaseTarget,
+  context: string,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (isLocalDatabaseHost(target.host) || isRemoteDatabaseAllowed(env)) {
+    return;
+  }
+  throw new Error(buildMessage(target, context));
+}
+
+/**
+ * Warn — loudly, on stderr — when the target is not local, and throw instead if
+ * `ENFORCE_LOCAL_DB=1` is set.
+ *
+ * This is the weaker form, for `migration:run`. A hard default there is not safe yet:
+ * production deploys are believed to apply migrations during the build, but that belief
+ * traces only to `packages/server/docs/demo-staging-guide.md:552-558`, which documents
+ * *staging on Render* while production Postgres runs on Azure — so it says nothing reliable
+ * about the production deploy path, and nothing else in the repo does either. Until someone
+ * confirms where production migrations actually run, throwing by default risks breaking a
+ * deploy nobody can see.
+ *
+ * Set `ENFORCE_LOCAL_DB=1` in your shell profile to get the strict behaviour locally, and
+ * flip this call site to `assertLocalDatabase` once the deploy path is known.
+ */
+export function warnIfRemoteDatabase(
+  target: DatabaseTarget,
+  context: string,
+  env: NodeJS.ProcessEnv = process.env,
+  logger: Pick<Console, 'warn'> = console,
+): void {
+  if (isLocalDatabaseHost(target.host) || isRemoteDatabaseAllowed(env)) {
+    return;
+  }
+
+  if (env[ENFORCE_LOCAL_DB_ENV] === '1') {
+    throw new Error(buildMessage(target, context));
+  }
+
+  logger.warn(
+    [
+      '',
+      '  ⚠️  ================================================================',
+      `  ⚠️  ${context} is targeting a NON-LOCAL database:`,
+      `  ⚠️    ${describeDatabaseTarget(target)}`,
+      '  ⚠️',
+      "  ⚠️  If that was not deliberate, stop now (Ctrl-C) and check: grep '^POSTGRES' .env",
+      `  ⚠️  Set ${ENFORCE_LOCAL_DB_ENV}=1 to make this a hard failure instead of a warning.`,
+      '  ⚠️  ================================================================',
+      '',
+    ].join('\n'),
+  );
+}

--- a/packages/server/src/__tests__/helpers/test-db-config.ts
+++ b/packages/server/src/__tests__/helpers/test-db-config.ts
@@ -1,5 +1,6 @@
 import type { PoolConfig } from 'pg';
 import { config } from 'dotenv';
+import { assertLocalDatabase } from '../../../../migrations/src/local-db-guard.js';
 
 // Load environment variables
 config({ path: [`.env`, `../../.env`] });
@@ -16,6 +17,20 @@ export const testDbConfig: PoolConfig = {
   database: process.env.POSTGRES_DB || 'accounter_test',
   ssl: process.env.POSTGRES_SSL === '1',
 };
+
+// Fail at import time rather than at first query. Every DB-backed test helper builds its
+// pool from `testDbConfig`, so this one call covers the whole harness -- including the
+// vitest global setup, which writes reference data before any test file is loaded.
+// Tests must never touch a deployed database; override POSTGRES_* or set ALLOW_REMOTE_DB=1.
+assertLocalDatabase(
+  {
+    host: testDbConfig.host,
+    port: testDbConfig.port,
+    db: testDbConfig.database,
+    user: testDbConfig.user,
+  },
+  'the test harness',
+);
 
 /**
  * Database schema name for queries

--- a/scripts/seed-demo-data.ts
+++ b/scripts/seed-demo-data.ts
@@ -1,5 +1,6 @@
 import { config } from 'dotenv';
 import pg from 'pg';
+import { assertLocalDatabase } from '../packages/migrations/src/local-db-guard.js';
 import { seedAdminCore } from '../packages/server/scripts/seed-admin-context.js';
 import { insertFixture } from '../packages/server/src/__tests__/helpers/fixture-loader.js';
 import type {
@@ -188,6 +189,19 @@ async function seedDemoData() {
     console.error('❌ ALLOW_DEMO_SEED=1 required to run demo seed');
     process.exit(1);
   }
+
+  // NODE_ENV above says nothing about which host POSTGRES_* points at -- and the root .env
+  // sets NODE_ENV=production while often pointing at the dev container, so the two are
+  // independent. Check the actual target too.
+  assertLocalDatabase(
+    {
+      host: process.env.POSTGRES_HOST,
+      port: process.env.POSTGRES_PORT,
+      db: process.env.POSTGRES_DB,
+      user: process.env.POSTGRES_USER,
+    },
+    'the demo data seed',
+  );
 
   const client = new pg.Client({
     user: process.env.POSTGRES_USER,

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,5 +1,6 @@
 import { config } from 'dotenv';
 import pg from 'pg';
+import { assertLocalDatabase } from '../packages/migrations/src/local-db-guard.js';
 import { seedCountries as seedCountriesUtil } from '../packages/server/src/modules/countries/helpers/seed-countries.helper.js';
 
 config();
@@ -7,6 +8,19 @@ config();
 type FinancialAccountType = 'BANK_ACCOUNT' | 'CREDIT_CARD' | 'CRYPTO_WALLET';
 
 async function seed() {
+  // This script INSERTs business, account and tax-category rows. It is named
+  // `seed:production` and targeting a deployed database is a legitimate use -- but it must
+  // be a decision, so require ALLOW_REMOTE_DB=1 rather than inheriting it from .env.
+  assertLocalDatabase(
+    {
+      host: process.env.POSTGRES_HOST,
+      port: process.env.POSTGRES_PORT,
+      db: process.env.POSTGRES_DB,
+      user: process.env.POSTGRES_USER,
+    },
+    'scripts/seed.ts',
+  );
+
   const client = new pg.Client({
     user: process.env.POSTGRES_USER,
     password: process.env.POSTGRES_PASSWORD,

--- a/scripts/vitest-global-setup.ts
+++ b/scripts/vitest-global-setup.ts
@@ -1,9 +1,23 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { assertLocalDatabase } from '../packages/migrations/src/local-db-guard.js';
 import { seedCountries } from '../packages/server/src/modules/countries/helpers/seed-countries.helper.js';
 
 export default async function globalSetup() {
+  // Before anything else: this setup writes (seedCountries below) and runs for *every*
+  // vitest project, `--project unit` included. It reads the root .env, so "I only ran unit
+  // tests" is not a reason to assume the target is local.
+  assertLocalDatabase(
+    {
+      host: process.env.POSTGRES_HOST,
+      port: process.env.POSTGRES_PORT,
+      db: process.env.POSTGRES_DB,
+      user: process.env.POSTGRES_USER,
+    },
+    'the vitest global setup',
+  );
+
   // Create isolated env file for test runs (seedAdminCore writes here)
   try {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'accounter-test-env-'));


### PR DESCRIPTION
The repo root `.env` is read by codegen, migrations, seeds and **every** DB-backed test, so a command that looks local is only as local as that file currently is — and it has historically defaulted to a deployed host. This adds a guard so that "am I about to touch a deployed database?" is an explicit decision rather than an assumption about a file nobody re-read.

## Why now

Two paths make the mistake expensive, and both were observed connecting to the deployed database in ordinary use — twice, purely because `.env` was edited between one command and the next:

- `scripts/vitest-global-setup.ts` runs before **every** vitest project, `--project unit` included, and executes `seedCountries()` — a write. "I only ran unit tests" is not protection.
- `packages/migrations/src/__tests__/rls-all-tables.test.ts` issues `CREATE DATABASE` and then runs every migration into the result. Against the deployed server this failed only because that role lacks `CREATEDB` — luck, not a safeguard.

## What it does

New `packages/migrations/src/local-db-guard.ts`, dependency-free (no dotenv, no zod, no side effects) so it is safe to import from a test helper, a root script, or a package entry point.

| Call site | Behaviour |
| --- | --- |
| `test-db-config.ts` (test harness) | **refuse** |
| `scripts/vitest-global-setup.ts` | **refuse** |
| `rls-all-tables.test.ts` | **refuse** |
| `scripts/seed.ts`, `scripts/seed-demo-data.ts` | **refuse** |
| `migration:run` | **warn** (refuse with `ENFORCE_LOCAL_DB=1`) |

`ALLOW_REMOTE_DB=1` is the per-command opt-in, mirroring the existing `ALLOW_DEMO_SEED=1` convention.

`test-db-config.ts` asserts at **import** time rather than first query: every DB-backed helper builds its pool from it, so that one call covers all 15 importers plus the global setup that writes before any test file loads.

## The one judgment call worth reviewing

**`migration:run` only warns.** Production deploys are *believed* to apply migrations during the build, but that belief traces solely to `packages/server/docs/demo-staging-guide.md:552-558`, which documents *staging on Render* while production Postgres runs on **Azure**. Nothing in the repo establishes the production deploy path. A throwing guard there could break a deploy that isn't visible from here, so warn-by-default is the deploy-safe choice.

`ENFORCE_LOCAL_DB=1` in a shell profile gives the strict behaviour immediately, and flipping the call site to `assertLocalDatabase` is a one-line change once someone confirms where production migrations run. That open question is referenced from the guard's own doc comment so it doesn't get lost.

If you already know where prod migrations run, say so and I'll make it strict in this PR.

## Verified

- **34 unit tests** for the guard: host classification (whole 127/8 loopback range, `::1`/`[::1]`, unix sockets, docker service name, quote/whitespace normalisation, `localhost.evil.com` correctly non-local), absent host treated as local to match libpq defaults, password never rendered into a message, both env vars, warn vs throw
- `POSTGRES_HOST=db.invalid.example.com yarn vitest` → refused **at the global setup**, before the write
- `ALLOW_REMOTE_DB=1` → passes through
- `migration:run` non-local → warning banner then proceeds; with `ENFORCE_LOCAL_DB=1` → refuses with **no connection attempt** (no `ENOTFOUND`, proving it threw before the pool was created)
- `yarn test` 3981 ✓ · `yarn test:integration` 4476 ✓ · `ALLOW_DEMO_SEED=1 yarn test:demo-seed` ✓
- `yarn lint` 0 errors (864 warnings, unchanged from baseline) · `tsc --noEmit` clean · `prettier` clean

## Limits, stated in the code

- The guard inspects the configured **host** only. A port-forward or tunnel presenting a deployed database as `localhost` passes it. It raises the floor; it is not a sandbox.
- pgTyped / `generate:sql` is intentionally **not** guarded — it only introspects.

`.env.template` now documents the convention: keep the root `.env` pointed at the dev container, and put credentials for a deployed database in a separate, explicitly named file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
