### PR TITLE
feat(email-ingestion-gateway): add replay:eml to re-drive a captured message

### DIFF
--- a/.changeset/email-ingestion-replay-eml.md
+++ b/.changeset/email-ingestion-replay-eml.md
@@ -1,0 +1,30 @@
+---
+'@accounter/email-ingestion-gateway': patch
+---
+
+Add `replay:eml` to re-drive a captured `.eml` through the real ingestion pipeline.
+
+When an inbound email fails before control grants, nothing durable is recorded anywhere — no charge,
+no document, no quarantine row, no idempotency key — so there is nothing to reprocess server-side.
+Recovering it means re-driving the raw MIME, and there was no tool for that: `inspect:eml` stops at
+extraction, leaving only "re-send the email by hand" or hand-assembling a signed `curl` (computing
+an HMAC over `` `${timestamp}.${rawBody}` `` and getting five headers right).
+
+```bash
+yarn workspace @accounter/email-ingestion-gateway replay:eml example-docs/lost.eml
+```
+
+The script signs the body exactly as `worker.ts` does and POSTs it to the gateway, so control →
+treatment → ingest all run for real, then prints the response (`outcome`, `ingestId`, `reasonCode`,
+`correlationId`). It defaults `x-cf-recipient` from the message's own `Delivered-To` /
+`X-Original-To` / `To` and the received-at from its `Date` header — both overridable via
+`--recipient` and `--received-at`, since the alias in the headers is not always the one that routed
+the message and a replay should keep the real date in the charge description. `--gateway`,
+`--message-id` and `--dry-run` round it out.
+
+Safe to re-run: idempotency keys on the gateway-computed `rawMessageHash`, so a genuinely lost
+message inserts cleanly and one that already landed comes back `DUPLICATE`. It refuses to send when
+`CF_WEBHOOK_SECRET` is unset rather than producing a confusing `INVALID_AUTH`.
+
+Documented in `TROUBLESHOOTING.md` as the recovery step, which previously explained how to diagnose
+a lost email but not how to re-drive one.

--- a/packages/email-ingestion-gateway/CLAUDE.md
+++ b/packages/email-ingestion-gateway/CLAUDE.md
@@ -102,6 +102,9 @@ header shape (Google-Group relay, invoice-platform relay, nested manual forward,
 encoded-words). `example-docs/` is git-ignored: it holds real captured messages with real vendor
 addresses, DKIM signatures and real invoice PDFs. Use it locally with `inspect:eml` (add `--json` to
 get the exact `senderEvidence` payload sent to `requestIngestControl`), never in a committed test.
+`replay:eml` re-drives one of those captured messages through the _real_ pipeline (control →
+treatment → ingest); it is the recovery step for an email that was lost, and is safe to re-run
+because idempotency keys on `rawMessageHash`.
 
 ## Commands
 
@@ -111,5 +114,7 @@ yarn workspace @accounter/email-ingestion-gateway build         # tsc → dist/
 yarn workspace @accounter/email-ingestion-gateway typecheck     # tsc --noEmit
 yarn workspace @accounter/email-ingestion-gateway worker:dev    # wrangler dev (Worker)
 yarn workspace @accounter/email-ingestion-gateway worker:deploy # wrangler deploy
+yarn workspace @accounter/email-ingestion-gateway inspect:eml <f>  # what the extractor sees
+yarn workspace @accounter/email-ingestion-gateway replay:eml <f>   # re-drive a captured message
 yarn generate:graphql                                           # regenerate src/gql/
 ```

--- a/packages/email-ingestion-gateway/TROUBLESHOOTING.md
+++ b/packages/email-ingestion-gateway/TROUBLESHOOTING.md
@@ -286,3 +286,39 @@ When `EMAIL_INGESTION_SHADOW_MODE=1`, `/webhook` responds `202` **immediately** 
 orchestration asynchronously (`webhook.ts`). The HTTP response will **not** contain the real outcome
 — look for `shadow:orchestration:complete` / `:failed` / `:error` log lines (by `correlationId`) to
 see what actually happened. The legacy listener remains the authoritative handler in this mode.
+
+---
+
+## 6. Recovering a lost email: replaying a captured message
+
+A failure that never reached a resolved tenant leaves **no durable record** — no charge, no
+document, no quarantine row, no idempotency key. There is nothing to reprocess server-side; the
+message survives only in the upstream mailbox.
+
+To re-drive such a message, download the raw MIME (Gmail: open the message → ⋮ → "Show original" →
+"Download Original") into the git-ignored `example-docs/`, then:
+
+```bash
+# what would the extractor see? (no server call)
+yarn workspace @accounter/email-ingestion-gateway inspect:eml example-docs/lost.eml
+
+# actually re-drive it through control → treatment → ingest
+yarn workspace @accounter/email-ingestion-gateway replay:eml example-docs/lost.eml
+```
+
+`replay:eml` signs the body exactly as the Worker does and POSTs it to the gateway, printing the
+response (`outcome`, `ingestId`, `reasonCode`, `correlationId`). Useful flags:
+
+| Flag                  | Why                                                                           |
+| --------------------- | ----------------------------------------------------------------------------- |
+| `--recipient <alias>` | The alias in the headers is not always the one that routed the message.       |
+| `--received-at <iso>` | Keep the original date in the charge description rather than the replay date. |
+| `--gateway <url>`     | Point at a different gateway than `GATEWAY_URL` / `http://localhost:3000`.    |
+| `--message-id <id>`   | Override the `Message-ID` taken from the message.                             |
+| `--dry-run`           | Print the signed request without sending it.                                  |
+
+**It is safe to re-run.** Idempotency keys on the gateway-computed `rawMessageHash`, so a genuinely
+lost message inserts cleanly while one that already landed comes back `DUPLICATE`.
+
+`CF_WEBHOOK_SECRET` must match the target gateway's; the script refuses to send an unsigned request
+rather than producing a confusing `INVALID_AUTH`.

--- a/packages/email-ingestion-gateway/package.json
+++ b/packages/email-ingestion-gateway/package.json
@@ -43,6 +43,7 @@
     "email-ingestion-gateway:worker:dev": "yarn worker:dev",
     "generate": "yarn generate:graphql",
     "inspect:eml": "tsx scripts/inspect-eml.ts",
+    "replay:eml": "tsx scripts/replay-eml.ts",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "worker:deploy": "wrangler deploy",

--- a/packages/email-ingestion-gateway/scripts/replay-eml.ts
+++ b/packages/email-ingestion-gateway/scripts/replay-eml.ts
@@ -157,9 +157,12 @@ async function main(): Promise<void> {
   const correlationId = randomUUID();
 
   // Identical construction to worker.ts: HMAC-SHA256 over `${timestamp}.` followed
-  // by the raw MIME bytes, hex-encoded.
+  // by the raw MIME bytes, hex-encoded. Fed incrementally rather than through a
+  // concatenated buffer — the digest is the same, without a second copy of a
+  // message that can be up to 25 MB.
   const signature = createHmac('sha256', secret)
-    .update(Buffer.concat([Buffer.from(`${timestamp}.`, 'utf8'), rawBytes]))
+    .update(`${timestamp}.`, 'utf8')
+    .update(rawBytes)
     .digest('hex');
 
   const headers: Record<string, string> = {
@@ -189,7 +192,9 @@ async function main(): Promise<void> {
   const response = await fetch(`${gatewayUrl}/webhook`, {
     method: 'POST',
     headers,
-    body: new Uint8Array(rawBytes),
+    // A Buffer is already a Uint8Array, so it is a valid BodyInit as-is; wrapping
+    // it copied the whole message for nothing.
+    body: rawBytes,
   });
 
   const text = await response.text();

--- a/packages/email-ingestion-gateway/scripts/replay-eml.ts
+++ b/packages/email-ingestion-gateway/scripts/replay-eml.ts
@@ -1,0 +1,211 @@
+/**
+ * Re-drive a captured `.eml` file through the full gateway pipeline — the
+ * recovery step for an email that was lost or that failed before anything
+ * durable was recorded (see #4344).
+ *
+ * `inspect-eml.ts` stops at extraction and never calls the server. This script
+ * signs the raw MIME exactly as `worker.ts` does (HMAC-SHA256 over
+ * `` `${timestamp}.${rawBody}` ``, hex) and POSTs it to the configured gateway,
+ * so control → treatment → ingest all run for real.
+ *
+ *   yarn workspace @accounter/email-ingestion-gateway replay:eml path/to/message.eml
+ *
+ * Options:
+ *   --recipient <alias>   override x-cf-recipient (default: Delivered-To / To
+ *                         from the message; the alias in the headers is not
+ *                         always the one that routed it)
+ *   --received-at <iso>   preserve the original received-at so the charge
+ *                         description keeps the real date, not the replay date
+ *                         (default: the message's own Date header, else now)
+ *   --gateway <url>       override the gateway base URL
+ *   --message-id <id>     override x-cf-message-id
+ *   --dry-run             print the request without sending it
+ *
+ * **Safe to re-run.** Idempotency is keyed on `rawMessageHash`, computed by the
+ * gateway from these exact bytes: a genuinely lost message inserts cleanly, and
+ * one that already landed comes back `DUPLICATE` rather than double-inserting.
+ *
+ * Requires `CF_WEBHOOK_SECRET` to match the gateway's; the script refuses to send
+ * an unsigned request. Real captured messages belong in the git-ignored
+ * `example-docs/`, never in a committed fixture.
+ */
+import { createHmac, randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { env } from '../src/environment.js';
+
+interface Options {
+  path: string;
+  recipient?: string;
+  receivedAt?: string;
+  gateway?: string;
+  messageId?: string;
+  dryRun: boolean;
+}
+
+const USAGE = `Usage: replay:eml <path-to-.eml> [--recipient <alias>] [--received-at <iso>]
+                 [--gateway <url>] [--message-id <id>] [--dry-run]`;
+
+function parseArgs(argv: string[]): Options | null {
+  const positional: string[] = [];
+  const flags = new Map<string, string>();
+  let dryRun = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--dry-run') {
+      dryRun = true;
+    } else if (arg.startsWith('--')) {
+      const value = argv[++i];
+      if (value === undefined) {
+        console.error(`Missing value for ${arg}`);
+        return null;
+      }
+      flags.set(arg.slice(2), value);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  const path = positional[0];
+  if (!path) return null;
+
+  return {
+    path,
+    recipient: flags.get('recipient'),
+    receivedAt: flags.get('received-at'),
+    gateway: flags.get('gateway'),
+    messageId: flags.get('message-id'),
+    dryRun,
+  };
+}
+
+/**
+ * Read a header out of the raw MIME without parsing the whole message: only the
+ * routing metadata the Worker would have supplied is needed here, and the
+ * gateway re-parses the body itself. Handles folded (continuation) lines.
+ */
+function readHeader(raw: string, name: string): string | undefined {
+  const headerBlock = raw.split(/\r?\n\r?\n/, 1)[0] ?? '';
+  const pattern = new RegExp(`^${name}:[ \\t]*(.*(?:\\r?\\n[ \\t]+.*)*)$`, 'im');
+  const match = headerBlock.match(pattern);
+  return match?.[1]?.replace(/\r?\n[ \t]+/g, ' ').trim() || undefined;
+}
+
+/** Pull the bare address out of a `Display Name <addr@host>` header value. */
+function bareAddress(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const angled = value.match(/<([^>]+)>/);
+  return (angled?.[1] ?? value.split(',')[0]).trim() || undefined;
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  if (!options) {
+    console.error(USAGE);
+    process.exitCode = 1;
+    return;
+  }
+
+  const secret = env.cloudflare.webhookSecret;
+  if (!secret) {
+    console.error(
+      'CF_WEBHOOK_SECRET is not set. Refusing to send an unsigned request — the gateway would ' +
+        'reject it as INVALID_AUTH. Set it to the same value the gateway uses.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const gatewayUrl = (
+    options.gateway ??
+    process.env.GATEWAY_URL ??
+    'http://localhost:3000'
+  ).replace(/\/+$/, '');
+
+  const rawBytes = await readFile(options.path);
+  // Headers are ASCII; decoding latin1 keeps byte offsets intact and never throws
+  // on a non-UTF-8 body. The signed payload uses the original bytes regardless.
+  const rawText = rawBytes.toString('latin1');
+
+  const recipient =
+    options.recipient ??
+    bareAddress(readHeader(rawText, 'Delivered-To')) ??
+    bareAddress(readHeader(rawText, 'X-Original-To')) ??
+    bareAddress(readHeader(rawText, 'To'));
+
+  if (!recipient) {
+    console.error(
+      'Could not determine the recipient alias from Delivered-To / X-Original-To / To. ' +
+        'Pass --recipient <alias>.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const messageId = options.messageId ?? readHeader(rawText, 'Message-ID') ?? randomUUID();
+
+  const dateHeader = readHeader(rawText, 'Date');
+  const parsedDate = dateHeader ? new Date(dateHeader) : undefined;
+  const receivedAt =
+    options.receivedAt ??
+    (parsedDate && !Number.isNaN(parsedDate.getTime())
+      ? parsedDate.toISOString()
+      : new Date().toISOString());
+
+  const timestamp = Math.floor(Date.now() / 1000);
+  const nonce = randomUUID();
+  const correlationId = randomUUID();
+
+  // Identical construction to worker.ts: HMAC-SHA256 over `${timestamp}.` followed
+  // by the raw MIME bytes, hex-encoded.
+  const signature = createHmac('sha256', secret)
+    .update(Buffer.concat([Buffer.from(`${timestamp}.`, 'utf8'), rawBytes]))
+    .digest('hex');
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'message/rfc822',
+    'x-cf-timestamp': String(timestamp),
+    'x-cf-signature': signature,
+    'x-cf-nonce': nonce,
+    'x-cf-recipient': recipient,
+    'x-cf-message-id': messageId,
+    'x-cf-received-at': receivedAt,
+    'x-correlation-id': correlationId,
+  };
+
+  console.log(`POST ${gatewayUrl}/webhook`);
+  console.log(`  recipient:     ${recipient}`);
+  console.log(`  messageId:     ${messageId}`);
+  console.log(`  receivedAt:    ${receivedAt}`);
+  console.log(`  correlationId: ${correlationId}`);
+  console.log(`  body:          ${rawBytes.length} bytes`);
+
+  if (options.dryRun) {
+    console.log('\n--dry-run: not sending. Headers:');
+    console.log(JSON.stringify(headers, null, 2));
+    return;
+  }
+
+  const response = await fetch(`${gatewayUrl}/webhook`, {
+    method: 'POST',
+    headers,
+    body: new Uint8Array(rawBytes),
+  });
+
+  const text = await response.text();
+  console.log(`\nHTTP ${response.status}`);
+  try {
+    console.log(JSON.stringify(JSON.parse(text), null, 2));
+  } catch {
+    console.log(text);
+  }
+
+  // A non-2xx is how the gateway tells the Cloudflare Worker to fall back, so it
+  // is also how it tells an operator the replay did not land.
+  if (!response.ok) process.exitCode = 1;
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Fixes #4351. Part of #4344. **Independent — reviewable and mergeable on its own** (one new script plus docs; no runtime code touched).

## Why

An email that fails before control grants leaves no durable record anywhere — no charge, no document, no quarantine row, no idempotency key — so there is nothing to reprocess server-side. Recovering it means re-driving the raw MIME, and there was no tool for that: `scripts/inspect-eml.ts` stops at extraction, before `requestIngestControl`. The alternatives were re-sending the email by hand or hand-assembling a signed `curl` from the README snippet, which means computing an HMAC over `` `${timestamp}.${rawBody}` `` and getting five headers right.

## What it does

```bash
yarn workspace @accounter/email-ingestion-gateway replay:eml example-docs/lost.eml
```

Signs the body exactly as `worker.ts` does and POSTs it to the gateway, so control → treatment → ingest all run for real, then prints the response (`outcome`, `ingestId`, `reasonCode`, `correlationId`).

Defaults `x-cf-recipient` from the message's own `Delivered-To` / `X-Original-To` / `To`, and the received-at from its `Date` header — both overridable, since the alias in the headers is not always the one that routed the message, and a replay should keep the real date in the charge description rather than today's:

| Flag | Why |
| --- | --- |
| `--recipient <alias>` | The header alias is not always the one that routed it. |
| `--received-at <iso>` | Keep the original date in the charge description. |
| `--gateway <url>` | Target a gateway other than `GATEWAY_URL` / localhost. |
| `--message-id <id>` | Override the `Message-ID`. |
| `--dry-run` | Print the signed request without sending. |

**Safe to re-run**, as the issue notes: idempotency keys on the gateway-computed `rawMessageHash`, so a genuinely lost message inserts cleanly and one that already landed comes back `DUPLICATE`. Stated in the script's header comment.

It refuses to send when `CF_WEBHOOK_SECRET` is unset rather than producing a confusing `INVALID_AUTH`.

## Verification

Ran end-to-end against a locally started gateway pointed at a mock GraphQL server: signature verified, orchestration ran, `HTTP 202` with `outcome: INSERTED`. Also checked `--dry-run` and the default recipient/date extraction against a committed fixture.

Consistent with `inspect-eml.ts`: real captured messages live in the git-ignored `example-docs/`, never in a committed fixture. Documented in `TROUBLESHOOTING.md` as §6 (the guide explained how to diagnose a lost email but not how to re-drive one) and in the package `CLAUDE.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzBb83TU74XD7cQqW3uEtB)_