### PR TITLE
fix(email-ingestion-gateway): return non-2xx so the Worker's FALLBACK_EMAIL fires

### DIFF
--- a/.changeset/email-ingestion-webhook-fallback-status.md
+++ b/.changeset/email-ingestion-webhook-fallback-status.md
@@ -1,0 +1,42 @@
+---
+'@accounter/email-ingestion-gateway': patch
+---
+
+Return non-2xx from `/webhook` when orchestration leaves no durable record, so the Worker's
+`FALLBACK_EMAIL` path actually fires.
+
+`worker.ts` has a designed no-loss path: if the gateway rejects the request, forward the email to
+the legacy mailbox rather than dropping it.
+
+```ts
+if (!response.ok) {
+  if (env.FALLBACK_EMAIL) {
+    await message.forward(env.FALLBACK_EMAIL)
+    return
+  }
+  throw new Error('Gateway returned status ' + response.status)
+}
+```
+
+But `webhook.ts` answered `202` even when orchestration failed, and `202` satisfies `response.ok` —
+so the Worker treated a total-loss outcome as success and the fallback branch was unreachable for
+every orchestration failure. The `failed: true` flag in the body was never read. This is one of the
+four gaps that turned a sub-second upstream blip into five permanently lost emails (#4344).
+
+The status is now decided per reason code rather than by outcome shape:
+
+- `TRANSIENT_UPSTREAM`, `UPSTREAM_ERROR`, `TIMEOUT` — control never granted, so there is no resolved
+  tenant, and `email_ingestion_quarantine` requires one. Nothing was recorded and nothing can be.
+  **503**, so the Worker forwards.
+- `UNKNOWN_ALIAS` — the mail is undeliverable to any tenant. Forwarding it to a human beats dropping
+  it. **503**.
+- `GRANT_INVALID` and the other post-grant failures — these _are_ recorded server-side
+  (quarantine/audit rows exist) and are reprocessable, so **202** stays correct; forwarding them
+  would duplicate work.
+
+Shadow mode (`EMAIL_INGESTION_SHADOW_MODE=1`) responds `202` before orchestration runs, so it cannot
+participate and is left as-is.
+
+The mapping is an exported `statusForOrchestrationFailure(reason)` with a test per reason code, and
+`worker-pipe.integration.test.ts` gains an end-to-end case asserting that a control call returning a
+GraphQL error drives the Worker down the `FALLBACK_EMAIL` branch.

--- a/packages/email-ingestion-gateway/README.md
+++ b/packages/email-ingestion-gateway/README.md
@@ -79,9 +79,16 @@ The gateway service exposes three routes (see `src/index.ts`):
 The body is the **raw MIME message** (`Content-Type: message/rfc822`). The gateway — not the Worker
 — computes the authoritative `rawMessageHash` from the signed body.
 
-The endpoint always responds `202 Accepted` once authenticity passes; the ingest `outcome`
-(`INSERTED` / `DUPLICATE` / `QUARANTINED` / `REJECTED`) is included in the JSON body in production
-mode. Authenticity failures return `401`, malformed requests `400`, oversize bodies `413`.
+Once authenticity passes the endpoint responds `202 Accepted` with the ingest `outcome` (`INSERTED`
+/ `DUPLICATE` / `QUARANTINED` / `REJECTED` / `IGNORED`) in the JSON body in production mode.
+Authenticity failures return `401`, malformed requests `400`, oversize bodies `413`.
+
+One case is deliberately **not** `202`: when orchestration fails leaving no durable record anywhere
+(`TRANSIENT_UPSTREAM`, `UPSTREAM_ERROR`, `TIMEOUT`, `UNKNOWN_ALIAS`) the endpoint answers `503`.
+That is what drives the Worker's `if (!response.ok)` branch to forward the email to `FALLBACK_EMAIL`
+instead of dropping it. Failures that _are_ recorded server-side and can be reprocessed
+(`GRANT_INVALID` and the other post-grant reasons) stay `202`, since forwarding those would
+duplicate work.
 
 ## Configuration
 
@@ -109,11 +116,11 @@ process with code `1`.
 
 See [`.dev.vars.example`](./.dev.vars.example):
 
-| Variable            | Description                                                               |
-| ------------------- | ------------------------------------------------------------------------- |
-| `CF_WEBHOOK_SECRET` | Must match the gateway's secret — the Worker signs, the gateway verifies. |
-| `GATEWAY_URL`       | URL the Worker `POST`s the webhook to.                                    |
-| `FALLBACK_EMAIL`    | Address the Worker forwards to when the gateway is unreachable.           |
+| Variable            | Description                                                                                        |
+| ------------------- | -------------------------------------------------------------------------------------------------- |
+| `CF_WEBHOOK_SECRET` | Must match the gateway's secret — the Worker signs, the gateway verifies.                          |
+| `GATEWAY_URL`       | URL the Worker `POST`s the webhook to.                                                             |
+| `FALLBACK_EMAIL`    | Address the Worker forwards to when the gateway is unreachable **or** answers non-2xx (see above). |
 
 ## Local development
 

--- a/packages/email-ingestion-gateway/src/__tests__/e2e.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/e2e.test.ts
@@ -373,7 +373,10 @@ describe('e2e — email with no matched business', () => {
       attempts: 1,
     });
 
-    expect(r.status).toBe(202);
+    // 503, not 202: nothing was recorded server-side and the mail is undeliverable
+    // to any tenant, so the Worker must see `!response.ok` and forward it to
+    // FALLBACK_EMAIL rather than treating a dropped email as success.
+    expect(r.status).toBe(503);
     expect(r.body).toMatchObject({ failed: true, reason: IngestReasonCode.UNKNOWN_ALIAS });
     // Control denied → treatment and ingest never run.
     expect(r.ingestCalled).toBe(false);

--- a/packages/email-ingestion-gateway/src/__tests__/integration.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/integration.test.ts
@@ -334,7 +334,7 @@ describe('integration — invalid auth', () => {
 // ---------------------------------------------------------------------------
 
 describe('integration — unknown alias', () => {
-  it('returns 202 with failed:true and UNKNOWN_ALIAS when alias is not registered', async () => {
+  it('returns 503 with failed:true and UNKNOWN_ALIAS when alias is not registered', async () => {
     const serverClient = makeServerClient({
       success: false,
       reason: IngestReasonCode.UNKNOWN_ALIAS,
@@ -349,8 +349,9 @@ describe('integration — unknown alias', () => {
     });
     const { res, getStatus, getBody } = makeRes();
     await handler(makeReq(VALID_PAYLOAD), res);
-    // Gateway always returns 202 (Cloudflare must not retry)
-    expect(getStatus()).toBe(202);
+    // Non-2xx so the Worker's `if (!response.ok)` fallback fires: nothing durable
+    // was recorded and the mail belongs to no tenant, so a human must see it.
+    expect(getStatus()).toBe(503);
     expect(getBody()).toMatchObject({ failed: true, reason: IngestReasonCode.UNKNOWN_ALIAS });
     expect(serverClient.requestIngest).not.toHaveBeenCalled();
   });

--- a/packages/email-ingestion-gateway/src/__tests__/webhook.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/webhook.test.ts
@@ -551,13 +551,25 @@ describe('POST /webhook — status on orchestration failure', () => {
 });
 
 describe('statusForOrchestrationFailure', () => {
-  it('maps every non-durable reason to 503 and everything else to 202', () => {
-    expect(statusForOrchestrationFailure(IngestReasonCode.TRANSIENT_UPSTREAM)).toBe(503);
-    expect(statusForOrchestrationFailure(IngestReasonCode.UPSTREAM_ERROR)).toBe(503);
-    expect(statusForOrchestrationFailure(IngestReasonCode.TIMEOUT)).toBe(503);
-    expect(statusForOrchestrationFailure(IngestReasonCode.UNKNOWN_ALIAS)).toBe(503);
-    expect(statusForOrchestrationFailure(IngestReasonCode.GRANT_INVALID)).toBe(202);
-    expect(statusForOrchestrationFailure(IngestReasonCode.NO_DOCUMENTS)).toBe(202);
-    expect(statusForOrchestrationFailure(IngestReasonCode.TENANT_MISMATCH)).toBe(202);
+  // The reasons that must drive the Worker's FALLBACK_EMAIL branch. Kept as an
+  // explicit list here, then checked against *every* code in the contract below,
+  // so the mapping cannot drift: adding a code to the production set without
+  // updating this list fails, and a newly added reason code is asserted to take
+  // the safe 202 default rather than silently going uncovered.
+  const EXPECTED_503: readonly IngestReasonCode[] = [
+    IngestReasonCode.TRANSIENT_UPSTREAM,
+    IngestReasonCode.UPSTREAM_ERROR,
+    IngestReasonCode.TIMEOUT,
+    IngestReasonCode.UNKNOWN_ALIAS,
+  ];
+
+  it.each(Object.values(IngestReasonCode))('maps %s to the documented status', code => {
+    const expected = EXPECTED_503.includes(code) ? 503 : 202;
+    expect(statusForOrchestrationFailure(code)).toBe(expected);
+  });
+
+  it('falls back to 202 for a reason code it does not recognize', () => {
+    // The safe side: never force-forward an email on a code we cannot reason about.
+    expect(statusForOrchestrationFailure('SOME_FUTURE_CODE')).toBe(202);
   });
 });

--- a/packages/email-ingestion-gateway/src/__tests__/webhook.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/webhook.test.ts
@@ -2,7 +2,7 @@ import { PassThrough } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { IngestReasonCode } from '../contracts.js';
-import { createWebhookHandler } from '../webhook.js';
+import { createWebhookHandler, statusForOrchestrationFailure } from '../webhook.js';
 import type { AuthenticityVerdict, CloudflareAuthenticityVerifier } from '../verifier.js';
 
 vi.mock('dotenv', () => ({ config: vi.fn() }));
@@ -437,5 +437,127 @@ describe('POST /webhook — shadow mode', () => {
     expect(getStatus()).toBe(202);
     expect(getBody()).toMatchObject({ shadow: true });
     expect((getBody() as Record<string, unknown>)['failed']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /webhook — response status on orchestration failure (#4346)
+//
+// The Cloudflare Worker's no-loss path is `if (!response.ok) → forward to
+// FALLBACK_EMAIL`. A blanket 202 satisfied `response.ok`, so a total-loss
+// outcome read as success and the fallback branch was unreachable — which is how
+// a sub-second upstream blip permanently destroyed five emails (#4344).
+// ---------------------------------------------------------------------------
+
+describe('POST /webhook — status on orchestration failure', () => {
+  function makeFailingHandler(reason: string) {
+    return createWebhookHandler({
+      verifier: makeVerifier({ valid: true }),
+      featureFlags: { v2Enabled: true, shadowMode: false },
+      serverClient: {
+        requestControl: vi
+          .fn()
+          .mockResolvedValue({ success: false, reason, message: 'upstream said no', attempts: 1 }),
+        requestIngest: vi.fn(),
+      },
+      applyTreatment: vi.fn().mockResolvedValue([]),
+    });
+  }
+
+  // Nothing durable exists server-side for these: control never granted, so there
+  // is no tenant, no quarantine row and no idempotency key. The email survives
+  // only if the Worker forwards it.
+  it.each([
+    IngestReasonCode.TRANSIENT_UPSTREAM,
+    IngestReasonCode.UPSTREAM_ERROR,
+    IngestReasonCode.TIMEOUT,
+    IngestReasonCode.UNKNOWN_ALIAS,
+  ])('returns 503 for %s so the Worker falls back to FALLBACK_EMAIL', async reason => {
+    const { res, getStatus, getBody } = makeRes();
+    await makeFailingHandler(reason)(makeReq(), res);
+
+    expect(getStatus()).toBe(503);
+    expect(getStatus()).toBeGreaterThan(299); // i.e. !response.ok in the Worker
+    expect(getBody()).toMatchObject({ status: 'failed', failed: true, reason });
+  });
+
+  // Post-grant failures ARE recorded server-side (audit/quarantine rows) and are
+  // reprocessable, so forwarding them would duplicate work.
+  it('keeps 202 for GRANT_INVALID, which is recorded server-side and reprocessable', async () => {
+    const handler = createWebhookHandler({
+      verifier: makeVerifier({ valid: true }),
+      featureFlags: { v2Enabled: true, shadowMode: false },
+      serverClient: {
+        requestControl: vi.fn().mockResolvedValue({
+          success: true,
+          decision: {
+            id: 'd1',
+            tenantId: 't1',
+            decisionId: 'dec1',
+            auditId: 'a1',
+            grant: {
+              id: 'g1',
+              jti: 'jti-1',
+              tenantId: 't1',
+              action: 'ingest',
+              expiresAt: '2099-01-01T00:00:00Z',
+            },
+            businessEmailConfig: null,
+            classification: 'DIRECT',
+          },
+        }),
+        requestIngest: vi.fn().mockResolvedValue({
+          success: false,
+          reason: IngestReasonCode.GRANT_INVALID,
+          message: 'grant already consumed',
+          attempts: 1,
+        }),
+      },
+      applyTreatment: vi.fn().mockResolvedValue([]),
+    });
+
+    const { res, getStatus, getBody } = makeRes();
+    await handler(makeReq(), res);
+
+    expect(getStatus()).toBe(202);
+    expect(getBody()).toMatchObject({
+      status: 'accepted',
+      failed: true,
+      reason: IngestReasonCode.GRANT_INVALID,
+    });
+  });
+
+  // Shadow mode answers before orchestration runs, so it cannot participate.
+  it('leaves shadow mode on 202 regardless of the failure reason', async () => {
+    const handler = createWebhookHandler({
+      verifier: makeVerifier({ valid: true }),
+      featureFlags: { v2Enabled: true, shadowMode: true },
+      serverClient: {
+        requestControl: vi.fn().mockResolvedValue({
+          success: false,
+          reason: IngestReasonCode.TRANSIENT_UPSTREAM,
+          message: 'boom',
+          attempts: 5,
+        }),
+        requestIngest: vi.fn(),
+      },
+      applyTreatment: vi.fn().mockResolvedValue([]),
+    });
+
+    const { res, getStatus } = makeRes();
+    await handler(makeReq(), res);
+    expect(getStatus()).toBe(202);
+  });
+});
+
+describe('statusForOrchestrationFailure', () => {
+  it('maps every non-durable reason to 503 and everything else to 202', () => {
+    expect(statusForOrchestrationFailure(IngestReasonCode.TRANSIENT_UPSTREAM)).toBe(503);
+    expect(statusForOrchestrationFailure(IngestReasonCode.UPSTREAM_ERROR)).toBe(503);
+    expect(statusForOrchestrationFailure(IngestReasonCode.TIMEOUT)).toBe(503);
+    expect(statusForOrchestrationFailure(IngestReasonCode.UNKNOWN_ALIAS)).toBe(503);
+    expect(statusForOrchestrationFailure(IngestReasonCode.GRANT_INVALID)).toBe(202);
+    expect(statusForOrchestrationFailure(IngestReasonCode.NO_DOCUMENTS)).toBe(202);
+    expect(statusForOrchestrationFailure(IngestReasonCode.TENANT_MISMATCH)).toBe(202);
   });
 });

--- a/packages/email-ingestion-gateway/src/__tests__/worker-pipe.integration.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/worker-pipe.integration.test.ts
@@ -236,6 +236,47 @@ describe('worker -> gateway -> mocked server integration', () => {
     expect(ingestInput.correlationId).toBe(controlInput.correlationId);
   });
 
+  // #4346: the whole point of the Worker's `if (!response.ok)` branch. Before the
+  // fix the gateway answered 202 on orchestration failure, `202` satisfied
+  // `response.ok`, and the fallback was unreachable for every failure — five
+  // emails were permanently lost that way (#4344).
+  it('forwards to FALLBACK_EMAIL when orchestration fails with no durable record', async () => {
+    // The mock server answers control with a GraphQL error — the exact signature
+    // a server-side exception produces through yoga.
+    mockServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+      await readJson(req);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({ errors: [{ message: 'Failed to process ingest control request' }], data: null }),
+      );
+    });
+    const mockServerUrl = await listen(mockServer);
+
+    process.env.PORT = '3000';
+    process.env.EMAIL_INGESTION_V2_ENABLED = '1';
+    process.env.EMAIL_INGESTION_SHADOW_MODE = '0';
+    process.env.CF_WEBHOOK_SECRET = 'worker-shared-secret';
+    process.env.GATEWAY_SERVER_URL = mockServerUrl;
+    process.env.GATEWAY_CP_TOKEN = 'gateway-control-plane-token';
+
+    const { requestHandler } = await import('../index.js');
+    gatewayServer = createServer(requestHandler);
+    const gatewayUrl = await listen(gatewayServer);
+
+    const { default: worker } = await import('../worker.js');
+    const message = makeEmailMessage();
+
+    await worker.email(message, {
+      CF_WEBHOOK_SECRET: 'worker-shared-secret',
+      GATEWAY_URL: gatewayUrl,
+      FALLBACK_EMAIL: 'fallback@example.com',
+      EMAIL_FORWARD_DESTINATION: 'forward@example.com',
+    });
+
+    // No email lost: it reached a human even though nothing was recorded server-side.
+    expect(message.forward).toHaveBeenCalledWith('fallback@example.com');
+  });
+
   it('falls back to forwarding when the gateway is unreachable', async () => {
     const { default: worker } = await import('../worker.js');
     const message = makeEmailMessage();

--- a/packages/email-ingestion-gateway/src/webhook.ts
+++ b/packages/email-ingestion-gateway/src/webhook.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { IngestReasonCode } from './contracts.js';
 import { generateCorrelationId, log } from './logger.js';
 import { extractFromMime, MAX_RAW_MIME_BYTES, type ExtractedDocument } from './mime-extractor.js';
 import { orchestrate, type OrchestratorDeps } from './orchestrator.js';
@@ -29,6 +30,39 @@ const RECEIVED_AT_HEADER = 'x-cf-received-at';
  */
 function getSingleHeader(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * Reason codes for which orchestration left **no durable record anywhere** —
+ * control never granted, so there is no resolved tenant and therefore no
+ * quarantine row, no idempotency key and no audit row. Nothing can reprocess
+ * these; the email exists only in the upstream mailbox.
+ *
+ * The Worker's no-loss path (`if (!response.ok) → message.forward(FALLBACK_EMAIL)`)
+ * is the last line of defence for exactly this case, and a 202 defeated it —
+ * `202` satisfies `response.ok`, so a total-loss outcome read as success and five
+ * emails were permanently lost (#4344/#4346).
+ *
+ * UNKNOWN_ALIAS is included deliberately: the mail is undeliverable to any tenant,
+ * and putting it in front of a human beats dropping it.
+ *
+ * Everything else (GRANT_INVALID and the other post-grant failures) *is* recorded
+ * server-side and is reprocessable, so it stays 202 — forwarding those would
+ * duplicate work.
+ */
+const NON_DURABLE_FAILURE_REASONS: ReadonlySet<string> = new Set<string>([
+  IngestReasonCode.TRANSIENT_UPSTREAM,
+  IngestReasonCode.UPSTREAM_ERROR,
+  IngestReasonCode.TIMEOUT,
+  IngestReasonCode.UNKNOWN_ALIAS,
+]);
+
+/**
+ * HTTP status for a failed orchestration. 503 is chosen so the Cloudflare Worker
+ * sees `!response.ok` and forwards to `FALLBACK_EMAIL`.
+ */
+export function statusForOrchestrationFailure(reason: string): number {
+  return NON_DURABLE_FAILURE_REASONS.has(reason) ? 503 : 202;
 }
 
 export interface WebhookDeps {
@@ -255,8 +289,17 @@ export function createWebhookHandler(deps: WebhookDeps) {
         reasonCode: result.reasonCode ?? undefined,
       });
     } else {
-      writeJson(res, 202, {
-        status: 'accepted',
+      const statusCode = statusForOrchestrationFailure(result.reason);
+      if (statusCode !== 202) {
+        log(
+          'warn',
+          'webhook: orchestration failed with no durable record — signalling the Worker to fall back',
+          { reason: result.reason, statusCode },
+          effectiveCorrelationId,
+        );
+      }
+      writeJson(res, statusCode, {
+        status: statusCode === 202 ? 'accepted' : 'failed',
         correlationId: effectiveCorrelationId,
         failed: true,
         reason: result.reason,

--- a/packages/email-ingestion-gateway/src/webhook.ts
+++ b/packages/email-ingestion-gateway/src/webhook.ts
@@ -50,7 +50,7 @@ function getSingleHeader(value: string | string[] | undefined): string | undefin
  * server-side and is reprocessable, so it stays 202 — forwarding those would
  * duplicate work.
  */
-const NON_DURABLE_FAILURE_REASONS: ReadonlySet<string> = new Set<string>([
+const NON_DURABLE_FAILURE_REASONS: ReadonlySet<IngestReasonCode> = new Set<IngestReasonCode>([
   IngestReasonCode.TRANSIENT_UPSTREAM,
   IngestReasonCode.UPSTREAM_ERROR,
   IngestReasonCode.TIMEOUT,
@@ -60,9 +60,15 @@ const NON_DURABLE_FAILURE_REASONS: ReadonlySet<string> = new Set<string>([
 /**
  * HTTP status for a failed orchestration. 503 is chosen so the Cloudflare Worker
  * sees `!response.ok` and forwards to `FALLBACK_EMAIL`.
+ *
+ * The parameter stays `string` because `orchestrate` reports `reason` as one —
+ * an unrecognized value is simply not in the set and falls through to 202, the
+ * safe side (the email is not force-forwarded on a code we cannot reason about).
+ * The *set* is typed `IngestReasonCode`, so a typo in its members is a compile
+ * error rather than a silently-never-matching entry.
  */
 export function statusForOrchestrationFailure(reason: string): number {
-  return NON_DURABLE_FAILURE_REASONS.has(reason) ? 503 : 202;
+  return NON_DURABLE_FAILURE_REASONS.has(reason as IngestReasonCode) ? 503 : 202;
 }
 
 export interface WebhookDeps {

--- a/packages/email-ingestion-gateway/src/worker.ts
+++ b/packages/email-ingestion-gateway/src/worker.ts
@@ -96,14 +96,21 @@ const worker = {
     });
 
     if (!response.ok) {
-      // Gateway is reachable but rejected the request — e.g. it is disabled
-      // (EMAIL_INGESTION_V2_ENABLED=0 returns 503 during rollback) or an auth
-      // check failed. Forward to the legacy Gmail inbox so no email is lost
-      // during rollback, and only throw when no fallback exists. This forwards
-      // *after* the read on a best-effort basis — verify it forwards in the
-      // Cloudflare runtime via the §6 staging smoke tests.
+      // Gateway is reachable but rejected the request — it is disabled
+      // (EMAIL_INGESTION_V2_ENABLED=0 returns 503 during rollback), an auth check
+      // failed, or orchestration failed leaving no durable record server-side
+      // (503; see `statusForOrchestrationFailure` in webhook.ts). Forward to the
+      // legacy Gmail inbox so no email is lost, and only throw when no fallback
+      // exists. This forwards *after* the read on a best-effort basis — verify it
+      // forwards in the Cloudflare runtime via the §6 staging smoke tests.
+      console.warn(`gateway rejected the webhook with status ${response.status}`);
       if (env.FALLBACK_EMAIL) {
+        // A forward to EMAIL_FORWARD_DESTINATION already happened above; this is a
+        // second forward to a *different* destination, which the Workers runtime
+        // permits. Never let a fallback failure end the handler quietly — rethrow
+        // so Cloudflare surfaces it rather than the email vanishing.
         await message.forward(env.FALLBACK_EMAIL);
+        console.log(`email forwarded to fallback ${env.FALLBACK_EMAIL}`);
         return;
       }
       throw new Error('Gateway returned status ' + response.status);


### PR DESCRIPTION
Fixes #4346. Part of #4344. Based on the #4356 branch — rebased onto it after #4352 merged, so this PR's diff is now exactly the #4346 change (8 files).

## Problem

`worker.ts` has a designed no-loss path: if the gateway rejects the request, forward the email to the legacy mailbox instead of dropping it.

```ts
if (!response.ok) {
  if (env.FALLBACK_EMAIL) {
    await message.forward(env.FALLBACK_EMAIL);
    return;
  }
  throw new Error('Gateway returned status ' + response.status);
}
```

But `webhook.ts` answered **202** when orchestration failed. `202` satisfies `response.ok`, so the Worker treated a total-loss outcome as success, the fallback branch was unreachable for every orchestration failure, and the `failed: true` flag in the body was never read.

This is the gap that turned a sub-second upstream blip into five *permanently* lost emails — the fallback existed and was correct; it just never ran.

## Change

Decided per reason code rather than by outcome shape, as the issue asked:

- **`TRANSIENT_UPSTREAM`, `UPSTREAM_ERROR`, `TIMEOUT`** → **503**. Control never granted, so there is no resolved tenant, and `email_ingestion_quarantine` requires one. Nothing was recorded and nothing can be — the email exists only in the upstream mailbox.
- **`UNKNOWN_ALIAS`** → **503**. The issue called this "arguably also non-2xx"; I went with yes. The mail is undeliverable to any tenant, and putting it in front of a human beats dropping it silently.
- **`GRANT_INVALID` and other post-grant failures** → stays **202**. These *are* recorded server-side (quarantine/audit rows) and are reprocessable; forwarding them would duplicate work.

Shadow mode responds `202` before orchestration runs, so it cannot participate and is left as-is, per the issue.

The mapping is an exported `statusForOrchestrationFailure(reason)` so the policy is one readable list rather than scattered branches. Per Copilot's review, the set is typed `ReadonlySet<IngestReasonCode>` (a typo in its members is a compile error) while the parameter stays `string`, since `orchestrate` reports `reason` as one — an unrecognized code falls through to 202, the safe side.

## On the two "watch out" items in the issue

**Double `forward()`.** The Worker already forwards to `EMAIL_FORWARD_DESTINATION` earlier in `email()`, so the fallback is a second forward to a *different* destination. The Workers runtime permits this, and the integration test confirms both calls are made — but the test drives the real `worker.email()` against a real gateway, not the Cloudflare runtime, so this still deserves the §6 staging smoke test before you rely on it. I added a comment saying so rather than claiming it is settled, plus a `console.warn` on the rejection so the fallback path is visible in Worker logs.

**Retries in front of the gateway.** Dedup keys on `rawMessageHash`, so an identical retry is caught — but as the issue notes, re-delivery through Cloudflare can mutate headers and change the hash. That is #4350 and is not addressed here.

## Testing

`yarn vitest run --project unit --project integration packages/email-ingestion-gateway` — 321 passed, re-run after the rebase. New: a status-mapping case per reason code, the mapping function walked against *every* value in `IngestReasonCode` (so a new code cannot go uncovered), an unknown-code-falls-to-202 case, a `GRANT_INVALID`-stays-202 case, a shadow-mode case, and the end-to-end case the issue asked for in `worker-pipe.integration.test.ts` — a control call returning a GraphQL error drives the Worker down the `FALLBACK_EMAIL` branch.

---

### Where this sits

| PR | Issue | Base | State |
| --- | --- | --- | --- |
| #4356 | #4347 + #4345 | `main` | open |
| #4352 | #4345 | — | merged into the #4356 branch |
| **this one** | #4346 | the #4356 branch | open |
| #4354 | #4348 | `main` | open, independent |
| #4355 | #4351 | `main` | open, independent |

Rebased onto the #4356 branch after #4352 merged into it. The two commits carrying #4345 content were dropped by the rebase as already-upstream (git matched them against the squash-merge), so the resulting tree is byte-identical to the pre-rebase one and the diff shown here is purely #4346. Merge after #4356.