### PR TITLE
feat(client): link a document to a charge from the documents table

### DIFF
--- a/.changeset/tidy-pears-shave.md
+++ b/.changeset/tidy-pears-shave.md
@@ -1,0 +1,6 @@
+---
+'@accounter/client': patch
+---
+
+Add a "Link to Charge" action to the documents table actions menu, so a document can be attached to
+an existing charge (or moved to another one) by pasting its charge ID or charge link.

--- a/packages/client/src/components/common/buttons/__tests__/link-document-button.test.ts
+++ b/packages/client/src/components/common/buttons/__tests__/link-document-button.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { extractChargeId } from '../link-document-button.js';
+
+describe('extractChargeId', () => {
+  const id = '3f2504e0-4f89-11d3-9a0c-0305e82c3301';
+
+  it('accepts a bare UUID', () => {
+    expect(extractChargeId(id)).toBe(id);
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(extractChargeId(`  ${id}\n`)).toBe(id);
+  });
+
+  it('lowercases the id', () => {
+    expect(extractChargeId(id.toUpperCase())).toBe(id);
+  });
+
+  it('extracts the id out of a charge link', () => {
+    expect(extractChargeId(`https://accounter.example.com/charges/${id}`)).toBe(id);
+  });
+
+  it('returns undefined for input without an id', () => {
+    expect(extractChargeId('')).toBeUndefined();
+    expect(extractChargeId('not-a-charge')).toBeUndefined();
+  });
+});

--- a/packages/client/src/components/common/buttons/index.ts
+++ b/packages/client/src/components/common/buttons/index.ts
@@ -8,6 +8,7 @@ export * from './download-csv-button.js';
 export * from './edit-mini-button.js';
 export * from './info-mini-button.js';
 export * from './insert-mini-button.js';
+export * from './link-document-button.js';
 export * from './logout-button.js';
 export * from './print-to-pdf-button.js';
 export * from './regenerate-ledger-records-button.js';

--- a/packages/client/src/components/common/buttons/link-document-button.tsx
+++ b/packages/client/src/components/common/buttons/link-document-button.tsx
@@ -1,0 +1,155 @@
+import {
+  useCallback,
+  useState,
+  type Dispatch,
+  type ReactElement,
+  type SetStateAction,
+} from 'react';
+import { Link as LinkIcon } from 'lucide-react';
+import { UUID_REGEX } from '../../../helpers/index.js';
+import { useUpdateDocument } from '../../../hooks/use-update-document.js';
+import { Button } from '../../ui/button.js';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '../../ui/dialog.js';
+import { Input } from '../../ui/input.js';
+import { Label } from '../../ui/label.js';
+
+const UUID_ANYWHERE_REGEX =
+  /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/;
+
+/**
+ * Accept either a bare charge ID or anything containing one - a charge URL copied from the
+ * "Copy Charge Link" action, for instance.
+ */
+export function extractChargeId(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (UUID_REGEX.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+  return UUID_ANYWHERE_REGEX.exec(trimmed)?.[0]?.toLowerCase();
+}
+
+interface Props {
+  documentId: string;
+  onChange: () => void;
+  onDone?: () => void;
+  /**
+   * Called when moving the document away left its former charge empty, so the server deleted it.
+   * The consumer should drop that charge instead of refetching it - `Query.charge` throws for a
+   * deleted id.
+   */
+  onChargeDeleted?: (chargeId: string) => void;
+  /**
+   * Drive the dialog from outside instead of from the built-in icon trigger. Hosts that already
+   * have their own trigger (the documents table's actions menu, for instance) pass both and no
+   * trigger button is rendered.
+   */
+  open?: boolean;
+  setOpen?: Dispatch<SetStateAction<boolean>>;
+}
+
+export function LinkDocumentButton({
+  documentId,
+  onChange,
+  onDone,
+  onChargeDeleted,
+  open: externalOpen,
+  setOpen: setExternalOpen,
+}: Props): ReactElement {
+  const [localOpen, setLocalOpen] = useState(false);
+  const setOpen = setExternalOpen ?? setLocalOpen;
+  const open = externalOpen ?? localOpen;
+  const [value, setValue] = useState('');
+  const [error, setError] = useState<string | undefined>(undefined);
+  const { fetching, updateDocument } = useUpdateDocument();
+
+  const onOpenChange = useCallback(
+    (nextOpen: boolean): void => {
+      setOpen(nextOpen);
+      if (!nextOpen) {
+        setValue('');
+        setError(undefined);
+      }
+    },
+    [setOpen],
+  );
+
+  const onLink = useCallback((): void => {
+    const chargeId = extractChargeId(value);
+    if (!chargeId) {
+      setError('Enter a valid charge ID or a charge link');
+      return;
+    }
+    setError(undefined);
+    updateDocument({ documentId, fields: { chargeId } }).then(result => {
+      if (!result) {
+        // failed: the hook already reported it, keep the dialog open
+        return;
+      }
+      if (result.deletedChargeId && onChargeDeleted) {
+        onChargeDeleted(result.deletedChargeId);
+      } else {
+        onChange();
+      }
+      onOpenChange(false);
+      onDone?.();
+    });
+  }, [value, documentId, updateDocument, onChange, onChargeDeleted, onDone, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {setExternalOpen ? undefined : (
+        <DialogTrigger asChild onClick={event => event.stopPropagation()}>
+          <Button variant="ghost" size="icon" className="size-7.5">
+            <LinkIcon className="size-5" />
+          </Button>
+        </DialogTrigger>
+      )}
+      <DialogContent className="sm:max-w-[425px]" onClick={event => event.stopPropagation()}>
+        <DialogHeader>
+          <DialogTitle>Link Document to Charge</DialogTitle>
+          <DialogDescription>
+            Paste the charge ID, or a charge link, to attach this document to it.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-2">
+          <Label htmlFor="link-document-charge-id">Charge ID</Label>
+          <Input
+            id="link-document-charge-id"
+            value={value}
+            aria-invalid={error ? true : undefined}
+            placeholder="00000000-0000-0000-0000-000000000000"
+            onChange={event => {
+              setValue(event.target.value);
+              setError(undefined);
+            }}
+            onKeyDown={event => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                onLink();
+              }
+            }}
+          />
+          {error && <p className="text-sm text-red-500">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="secondary" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={onLink} disabled={fetching || value.trim().length === 0}>
+            Link
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/documents-table/document-actions-menu.tsx
+++ b/packages/client/src/components/documents-table/document-actions-menu.tsx
@@ -6,6 +6,7 @@ import {
   ExternalLink,
   File,
   Image,
+  Link2,
   Link as LinkIcon,
   ListPlus,
   MoreVertical,
@@ -20,6 +21,7 @@ import {
   CloseDocumentButton,
   DeleteDocumentButton,
   DocumentImageDrawer,
+  LinkDocumentButton,
   PreviewDocumentModal,
   UnlinkDocumentButton,
 } from '../common/index.js';
@@ -57,6 +59,7 @@ export function DocumentActionsMenu({
   const [imageOpen, setImageOpen] = useState(false);
   const [closeDocumentOpen, setCloseDocumentOpen] = useState(false);
   const [issueDocumentOpen, setIssueDocumentOpen] = useState(false);
+  const [linkOpen, setLinkOpen] = useState(false);
   const [unlinkOpen, setUnlinkOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
@@ -161,6 +164,10 @@ export function DocumentActionsMenu({
 
           <DropdownMenuSeparator />
 
+          <DropdownMenuItem onSelect={() => setLinkOpen(true)}>
+            <Link2 className="size-4" />
+            {chargeId ? 'Link to Another Charge' : 'Link to Charge'}
+          </DropdownMenuItem>
           <DropdownMenuItem disabled={!chargeId} onSelect={() => setUnlinkOpen(true)}>
             <Unlink className="size-4" />
             Unlink Document
@@ -178,6 +185,13 @@ export function DocumentActionsMenu({
         onClose={(): void => setImageOpen(false)}
       />
 
+      <LinkDocumentButton
+        documentId={document.id}
+        onChange={document.onUpdate}
+        onChargeDeleted={document.onChargeDeleted}
+        open={linkOpen}
+        setOpen={setLinkOpen}
+      />
       <UnlinkDocumentButton
         documentId={document.id}
         onChange={document.onUpdate}


### PR DESCRIPTION
## What

Adds a **Link to Charge** action to the documents table actions menu
(`document-actions-menu.tsx`).

The menu could already unlink a document from its charge, open the charge and copy its link, but
there was no way to attach a document *to* a charge. The new item opens a small dialog that takes a
charge ID — or anything containing one, so a charge URL copied via "Copy Charge Link" pastes
straight in — and moves the document onto that charge through the existing `updateDocument`
mutation.

- The item reads "Link to Charge" for an unlinked document and "Link to Another Charge" when the
  document already belongs to one.
- If the move empties the former charge, the server-returned `deletedChargeId` is forwarded to
  `onChargeDeleted`, same as the unlink flow, so hosts drop the charge instead of refetching a
  deleted id.

## Changes

- New `LinkDocumentButton` (`components/common/buttons/link-document-button.tsx`), controlled the
  same way as `UnlinkDocumentButton` (external `open`/`setOpen`, or its own icon trigger).
- Wired into the documents-table actions menu next to Unlink/Delete.
- Unit tests for the charge-id/link parsing helper.
- Changeset (`@accounter/client`, patch).

No schema changes — this reuses `updateDocument(fields: { chargeId })`.

## Verification

- `yarn generate`
- `yarn tsc --noEmit` in `packages/client` — clean
- `yarn eslint` on the touched files — clean
- `yarn vitest run --project unit .../link-document-button.test.ts` — 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsQFhAGxqopfrhXwwnsqPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsQFhAGxqopfrhXwwnsqPJ)_