### PR TITLE
Add state persistence hooks for table preferences

### DIFF
--- a/.changeset/businesses-table-state-persistence.md
+++ b/.changeset/businesses-table-state-persistence.md
@@ -1,0 +1,26 @@
+---
+'@accounter/client': patch
+---
+
+Persist the businesses table's column selection, sorting and row selection.
+
+Column visibility and sorting were plain component state, so both were lost on a page refresh. Row
+selection had two separate problems: it lived in the component, so navigating away from the screen
+and back dropped it, and `selectedIds` was derived from the *filtered* rows, so a row selected under
+one filter disappeared from the batch-action buttons as soon as the filters changed.
+
+Column visibility and sorting now persist to `localStorage` and survive a refresh. Stored values are
+revived defensively, since an entry may have been written by an older build: sorting is accepted only
+when every entry has the `{ id, desc }` shape, and column visibility is merged over the current
+defaults so a column added since the value was stored keeps its default rather than disappearing.
+
+Row selection is instead kept in a module-level store — it survives navigation and filter changes,
+but a page refresh starts from a clean slate (`sessionStorage` would have survived the refresh too).
+`selectedIds` now derives from the unfiltered row set, so a selection made under one filter is still
+there after the filter changes; ids of rows that no longer exist drop out on their own.
+
+Adds two reusable hooks for this: `usePersistentState` (`useState` mirrored to `localStorage`, with a
+`revive` callback to validate and merge a stored value, and re-hydration when the storage key
+changes) and `useEphemeralState` (`useState` backed by a module-level store, surviving unmount but
+not a page load). Both guard every storage access, so a disabled or full `localStorage` degrades to
+the fallback instead of crashing the screen.

--- a/packages/client/src/components/businesses/__tests__/table-state-storage.test.ts
+++ b/packages/client/src/components/businesses/__tests__/table-state-storage.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { ColumnVisibilityState, SortingState } from '@tanstack/react-table';
+import { reviveColumnVisibility, reviveSorting } from '../table-state-storage.js';
+
+const SORTING_FALLBACK: SortingState = [];
+const VISIBILITY_FALLBACK: ColumnVisibilityState = { name: true, city: false };
+
+describe('reviveSorting', () => {
+  it('accepts a well-shaped sorting state', () => {
+    const stored = [{ id: 'name', desc: true }];
+    expect(reviveSorting(stored, SORTING_FALLBACK)).toEqual(stored);
+  });
+
+  it('accepts an empty array', () => {
+    expect(reviveSorting([], SORTING_FALLBACK)).toEqual([]);
+  });
+
+  it.each([
+    ['a non-array', { id: 'name', desc: true }],
+    ['null', null],
+    ['entries missing desc', [{ id: 'name' }]],
+    ['entries with a non-string id', [{ id: 3, desc: true }]],
+    ['entries that are not objects', ['name']],
+  ])('falls back on %s', (_label, stored) => {
+    expect(reviveSorting(stored, SORTING_FALLBACK)).toBe(SORTING_FALLBACK);
+  });
+});
+
+describe('reviveColumnVisibility', () => {
+  it('merges the stored value over the defaults', () => {
+    expect(reviveColumnVisibility({ name: false }, VISIBILITY_FALLBACK)).toEqual({
+      name: false,
+      city: false,
+    });
+  });
+
+  it('keeps defaults for columns added since the value was stored', () => {
+    expect(reviveColumnVisibility({ name: false, gone: true }, VISIBILITY_FALLBACK)).toEqual({
+      name: false,
+      city: false,
+      gone: true,
+    });
+  });
+
+  it('ignores non-boolean entries', () => {
+    expect(reviveColumnVisibility({ name: 'yes', city: true }, VISIBILITY_FALLBACK)).toEqual({
+      name: true,
+      city: true,
+    });
+  });
+
+  it.each([
+    ['an array', []],
+    ['null', null],
+    ['a primitive', 'name'],
+  ])('falls back on %s', (_label, stored) => {
+    expect(reviveColumnVisibility(stored, VISIBILITY_FALLBACK)).toBe(VISIBILITY_FALLBACK);
+  });
+});

--- a/packages/client/src/components/businesses/__tests__/table-state-storage.test.ts
+++ b/packages/client/src/components/businesses/__tests__/table-state-storage.test.ts
@@ -34,9 +34,19 @@ describe('reviveColumnVisibility', () => {
     });
   });
 
-  it('keeps defaults for columns added since the value was stored', () => {
-    expect(reviveColumnVisibility({ name: false, gone: true }, VISIBILITY_FALLBACK)).toEqual({
+  it('keeps the default for a column added since the value was stored', () => {
+    // `city` is absent from the stored value, so it keeps its (hidden) default.
+    expect(reviveColumnVisibility({ name: false }, VISIBILITY_FALLBACK)).toEqual({
       name: false,
+      city: false,
+    });
+  });
+
+  it('carries over a stored entry for a column that no longer exists', () => {
+    // Harmless: the table ignores visibility entries with no matching column, and keeping the
+    // entry means a column that comes back keeps the visibility the user last chose for it.
+    expect(reviveColumnVisibility({ gone: true }, VISIBILITY_FALLBACK)).toEqual({
+      name: true,
       city: false,
       gone: true,
     });

--- a/packages/client/src/components/businesses/index.tsx
+++ b/packages/client/src/components/businesses/index.tsx
@@ -8,6 +8,8 @@ import {
   type RowSelectionState,
   type SortingState,
 } from '@tanstack/react-table';
+import { useEphemeralState } from '@/hooks/use-ephemeral-state.js';
+import { usePersistentState } from '@/hooks/use-persistent-state.js';
 import { tableFeaturesConfig } from '@/lib/table-features.js';
 import { AllBusinessesForScreenDocument, BusinessesUsageDocument } from '../../gql/graphql.js';
 import { FiltersContext } from '../../providers/filters-context.js';
@@ -41,6 +43,15 @@ import {
 import { BusinessesFilters } from './businesses-filters.js';
 import { COLUMN_GROUPS, columns, DEFAULT_COLUMN_VISIBILITY, USAGE_COLUMN_IDS } from './columns.js';
 import { TableScrollContainer } from './table-scroll-container.js';
+import {
+  BUSINESSES_ROW_SELECTION_KEY,
+  BUSINESSES_STORAGE_KEYS,
+  reviveColumnVisibility,
+  reviveSorting,
+} from './table-state-storage.js';
+
+const EMPTY_ROW_SELECTION: RowSelectionState = {};
+const EMPTY_SORTING: SortingState = [];
 
 // Fetch all businesses (no server pagination) so filtering/sorting/pagination are all client-side
 // and apply across the whole set, not just one page. The resolver already loads them all in memory.
@@ -116,10 +127,23 @@ export const Businesses = (): ReactElement => {
     [data?.allBusinesses?.nodes],
   );
 
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
-  const [columnVisibility, setColumnVisibility] =
-    useState<ColumnVisibilityState>(DEFAULT_COLUMN_VISIBILITY);
-  const [sorting, setSorting] = useState<SortingState>([]);
+  // Selection is transient: it follows the user across navigation and filter changes, but a page
+  // refresh starts from a clean slate — hence an in-memory store rather than localStorage.
+  const [rowSelection, setRowSelection] = useEphemeralState<RowSelectionState>(
+    BUSINESSES_ROW_SELECTION_KEY,
+    EMPTY_ROW_SELECTION,
+  );
+  // Column visibility and sorting are preferences: they stick across refreshes.
+  const [columnVisibility, setColumnVisibility] = usePersistentState<ColumnVisibilityState>(
+    BUSINESSES_STORAGE_KEYS.COLUMN_VISIBILITY,
+    DEFAULT_COLUMN_VISIBILITY,
+    reviveColumnVisibility,
+  );
+  const [sorting, setSorting] = usePersistentState<SortingState>(
+    BUSINESSES_STORAGE_KEYS.SORTING,
+    EMPTY_SORTING,
+    reviveSorting,
+  );
   const [filters, setFilters] = useState<BusinessRowFilters>({
     name: '',
     client: false,
@@ -171,12 +195,13 @@ export const Businesses = (): ReactElement => {
     } as BusinessTableMeta,
   });
 
-  // Derive selected ids from the stable `filteredRows` (the table's data) and `rowSelection`
-  // (keyed by row id via getRowId), avoiding the unstable `table` object. This stays in sync
-  // when filters or data change, unlike memoizing on `rowSelection` alone.
+  // Derive selected ids from `rows` and `rowSelection` (keyed by row id via getRowId), avoiding
+  // the unstable `table` object. Deliberately the *unfiltered* row set: a row selected under one
+  // filter stays selected when the filter changes (and is still checked once it is visible
+  // again). Ids of rows that no longer exist at all drop out on their own.
   const selectedIds = useMemo(
-    () => filteredRows.filter(row => rowSelection[row.id]).map(row => row.id),
-    [filteredRows, rowSelection],
+    () => rows.filter(row => rowSelection[row.id]).map(row => row.id),
+    [rows, rowSelection],
   );
 
   // Footer
@@ -210,7 +235,16 @@ export const Businesses = (): ReactElement => {
         />
       </div>,
     );
-  }, [setFiltersContext, selectedIds, refetch, filters, setFilters, usageEnabled, usageFetching]);
+  }, [
+    setFiltersContext,
+    selectedIds,
+    refetch,
+    filters,
+    setFilters,
+    setRowSelection,
+    usageEnabled,
+    usageFetching,
+  ]);
 
   return (
     <PageLayout

--- a/packages/client/src/components/businesses/table-state-storage.ts
+++ b/packages/client/src/components/businesses/table-state-storage.ts
@@ -1,0 +1,58 @@
+/**
+ * Storage keys and revivers for the businesses table state.
+ *
+ * Kept free of React imports so the (defensive) parsing of previously stored values is easy to
+ * unit test: entries may have been written by an older version of the app, hand-edited, or
+ * reference columns that no longer exist.
+ */
+
+import type { ColumnVisibilityState, SortingState } from '@tanstack/react-table';
+
+const STORAGE_KEY_PREFIX = 'businesses';
+
+/** Persisted across refreshes (localStorage). */
+export const BUSINESSES_STORAGE_KEYS = {
+  SORTING: `${STORAGE_KEY_PREFIX}_sorting`,
+  COLUMN_VISIBILITY: `${STORAGE_KEY_PREFIX}_columnVisibility`,
+} as const;
+
+/** Kept in memory only — selection survives navigation, but not a page refresh. */
+export const BUSINESSES_ROW_SELECTION_KEY = `${STORAGE_KEY_PREFIX}_rowSelection`;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Accepts a stored sorting state only when every entry has the `{ id, desc }` shape. Entries
+ * pointing at columns that no longer exist are harmless — the sorted row model skips them.
+ */
+export function reviveSorting(parsed: unknown, fallback: SortingState): SortingState {
+  if (!Array.isArray(parsed)) {
+    return fallback;
+  }
+  const isValid = parsed.every(
+    entry => isRecord(entry) && typeof entry.id === 'string' && typeof entry.desc === 'boolean',
+  );
+  return isValid ? (parsed as SortingState) : fallback;
+}
+
+/**
+ * Merges the stored visibility over the current defaults, so columns added since the value was
+ * stored keep their default visibility instead of disappearing.
+ */
+export function reviveColumnVisibility(
+  parsed: unknown,
+  fallback: ColumnVisibilityState,
+): ColumnVisibilityState {
+  if (!isRecord(parsed)) {
+    return fallback;
+  }
+  const stored: ColumnVisibilityState = {};
+  for (const [columnId, isVisible] of Object.entries(parsed)) {
+    if (typeof isVisible === 'boolean') {
+      stored[columnId] = isVisible;
+    }
+  }
+  return { ...fallback, ...stored };
+}

--- a/packages/client/src/hooks/__tests__/use-ephemeral-state.test.ts
+++ b/packages/client/src/hooks/__tests__/use-ephemeral-state.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+
+import React, { act, type Dispatch, type SetStateAction } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearEphemeralState, useEphemeralState } from '../use-ephemeral-state.js';
+
+const KEY = 'test_ephemeral_state';
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  clearEphemeralState(KEY);
+  localStorage.clear();
+  sessionStorage.clear();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  container.remove();
+});
+
+/** Mounts the hook on a fresh root, emulating navigating to the screen. */
+function mount<T>(fallback: T): {
+  current: () => T;
+  set: (value: SetStateAction<T>) => void;
+  unmount: () => void;
+} {
+  let state: T = fallback;
+  let setState: Dispatch<SetStateAction<T>> = () => {};
+
+  function Harness(): null {
+    [state, setState] = useEphemeralState(KEY, fallback);
+    return null;
+  }
+
+  const localRoot = createRoot(container);
+  act(() => localRoot.render(React.createElement(Harness)));
+  return {
+    current: () => state,
+    set: value => act(() => setState(value)),
+    unmount: () => act(() => localRoot.unmount()),
+  };
+}
+
+describe('useEphemeralState', () => {
+  it('starts from the fallback', () => {
+    expect(mount({ a: true }).current()).toEqual({ a: true });
+  });
+
+  it('restores the value after an unmount/remount', () => {
+    const first = mount<Record<string, boolean>>({});
+    first.set({ a: true });
+    first.unmount();
+
+    expect(mount<Record<string, boolean>>({}).current()).toEqual({ a: true });
+  });
+
+  it('does not touch web storage', () => {
+    const hook = mount<Record<string, boolean>>({});
+    hook.set({ a: true });
+    hook.unmount();
+
+    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('starts from the fallback again once cleared', () => {
+    const hook = mount<Record<string, boolean>>({});
+    hook.set({ a: true });
+    hook.unmount();
+
+    clearEphemeralState(KEY);
+    expect(mount<Record<string, boolean>>({}).current()).toEqual({});
+  });
+});

--- a/packages/client/src/hooks/__tests__/use-ephemeral-state.test.ts
+++ b/packages/client/src/hooks/__tests__/use-ephemeral-state.test.ts
@@ -1,23 +1,29 @@
 // @vitest-environment happy-dom
 
 import React, { act, type Dispatch, type SetStateAction } from 'react';
-import { createRoot } from 'react-dom/client';
+import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearEphemeralState, useEphemeralState } from '../use-ephemeral-state.js';
 
 const KEY = 'test_ephemeral_state';
 
 let container: HTMLDivElement;
+/** Every root mounted by `mount`, so any still-live one is torn down after the test. */
+let mountedRoots: Root[];
 
 beforeEach(() => {
   clearEphemeralState(KEY);
   localStorage.clear();
   sessionStorage.clear();
+  mountedRoots = [];
   container = document.createElement('div');
   document.body.appendChild(container);
 });
 
 afterEach(() => {
+  for (const root of mountedRoots) {
+    act(() => root.unmount());
+  }
   container.remove();
 });
 
@@ -36,11 +42,15 @@ function mount<T>(fallback: T): {
   }
 
   const localRoot = createRoot(container);
+  mountedRoots.push(localRoot);
   act(() => localRoot.render(React.createElement(Harness)));
   return {
     current: () => state,
     set: value => act(() => setState(value)),
-    unmount: () => act(() => localRoot.unmount()),
+    unmount: () => {
+      act(() => localRoot.unmount());
+      mountedRoots = mountedRoots.filter(root => root !== localRoot);
+    },
   };
 }
 

--- a/packages/client/src/hooks/__tests__/use-persistent-state.test.ts
+++ b/packages/client/src/hooks/__tests__/use-persistent-state.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+
+import React, { act, type Dispatch, type SetStateAction } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePersistentState } from '../use-persistent-state.js';
+
+const KEY = 'test_persistent_state';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  localStorage.clear();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+/** Mounts the hook and exposes the latest state and setter. */
+function mount<T>(
+  fallback: T,
+  revive?: (parsed: unknown, fallback: T) => T,
+): { current: () => T; set: (value: SetStateAction<T>) => void } {
+  let state: T = fallback;
+  let setState: Dispatch<SetStateAction<T>> = () => {};
+
+  function Harness(): null {
+    [state, setState] = usePersistentState(KEY, fallback, revive);
+    return null;
+  }
+
+  act(() => root.render(React.createElement(Harness)));
+  return {
+    current: () => state,
+    set: value => act(() => setState(value)),
+  };
+}
+
+describe('usePersistentState', () => {
+  it('starts from the fallback and writes it to localStorage', () => {
+    const hook = mount({ name: true });
+    expect(hook.current()).toEqual({ name: true });
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual({ name: true });
+  });
+
+  it('persists updates', () => {
+    const hook = mount<string[]>([]);
+    hook.set(['a']);
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual(['a']);
+  });
+
+  it('restores a stored value on a later mount', () => {
+    localStorage.setItem(KEY, JSON.stringify({ name: false }));
+    const hook = mount({ name: true });
+    expect(hook.current()).toEqual({ name: false });
+  });
+
+  it('passes the stored value through `revive`', () => {
+    localStorage.setItem(KEY, JSON.stringify({ name: false }));
+    const hook = mount({ name: true, city: true }, (parsed, fallback) => ({
+      ...fallback,
+      ...(parsed as Record<string, boolean>),
+    }));
+    expect(hook.current()).toEqual({ name: false, city: true });
+  });
+
+  it('falls back when the stored value is not valid JSON', () => {
+    localStorage.setItem(KEY, '{not json');
+    const hook = mount({ name: true });
+    expect(hook.current()).toEqual({ name: true });
+  });
+
+  it('falls back when `revive` throws', () => {
+    localStorage.setItem(KEY, JSON.stringify({ name: false }));
+    const hook = mount({ name: true }, () => {
+      throw new Error('bad shape');
+    });
+    expect(hook.current()).toEqual({ name: true });
+  });
+
+  it('keeps working when localStorage writes fail', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded');
+    });
+
+    const hook = mount<string[]>([]);
+    hook.set(['a']);
+
+    expect(hook.current()).toEqual(['a']);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/hooks/__tests__/use-persistent-state.test.ts
+++ b/packages/client/src/hooks/__tests__/use-persistent-state.test.ts
@@ -43,6 +43,26 @@ function mount<T>(
   };
 }
 
+/** Mounts the hook with a `storageKey` that can be changed after mount. */
+function mountWithKey<T>(
+  initialKey: string,
+  fallback: T,
+): { current: () => T; setKey: (key: string) => void } {
+  let state: T = fallback;
+
+  function Harness({ storageKey }: { storageKey: string }): null {
+    [state] = usePersistentState(storageKey, fallback);
+    return null;
+  }
+
+  const render = (storageKey: string): void => {
+    act(() => root.render(React.createElement(Harness, { storageKey })));
+  };
+
+  render(initialKey);
+  return { current: () => state, setKey: render };
+}
+
 describe('usePersistentState', () => {
   it('starts from the fallback and writes it to localStorage', () => {
     const hook = mount({ name: true });
@@ -83,6 +103,28 @@ describe('usePersistentState', () => {
       throw new Error('bad shape');
     });
     expect(hook.current()).toEqual({ name: true });
+  });
+
+  it('re-hydrates from a changed storageKey', () => {
+    localStorage.setItem('key_a', JSON.stringify(['from a']));
+    localStorage.setItem('key_b', JSON.stringify(['from b']));
+
+    const hook = mountWithKey<string[]>('key_a', []);
+    expect(hook.current()).toEqual(['from a']);
+
+    hook.setKey('key_b');
+    expect(hook.current()).toEqual(['from b']);
+    // The old key's value must not leak into the new key.
+    expect(JSON.parse(localStorage.getItem('key_b')!)).toEqual(['from b']);
+  });
+
+  it('falls back when a changed storageKey has nothing stored', () => {
+    localStorage.setItem('key_a', JSON.stringify(['from a']));
+
+    const hook = mountWithKey<string[]>('key_a', []);
+    hook.setKey('key_unstored');
+
+    expect(hook.current()).toEqual([]);
   });
 
   it('keeps working when localStorage writes fail', () => {

--- a/packages/client/src/hooks/use-ephemeral-state.ts
+++ b/packages/client/src/hooks/use-ephemeral-state.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+
+/** Module-level store: lives as long as the loaded app, and dies with it. */
+const ephemeralStore = new Map<string, unknown>();
+
+/**
+ * `useState` whose value is kept in a module-level store rather than in the component, so it
+ * survives unmount/remount — navigating to another screen and back — but is gone after a page
+ * refresh (nothing is written to `localStorage`/`sessionStorage`).
+ *
+ * Intended for transient, session-scoped selections (e.g. which table rows are checked) that
+ * should not follow the user into a fresh page load.
+ *
+ * `key` is read only on mount, so pass a constant one per state slice.
+ */
+export function useEphemeralState<T>(key: string, fallback: T): [T, Dispatch<SetStateAction<T>>] {
+  const [state, setState] = useState<T>(() =>
+    ephemeralStore.has(key) ? (ephemeralStore.get(key) as T) : fallback,
+  );
+
+  useEffect(() => {
+    ephemeralStore.set(key, state);
+  }, [key, state]);
+
+  return [state, setState];
+}
+
+/** Drops a stored value, so the next mount starts from its fallback. Exported for tests. */
+export function clearEphemeralState(key: string): void {
+  ephemeralStore.delete(key);
+}

--- a/packages/client/src/hooks/use-persistent-state.ts
+++ b/packages/client/src/hooks/use-persistent-state.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+
+/**
+ * `useState` whose value is mirrored to `localStorage`, so it survives a page refresh.
+ *
+ * Intended for table preferences (sorting, column visibility, ...) that a user expects to stick
+ * between visits. Storage access is fully guarded: a disabled/full `localStorage` or a stale,
+ * corrupt entry simply falls back to `fallback` instead of crashing the screen.
+ *
+ * `revive` maps the raw parsed JSON back to state — use it to validate the stored shape (it may
+ * come from an older version of the app) and to merge it with the current defaults. It runs only
+ * on mount; returning `fallback` from it discards the stored value.
+ */
+export function usePersistentState<T>(
+  storageKey: string,
+  fallback: T,
+  revive: (parsed: unknown, fallback: T) => T = parsed => parsed as T,
+): [T, Dispatch<SetStateAction<T>>] {
+  const [state, setState] = useState<T>(() => {
+    try {
+      const stored = localStorage.getItem(storageKey);
+      return stored == null ? fallback : revive(JSON.parse(stored), fallback);
+    } catch {
+      return fallback;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(state));
+    } catch (error) {
+      console.warn(`Failed to persist "${storageKey}" to localStorage:`, error);
+    }
+  }, [storageKey, state]);
+
+  return [state, setState];
+}

--- a/packages/client/src/hooks/use-persistent-state.ts
+++ b/packages/client/src/hooks/use-persistent-state.ts
@@ -1,5 +1,19 @@
 import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
 
+/** Reads and revives the value stored under `storageKey`, falling back on anything unexpected. */
+function readStored<T>(
+  storageKey: string,
+  fallback: T,
+  revive: (parsed: unknown, fallback: T) => T,
+): T {
+  try {
+    const stored = localStorage.getItem(storageKey);
+    return stored == null ? fallback : revive(JSON.parse(stored), fallback);
+  } catch {
+    return fallback;
+  }
+}
+
 /**
  * `useState` whose value is mirrored to `localStorage`, so it survives a page refresh.
  *
@@ -8,22 +22,19 @@ import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
  * corrupt entry simply falls back to `fallback` instead of crashing the screen.
  *
  * `revive` maps the raw parsed JSON back to state — use it to validate the stored shape (it may
- * come from an older version of the app) and to merge it with the current defaults. It runs only
- * on mount; returning `fallback` from it discards the stored value.
+ * come from an older version of the app) and to merge it with the current defaults. Returning
+ * `fallback` from it discards the stored value.
+ *
+ * A changed `storageKey` re-hydrates from that key rather than persisting the old key's value
+ * under it, so the hook stays correct when the key is derived (e.g. per user or per screen).
  */
 export function usePersistentState<T>(
   storageKey: string,
   fallback: T,
   revive: (parsed: unknown, fallback: T) => T = parsed => parsed as T,
 ): [T, Dispatch<SetStateAction<T>>] {
-  const [state, setState] = useState<T>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey);
-      return stored == null ? fallback : revive(JSON.parse(stored), fallback);
-    } catch {
-      return fallback;
-    }
-  });
+  const [state, setState] = useState<T>(() => readStored(storageKey, fallback, revive));
+  const [hydratedKey, setHydratedKey] = useState(storageKey);
 
   useEffect(() => {
     try {
@@ -32,6 +43,16 @@ export function usePersistentState<T>(
       console.warn(`Failed to persist "${storageKey}" to localStorage:`, error);
     }
   }, [storageKey, state]);
+
+  // Updating state during render is React's supported pattern for deriving state from arguments:
+  // it re-runs this component before committing, so the stale value is never rendered. Returning
+  // the fresh value keeps this render pass consistent too.
+  if (hydratedKey !== storageKey) {
+    const hydrated = readStored(storageKey, fallback, revive);
+    setHydratedKey(storageKey);
+    setState(hydrated);
+    return [hydrated, setState];
+  }
 
   return [state, setState];
 }


### PR DESCRIPTION
## Summary

Introduces two new React hooks for managing component state with different persistence strategies, and applies them to the businesses table to preserve user preferences (sorting, column visibility) across page refreshes while keeping row selection transient.

## Key Changes

- **`usePersistentState` hook** (`packages/client/src/hooks/use-persistent-state.ts`): A `useState` wrapper that mirrors state to `localStorage`. Includes a `revive` callback to validate and transform stored values (handling stale/corrupt entries from older app versions). Gracefully falls back to the fallback value if storage is unavailable or parsing fails.

- **`useEphemeralState` hook** (`packages/client/src/hooks/use-ephemeral-state.ts`): A `useState` wrapper that keeps state in a module-level store, surviving unmount/remount (navigation) but not page refreshes. Intended for transient selections that should not persist across reloads.

- **Table state storage utilities** (`packages/client/src/components/businesses/table-state-storage.ts`): Defensive revivers for sorting and column visibility state that validate stored shapes and merge with current defaults, allowing graceful handling of schema changes and missing columns.

- **Comprehensive test coverage**: Unit tests for both hooks and the storage utilities, covering happy paths, error cases, and edge cases (corrupt JSON, reviver failures, storage quota exceeded, etc.).

- **Businesses table integration**: Replaced plain `useState` calls with the new hooks:
  - Row selection uses `useEphemeralState` (transient across navigation, cleared on refresh)
  - Column visibility and sorting use `usePersistentState` (preserved across refreshes)
  - Fixed row selection to track the unfiltered row set so selections persist when filters change

## Notable Implementation Details

- Storage access is fully guarded: failures in `localStorage` or JSON parsing fall back gracefully without crashing the screen.
- The `revive` callback enables safe schema evolution—stored values from older app versions are validated and merged with current defaults rather than blindly restored.
- Row selection now correctly uses the full unfiltered row set rather than just visible rows, so selections survive filter changes and are re-checked when the filter is removed.

https://claude.ai/code/session_01Pwx8BHZDnssEpQJDmDyvbv