### PR TITLE
Expose matched tax category on business directory

### DIFF
--- a/.changeset/mcp-businesses-tax-category.md
+++ b/.changeset/mcp-businesses-tax-category.md
@@ -1,0 +1,21 @@
+---
+'@accounter/mcp-server': minor
+---
+
+Expose each business's matched tax category on the MCP business directory.
+
+`accounter_list_businesses` returned a business's identity and status but nothing about how its
+charges book. A tax category is what a business is *for* in the ledger, so an assistant asked to
+categorize a charge, or to check that a counterparty is set up at all, had no way to tell an
+unmapped business from one already pointing at "Income" — the directory looked identical either way.
+The connector does list tax categories separately, but nothing joined the two: with the mapping
+invisible, the model's only honest move was to ask.
+
+Rows now carry `taxCategory` as `{ id, name }`, or `null` when no tax category is mapped to the
+business. The `null` is a real answer rather than a missing field: an auto-generated business with
+nothing matched yet is exactly the case worth acting on, and the `id` lines up with
+`accounter_list_tax_categories` rows without a second lookup.
+
+It reads through the existing `LtdFinancialEntity` inline fragment on `allBusinesses`, alongside
+`isClient`, and resolves through the business-id DataLoader — so it batches per page rather than
+adding a query per row, and no new upstream field was needed.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -224,16 +224,17 @@ scope, because it _is_ the scope.
   bookkeeping sort code, active flag), optionally filtered by name, active status, or
   `memberBusinessIds`. Same deterministic sort + cap.
 - **`accounter_list_businesses`** — list the full business directory (id, name, `ownerId`, active
-  flag, and `isClient`) — every business visible to the caller, not just their memberships —
-  optionally filtered by name (forwarded to the upstream `allBusinesses(name:)` filter), active
-  status, client status, or `memberBusinessIds`, and paginated with `limit` + 1-based `page`
-  (forwarded as the upstream `limit`/`page` args; the response echoes `pagination`). Same
-  deterministic sort + cap. Note that `activeOnly`/`nameContains` narrowing happens within the
-  fetched page, so a page can come back short — `isClient` is the exception, forwarded to the
-  upstream `allBusinesses(isClient:)` predicate so counts and paging describe the filtered
-  directory. Use `accounter_list_business_memberships` instead for just the caller's own memberships
-  and roles, and `accounter_list_clients` to enumerate clients with their emails and integrations
-  rather than paging this directory for them.
+  flag, `isClient`, and the matched `taxCategory` as `{ id, name }`, or `null` when the business has
+  none mapped) — every business visible to the caller, not just their memberships — optionally
+  filtered by name (forwarded to the upstream `allBusinesses(name:)` filter), active status, client
+  status, or `memberBusinessIds`, and paginated with `limit` + 1-based `page` (forwarded as the
+  upstream `limit`/`page` args; the response echoes `pagination`). Same deterministic sort + cap.
+  Note that `activeOnly`/`nameContains` narrowing happens within the fetched page, so a page can
+  come back short — `isClient` is the exception, forwarded to the upstream
+  `allBusinesses(isClient:)` predicate so counts and paging describe the filtered directory. Use
+  `accounter_list_business_memberships` instead for just the caller's own memberships and roles, and
+  `accounter_list_clients` to enumerate clients with their emails and integrations rather than
+  paging this directory for them.
 - **`accounter_balance_report`** — read-only balance report (transactions) for **exactly one** of
   your businesses over a bounded date range (≤ 1096 days), selected by the required singular
   `memberBusinessId`. Requires `business_owner`/`accountant` role; rows are capped at 1000 with a

--- a/packages/mcp-server/src/tools/__tests__/lookups.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/lookups.test.ts
@@ -146,12 +146,28 @@ describe('listBusinessesTool', () => {
     clientReturning({
       allBusinesses: {
         nodes: [
-          { id: '3', name: 'Zebra', ownerId: 'o1', isActive: true, isClient: true },
-          // No `isClient` key at all: stands in for a node that did not resolve
-          // to LtdFinancialEntity, which the row mapper must read as `false`
-          // rather than `undefined`.
+          {
+            id: '3',
+            name: 'Zebra',
+            ownerId: 'o1',
+            isActive: true,
+            isClient: true,
+            taxCategory: { id: 'tc1', name: 'Income' },
+          },
+          // No `isClient`/`taxCategory` keys at all: stands in for a node that
+          // did not resolve to LtdFinancialEntity, which the row mapper must
+          // read as `false`/`null` rather than `undefined`.
           { id: '1', name: 'apple', ownerId: 'o1', isActive: false },
-          { id: '2', name: 'Banana', ownerId: 'o1', isActive: true, isClient: false },
+          // Resolved to LtdFinancialEntity but with no tax category matched —
+          // the common case for auto-generated businesses.
+          {
+            id: '2',
+            name: 'Banana',
+            ownerId: 'o1',
+            isActive: true,
+            isClient: false,
+            taxCategory: null,
+          },
         ],
       },
     });
@@ -200,6 +216,32 @@ describe('listBusinessesTool', () => {
       ['Banana', false],
       ['Zebra', true],
     ]);
+  });
+
+  // The matched tax category is what makes the directory usable for
+  // categorization work: without it the model can only see that a business
+  // exists, not what its charges book to. `null` must survive as `null` — an
+  // unmapped business is a real, actionable answer, not a missing field.
+  it('reports the matched taxCategory per row, or null when none is mapped', async () => {
+    const result = await runTool(listBusinessesTool, client(), authContext(['b1']), {});
+    const rows = (
+      result.structuredContent as {
+        businesses: Array<{ name: string; taxCategory: { id: string; name: string } | null }>;
+      }
+    ).businesses;
+    expect(rows.map(b => [b.name, b.taxCategory])).toEqual([
+      ['apple', null],
+      ['Banana', null],
+      ['Zebra', { id: 'tc1', name: 'Income' }],
+    ]);
+  });
+
+  it('selects the business tax category upstream', async () => {
+    let sentInit: RequestInit | undefined;
+    const capturing = clientReturning({ allBusinesses: { nodes: [] } }, init => (sentInit = init));
+    await runTool(listBusinessesTool, capturing, authContext(['b1']), {});
+    const { query } = JSON.parse(sentInit!.body as string) as { query: string };
+    expect(query).toContain('taxCategory');
   });
 
   // `isClient` is a real upstream predicate, unlike `activeOnly`: it must reach

--- a/packages/mcp-server/src/tools/__tests__/schema-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/schema-contract.test.ts
@@ -144,6 +144,18 @@ describe('generated schema contract', () => {
     expect(typeBlock(loadSchema(), 'LtdFinancialEntity')).toContain('isClient: Boolean!');
   });
 
+  /**
+   * The directory reports each business's matched tax category through the same
+   * inline fragment, so it depends on the field living on `LtdFinancialEntity`
+   * rather than on the `Business` interface. It is deliberately nullable
+   * upstream — a business with no mapping yet — and the tool passes that `null`
+   * through, so pin the nullability too: a change to `TaxCategory!` would mean
+   * unmapped businesses now fail the selection instead of reporting `null`.
+   */
+  it('LtdFinancialEntity exposes a nullable taxCategory', () => {
+    expect(typeBlock(loadSchema(), 'LtdFinancialEntity')).toMatch(/^ {2}taxCategory: TaxCategory$/m);
+  });
+
   // The flag is only useful as a filter if upstream can apply it before paging.
   // Filtering an already-sliced page would report "the clients on page 1" while
   // reading as "the clients".

--- a/packages/mcp-server/src/tools/lookups.ts
+++ b/packages/mcp-server/src/tools/lookups.ts
@@ -254,6 +254,14 @@ const LIST_BUSINESSES_QUERY = /* GraphQL */ `
         # schema-contract.test.ts pins both halves of that assumption.
         ... on LtdFinancialEntity {
           isClient
+          # The tax category the business's charges are booked to. Null is a
+          # real answer here — a business with no mapping yet — and the model
+          # needs it to tell "not categorized" from "categorized as X" without
+          # a second round-trip through accounter_list_tax_categories.
+          taxCategory {
+            id
+            name
+          }
         }
       }
       pageInfo {
@@ -281,6 +289,28 @@ type RawBusinessNode = NonNullable<McpListBusinessesQuery['allBusinesses']>['nod
  */
 function rawBusinessIsClient(business: RawBusinessNode): boolean {
   return 'isClient' in business ? business.isClient : false;
+}
+
+/** The `{ id, name }` pair the directory reports for a matched tax category. */
+interface BusinessTaxCategory {
+  id: string;
+  name: string;
+}
+
+/**
+ * Read the matched tax category off a directory row.
+ *
+ * Narrowed structurally for the same reason as `rawBusinessIsClient`: the field
+ * is selected through the `LtdFinancialEntity` inline fragment, so the compiler
+ * sees it on only one arm of the union. `null` covers both "not an
+ * LtdFinancialEntity" (unreachable in practice) and the genuine case of a
+ * business with no tax category mapped yet — the two are the same answer to the
+ * caller: nothing to book against.
+ */
+function rawBusinessTaxCategory(business: RawBusinessNode): BusinessTaxCategory | null {
+  if (!('taxCategory' in business)) return null;
+  const taxCategory = business.taxCategory;
+  return taxCategory ? { id: taxCategory.id, name: taxCategory.name } : null;
 }
 
 async function listBusinessesHandler(
@@ -314,6 +344,7 @@ async function listBusinessesHandler(
     ownerId: business.ownerId,
     isActive: business.isActive,
     isClient: rawBusinessIsClient(business),
+    taxCategory: rawBusinessTaxCategory(business),
   }));
 
   // `totalRecords` counts upstream's whole (name-filtered) directory rather than
@@ -361,7 +392,7 @@ const DIRECTORY_SCOPE_DESCRIPTION_SUFFIX =
 export const listBusinessesTool: ToolDefinition<typeof listBusinessesInput> = {
   name: LIST_BUSINESSES_TOOL_NAME,
   description:
-    'List the full business directory (id, name, ownerId, active flag, and whether the business is a client) — every business visible to you, not just the ones you are a member of — optionally filtered by name, active status, or client status, with `limit`/`page` pagination over the name-ordered directory. For your own memberships and roles use `accounter_list_business_memberships`; for client emails and integrations use `accounter_list_clients`, whose ids are these same business ids. Read-only. ' +
+    'List the full business directory — every business visible to you, not just the ones you are a member of — optionally filtered by name, active status, or client status, with `limit`/`page` pagination over the name-ordered directory. Each row is `{ id, name, ownerId, isActive, isClient, taxCategory }`, where `taxCategory` is the `{ id, name }` of the tax category the business is matched to, or `null` when no tax category is mapped to it. For your own memberships and roles use `accounter_list_business_memberships`; for client emails and integrations use `accounter_list_clients`, whose ids are these same business ids. Read-only. ' +
     resultEnvelopeDescription('businesses') +
     ' ' +
     DIRECTORY_SCOPE_DESCRIPTION_SUFFIX,


### PR DESCRIPTION
Adds the matched tax category to each business row in `accounter_list_businesses`, enabling the model to distinguish between unmapped businesses and those already categorized without a second lookup.

## Summary

The business directory previously returned only identity and status fields (`id`, `name`, `ownerId`, `isActive`, `isClient`), leaving the model unable to tell whether a business had a tax category mapped or not. This required asking the user or making a separate call to `accounter_list_tax_categories` to understand what a business is *for* in the ledger.

Now each row includes `taxCategory` as `{ id, name }` when matched, or `null` when unmapped — a real answer that distinguishes "not yet categorized" from "categorized as X".

## Changes

- **Query**: Added `taxCategory { id, name }` selection to `LIST_BUSINESSES_QUERY` through the existing `LtdFinancialEntity` inline fragment, batching per page via the business-id DataLoader
- **Handler**: New `rawBusinessTaxCategory()` function reads the field off directory rows, mirroring the existing `rawBusinessIsClient()` pattern; added `taxCategory` to the mapped business output
- **Schema contract**: Added test pinning `LtdFinancialEntity.taxCategory` as nullable (to preserve `null` for unmapped businesses)
- **Tests**: Updated test data to include `taxCategory` in mock responses; added two new tests verifying the field is reported correctly and selected upstream
- **Documentation**: Updated tool description and README to document the new field and its semantics

## Implementation Details

- The field is selected through the `LtdFinancialEntity` inline fragment (same as `isClient`), so it only appears on resolved financial entities; the accessor function returns `null` for both "not an LtdFinancialEntity" and "no tax category mapped" — the same answer to the caller
- No new upstream field was needed; the tax category already exists in the schema
- Nullability is preserved: `null` is a real, actionable answer (unmapped business), not a missing field

https://claude.ai/code/session_01LavsbpkYVWuNWYXQgCqVeu