### PR TITLE
fix(server): pin the demo seed's RLS context to the row owner, not the counterparty

### DIFF
--- a/.changeset/demo-seed-transactions-rls-context.md
+++ b/.changeset/demo-seed-transactions-rls-context.md
@@ -14,11 +14,14 @@ business while the row named another and every transaction whose counterparty is
 which is every realistic transaction — was rejected. The sections before it (businesses, tax
 categories, accounts, charges) set the context from `owner_id` and so were unaffected.
 
-The transactions loop now pins the context to `transaction.owner_id ?? adminBusinessId`, and a
+The transactions loop now pins the context to `transaction.owner_id || adminBusinessId`, and a
 failure to set it propagates instead of being swallowed by a `console.warn` — a broken context
 otherwise turns into a cascade of policy violations downstream that say nothing about the real
 cause. The documents loop, which set no context at all and inherited whatever the previous section
-left behind, pins its own owner the same way; it would have been the next section to fail.
+left behind, pins its own owner the same way; it would have been the next section to fail. Both
+loops now treat a resolvable owner as a precondition and throw naming the offending row, rather than
+skipping the `set_config` and letting the row fail several statements later against the RLS or
+`NOT NULL` constraint on `owner_id`.
 
 This never reproduced locally or in CI because both connect as the `postgres` superuser, which
 bypasses RLS even under `FORCE ROW LEVEL SECURITY`. Deployed runs connect as a non-superuser and do

--- a/.changeset/demo-seed-transactions-rls-context.md
+++ b/.changeset/demo-seed-transactions-rls-context.md
@@ -1,0 +1,25 @@
+---
+'@accounter/server': patch
+---
+
+Stop the demo seed from pointing the RLS write target at a transaction's counterparty.
+
+The staging deploy failed on `yarn seed:staging-demo` with
+`new row violates row-level security policy for table "transactions"`, aborting the build on the
+first use-case. The fixture loader re-set `app.current_business_id` from `transaction.business_id`
+before each transaction insert, but `business_id` is the counterparty on the other side of the money
+movement (`us-supplier-acme-llc` in the fixture that failed), not the tenant that owns the row.
+`tenant_isolation` is `WITH CHECK (owner_id = get_current_business_id())`, so the context named one
+business while the row named another and every transaction whose counterparty is not its owner —
+which is every realistic transaction — was rejected. The sections before it (businesses, tax
+categories, accounts, charges) set the context from `owner_id` and so were unaffected.
+
+The transactions loop now pins the context to `transaction.owner_id ?? adminBusinessId`, and a
+failure to set it propagates instead of being swallowed by a `console.warn` — a broken context
+otherwise turns into a cascade of policy violations downstream that say nothing about the real
+cause. The documents loop, which set no context at all and inherited whatever the previous section
+left behind, pins its own owner the same way; it would have been the next section to fail.
+
+This never reproduced locally or in CI because both connect as the `postgres` superuser, which
+bypasses RLS even under `FORCE ROW LEVEL SECURITY`. Deployed runs connect as a non-superuser and do
+not, so the seed path stays untested against the policies it has to satisfy.

--- a/packages/server/src/__tests__/helpers/fixture-loader.ts
+++ b/packages/server/src/__tests__/helpers/fixture-loader.ts
@@ -329,15 +329,21 @@ export async function insertFixture(
   if (fixture.transactions?.transactions && fixture.transactions.transactions.length > 0) {
     await executeSavepointSection('transactions', async () => {
       for (const transaction of fixture.transactions!.transactions) {
-        // Set RLS context for each transaction
-        if (transaction.business_id) {
-          try {
-             await client.query("SELECT set_config('app.current_business_id', $1, true)", [transaction.business_id]);
-          } catch(e) {
-            console.warn('Failed to set RLS context for transaction in fixture-loader:', e);
-          }
+        // Point the RLS write target at the row's *owner*, never at `business_id`.
+        //
+        // `transactions.business_id` is the counterparty (the vendor/customer on the other
+        // side of the money movement), not the tenant that owns the row. `tenant_isolation`
+        // is `WITH CHECK (owner_id = get_current_business_id())`, so setting the context from
+        // `business_id` guarantees a policy violation on every transaction whose counterparty
+        // is not the owner -- which is every real transaction. Superuser connections (local
+        // dev, CI) bypass RLS and hid this; deployed non-superuser runs did not.
+        const transactionOwnerId = transaction.owner_id ?? adminBusinessId;
+        if (transactionOwnerId) {
+          await client.query("SELECT set_config('app.current_business_id', $1, true)", [
+            transactionOwnerId,
+          ]);
         }
-        
+
         // If account_id looks like an account_number (not a UUID), look up the actual UUID.
         // Prefer the UUID cached from step 3 (financial_accounts insert) to avoid
         // non-deterministic SELECT when duplicate account_number rows exist in DB.
@@ -411,6 +417,15 @@ export async function insertFixture(
   if (fixture.documents?.documents && fixture.documents.documents.length > 0) {
     await executeSavepointSection('documents', async () => {
       for (const document of fixture.documents!.documents) {
+        // Same as transactions above: pin the write target to this row's owner rather than
+        // inheriting whatever the previous section happened to leave in the session.
+        const documentOwnerId = document.owner_id ?? adminBusinessId;
+        if (documentOwnerId) {
+          await client.query("SELECT set_config('app.current_business_id', $1, true)", [
+            documentOwnerId,
+          ]);
+        }
+
         await client.query(
           `INSERT INTO ${qualifyTable('documents')} (
             id, image_url, file_url, type, serial_number, date,

--- a/packages/server/src/__tests__/helpers/fixture-loader.ts
+++ b/packages/server/src/__tests__/helpers/fixture-loader.ts
@@ -337,12 +337,23 @@ export async function insertFixture(
         // `business_id` guarantees a policy violation on every transaction whose counterparty
         // is not the owner -- which is every real transaction. Superuser connections (local
         // dev, CI) bypass RLS and hid this; deployed non-superuser runs did not.
-        const transactionOwnerId = transaction.owner_id ?? adminBusinessId;
-        if (transactionOwnerId) {
-          await client.query("SELECT set_config('app.current_business_id', $1, true)", [
-            transactionOwnerId,
-          ]);
+        //
+        // Resolving it is not optional: skipping the `set_config` when the owner is missing
+        // would leave the previous section's context in place and surface as an unrelated RLS
+        // (or NOT NULL) error several statements later -- the same misdirection this whole fix
+        // is about. `owner_id` is a required `string` on `TransactionInsertParams`, but the
+        // demo seed builds these objects from use-case specs and casts, so an empty value can
+        // still reach here at runtime. Fail here, naming the row.
+        const transactionOwnerId = transaction.owner_id || adminBusinessId;
+        if (!transactionOwnerId) {
+          throw new Error(
+            `Transaction ${transaction.id ?? '(no id)'} has no owner_id and no adminBusinessId ` +
+              `was provided, so the RLS write target cannot be determined.`,
+          );
         }
+        await client.query("SELECT set_config('app.current_business_id', $1, true)", [
+          transactionOwnerId,
+        ]);
 
         // If account_id looks like an account_number (not a UUID), look up the actual UUID.
         // Prefer the UUID cached from step 3 (financial_accounts insert) to avoid
@@ -419,12 +430,16 @@ export async function insertFixture(
       for (const document of fixture.documents!.documents) {
         // Same as transactions above: pin the write target to this row's owner rather than
         // inheriting whatever the previous section happened to leave in the session.
-        const documentOwnerId = document.owner_id ?? adminBusinessId;
-        if (documentOwnerId) {
-          await client.query("SELECT set_config('app.current_business_id', $1, true)", [
-            documentOwnerId,
-          ]);
+        const documentOwnerId = document.owner_id || adminBusinessId;
+        if (!documentOwnerId) {
+          throw new Error(
+            `Document ${document.id ?? '(no id)'} has no owner_id and no adminBusinessId was ` +
+              `provided, so the RLS write target cannot be determined.`,
+          );
         }
+        await client.query("SELECT set_config('app.current_business_id', $1, true)", [
+          documentOwnerId,
+        ]);
 
         await client.query(
           `INSERT INTO ${qualifyTable('documents')} (


### PR DESCRIPTION
## Problem

The staging deploy fails during its build command, on `ALLOW_DEMO_SEED=1 yarn seed:staging-demo`:

```
📦 Monthly Expense (Foreign Currency) (monthly-expense-foreign-currency)
❌ Seed failed:
Caused by: FixtureInsertionError: Failed to insert fixture section "transactions":
  new row violates row-level security policy for table "transactions"
==> Build failed 😞
```

## Cause

`insertFixture` re-set the RLS write target from each transaction's `business_id` right before inserting it:

```ts
if (transaction.business_id) {
  await client.query("SELECT set_config('app.current_business_id', $1, true)", [transaction.business_id]);
}
```

`transactions.business_id` is the **counterparty** — the vendor or customer on the other side of the money movement (`makeUUID('business', 'us-supplier-acme-llc')` in the fixture that failed) — not the tenant that owns the row. `tenant_isolation`, from `2026-05-25T10-00-00.rls-multi-business-scope.ts`, is:

```sql
WITH CHECK (owner_id = accounter_schema.get_current_business_id())
```

So the session context named the counterparty while the row named the admin business, and every transaction whose counterparty is not its owner — every realistic transaction — was rejected. The sections that run before it (businesses, tax categories, accounts, charges) set the context from `owner_id`, which matches what they insert, so they passed.

The line dates to #3057.

## Fix

- Transactions pin the context to `transaction.owner_id ?? adminBusinessId`. The `set_config` failure is no longer swallowed by a `console.warn`: a broken context turns into a cascade of downstream policy violations that say nothing about the real cause, so it should abort.
- Documents get the same explicit owner-pinning. That section set no context at all and inherited whatever the previous section left behind, so it would have been the very next thing to fail once transactions passed.

## Why CI didn't catch it

Local dev and CI connect as the `postgres` superuser, which bypasses RLS even under `FORCE ROW LEVEL SECURITY`. Deployed runs connect as a non-superuser and do not. The seed path is therefore never exercised against the policies it has to satisfy — `packages/migrations/src/__tests__/rls-all-tables.test.ts` already has the harness for this (it creates a `NOSUPERUSER` role and `SET ROLE`s into it), so a regression test for the fixture loader is feasible as a follow-up.

## Verification

- `tsc --noEmit -p packages/server/tsconfig.json` — clean.
- Prettier clean.
- Swept every use-case under `packages/server/src/demo-fixtures/use-cases`: every `transactions` / `documents` / `charges` / `financialAccounts` entry declares an `ownerId`, and all of them are `{{ADMIN_BUSINESS_ID}}`, which `resolveAdminPlaceholders` rewrites to the same id the seed pins the session to. The new context matches `owner_id` on every row.

Not verified end-to-end against a non-superuser database — the root `.env` points at production, so running the seed locally would target the wrong host. The next staging deploy is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)