### PR TITLE
fix(client): searchable, business-sourced counterparty in edit-transaction form

### DIFF
--- a/.changeset/edit-transaction-counterparty-combobox.md
+++ b/.changeset/edit-transaction-counterparty-combobox.md
@@ -1,0 +1,13 @@
+---
+'@accounter/client': patch
+---
+
+Make the counterparty field in the edit-transaction form searchable.
+
+The field was a plain `Select`, so picking a counterparty meant scrolling the entire financial
+entities list (its placeholder literally read "Scroll to see all options"). It now uses the same
+`ComboBox` the other business pickers use — the creditor/debtor fields in the misc-expense form and
+the debtor/creditor fields in the document form — which has a filter input over the options.
+
+`ComboBox` resolves the portal container itself, so the explicit `usePortalContainer` wiring the
+`Select` needed to stay clickable inside `PopUpDrawer` is gone from this form.

--- a/.changeset/edit-transaction-counterparty-combobox.md
+++ b/.changeset/edit-transaction-counterparty-combobox.md
@@ -2,12 +2,17 @@
 '@accounter/client': patch
 ---
 
-Make the counterparty field in the edit-transaction form searchable.
+Make the counterparty field in the edit-transaction form searchable, and offer businesses rather
+than all financial entities.
 
-The field was a plain `Select`, so picking a counterparty meant scrolling the entire financial
-entities list (its placeholder literally read "Scroll to see all options"). It now uses the same
-`ComboBox` the other business pickers use — the creditor/debtor fields in the misc-expense form and
-the debtor/creditor fields in the document form — which has a filter input over the options.
+The field was a plain `Select`, so picking a counterparty meant scrolling the entire list (its
+placeholder literally read "Scroll to see all options"). It now uses the same `ComboBox` the other
+business pickers use — the creditor/debtor fields in the misc-expense form and the debtor/creditor
+fields in the document form — which has a filter input over the options.
+
+Its options now come from `useGetBusinesses` instead of `useGetFinancialEntities`, matching the
+transactions table's own counterparty cell. `allFinancialEntities` also returns tax categories,
+which are never a valid transaction counterparty, so they were only noise in the list.
 
 `ComboBox` resolves the portal container itself, so the explicit `usePortalContainer` wiring the
 `Select` needed to stay clickable inside `PopUpDrawer` is gone from this form.

--- a/packages/client/src/components/common/forms/edit-transaction.tsx
+++ b/packages/client/src/components/common/forms/edit-transaction.tsx
@@ -12,7 +12,7 @@ import {
   TIMELESS_DATE_REGEX,
   type MakeBoolean,
 } from '../../../helpers/index.js';
-import { useGetFinancialEntities } from '../../../hooks/use-get-financial-entities.js';
+import { useGetBusinesses } from '../../../hooks/use-get-businesses.js';
 import { useUpdateTransaction } from '../../../hooks/use-update-transaction.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { Switch } from '../../ui/switch.js';
@@ -84,8 +84,7 @@ export const EditTransaction = ({ transactionID, onDone, onChange }: Props): Rea
     }
   };
 
-  const { selectableFinancialEntities: financialEntities, fetching: fetchingFinancialEntities } =
-    useGetFinancialEntities();
+  const { selectableBusinesses: businesses, fetching: fetchingBusinesses } = useGetBusinesses();
 
   return (
     <>
@@ -109,9 +108,9 @@ export const EditTransaction = ({ transactionID, onDone, onChange }: Props): Rea
                       <FormLabel>Counterparty</FormLabel>
                       <ComboBox
                         {...field}
-                        data={financialEntities}
+                        data={businesses}
                         value={field.value ?? undefined}
-                        disabled={fetchingFinancialEntities}
+                        disabled={fetchingBusinesses}
                         placeholder="Select counterparty"
                         formPart
                       />

--- a/packages/client/src/components/common/forms/edit-transaction.tsx
+++ b/packages/client/src/components/common/forms/edit-transaction.tsx
@@ -14,11 +14,9 @@ import {
 } from '../../../helpers/index.js';
 import { useGetFinancialEntities } from '../../../hooks/use-get-financial-entities.js';
 import { useUpdateTransaction } from '../../../hooks/use-update-transaction.js';
-import { usePortalContainer } from '../../../providers/portal-container.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../ui/select.js';
 import { Switch } from '../../ui/switch.js';
-import { DatePickerInput, SimpleGrid } from '../index.js';
+import { ComboBox, DatePickerInput, SimpleGrid } from '../index.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -46,9 +44,6 @@ type Props = {
 };
 
 export const EditTransaction = ({ transactionID, onDone, onChange }: Props): ReactElement => {
-  // This form renders inside PopUpDrawer, whose focus-trapping dialog blocks interaction with
-  // anything portaled to `document.body`. See `usePortalContainer`.
-  const portalContainer = usePortalContainer();
   const [{ data: transactionData, fetching: fetchingTransaction }] = useQuery({
     query: EditTransactionDocument,
     variables: {
@@ -110,29 +105,16 @@ export const EditTransaction = ({ transactionID, onDone, onChange }: Props): Rea
                     minLength: { value: 2, message: 'Minimum 2 characters' },
                   }}
                   render={({ field }): ReactElement => (
-                    <FormItem>
+                    <FormItem className="flex flex-col">
                       <FormLabel>Counterparty</FormLabel>
-                      <Select
-                        onValueChange={field.onChange}
+                      <ComboBox
+                        {...field}
+                        data={financialEntities}
                         value={field.value ?? undefined}
                         disabled={fetchingFinancialEntities}
-                      >
-                        <FormControl>
-                          <SelectTrigger className="w-full truncate">
-                            <SelectValue placeholder="Scroll to see all options" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent
-                          onClick={event => event.stopPropagation()}
-                          container={portalContainer}
-                        >
-                          {financialEntities.map(({ value, label }) => (
-                            <SelectItem key={value} value={value}>
-                              {label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                        placeholder="Select counterparty"
+                        formPart
+                      />
                       <FormMessage />
                     </FormItem>
                   )}


### PR DESCRIPTION
## What

Two fixes to the counterparty field in the edit-transaction form:

1. **It had no search.** The field was a plain `Select`, so picking a counterparty meant scrolling the whole list — its placeholder literally read *"Scroll to see all options"*. It now uses the same `ComboBox` as the other business pickers in parallel forms (`creditorId`/`debtorId` in the misc-expense form, `debtorId`/`creditorId` in the document form), which has a filter input over the options.

2. **It offered the wrong list.** Options came from `useGetFinancialEntities`; `allFinancialEntities` returns tax categories alongside businesses, and a tax category is never a valid transaction counterparty. It now uses `useGetBusinesses`, matching what the transactions table's own counterparty cell (`transactions-table/cells/counterparty.tsx`) already does. The two hooks return the same `{ value, label }` option shape, so this is a drop-in swap.

## Notes

- `ComboBox` resolves the portal container itself, so the explicit `usePortalContainer` wiring the `Select` needed to stay clickable inside `PopUpDrawer` is dropped from this form.
- Placeholder is now `"Select counterparty"` (it feeds both the trigger label and the filter input).
- No schema or query changes; `tsc --noEmit` and `eslint` on the touched file both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)