### PR TITLE
Remove bank transactions table from foreign securities charge info

### DIFF
--- a/.changeset/foreign-securities-drop-duplicate-transactions.md
+++ b/.changeset/foreign-securities-drop-duplicate-transactions.md
@@ -1,0 +1,15 @@
+---
+'@accounter/client': patch
+---
+
+Drop the duplicate transactions table from the charge's Foreign Securities accordion tab.
+
+Each security block rendered a "Bank transactions" table listing the charge transactions carrying
+that security's key — the same rows the charge's own Transactions accordion tab already shows, just
+without the editing affordances. The tab now shows only what is specific to it: the security's
+reference details and the matched "Portfolio activity" executions.
+
+`ForeignSecuritiesChargeInfo` no longer selects `securities.transactions`, so the charge query stops
+resolving those transactions as well. `ChargeSecurity.transactions` stays in the schema — the
+executions matcher still needs the underlying transaction ids server-side, and the field remains
+available to other API consumers.

--- a/packages/client/src/components/charges/extended-info/foreign-securities-info.tsx
+++ b/packages/client/src/components/charges/extended-info/foreign-securities-info.tsx
@@ -1,7 +1,6 @@
 import { useMemo, type ReactElement, type ReactNode } from 'react';
 import {
   ForeignSecuritiesChargeInfoFragmentDoc,
-  TransactionForTransactionsTableFieldsFragmentDoc,
   type ForeignSecuritiesChargeInfoFragment,
 } from '../../../gql/graphql.js';
 import { getFragmentData, type FragmentType } from '../../../gql/index.js';
@@ -9,16 +8,7 @@ import {
   formatSecurityDate,
   SecurityExecutionsTable,
 } from '../../securities/security-executions-table.js';
-import {
-  Account,
-  Amount,
-  DebitDate,
-  Description,
-  EventDate,
-  SourceID,
-} from '../../transactions-table/cells/index.js';
 import { Badge } from '../../ui/badge.js';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../../ui/table.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -41,10 +31,6 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '.
           isEtf
           isForeign
           asOfDate
-        }
-        transactions {
-          id
-          ...TransactionForTransactionsTableFields
         }
         executions {
           id
@@ -114,7 +100,6 @@ const SecuritySection = ({ security }: { security: ChargeSecurity }): ReactEleme
           </div>
         </div>
       )}
-      <SecurityTransactionsTable transactions={security.transactions} />
       {security.executions.length > 0 && (
         <TableSection title="Portfolio activity">
           <SecurityExecutionsTable rows={security.executions.map(execution => ({ execution }))} />
@@ -136,67 +121,3 @@ const TableSection = ({
     {children}
   </div>
 );
-
-const SecurityTransactionsTable = ({
-  transactions,
-}: {
-  transactions: ChargeSecurity['transactions'];
-}): ReactNode => {
-  const rows = useMemo(
-    () =>
-      transactions.map(transaction =>
-        getFragmentData(TransactionForTransactionsTableFieldsFragmentDoc, transaction),
-      ),
-    [transactions],
-  );
-
-  return rows.length ? (
-    <TableSection title="Bank transactions">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Event Date</TableHead>
-            <TableHead>Debit Date</TableHead>
-            <TableHead>Amount</TableHead>
-            <TableHead>Account</TableHead>
-            <TableHead>Description</TableHead>
-            <TableHead>Reference#</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {rows.map(transaction => {
-            const extendedTransaction = {
-              ...transaction,
-              onUpdate: () => void 0,
-              editTransaction: () => void 0,
-              enableEdit: false,
-              enableChargeLink: false,
-            };
-            return (
-              <TableRow key={transaction.id}>
-                <TableCell>
-                  <EventDate transaction={extendedTransaction} />
-                </TableCell>
-                <TableCell>
-                  <DebitDate transaction={extendedTransaction} />
-                </TableCell>
-                <TableCell>
-                  <Amount transaction={extendedTransaction} />
-                </TableCell>
-                <TableCell>
-                  <Account transaction={extendedTransaction} />
-                </TableCell>
-                <TableCell>
-                  <Description transaction={extendedTransaction} />
-                </TableCell>
-                <TableCell>
-                  <SourceID transaction={extendedTransaction} />
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </TableSection>
-  ) : null;
-};


### PR DESCRIPTION
## Summary
Removes the "Bank transactions" table from the foreign securities charge info component. This simplifies the UI by eliminating the `SecurityTransactionsTable` component and its associated GraphQL fragment query.

## Changes
- Removed `TransactionForTransactionsTableFieldsFragmentDoc` import and usage
- Removed all transaction-related table cell imports (`Account`, `Amount`, `DebitDate`, `Description`, `EventDate`, `SourceID`)
- Removed UI table component imports (`Table`, `TableBody`, `TableCell`, `TableHead`, `TableHeader`, `TableRow`)
- Removed `transactions` field from the GraphQL fragment query for `ForeignSecuritiesChargeInfo`
- Deleted the `SecurityTransactionsTable` component entirely (~67 lines)
- Removed the call to `<SecurityTransactionsTable />` from the `SecuritySection` component

## Result
The foreign securities charge info view now displays only the security details and portfolio activity (executions), with bank transactions no longer shown.

https://claude.ai/code/session_011ZjXho4wB1af3vX8HsQpHr