### PR TITLE
Fix date formatting in securities tables to use dd/MM/yyyy

### DIFF
--- a/.changeset/securities-date-format.md
+++ b/.changeset/securities-date-format.md
@@ -1,0 +1,19 @@
+---
+'@accounter/client': patch
+---
+
+Align the securities date formatting with the rest of the app.
+
+`formatSecurityDate` rendered through `toLocaleDateString()` with no locale, which follows the
+browser's, so every securities date read as `m/d/yy` for anyone running en-US instead of the
+`dd/MM/yyyy` used everywhere else. That one helper feeds the Portfolio activity table's trade and
+value dates (both inside a charge and on a security's own business page), the `Last execution` and
+`History since` columns of the securities screen, and the "added up since … last one …" line of the
+business security section. The reference-data `as of` line in a charge's securities panel had the
+same call written out inline, and now goes through the same helper.
+
+Trade, value and settlement dates — like `historyStartDate` and `lastExecutionDate` — are
+`TimelessDate`s, a calendar day with no time of day. `new Date('2024-01-15')` would resolve one to
+UTC midnight and render it as the previous day anywhere west of Greenwich, so those digits are
+reordered as text and only real timestamps (the reference data's `asOfDate`) are parsed into a
+`Date`.

--- a/packages/client/src/components/charges/extended-info/foreign-securities-info.tsx
+++ b/packages/client/src/components/charges/extended-info/foreign-securities-info.tsx
@@ -5,7 +5,10 @@ import {
   type ForeignSecuritiesChargeInfoFragment,
 } from '../../../gql/graphql.js';
 import { getFragmentData, type FragmentType } from '../../../gql/index.js';
-import { SecurityExecutionsTable } from '../../securities/security-executions-table.js';
+import {
+  formatSecurityDate,
+  SecurityExecutionsTable,
+} from '../../securities/security-executions-table.js';
 import {
   Account,
   Amount,
@@ -100,8 +103,7 @@ const SecuritySection = ({ security }: { security: ChargeSecurity }): ReactEleme
             {details.isForeign && <Badge variant="outline">Foreign</Badge>}
           </div>
           <div className="text-xs text-gray-400">
-            Key {security.securityKey} · reference data as of{' '}
-            {new Date(details.asOfDate).toLocaleDateString()}
+            Key {security.securityKey} · reference data as of {formatSecurityDate(details.asOfDate)}
           </div>
         </div>
       ) : (

--- a/packages/client/src/components/securities/__tests__/security-executions-table.test.ts
+++ b/packages/client/src/components/securities/__tests__/security-executions-table.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { formatSecurityDate } from '../security-executions-table.js';
+
+describe('formatSecurityDate', () => {
+  it('renders a TimelessDate as dd/MM/yyyy', () => {
+    expect(formatSecurityDate('2024-03-09')).toBe('09/03/2024');
+  });
+
+  it('keeps the calendar day of a TimelessDate regardless of the viewer timezone', () => {
+    // `new Date('2024-01-01')` is UTC midnight, which is still 2023-12-31 in the Americas.
+    expect(formatSecurityDate('2024-01-01')).toBe('01/01/2024');
+  });
+
+  it('renders a timestamp as dd/MM/yyyy', () => {
+    expect(formatSecurityDate(new Date(2024, 2, 9, 13, 45))).toBe('09/03/2024');
+  });
+
+  it('renders a timestamp string as dd/MM/yyyy', () => {
+    // No trailing `Z`: local time, so the expectation holds in whatever zone the suite runs in.
+    expect(formatSecurityDate('2024-03-09T12:00:00')).toBe('09/03/2024');
+  });
+
+  it('renders nothing for a missing date', () => {
+    expect(formatSecurityDate(null)).toBe('');
+    expect(formatSecurityDate(undefined)).toBe('');
+    expect(formatSecurityDate('')).toBe('');
+  });
+
+  it('renders nothing for an unparsable date', () => {
+    expect(formatSecurityDate('not a date')).toBe('');
+  });
+});

--- a/packages/client/src/components/securities/security-executions-table.tsx
+++ b/packages/client/src/components/securities/security-executions-table.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import { format } from 'date-fns';
 import {
   SecurityExecutionFieldsFragmentDoc,
   type SecurityExecutionFieldsFragment,
@@ -48,8 +49,29 @@ const securityDecimalFormat = new Intl.NumberFormat('en-US', {
 export const formatSecurityDecimal = (value: number | null | undefined): string =>
   value == null ? '' : securityDecimalFormat.format(value);
 
-export const formatSecurityDate = (value: string | Date | null | undefined): string =>
-  value ? new Date(value).toLocaleDateString() : '';
+/** `YYYY-MM-DD` and nothing else, as a `TimelessDate` field hands it over. */
+const timelessDatePattern = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Dates read `dd/MM/yyyy` across the app. `toLocaleDateString` followed the browser's locale
+ * instead, so every securities table showed `m/d/yy` to anyone running en-US.
+ *
+ * Trade, value and settlement dates are `TimelessDate`s — a calendar day with no time of day —
+ * and `new Date('2024-01-15')` would pin one to UTC midnight, which renders as the day before
+ * anywhere west of Greenwich. Reorder those digits as text and keep `Date` for the timestamps.
+ */
+export const formatSecurityDate = (value: string | Date | null | undefined): string => {
+  if (!value) return '';
+  if (typeof value === 'string') {
+    const timeless = timelessDatePattern.exec(value);
+    if (timeless) {
+      const [, year, month, day] = timeless;
+      return `${day}/${month}/${year}`;
+    }
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '' : format(date, 'dd/MM/yyyy');
+};
 
 /** The bank's enum values read better as words than as SCREAMING_SNAKE_CASE. */
 export const humanizeSecurityEnum = (value: string): string =>


### PR DESCRIPTION
## Summary

Fixes date formatting in securities tables to consistently display dates as `dd/MM/yyyy` instead of following the browser's locale (which shows `m/d/yy` for en-US users). Properly handles `TimelessDate` fields (calendar days without time) to avoid timezone-related off-by-one errors.

## Key Changes

- **Updated `formatSecurityDate` function** in `security-executions-table.tsx`:
  - Detects `YYYY-MM-DD` format (TimelessDate) and reformats as text to `dd/MM/yyyy` without timezone conversion
  - Uses `date-fns` `format()` for timestamp strings and Date objects to ensure consistent `dd/MM/yyyy` output
  - Returns empty string for null, undefined, empty, or unparsable dates
  - Replaces `toLocaleDateString()` which was locale-dependent

- **Added comprehensive test suite** (`security-executions-table.test.ts`):
  - Tests TimelessDate string parsing and formatting
  - Verifies timezone-safe handling (calendar day preserved regardless of viewer timezone)
  - Tests timestamp and timestamp string inputs
  - Covers edge cases (null, undefined, empty string, unparsable dates)

- **Applied fix to dependent code** in `foreign-securities-info.tsx`:
  - Updated reference data date display to use `formatSecurityDate()` for consistency

## Implementation Details

The key insight is that `TimelessDate` fields (trade, value, settlement dates) are calendar days with no time component. Parsing them with `new Date('2024-01-01')` pins them to UTC midnight, which renders as the previous day in western timezones. The fix detects this pattern and reformats the digits as text instead, preserving the intended calendar day across all timezones.

https://claude.ai/code/session_012RMZo98xEip9GjZkDtwy25