### PR TITLE
chore(deps): dedupe the duplicate tinyexec entry in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -25774,14 +25774,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^1.0.2, tinyexec@npm:^1.3.0":
-  version: 1.3.1
-  resolution: "tinyexec@npm:1.3.1"
-  checksum: 10c0/c590369cb3fa73cc18a3998caec8a00f9712d91309c881be3ac52b160fb2f80c7b1fbf3591858ab6abab47ad55385b0c86ec19982e32441a01f55298dab9ccd2
-  languageName: node
-  linkType: hard
-
-"tinyexec@npm:^1.3.1":
+"tinyexec@npm:^1.0.2, tinyexec@npm:^1.3.0, tinyexec@npm:^1.3.1":
   version: 1.3.1
   resolution: "tinyexec@npm:1.3.1"
   checksum: 10c0/c590369cb3fa73cc18a3998caec8a00f9712d91309c881be3ac52b160fb2f80c7b1fbf3591858ab6abab47ad55385b0c86ec19982e32441a01f55298dab9ccd2


### PR DESCRIPTION
**`main` is red, and so is every open PR — all of them at the install step, before any test or lint rule runs.** This is a one-line lockfile fix for that.

## The defect

`yarn.lock` carries two entries resolving to the same `tinyexec@1.3.1`, with the same checksum:

```
"tinyexec@npm:^1.0.2, tinyexec@npm:^1.3.0":
  version: 1.3.1
  ...
"tinyexec@npm:^1.3.1":          # ← redundant
  version: 1.3.1
  ...
```

The standalone `^1.3.1` range arrived with lint-staged 17.5.0 (#4389) as its own entry rather than being folded into the existing group.

Yarn's fresh resolution merges all three ranges into one, so `yarn install --immutable` fails:

```
➤ YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
-"tinyexec@npm:^1.0.2, tinyexec@npm:^1.3.0":
+"tinyexec@npm:^1.0.2, tinyexec@npm:^1.3.0, tinyexec@npm:^1.3.1":
-"tinyexec@npm:^1.3.1":
```

## Why it wasn't caught locally

Hardened mode is what re-resolves ranges from the registry, and Yarn enables it **automatically for public pull requests** — not on a developer machine, and not against a warm cache. So `yarn install --immutable` passes locally and fails in CI, which is exactly the shape of bug that gets attributed to the PR that happens to be sitting on top of it.

Observed on `main` itself (#4390, #4389) and on every open PR I checked, in `Lint / lint`, `Validate GraphQL schema`, `Migration conflicts`, `Dependencies changesets`, `Snapshot (alpha)` and `test` — each dying in `setup environment` / `Install Dependencies`.

## The change

Produced by `yarn dedupe tinyexec`. **No version change and no checksum change** — only the range grouping:

```
 1 file changed, 1 insertion(+), 8 deletions(-)
```

Verified afterwards:
- `yarn install --immutable` → clean, exit 0
- `yarn dedupe --check` → `No packages can be deduped using the highest strategy`

No changeset: `require-changeset.yml` triggers on `packages/**`, and this touches only the root lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
