### PR TITLE
chore(client): add a test and Storybook safety net for the client

### DIFF
--- a/.changeset/client-test-and-storybook-safety-net.md
+++ b/.changeset/client-test-and-storybook-safety-net.md
@@ -1,0 +1,42 @@
+---
+'@accounter/client': patch
+---
+
+Give the client a CI safety net: run its tests and its Storybook on every client PR.
+
+Client-only pull requests previously ran lint, Prettier and GraphQL validation and nothing else.
+`server-tests.yml` is the only workflow invoking vitest and its `paths` filter covers just
+`packages/server`, `packages/migrations` and `packages/email-ingestion-gateway`; `pr.yml`'s
+`compile` job runs for forked PRs only. So the client's 44 test files were exercised only when an
+unrelated server PR happened to trigger that workflow, or after merge to `main` — and
+`storybook:build` never ran in CI at all, leaving a broken story to be caught by `tsc` on `main`.
+
+Running client tests on their own was also impossible: `scripts/vitest-global-setup.ts` calls
+`assertLocalDatabase()` and connects to Postgres, and it was declared on every vitest project
+including `unit`, so a pure client test still required a database.
+
+- New `client` vitest project that declares no `globalSetup`, so it runs with no Postgres, and sets
+  `environment: 'happy-dom'` at the project level (the ~27 per-file `@vitest-environment` pragmas
+  are now redundant and can be dropped separately). The root-level `globalSetup` is removed — it
+  applied to every project; each database-backed project (`unit`, `integration`, `demo-seed`)
+  already declared it individually. `packages/client/**` is excluded from `unit` so its tests do
+  not run twice, and `yarn test` / `test:integration` now name `--project client` explicitly so
+  nothing loses coverage. Added `yarn test:client`.
+- `.storybook/` is now typechecked and linted. It was excluded from `packages/client/tsconfig.json`'s
+  `include` and matched `'**/.storybook/'` in the ESLint ignore list, so the config the stories
+  depend on was covered by neither. (TypeScript's wildcard include does not descend into
+  dot-directories by name alone, hence the explicit `.storybook/**/*` glob.)
+- `src/__tests__/stories.test.tsx` mounts every story via portable stories (`composeStories`), so a
+  story that stops compiling or throws on render now fails CI. Storybook's own
+  `@storybook/addon-vitest` would normally cover this in a real browser with a11y assertions, but as
+  of 10.6.0 it peer-requires vitest `^3 || ^4` and this repo is on vitest 5; revisit when it
+  supports 5.
+- Added `@storybook/addon-a11y` for the accessibility panel, and moved the `MantineProvider`, urql,
+  `UserContext` and router wrappers out of individual stories into `.storybook/preview.tsx`. Stories
+  needing a specific route set `parameters.router.initialEntries` — react-router throws on a nested
+  `<Router>`, which the new story test caught immediately.
+
+The matching `client-tests.yml` workflow — which would run these on every PR touching
+`packages/client/**` — is not included here: pushing `.github/workflows/**` needs a GitHub token
+with `workflow` scope. Until it is added, the client tests run through `yarn test` and
+`yarn test:integration` rather than on a client-path trigger.

--- a/.changeset/mantine-indicator-overlay-primitives.md
+++ b/.changeset/mantine-indicator-overlay-primitives.md
@@ -1,0 +1,35 @@
+---
+'@accounter/client': patch
+---
+
+Replace Mantine's `Indicator`, `Overlay`, `LoadingOverlay`, `SimpleGrid`, `Loader` and `Image` with
+local Tailwind primitives — the first component cluster of the Mantine removal.
+
+Two new primitives fill genuine gaps in shadcn's catalogue and live in `components/ui/` as
+first-class components rather than compatibility shims:
+
+- `ui/indicator.tsx` — the status dot used on table cells and filter buttons. Mantine's usage was
+  near-identical at all 21 call sites (`inline`, `size`, `disabled`, `color`, `processing`), so the
+  swap was mechanical. Mantine's `processing` ripple becomes `animate-pulse`; the `zIndex="auto"`
+  plumbing every call site carried is dropped, as the new dot needs no stacking override.
+- `ui/overlay.tsx` — `Overlay` and `LoadingOverlay`, the scrim veiling a form while a mutation runs.
+  Mantine's default appearance was a 60% white wash, matched here so this is not also a visual
+  change. `LoadingOverlay`'s prop is now `blur` rather than `overlayBlur`.
+
+Four wrappers were reimplemented in Tailwind, so their consumers were untouched:
+
+- `common/simple-grid.tsx` — Mantine v6's `breakpoints` array is max-width based (desktop-first)
+  while Tailwind's variants are min-width based, so the ladder is inverted rather than translated.
+  Column classes are spelled out per count because Tailwind only emits utilities it finds as
+  literals. The old config listed both `maxWidth: 900, cols: 2` and `maxWidth: 755, cols: 2`, the
+  latter unreachable — these boundaries were never precision-tuned.
+- `common/loaders/loader.tsx` — Mantine's `variant="dots"` loader has no lucide equivalent, so
+  `AccounterLoader` now uses the house `Spinner`. **This is a deliberate, visible change** to the
+  full-page loading animation.
+- `common/icon.tsx` — Mantine `Image` becomes a plain `<img>`, and now carries an `alt`.
+- `common/divider.tsx` — deleted. `AccounterDivider` had no consumers anywhere.
+
+Also adds stories for both new primitives, and escalates the `no-restricted-imports` Mantine rule to
+`error` across the 19 directories that now have no Mantine imports at all.
+
+Mantine imports: 123 → 103, across 117 → 96 files.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -277,6 +277,46 @@ export default [
     },
     rules: {
       'react-hooks/set-state-in-effect': 'off',
+      // Mantine is being removed from the client in favour of shadcn/ui + Tailwind.
+      // This starts as a warning across the package and is escalated to 'error' per
+      // directory as each cluster is migrated (see the blocks below), so cleaned areas
+      // cannot regress while the rest of the migration is still in flight.
+      'no-restricted-imports': [
+        'warn',
+        {
+          patterns: [
+            {
+              group: ['@mantine/*'],
+              message:
+                'Mantine is being removed. Use src/components/ui/ (shadcn) or Tailwind utilities instead.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // Directories with no Mantine imports left: keep them that way.
+    files: [
+      'packages/client/src/components/ui/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/hooks/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/lib/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/helpers/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/providers/**/*.{,c,m}{j,t}s{,x}',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@mantine/*'],
+              message:
+                'Mantine is being removed. Use src/components/ui/ (shadcn) or Tailwind utilities instead.',
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -57,7 +57,6 @@ export default [
       '**/schema.graphql',
       '**/__tests__/',
       '**/tests/',
-      '**/.storybook/',
       '**/vite.config.ts',
       '**/vitest.config.ts',
       'packages/*/scripts/',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -296,12 +296,27 @@ export default [
     },
   },
   {
-    // Directories with no Mantine imports left: keep them that way.
+    // Directories with no Mantine imports left: keep them that way. Each migrated
+    // cluster adds its directories here, so the migration cannot regress behind itself.
     files: [
+      'packages/client/src/components/admin-settings/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/bank-deposits/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/business/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/businesses/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/charge-matching/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/clients/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/financial-accounts/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/landing/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/layout/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/ledger-table/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/securities/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/tags/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/tax-categories/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/transactions-table/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/ui/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/helpers/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/hooks/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/lib/**/*.{,c,m}{j,t}s{,x}',
-      'packages/client/src/helpers/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/providers/**/*.{,c,m}{j,t}s{,x}',
     ],
     rules: {

--- a/package.json
+++ b/package.json
@@ -43,9 +43,10 @@
     "seed:reset-staging": "echo \"DESTRUCTIVE: Implement seed reset script as needed\"",
     "seed:staging-demo": "tsx scripts/seed-demo-data.ts",
     "setup": "yarn db:init && yarn generate",
-    "test": "vitest run --project unit",
+    "test": "vitest run --project unit --project client",
+    "test:client": "vitest run --project client",
     "test:demo-seed": "vitest run --project demo-seed",
-    "test:integration": "vitest run --project unit --project integration",
+    "test:integration": "vitest run --project unit --project client --project integration",
     "validate:demo": "tsx packages/server/src/demo-fixtures/validate-demo-data.ts"
   },
   "devDependencies": {

--- a/packages/client/.storybook/main.ts
+++ b/packages/client/.storybook/main.ts
@@ -3,6 +3,11 @@ import type { StorybookConfig } from '@storybook/react-vite';
 const config: StorybookConfig = {
   framework: '@storybook/react-vite',
   stories: ['../src/**/*.stories.@(ts|tsx)'],
+  // `@storybook/addon-vitest` (which would run these stories as browser tests in CI) is
+  // deliberately absent: as of 10.6.0 it peer-requires vitest ^3 || ^4 and this repo is on
+  // vitest 5. Stories are exercised in CI through portable stories instead — see
+  // `src/__tests__/stories.test.tsx`. Revisit once the addon supports vitest 5.
+  addons: ['@storybook/addon-a11y'],
 };
 
 export default config;

--- a/packages/client/.storybook/preview.tsx
+++ b/packages/client/.storybook/preview.tsx
@@ -1,22 +1,63 @@
+import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'urql';
+import { MantineProvider } from '@mantine/core';
 import type { Preview } from '@storybook/react-vite';
 import 'json-bigint-patch';
 import '../src/index.css';
 import { getUrqlClient } from '../src/providers/urql.js';
+import { UserContext } from '../src/providers/user-provider.js';
+
+/**
+ * Minimal stand-in for the signed-in user. Stories that care about specific business
+ * ids nest their own `UserContext.Provider` — the nearest provider wins.
+ */
+const USER_CONTEXT = {
+  userContext: {
+    username: 'storybook',
+    context: { adminBusinessId: 'owner-1' },
+  },
+  setUserContext: () => void 0,
+} as never;
 
 const preview: Preview = {
   decorators: [
+    // Mantine is being removed from the client. This provider exists so components that
+    // still import from `@mantine/*` render with their theme while the migration is in
+    // flight; it is deleted along with the last Mantine import.
+    Story => (
+      <MantineProvider
+        withGlobalStyles
+        theme={{ fontFamily: 'Roboto, sans-serif', fontSizes: { md: '14' } }}
+      >
+        <Story />
+      </MantineProvider>
+    ),
     // Components that call useQuery/useMutation get a real urql client pointing
     // at http://localhost:4000/graphql — run `yarn mock:server` (repo root) to
-    // feed them auto-mocked data.
+    // feed them auto-mocked data. Stories that mock their own client nest a
+    // `Provider` of their own, which takes precedence.
     Story => (
       <Provider value={getUrqlClient()}>
         <Story />
       </Provider>
     ),
+    Story => (
+      <UserContext.Provider value={USER_CONTEXT}>
+        <Story />
+      </UserContext.Provider>
+    ),
+    // react-router throws if a Router is nested inside another Router, so this is the
+    // only one: stories needing a specific entry set `parameters.router.initialEntries`
+    // rather than wrapping in their own MemoryRouter.
+    (Story, { parameters }) => (
+      <MemoryRouter initialEntries={parameters['router']?.initialEntries ?? ['/']}>
+        <Story />
+      </MemoryRouter>
+    ),
   ],
   parameters: {
     controls: { expanded: true },
+    a11y: { test: 'todo' },
   },
 };
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -82,6 +82,7 @@
     "zustand": "5.0.15"
   },
   "devDependencies": {
+    "@storybook/addon-a11y": "10.6.0",
     "@storybook/react-vite": "10.6.0",
     "@tailwindcss/vite": "4.3.3",
     "@types/chart.js": "4.0.1",
@@ -90,6 +91,7 @@
     "@types/react-dom": "19.2.5",
     "@vitejs/plugin-react": "6.1.1",
     "autoprefixer": "10.5.4",
+    "axe-core": "4.11.0",
     "happy-dom": "20.14.0",
     "storybook": "10.6.0",
     "tailwindcss": "4.3.3",

--- a/packages/client/src/__tests__/stories.test.tsx
+++ b/packages/client/src/__tests__/stories.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { composeStories, setProjectAnnotations } from '@storybook/react-vite';
+import * as previewAnnotations from '../../.storybook/preview.js';
+
+/**
+ * Runs every Storybook story as a test.
+ *
+ * Storybook's own `@storybook/addon-vitest` would normally do this (in a real browser, with
+ * a11y assertions), but as of 10.6.0 it peer-requires vitest ^3 || ^4 and this repo is on
+ * vitest 5. Portable stories give us the part that matters most in CI — every story is
+ * mounted on every push, so a story that stops compiling or throws on render fails the
+ * build instead of rotting silently. Visual and a11y checking stay manual in the Storybook
+ * UI (`yarn workspace @accounter/client storybook`) until the addon supports vitest 5.
+ *
+ * This matters for the Mantine removal specifically: stories are the characterization
+ * harness each migration PR is checked against, so they have to be known-good.
+ */
+setProjectAnnotations([previewAnnotations]);
+
+// Vite turns this into a static map of story module path -> loader.
+type StoryModule = Parameters<typeof composeStories>[0];
+const storyModules = import.meta.glob<StoryModule>('../**/*.stories.tsx');
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('storybook stories', () => {
+  it('finds story files to run', () => {
+    expect(Object.keys(storyModules).length).toBeGreaterThan(0);
+  });
+
+  for (const [path, load] of Object.entries(storyModules)) {
+    describe(path, () => {
+      // Generous: a single file can hold a dozen stories, each mounting a whole screen.
+      it('renders every story without throwing', { timeout: 60_000 }, async () => {
+        const composed = composeStories(await load());
+        const names = Object.keys(composed);
+        expect(names.length).toBeGreaterThan(0);
+
+        for (const name of names) {
+          const Story = composed[name as keyof typeof composed] as React.ComponentType;
+          await act(async () => {
+            root.render(<Story />);
+          });
+          expect(container.innerHTML.length).toBeGreaterThan(0);
+        }
+      });
+    });
+  }
+});

--- a/packages/client/src/components/business-ledger/business-ledger-filters.tsx
+++ b/packages/client/src/components/business-ledger/business-ledger-filters.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useState, type ReactElement } from 'react';
 import equal from 'deep-equal';
 import { Filter } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Indicator, MultiSelect, Select } from '@mantine/core';
+import { MultiSelect, Select } from '@mantine/core';
 import { encodeFilters } from '@/router/routes.js';
 import { type BusinessTransactionsFilter } from '../../gql/graphql.js';
 import { isObjectEmpty, TIMELESS_DATE_REGEX } from '../../helpers/index.js';
@@ -14,6 +14,7 @@ import { PopUpModal } from '../common/index.js';
 import { DatePickerInput } from '../common/inputs/date-picker-input.js';
 import { Button } from '../ui/button.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form.js';
+import { Indicator } from '../ui/indicator.js';
 
 interface BusinessLedgerRecordsFilterFormProps {
   filter: BusinessTransactionsFilter;

--- a/packages/client/src/components/business-trips/business-trips-row.tsx
+++ b/packages/client/src/components/business-trips/business-trips-row.tsx
@@ -1,12 +1,12 @@
 import { useMemo, type ReactElement } from 'react';
 import { useQuery } from 'urql';
-import { Indicator } from '@mantine/core';
 import {
   BusinessTripsRowFieldsFragmentDoc,
   BusinessTripsRowValidationDocument,
 } from '../../gql/graphql.js';
 import { getFragmentData, type FragmentType } from '../../gql/index.js';
 import { AccordionContent, AccordionItem, AccordionTrigger } from '../ui/accordion.js';
+import { Indicator } from '../ui/indicator.js';
 import { EditableBusinessTrip } from './editable-business-trip.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
@@ -76,7 +76,6 @@ export const BusinessTripsRow = ({
           processing={fetching}
           disabled={!indicatorUp}
           color={isError ? 'red' : 'yellow'}
-          zIndex="auto"
         >
           {trip.name}
         </Indicator>

--- a/packages/client/src/components/charges/cells/amount.tsx
+++ b/packages/client/src/components/charges/cells/amount.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { Currency } from '../../../gql/graphql.js';
 import { formatAmountWithCurrency } from '../../../helpers/index.js';
+import { Indicator } from '../../ui/indicator.js';
 
 export type AmountProps = {
   amount?: {
@@ -24,7 +24,6 @@ export const Amount = ({ amount }: AmountProps): ReactElement | null => {
       disabled={isValid === undefined ? true : isValid}
       processing={shouldValidate && isValid === undefined}
       color="red"
-      zIndex="auto"
     >
       <p
         className={

--- a/packages/client/src/components/charges/cells/counterparty.tsx
+++ b/packages/client/src/components/charges/cells/counterparty.tsx
@@ -1,8 +1,8 @@
 import { type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { Indicator } from '@mantine/core';
 import { ROUTES } from '@/router/routes.js';
 import type { ChargeType } from '../../../helpers/index.js';
+import { Indicator } from '../../ui/indicator.js';
 import { shouldHaveCounterparty } from '../utils.js';
 
 export type CounterpartyProps = {
@@ -26,7 +26,7 @@ export const Counterparty = ({
 
   return (
     <div className="whitespace-normal">
-      <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+      <Indicator inline size={12} disabled={!isError} color="red">
         {!isError && id && (
           <Link
             to={ROUTES.BUSINESSES.DETAIL(id)}

--- a/packages/client/src/components/charges/cells/description.tsx
+++ b/packages/client/src/components/charges/cells/description.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState, type ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { useUpdateCharge } from '../../../hooks/use-update-charge.js';
 import { ConfirmMiniButton, SimilarChargesByIdModal } from '../../common/index.js';
+import { Indicator } from '../../ui/indicator.js';
 
 export type DescriptionProps = {
   chargeId: string;
@@ -63,7 +63,7 @@ export const Description = ({
   return (
     <>
       <div className="flex flex-wrap whitespace-normal">
-        <Indicator inline size={12} disabled={!isMissing} color="red" zIndex="auto">
+        <Indicator inline size={12} disabled={!isMissing} color="red">
           <p className={hasAlternative ? 'bg-yellow-400' : undefined}>{cellText}</p>
         </Indicator>
         {hasAlternative && (

--- a/packages/client/src/components/charges/cells/more-info.tsx
+++ b/packages/client/src/components/charges/cells/more-info.tsx
@@ -1,7 +1,7 @@
 import { useMemo, type ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import type { ChargeType } from '../../../helpers/index.js';
 import { DragFile, ListCapsule } from '../../common/index.js';
+import { Indicator } from '../../ui/indicator.js';
 
 export type MoreInfoProps = {
   chargeId: string;
@@ -76,14 +76,7 @@ export const MoreInfo = ({
       extraClassName:
         info?.transactionsCount || !shouldHaveTransactions ? undefined : 'bg-yellow-400',
       content: (
-        <Indicator
-          key="transactions"
-          inline
-          size={12}
-          disabled={!isTransactionsError}
-          color="red"
-          zIndex="auto"
-        >
+        <Indicator key="transactions" inline size={12} disabled={!isTransactionsError} color="red">
           <div className="whitespace-nowrap">Transactions: {info?.transactionsCount ?? 0}</div>
         </Indicator>
       ),
@@ -99,7 +92,6 @@ export const MoreInfo = ({
         processing={!ledgerStatus}
         disabled={ledgerStatus === 'VALID'}
         color={ledgerStatus === 'DIFF' ? 'orange' : 'red'}
-        zIndex="auto"
       >
         <div className="whitespace-nowrap">Ledger Records: {info?.ledgerCount ?? 0}</div>
       </Indicator>
@@ -109,14 +101,7 @@ export const MoreInfo = ({
   if (isDocumentsError || info?.documentsCount) {
     list.push({
       content: (
-        <Indicator
-          key="documents"
-          inline
-          size={12}
-          disabled={!isDocumentsError}
-          color="red"
-          zIndex="auto"
-        >
+        <Indicator key="documents" inline size={12} disabled={!isDocumentsError} color="red">
           <div className="whitespace-nowrap">Documents: {info?.documentsCount ?? 0}</div>
         </Indicator>
       ),

--- a/packages/client/src/components/charges/cells/tags.tsx
+++ b/packages/client/src/components/charges/cells/tags.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useState, type ReactElement } from 'react';
-import { Group, Indicator, Text } from '@mantine/core';
+import { Group, Text } from '@mantine/core';
 import { useUpdateCharge } from '../../../hooks/use-update-charge.js';
 import { ConfirmMiniButton, ListCapsule, SimilarChargesByIdModal } from '../../common/index.js';
+import { Indicator } from '../../ui/indicator.js';
 
 export type TagsProps = {
   chargeId: string;
@@ -51,7 +52,7 @@ export const Tags = ({
 
   return (
     <>
-      <Indicator inline size={12} disabled={!isMissing} color="red" zIndex="auto">
+      <Indicator inline size={12} disabled={!isMissing} color="red">
         <ListCapsule
           items={tags.map(t => (
             <Group key={t.id}>

--- a/packages/client/src/components/charges/cells/tax-category.tsx
+++ b/packages/client/src/components/charges/cells/tax-category.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
+import { Indicator } from '../../ui/indicator.js';
 
 export type TaxCategoryProps = {
   taxCategory?: {
@@ -11,7 +11,7 @@ export type TaxCategoryProps = {
 
 export const TaxCategory = ({ taxCategory, isMissing }: TaxCategoryProps): ReactElement => {
   return (
-    <Indicator inline size={12} disabled={!isMissing} color="red" zIndex="auto">
+    <Indicator inline size={12} disabled={!isMissing} color="red">
       {taxCategory?.name ?? 'N/A'}
     </Indicator>
   );

--- a/packages/client/src/components/charges/cells/vat.tsx
+++ b/packages/client/src/components/charges/cells/vat.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { Currency } from '../../../gql/graphql.js';
 import { formatAmountWithCurrency } from '../../../helpers/index.js';
+import { Indicator } from '../../ui/indicator.js';
 
 export type VatProps = {
   value?: number;
@@ -20,7 +20,7 @@ export const Vat = ({ value, currency, amountValue, missingInfo }: VatProps): Re
     <div
       className={isError ? 'whitespace-nowrap text-red-500' : 'whitespace-nowrap text-green-700'}
     >
-      <Indicator inline size={12} disabled={!missingInfo} color="red" zIndex="auto">
+      <Indicator inline size={12} disabled={!missingInfo} color="red">
         {value != null && currency ? formatAmountWithCurrency(value, currency) : null}
       </Indicator>
     </div>

--- a/packages/client/src/components/charges/charges-filters/charges-filters.stories.tsx
+++ b/packages/client/src/components/charges/charges-filters/charges-filters.stories.tsx
@@ -1,5 +1,4 @@
 import { useState, type ReactElement } from 'react';
-import { MemoryRouter } from 'react-router-dom';
 import { Client, Provider, type Exchange, type OperationResult } from 'urql';
 import { map, never, pipe } from 'wonka';
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -132,24 +131,22 @@ function Harness({
   return (
     <Provider value={mockClient(loading ? pendingExchange : resolvedExchange)}>
       <UserContext.Provider value={USER_CONTEXT}>
-        <MemoryRouter initialEntries={['/charges']}>
-          <div className="flex min-h-screen flex-col gap-4 bg-gray-100 p-6">
-            <div className="flex h-14 items-center justify-center rounded-lg border bg-white">
-              <ChargesFilters
-                filter={filter}
-                setFilter={setFilter}
-                activePage={page}
-                setPage={setPage}
-                totalPages={totalPages}
-                initiallyOpened={initiallyOpened}
-                withDefaultDateRange={withDefaultDateRange}
-              />
-            </div>
-            <pre className="overflow-x-auto rounded-lg border bg-white p-3 text-xs">
-              {JSON.stringify(filter, null, 2)}
-            </pre>
+        <div className="flex min-h-screen flex-col gap-4 bg-gray-100 p-6">
+          <div className="flex h-14 items-center justify-center rounded-lg border bg-white">
+            <ChargesFilters
+              filter={filter}
+              setFilter={setFilter}
+              activePage={page}
+              setPage={setPage}
+              totalPages={totalPages}
+              initiallyOpened={initiallyOpened}
+              withDefaultDateRange={withDefaultDateRange}
+            />
           </div>
-        </MemoryRouter>
+          <pre className="overflow-x-auto rounded-lg border bg-white p-3 text-xs">
+            {JSON.stringify(filter, null, 2)}
+          </pre>
+        </div>
       </UserContext.Provider>
     </Provider>
   );
@@ -161,7 +158,11 @@ function Harness({
 const meta = {
   title: 'Charges/ChargesFilters',
   component: Harness,
-  parameters: { layout: 'fullscreen' },
+  parameters: {
+    layout: 'fullscreen',
+    // The router now comes from `.storybook/preview.tsx`.
+    router: { initialEntries: ['/charges'] },
+  },
 } satisfies Meta<typeof Harness>;
 
 export default meta;

--- a/packages/client/src/components/common/business-trip-report/buttons/add-accommodation-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-accommodation-expense.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, Overlay } from '@mantine/core';
+import { Loader, Modal } from '@mantine/core';
 import { type AddBusinessTripAccommodationsExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripAccommodationsExpense } from '../../../../hooks/use-add-business-trip-accommodations-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -14,6 +14,7 @@ import {
   FormMessage,
 } from '../../../ui/form.js';
 import { Input } from '../../../ui/input.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { NumberInput, Tooltip } from '../../index.js';
 import { AttendeesStayInput } from '../parts/attendee-stay-input.js';
 import { AddExpenseFields } from './add-expense-fields.js';

--- a/packages/client/src/components/common/business-trip-report/buttons/add-attendee.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-attendee.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, Overlay, Select } from '@mantine/core';
+import { Loader, Modal, Select } from '@mantine/core';
 import type { InsertBusinessTripAttendeeInput } from '../../../../gql/graphql.js';
 import { TIMELESS_DATE_REGEX } from '../../../../helpers/index.js';
 import { useGetBusinesses } from '../../../../hooks/use-get-businesses.js';
@@ -15,6 +15,7 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../ui/form.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Tooltip } from '../../index.js';
 import { DatePickerInput } from '../../inputs/date-picker-input.js';
 

--- a/packages/client/src/components/common/business-trip-report/buttons/add-car-rental-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-car-rental-expense.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, NumberInput, Overlay } from '@mantine/core';
+import { Loader, Modal, NumberInput } from '@mantine/core';
 import type { AddBusinessTripCarRentalExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripCarRentalExpense } from '../../../../hooks/use-add-business-trip-car-rental-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -13,6 +13,7 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../ui/form.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Switch } from '../../../ui/switch.js';
 import { Tooltip } from '../../index.js';
 import { AddExpenseFields } from './add-expense-fields.js';

--- a/packages/client/src/components/common/business-trip-report/buttons/add-flight-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-flight-expense.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { useQuery } from 'urql';
-import { Loader, Modal, MultiSelect, Overlay, Select } from '@mantine/core';
+import { Loader, Modal, MultiSelect, Select } from '@mantine/core';
 import {
   AttendeesByBusinessTripDocument,
   FlightClass,
@@ -11,6 +11,7 @@ import {
 import { useAddBusinessTripFlightsExpense } from '../../../../hooks/use-add-business-trip-flights-expense.js';
 import { Button } from '../../../ui/button.js';
 import { Form } from '../../../ui/form.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Tooltip } from '../../index.js';
 import { FlightPathInput } from '../parts/flight-path-input.js';
 import { AddExpenseFields } from './add-expense-fields.js';

--- a/packages/client/src/components/common/business-trip-report/buttons/add-other-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-other-expense.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, Overlay } from '@mantine/core';
+import { Loader, Modal } from '@mantine/core';
 import type { AddBusinessTripOtherExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripOtherExpense } from '../../../../hooks/use-add-business-trip-other-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -14,6 +14,7 @@ import {
   FormMessage,
 } from '../../../ui/form.js';
 import { Input } from '../../../ui/input.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Switch } from '../../../ui/switch.js';
 import { Tooltip } from '../../index.js';
 import { AddExpenseFields } from './add-expense-fields.js';

--- a/packages/client/src/components/common/business-trip-report/buttons/add-travel-and-subsistence-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-travel-and-subsistence-expense.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, Overlay } from '@mantine/core';
+import { Loader, Modal } from '@mantine/core';
 import type { AddBusinessTripTravelAndSubsistenceExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripTravelAndSubsistenceExpense } from '../../../../hooks/use-add-business-trip-travel-and-subsistence-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -14,6 +14,7 @@ import {
   FormMessage,
 } from '../../../ui/form.js';
 import { Input } from '../../../ui/input.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Tooltip } from '../../index.js';
 import { AddExpenseFields } from './add-expense-fields.js';
 

--- a/packages/client/src/components/common/business-trip-report/buttons/categorize-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/categorize-expense.tsx
@@ -1,13 +1,14 @@
 import { useState, type ReactElement } from 'react';
 import { Edit } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, NumberInput, Overlay, Select } from '@mantine/core';
+import { Loader, Modal, NumberInput, Select } from '@mantine/core';
 import {
   BusinessTripExpenseCategories,
   type CategorizeBusinessTripExpenseInput,
 } from '../../../../gql/graphql.js';
 import { useCategorizeBusinessTripExpense } from '../../../../hooks/use-categorize-business-trip-expense.js';
 import { Button } from '../../../ui/button.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Tooltip } from '../../index.js';
 
 export function CategorizeExpense(props: {

--- a/packages/client/src/components/common/business-trip-report/buttons/categorize-into-existing-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/categorize-into-existing-expense.tsx
@@ -3,7 +3,7 @@ import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { toast } from 'sonner';
 import { useQuery } from 'urql';
-import { Grid, Loader, Modal, NumberInput, Overlay, Select, Text } from '@mantine/core';
+import { Grid, Loader, Modal, NumberInput, Select, Text } from '@mantine/core';
 import {
   UncategorizedTransactionsByBusinessTripDocument,
   type CategorizeIntoExistingBusinessTripExpenseInput,
@@ -11,6 +11,7 @@ import {
 } from '../../../../gql/graphql.js';
 import { useCategorizeIntoExistingBusinessTripExpense } from '../../../../hooks/use-categorize-into-existing-business-trip-expense.js';
 import { Button } from '../../../ui/button.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Tooltip } from '../../index.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen

--- a/packages/client/src/components/common/depreciation/add-depreciation-record.tsx
+++ b/packages/client/src/components/common/depreciation/add-depreciation-record.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { useQuery } from 'urql';
-import { Loader, Modal, Overlay, Select } from '@mantine/core';
+import { Loader, Modal, Select } from '@mantine/core';
 import {
   AllDepreciationCategoriesDocument,
   type InsertDepreciationRecordInput,
@@ -11,6 +11,7 @@ import { TIMELESS_DATE_REGEX } from '../../../helpers/index.js';
 import { useAddDepreciationRecord } from '../../../hooks/use-add-depreciation-record.js';
 import { Button } from '../../ui/button.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
+import { Overlay } from '../../ui/overlay.js';
 import { CurrencyInput, DatePickerInput, Tooltip } from '../index.js';
 import { depreciationTypes } from './index.js';
 

--- a/packages/client/src/components/common/divider.tsx
+++ b/packages/client/src/components/common/divider.tsx
@@ -1,4 +1,0 @@
-import type { ReactElement } from 'react';
-import { Divider, type DividerProps } from '@mantine/core';
-
-export const AccounterDivider = (props: DividerProps): ReactElement => <Divider {...props} />;

--- a/packages/client/src/components/common/icon.tsx
+++ b/packages/client/src/components/common/icon.tsx
@@ -1,12 +1,11 @@
-import type { ReactElement, RefAttributes } from 'react';
-import { Image, type ImageProps } from '@mantine/core';
+import type { ComponentProps, ReactElement } from 'react';
 
 export type IconName = 'logo';
 
-interface IconProps extends ImageProps, RefAttributes<HTMLDivElement> {
+interface IconProps extends Omit<ComponentProps<'img'>, 'src' | 'alt'> {
   name: IconName;
 }
 
 export const Icon = ({ name, ...props }: IconProps): ReactElement => {
-  return <Image src={`/icons/${name}.svg`} {...props} />;
+  return <img src={`/icons/${name}.svg`} alt={name} {...props} />;
 };

--- a/packages/client/src/components/common/index.ts
+++ b/packages/client/src/components/common/index.ts
@@ -4,7 +4,6 @@ export * from './buttons/index.js';
 export * from './common-wrappers.js';
 export * from './data-table-column-header.js';
 export * from './data-table-pagination.js';
-export * from './divider.js';
 export * from './document-image-drawer.js';
 export * from './footer.js';
 export * from './forms/index.js';

--- a/packages/client/src/components/common/loaders/loader.tsx
+++ b/packages/client/src/components/common/loaders/loader.tsx
@@ -1,12 +1,14 @@
 import type { ReactElement } from 'react';
-import { Loader } from '@mantine/core';
+import { Spinner } from '../../ui/spinner.js';
 import { Icon } from '../icon.js';
 
 export const AccounterLoader = (): ReactElement => {
   return (
     <div className="flex flex-col justify-center items-center content-center h-screen">
       <Icon name="logo" className="max-w-xs" />
-      <Loader className="flex self-center" color="dark" size="xl" variant="dots" />
+      {/* Mantine's `variant="dots"` loader has no lucide equivalent; this is the house
+          convention (a spinning Loader2) at the same visual weight. */}
+      <Spinner className="size-12 self-center text-gray-900" />
     </div>
   );
 };

--- a/packages/client/src/components/common/simple-grid.tsx
+++ b/packages/client/src/components/common/simple-grid.tsx
@@ -1,25 +1,36 @@
 import type { ReactElement } from 'react';
-import { SimpleGrid as Grid } from '@mantine/core';
+import { cn } from '../../lib/utils.js';
 
 export interface SimpleGridProps {
   cols: number;
-  spacing?: number;
+  className?: string;
   children?: ReactElement | ReactElement[];
 }
 
-export const SimpleGrid = ({ cols, spacing, children }: SimpleGridProps): ReactElement => {
+/**
+ * Responsive grid stepping up to `cols` on wide viewports.
+ *
+ * Replaces Mantine's `SimpleGrid`, whose v6 `breakpoints` array was max-width based
+ * (desktop-first) while Tailwind's variants are min-width based, so the ladder below is the
+ * inverted equivalent: one column on phones, two on small screens, then up to `cols`. The
+ * original config listed both `maxWidth: 900, cols: 2` and `maxWidth: 755, cols: 2` — the
+ * latter was unreachable, so these boundaries were never precision-tuned.
+ *
+ * Classes are spelled out per column count rather than interpolated because Tailwind only
+ * emits utilities it can find as literals in the source.
+ */
+const columnClasses: Record<number, string> = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-1 sm:grid-cols-2',
+  3: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+  4: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+  5: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5',
+};
+
+export const SimpleGrid = ({ cols, className, children }: SimpleGridProps): ReactElement => {
   return (
-    <Grid
-      cols={cols}
-      spacing={spacing}
-      breakpoints={[
-        { maxWidth: 980, cols: 3, spacing: 'md' },
-        { maxWidth: 900, cols: 2, spacing: 'sm' },
-        { maxWidth: 755, cols: 2, spacing: 'sm' },
-        { maxWidth: 600, cols: 1, spacing: 'sm' },
-      ]}
-    >
+    <div className={cn('grid gap-3 sm:gap-4', columnClasses[cols] ?? columnClasses[1], className)}>
       {children}
-    </Grid>
+    </div>
   );
 };

--- a/packages/client/src/components/documents-table/cells/amount.tsx
+++ b/packages/client/src/components/documents-table/cells/amount.tsx
@@ -1,8 +1,8 @@
 import { useCallback, type ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { Currency, DocumentType } from '../../../gql/graphql.js';
 import { useUpdateDocument } from '../../../hooks/use-update-document.js';
 import { ConfirmMiniButton } from '../../common/index.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 type Props = {
@@ -43,7 +43,7 @@ export const Amount = ({ document }: Props): ReactElement => {
   return (
     <div className="flex flex-wrap">
       <div className="flex flex-col justify-center">
-        <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+        <Indicator inline size={12} disabled={!isError} color="red">
           <p
             className={[
               'whitespace-nowrap',

--- a/packages/client/src/components/documents-table/cells/creditor.tsx
+++ b/packages/client/src/components/documents-table/cells/creditor.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useMemo, useState, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { Indicator } from '@mantine/core';
 import { DocumentType } from '@/gql/graphql.js';
 import { useGetBusinesses } from '@/hooks/use-get-businesses.js';
 import { useUpdateDocument } from '@/hooks/use-update-document.js';
 import { ROUTES } from '@/router/routes.js';
 import { ConfirmMiniButton, InsertBusiness, SelectWithSearch } from '../../common/index.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 export const COUNTERPARTIES_LESS_DOCUMENT_TYPES: DocumentType[] = [
@@ -93,7 +93,7 @@ export const Creditor = ({ document, onChange }: Props): ReactElement => {
   return (
     <div className="flex flex-wrap">
       <div className="flex flex-col justify-center whitespace-normal">
-        <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+        <Indicator inline size={12} disabled={!isError} color="red">
           {shouldHaveCreditor &&
             (id ? (
               <Link

--- a/packages/client/src/components/documents-table/cells/date.tsx
+++ b/packages/client/src/components/documents-table/cells/date.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { format } from 'date-fns';
-import { Indicator } from '@mantine/core';
 import { DocumentType } from '../../../gql/graphql.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 type Props = {
@@ -18,7 +18,7 @@ export const DateCell = ({ document }: Props): ReactElement => {
   const dateContentValue = shouldHaveDate ? formattedDate : null;
 
   return (
-    <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+    <Indicator inline size={12} disabled={!isError} color="red">
       <div>{dateContentValue}</div>
     </Indicator>
   );

--- a/packages/client/src/components/documents-table/cells/debtor.tsx
+++ b/packages/client/src/components/documents-table/cells/debtor.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useMemo, useState, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { Indicator } from '@mantine/core';
 import { useGetBusinesses } from '@/hooks/use-get-businesses.js';
 import { ROUTES } from '@/router/routes.js';
 import { DocumentType } from '../../../gql/graphql.js';
 import { useUpdateDocument } from '../../../hooks/use-update-document.js';
 import { ConfirmMiniButton, InsertBusiness, SelectWithSearch } from '../../common/index.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 import { COUNTERPARTIES_LESS_DOCUMENT_TYPES } from './index.js';
 
@@ -89,7 +89,7 @@ export const Debtor = ({ document, onChange }: Props): ReactElement => {
   return (
     <div className="flex flex-wrap">
       <div className="flex flex-col justify-center whitespace-normal">
-        <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+        <Indicator inline size={12} disabled={!isError} color="red">
           {shouldHaveDebtor &&
             (id ? (
               <Link

--- a/packages/client/src/components/documents-table/cells/files.tsx
+++ b/packages/client/src/components/documents-table/cells/files.tsx
@@ -1,8 +1,9 @@
 import { useState, type ReactElement } from 'react';
 import { File, Image } from 'lucide-react';
-import { Indicator, SimpleGrid } from '@mantine/core';
+import { SimpleGrid } from '@mantine/core';
 import { DocumentImageDrawer, Tooltip } from '../../common/index.js';
 import { Button } from '../../ui/button.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 type Props = {
@@ -18,7 +19,7 @@ export const Files = ({ document: { image, file } }: Props): ReactElement => {
         <div className="flex flex-col justify-center">
           <SimpleGrid cols={1}>
             <Tooltip disabled={!image} content="Open Image">
-              <Indicator inline size={12} disabled={!!image} color="red" zIndex="auto">
+              <Indicator inline size={12} disabled={!!image} color="red">
                 <Button
                   variant="ghost"
                   size="icon"
@@ -31,7 +32,7 @@ export const Files = ({ document: { image, file } }: Props): ReactElement => {
               </Indicator>
             </Tooltip>
             <Tooltip disabled={!file} content="Open File">
-              <Indicator inline size={12} disabled={!!file} color="red" zIndex="auto">
+              <Indicator inline size={12} disabled={!!file} color="red">
                 {file ? (
                   <a
                     href={typeof file === 'string' ? file : file.href}

--- a/packages/client/src/components/documents-table/cells/serial.tsx
+++ b/packages/client/src/components/documents-table/cells/serial.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { DocumentType } from '../../../gql/graphql.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 type Props = {
@@ -16,7 +16,7 @@ export const Serial = ({ document }: Props): ReactElement => {
 
   return (
     <div className="flex flex-col align-center justify-center flex-wrap">
-      <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+      <Indicator inline size={12} disabled={!isError} color="red">
         <p>{serialNumber}</p>
       </Indicator>
       {allocationNumber && <p className="text-xs">({allocationNumber})</p>}

--- a/packages/client/src/components/documents-table/cells/type.tsx
+++ b/packages/client/src/components/documents-table/cells/type.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { DocumentType } from '../../../gql/graphql.js';
 import { getDocumentNameFromType } from '../../../helpers/index.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 type Props = {
@@ -17,7 +17,7 @@ export const TypeCell = ({ document: { documentType }, isOpen }: Props): ReactEl
   return (
     <div className="flex flex-wrap">
       <div className="flex flex-col justify-center whitespace-normal">
-        <Indicator inline size={12} disabled={!isError && !isOpen} color={color} zIndex="auto">
+        <Indicator inline size={12} disabled={!isError && !isOpen} color={color}>
           <p>{getDocumentNameFromType(cellText)}</p>
         </Indicator>
       </div>

--- a/packages/client/src/components/documents-table/cells/vat.tsx
+++ b/packages/client/src/components/documents-table/cells/vat.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { DocumentType } from '../../../gql/graphql.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 type Props = {
@@ -14,7 +14,7 @@ export const Vat = ({ document }: Props): ReactElement => {
   const isError = shouldHaveVat && vat?.formatted == null;
 
   return (
-    <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+    <Indicator inline size={12} disabled={!isError} color="red">
       <div
         style={{
           color: Number(vat?.raw) > 0 ? 'green' : 'red',

--- a/packages/client/src/components/reports/corporate-tax-ruling-compliance-report/index.tsx
+++ b/packages/client/src/components/reports/corporate-tax-ruling-compliance-report/index.tsx
@@ -2,12 +2,13 @@ import { useContext, useEffect, useState, type ReactElement } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from 'urql';
-import { Indicator, Table } from '@mantine/core';
+import { Table } from '@mantine/core';
 import { CorporateTaxRulingComplianceReportDocument, Currency } from '../../../gql/graphql.js';
 import { dedupeFragments, getCurrencyFormatter } from '../../../helpers/index.js';
 import { FiltersContext } from '../../../providers/filters-context.js';
 import { PrintToPdfButton, Tooltip } from '../../common/index.js';
 import { PageLayout } from '../../layout/page-layout.js';
+import { Indicator } from '../../ui/indicator.js';
 import { AmountCell } from './amount-cell.js';
 import { CorporateTaxRulingComplianceReportFilter } from './corporate-tax-ruling-compliance-report-filters.js';
 import { RuleCell } from './rule-cell.js';
@@ -167,7 +168,6 @@ export const CorporateTaxRulingComplianceReport = (): ReactElement => {
                             !!yearlyReports.find(report => report.year === year)?.differences
                           }
                           color="orange"
-                          zIndex="auto"
                         >
                           {year}
                         </Indicator>

--- a/packages/client/src/components/reports/trial-balance-report/trial-balance-report-filters.tsx
+++ b/packages/client/src/components/reports/trial-balance-report/trial-balance-report-filters.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useState, type ReactElement } from 'react';
 import equal from 'deep-equal';
 import { Filter } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Indicator, MultiSelect } from '@mantine/core';
+import { MultiSelect } from '@mantine/core';
 import { encodeFilters } from '@/router/routes.js';
 import type { BusinessTransactionsFilter } from '../../../gql/graphql.js';
 import { isObjectEmpty, TIMELESS_DATE_REGEX } from '../../../helpers/index.js';
@@ -13,6 +13,7 @@ import { UserContext } from '../../../providers/user-provider.js';
 import { DatePickerInput, PopUpModal } from '../../common/index.js';
 import { Button } from '../../ui/button.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
+import { Indicator } from '../../ui/indicator.js';
 import { Switch } from '../../ui/switch.js';
 
 export type TrialBalanceReportFilters = BusinessTransactionsFilter & {

--- a/packages/client/src/components/screens/charges/all-charges.stories.tsx
+++ b/packages/client/src/components/screens/charges/all-charges.stories.tsx
@@ -1,6 +1,4 @@
 import { useState, type ReactElement } from 'react';
-import { MemoryRouter } from 'react-router-dom';
-import { MantineProvider } from '@mantine/core';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { FiltersContext } from '../../../providers/filters-context.js';
 import { AllCharges } from './all-charges.js';
@@ -29,16 +27,9 @@ const meta = {
   component: AllCharges,
   parameters: {
     layout: 'fullscreen',
+    // MantineProvider and the router now come from `.storybook/preview.tsx`.
+    router: { initialEntries: [initialEntry] },
   },
-  decorators: [
-    Story => (
-      <MantineProvider theme={{ fontFamily: 'Roboto, sans-serif', fontSizes: { md: '14' } }}>
-        <MemoryRouter initialEntries={[initialEntry]}>
-          <Story />
-        </MemoryRouter>
-      </MantineProvider>
-    ),
-  ],
 } satisfies Meta<typeof AllCharges>;
 
 export default meta;

--- a/packages/client/src/components/screens/charges/all-charges.tsx
+++ b/packages/client/src/components/screens/charges/all-charges.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Loader2, PanelTopClose, PanelTopOpen } from 'lucide-react';
 import { useQuery } from 'urql';
-import { LoadingOverlay } from '@mantine/core';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { ChargesTable } from '@/components/charges/charges-table.js';
 import { AllChargesDocument, type ChargeFilter } from '../../../gql/graphql.js';
@@ -12,6 +11,7 @@ import { ChargesFilters } from '../../charges/charges-filters/index.js';
 import { MergeChargesButton, Tooltip } from '../../common/index.js';
 import { PageLayout } from '../../layout/page-layout.js';
 import { Button } from '../../ui/button.js';
+import { LoadingOverlay } from '../../ui/overlay.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -145,7 +145,7 @@ export const AllCharges = (): ReactElement => {
         // but overlay a spinner so it's clear the charges are being reloaded
         // (the stale rows stay visible underneath instead of blinking away).
         <div className="relative">
-          <LoadingOverlay visible={fetching} overlayBlur={1} />
+          <LoadingOverlay visible={fetching} blur={1} />
           <ChargesTable
             data={chargeNodes}
             rowSelection={rowSelection}

--- a/packages/client/src/components/screens/charges/missing-info-charges.tsx
+++ b/packages/client/src/components/screens/charges/missing-info-charges.tsx
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Loader2, PanelTopClose, PanelTopOpen } from 'lucide-react';
 import { useQuery } from 'urql';
-import { LoadingOverlay } from '@mantine/core';
 import { ChargesTable } from '@/components/charges/charges-table.js';
 import { MissingInfoChargesDocument, type ChargeFilter } from '../../../gql/graphql.js';
 import { useStableValue } from '../../../hooks/use-stable-value.js';
@@ -11,6 +10,7 @@ import { ChargesFilters } from '../../charges/charges-filters/index.js';
 import { Tooltip } from '../../common/index.js';
 import { PageLayout } from '../../layout/page-layout.js';
 import { Button } from '../../ui/button.js';
+import { LoadingOverlay } from '../../ui/overlay.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -118,7 +118,7 @@ export const MissingInfoCharges = (): ReactElement => {
         // but overlay a spinner so it's clear the charges are being reloaded
         // (the stale rows stay visible underneath instead of blinking away).
         <div className="relative">
-          <LoadingOverlay visible={fetching} overlayBlur={1} />
+          <LoadingOverlay visible={fetching} blur={1} />
           <ChargesTable data={chargeNodes ?? []} isAllOpened={isAllOpened} />
         </div>
       )}

--- a/packages/client/src/components/screens/documents/all-documents/documents-filters.tsx
+++ b/packages/client/src/components/screens/documents/all-documents/documents-filters.tsx
@@ -3,7 +3,7 @@ import { format, sub } from 'date-fns';
 import equal from 'deep-equal';
 import { Filter } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Indicator, MultiSelect, SimpleGrid } from '@mantine/core';
+import { MultiSelect, SimpleGrid } from '@mantine/core';
 import { encodeFilters } from '@/router/routes.js';
 import {
   DocumentType,
@@ -29,6 +29,7 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../ui/form.js';
+import { Indicator } from '../../../ui/indicator.js';
 import { Input } from '../../../ui/input.js';
 import { Switch } from '../../../ui/switch.js';
 

--- a/packages/client/src/components/screens/reports/balance-report/balance-report-filters.tsx
+++ b/packages/client/src/components/screens/reports/balance-report/balance-report-filters.tsx
@@ -4,7 +4,7 @@ import { Filter } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Indicator, SimpleGrid } from '@mantine/core';
+import { SimpleGrid } from '@mantine/core';
 import { useGetAdminBusinesses } from '@/hooks/use-get-admin-businesses.js';
 import { useGetFinancialAccounts } from '@/hooks/use-get-financial-accounts.js';
 import { encodeFilters } from '@/router/routes.js';
@@ -24,6 +24,7 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../ui/form.js';
+import { Indicator } from '../../../ui/indicator.js';
 import { Switch } from '../../../ui/switch.js';
 
 export function encodeBalanceReportFilters(filter?: BalanceReportFilter | null): string | null {

--- a/packages/client/src/components/ui/indicator.stories.tsx
+++ b/packages/client/src/components/ui/indicator.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from './button.js';
+import { Indicator } from './indicator.js';
+
+const meta = {
+  title: 'UI/Indicator',
+  component: Indicator,
+  parameters: { layout: 'centered' },
+  args: { inline: true, size: 12, disabled: false, color: 'red' },
+} satisfies Meta<typeof Indicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: <span className="text-sm">Invoice #4821</span> },
+};
+
+/** `disabled` is how every call site spells "nothing is wrong here". */
+export const Disabled: Story = {
+  args: { disabled: true, children: <span className="text-sm">Invoice #4821</span> },
+};
+
+/** The pending state, while a validation result is still resolving. */
+export const Processing: Story = {
+  args: { processing: true, children: <span className="text-sm">Invoice #4821</span> },
+};
+
+export const Colors: Story = {
+  args: { children: null },
+  render: args => (
+    <div className="flex items-center gap-6">
+      {(['red', 'orange', 'yellow', 'green', 'blue'] as const).map(color => (
+        <Indicator key={color} {...args} color={color}>
+          <span className="text-sm">{color}</span>
+        </Indicator>
+      ))}
+    </div>
+  ),
+};
+
+/** The filter-button case: a larger dot marking an active filter set. */
+export const OnIconButton: Story = {
+  args: {
+    size: 16,
+    children: (
+      <Button variant="outline" size="icon">
+        F
+      </Button>
+    ),
+  },
+};

--- a/packages/client/src/components/ui/indicator.tsx
+++ b/packages/client/src/components/ui/indicator.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils.js';
+
+const indicatorDotVariants = cva(
+  'pointer-events-none absolute top-0 right-0 -translate-y-1/2 translate-x-1/2 rounded-full',
+  {
+    variants: {
+      color: {
+        red: 'bg-red-500',
+        orange: 'bg-orange-500',
+        yellow: 'bg-yellow-500',
+        green: 'bg-green-500',
+        blue: 'bg-blue-500',
+      },
+      // Mantine's `processing` ripples the dot outward. `animate-pulse` is the calmer
+      // Tailwind equivalent — same "something is still resolving" read, one element.
+      processing: {
+        true: 'animate-pulse',
+        false: '',
+      },
+    },
+    defaultVariants: {
+      color: 'red',
+      processing: false,
+    },
+  },
+);
+
+type IndicatorProps = React.ComponentProps<'div'> &
+  VariantProps<typeof indicatorDotVariants> & {
+    /** Lay the wrapper out inline rather than as a block. */
+    inline?: boolean;
+    /** Dot diameter in pixels. Dynamic, so it is applied as a style rather than a class. */
+    size?: number;
+    /** Hide the dot. Named for parity with the call sites, which all read `disabled={!isError}`. */
+    disabled?: boolean;
+    zIndex?: React.CSSProperties['zIndex'];
+  };
+
+/**
+ * Wraps content with a small status dot in its top-right corner — a "this row has an
+ * error" / "this filter is active" marker.
+ *
+ * There is no shadcn equivalent, so this is a first-class local primitive rather than a
+ * compatibility shim, and it is what replaced Mantine's `Indicator` across the client.
+ */
+function Indicator({
+  className,
+  children,
+  inline = false,
+  size = 10,
+  disabled = false,
+  color,
+  processing,
+  zIndex,
+  ...props
+}: IndicatorProps) {
+  return (
+    <div
+      data-slot="indicator"
+      className={cn('relative', inline ? 'inline-block' : 'block', className)}
+      {...props}
+    >
+      {children}
+      {!disabled && (
+        <span
+          data-slot="indicator-dot"
+          className={cn(indicatorDotVariants({ color, processing }))}
+          style={{ width: size, height: size, zIndex }}
+        />
+      )}
+    </div>
+  );
+}
+
+export { Indicator, indicatorDotVariants };

--- a/packages/client/src/components/ui/overlay.stories.tsx
+++ b/packages/client/src/components/ui/overlay.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from './button.js';
+import { LoadingOverlay, Overlay } from './overlay.js';
+
+const Panel = ({ children }: { children?: React.ReactNode }) => (
+  <div className="relative h-48 w-80 rounded-lg border bg-white p-4">
+    <p className="text-sm font-medium">Trip expense</p>
+    <p className="mt-2 text-xs text-gray-500">
+      Amsterdam, 14–17 March. Three receipts pending categorisation.
+    </p>
+    <Button className="mt-4" size="sm">
+      Categorise
+    </Button>
+    {children}
+  </div>
+);
+
+const meta = {
+  title: 'UI/Overlay',
+  component: Overlay,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof Overlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The shape used across the business-trip-report buttons: `blur={1}` and centred. */
+export const Centered: Story = {
+  render: () => (
+    <Panel>
+      <Overlay blur={1} center>
+        <Button size="sm">Confirm</Button>
+      </Overlay>
+    </Panel>
+  ),
+};
+
+export const WithoutBlur: Story = {
+  render: () => (
+    <Panel>
+      <Overlay center>
+        <span className="text-sm">No blur</span>
+      </Overlay>
+    </Panel>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <Panel>
+      <LoadingOverlay visible />
+    </Panel>
+  ),
+};
+
+/** Renders nothing at all, so the panel underneath stays interactive. */
+export const LoadingHidden: Story = {
+  render: () => (
+    <Panel>
+      <LoadingOverlay visible={false} />
+    </Panel>
+  ),
+};

--- a/packages/client/src/components/ui/overlay.tsx
+++ b/packages/client/src/components/ui/overlay.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { cn } from '@/lib/utils.js';
+import { Spinner } from './spinner.js';
+
+type OverlayProps = React.ComponentProps<'div'> & {
+  /** Backdrop blur radius in pixels. Dynamic, so applied as a style rather than a class. */
+  blur?: number;
+  /** Centre the children within the overlay. */
+  center?: boolean;
+};
+
+/**
+ * A scrim filling its nearest positioned ancestor. Used to veil a form or table while a
+ * mutation is in flight.
+ *
+ * No shadcn equivalent exists, so this is a first-class local primitive. It replaced
+ * Mantine's `Overlay`, whose default appearance was a 60% white wash — matched here so
+ * the migration was not also a visual change.
+ */
+function Overlay({ className, children, blur, center = false, style, ...props }: OverlayProps) {
+  return (
+    <div
+      data-slot="overlay"
+      className={cn(
+        'absolute inset-0 bg-white/60',
+        center && 'flex items-center justify-center',
+        className,
+      )}
+      style={{ backdropFilter: blur ? `blur(${blur}px)` : undefined, ...style }}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+type LoadingOverlayProps = Omit<OverlayProps, 'center'> & {
+  /** Render nothing when false. */
+  visible?: boolean;
+};
+
+/** An `Overlay` with a centred spinner, shown while `visible`. */
+function LoadingOverlay({ visible = false, blur = 1, ...props }: LoadingOverlayProps) {
+  if (!visible) {
+    return null;
+  }
+  return (
+    <Overlay center blur={blur} {...props}>
+      <Spinner className="size-8 text-gray-500" />
+    </Overlay>
+  );
+}
+
+export { Overlay, LoadingOverlay };

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -22,5 +22,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "vite.config.ts", ".storybook/**/*"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,7 +34,9 @@ export default defineConfig({
     alias,
     exclude: [...defaultExclude, '**/dist/**', '**/build/**'],
     setupFiles: ['./scripts/vitest-setup.ts'],
-    globalSetup: ['./scripts/vitest-global-setup.ts'],
+    // No root-level `globalSetup`: it asserts a local Postgres and would apply to every
+    // project, including `client`, which must run without one. Each database-backed project
+    // (`unit`, `integration`, `demo-seed`) declares it individually below.
     projects: [
       {
         test: {
@@ -44,7 +46,31 @@ export default defineConfig({
             'packages/server/src/__tests__/**',
             'packages/server/src/demo-fixtures/**',
             '**/*.integration.test.ts',
+            // Client tests live in the `client` project below, which runs without a database.
+            'packages/client/**',
           ],
+        },
+      },
+      {
+        test: {
+          // Browser-facing client tests. Deliberately declares no `globalSetup`: the shared
+          // one asserts a local Postgres and seeds it, which client tests have no use for.
+          // Keeping it off is what lets `yarn test:client` run with no database at all.
+          name: 'client',
+          include: [
+            'packages/client/src/**/*.test.ts',
+            'packages/client/src/**/*.test.tsx',
+            'packages/client/src/**/*.spec.ts',
+            'packages/client/src/**/*.spec.tsx',
+          ],
+          exclude: [...defaultExclude, '**/dist/**', '**/build/**'],
+          // Set here so the per-file `// @vitest-environment happy-dom` pragmas become redundant.
+          environment: 'happy-dom',
+          globals: true,
+          alias: {
+            '@': resolve(__dirname, 'packages/client/src'),
+          },
+          setupFiles: ['./scripts/vitest-setup.ts'],
         },
       },
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,7 @@ __metadata:
     "@minoru/react-dnd-treeview": "npm:3.5.4"
     "@mui/material": "npm:9.4.0"
     "@mui/x-charts": "npm:8.29.3"
+    "@storybook/addon-a11y": "npm:10.6.0"
     "@storybook/react-vite": "npm:10.6.0"
     "@tailwindcss/vite": "npm:4.3.3"
     "@tanstack/react-query": "npm:5.102.8"
@@ -92,6 +93,7 @@ __metadata:
     "@urql/exchange-auth": "npm:3.0.0"
     "@vitejs/plugin-react": "npm:6.1.1"
     autoprefixer: "npm:10.5.4"
+    axe-core: "npm:4.11.0"
     chart.js: "npm:4.5.1"
     class-variance-authority: "npm:0.7.1"
     clsx: "npm:2.1.1"
@@ -9835,6 +9837,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/addon-a11y@npm:10.6.0":
+  version: 10.6.0
+  resolution: "@storybook/addon-a11y@npm:10.6.0"
+  dependencies:
+    "@storybook/global": "npm:^5.0.0"
+    axe-core: "npm:^4.2.0"
+  peerDependencies:
+    storybook: ^10.6.0
+  checksum: 10c0/23ed0a30b8cdeb132f724bb2486d8f1ed194aa8ca9ab78c0fed9a356d0fb1f6e61234ca9718a6c0dd6ed210e65708072f520222c0fa5c1a45f88a961bc6b40b8
+  languageName: node
+  linkType: hard
+
 "@storybook/builder-vite@npm:10.6.0":
   version: 10.6.0
   resolution: "@storybook/builder-vite@npm:10.6.0"
@@ -12170,7 +12184,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:^4.10.0":
+"axe-core@npm:4.11.0":
+  version: 4.11.0
+  resolution: "axe-core@npm:4.11.0"
+  checksum: 10c0/7d7020a568a824c303711858c2fcfe56d001d27e46c0c2ff75dc31b436cfddfd4857a301e70536cc9e64829d25338f7fb782102d23497ebdc66801e9900fc895
+  languageName: node
+  linkType: hard
+
+"axe-core@npm:^4.10.0, axe-core@npm:^4.2.0":
   version: 4.13.0
   resolution: "axe-core@npm:4.13.0"
   checksum: 10c0/0e3be8be10eea64beddefd3007e1425424ff60c26c5f4d5f748ec48c2825356839c02ad4167fc1f03a6d84ecd82108f49fb2846ab7fe949273787391745561ca


### PR DESCRIPTION
Closed in favour of three focused PRs off `main`, one per migration step:

- #4403 — `chore(client): add a test and Storybook safety net for the client`
- #4404 — `chore(client): warn on @mantine imports, error where none are left`
- #4405 — `feat(client): replace Mantine Indicator, Overlay, SimpleGrid, Loader and Image`

This PR reused `renovate/major-vitest-monorepo`, a Renovate-owned branch whose own PR (#4374) had already merged and whose remote branch Renovate had deleted. The three PRs above carry the same work, each on a dedicated branch based on `main`, and are mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR