### PR TITLE
chore(client): warn on @mantine imports, error where none are left

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -278,6 +278,60 @@ export default [
     },
     rules: {
       'react-hooks/set-state-in-effect': 'off',
+      // Mantine is being removed from the client in favour of shadcn/ui + Tailwind.
+      // This is a warning package-wide — the count doubles as a burn-down metric — and an
+      // error in the directories below, which already contain no Mantine imports at all.
+      // Each migrated cluster adds its directories to that list, so the migration cannot
+      // regress behind itself.
+      'no-restricted-imports': [
+        'warn',
+        {
+          patterns: [
+            {
+              group: ['@mantine/*'],
+              message:
+                'Mantine is being removed. Use src/components/ui/ (shadcn) or Tailwind utilities instead.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: [
+      'packages/client/src/components/admin-settings/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/bank-deposits/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/business/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/businesses/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/charge-matching/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/clients/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/financial-accounts/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/landing/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/layout/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/ledger-table/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/securities/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/tags/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/tax-categories/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/transactions-table/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/ui/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/helpers/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/hooks/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/lib/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/providers/**/*.{,c,m}{j,t}s{,x}',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@mantine/*'],
+              message:
+                'Mantine is being removed. Use src/components/ui/ (shadcn) or Tailwind utilities instead.',
+            },
+          ],
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
Step 1 of the Mantine removal: the guardrail that keeps the migration moving in one direction.

## Why

Mantine is being removed from the client in favour of shadcn/ui + Tailwind. The repo's own docs (root `CLAUDE.md`, `packages/client/CLAUDE.md`, `.claude/rules/client-components.md`) already describe **only** shadcn + Tailwind — Mantine is undocumented legacy that new code keeps reaching for. A migration spread over many PRs needs something stopping fresh Mantine imports appearing in areas already cleaned.

## What

A `no-restricted-imports` rule on `@mantine/*` in the client ESLint block, at two levels:

- **`warn` package-wide** — 124 violations today, so `yarn lint | grep -c no-restricted-imports` doubles as a burn-down counter.
- **`error` across the 19 directories that already contain no Mantine imports at all**: `components/ui`, the 14 feature directories that never adopted it (`admin-settings`, `bank-deposits`, `business`, `businesses`, `charge-matching`, `clients`, `financial-accounts`, `landing`, `layout`, `ledger-table`, `securities`, `tags`, `tax-categories`, `transactions-table`), plus `helpers`, `hooks`, `lib` and `providers`.

Each migrated cluster moves its directories into the error list, so the migration ratchets rather than drifting.

## Notes for the reviewer

Verified the rule actually bites — adding `import { Loader } from '@mantine/core'` to `components/ui/spinner.tsx` produces:

```
1:1  error  '@mantine/core' import is restricted from being used by a pattern.
            Mantine is being removed. Use src/components/ui/ (shadcn) or Tailwind
            utilities instead  no-restricted-imports
```

**A note worth carrying to the teardown step:** `@mantine/hooks` looks like a free removal — nothing in `src` imports it, and it is only in `package.json` because `@mantine/core` peer-depends on it. It is not. Yarn's node-modules linker does not install peer dependencies, so removing it breaks the build with `failed to resolve import "@mantine/hooks" from @mantine/core/esm/Alert/Alert.js` and takes 6 test files with it. It can only go once `@mantine/core` does. (Tried, reverted, recorded in the commit message so nobody repeats it.)

No changeset: this touches only root `eslint.config.mjs`, and `require-changeset.yml` filters on `packages/**`.

## Verification

```
yarn lint            # 0 errors, 124 @mantine warnings
yarn prettier:check  # clean
```

## Related

Part of the Mantine → shadcn/ui migration. Independent of, and mergeable in any order with, the safety-net and first-component-cluster PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR)_