### PR TITLE
feat(client): replace Mantine Indicator, Overlay, SimpleGrid, Loader and Image

### DIFF
--- a/.changeset/mantine-indicator-overlay-primitives.md
+++ b/.changeset/mantine-indicator-overlay-primitives.md
@@ -1,0 +1,34 @@
+---
+'@accounter/client': patch
+---
+
+Replace Mantine's `Indicator`, `Overlay`, `LoadingOverlay`, `SimpleGrid`, `Loader` and `Image` with
+local Tailwind primitives — the first component cluster of the Mantine removal.
+
+Two new primitives fill genuine gaps in shadcn's catalogue and live in `components/ui/` as
+first-class components rather than compatibility shims:
+
+- `ui/indicator.tsx` — the status dot used on table cells and filter buttons. Mantine's usage was
+  near-identical at all 21 call sites (`inline`, `size`, `disabled`, `color`, `processing`), so the
+  swap was mechanical. Mantine's `processing` ripple becomes `animate-pulse`; the `zIndex="auto"`
+  plumbing every call site carried is dropped, as the new dot needs no stacking override.
+- `ui/overlay.tsx` — `Overlay` and `LoadingOverlay`, the scrim veiling a form while a mutation runs.
+  Mantine's default appearance was a 60% white wash, matched here so this is not also a visual
+  change. `LoadingOverlay`'s prop is now `blur` rather than `overlayBlur`.
+
+Four wrappers were reimplemented in Tailwind, so their consumers were untouched:
+
+- `common/simple-grid.tsx` — Mantine v6's `breakpoints` array is max-width based (desktop-first)
+  while Tailwind's variants are min-width based, so the ladder is inverted rather than translated.
+  Column classes are spelled out per count because Tailwind only emits utilities it finds as
+  literals. The old config listed both `maxWidth: 900, cols: 2` and `maxWidth: 755, cols: 2`, the
+  latter unreachable — these boundaries were never precision-tuned.
+- `common/loaders/loader.tsx` — Mantine's `variant="dots"` loader has no lucide equivalent, so
+  `AccounterLoader` now uses the house `Spinner`. **This is a deliberate, visible change** to the
+  full-page loading animation.
+- `common/icon.tsx` — Mantine `Image` becomes a plain `<img>`, and now carries an `alt`.
+- `common/divider.tsx` — deleted. `AccounterDivider` had no consumers anywhere.
+
+Also adds stories for both new primitives.
+
+Mantine imports: 124 → 104, across 117 → 97 files.

--- a/.changeset/mantine-indicator-overlay-primitives.md
+++ b/.changeset/mantine-indicator-overlay-primitives.md
@@ -20,9 +20,13 @@ Four wrappers were reimplemented in Tailwind, so their consumers were untouched:
 
 - `common/simple-grid.tsx` — Mantine v6's `breakpoints` array is max-width based (desktop-first)
   while Tailwind's variants are min-width based, so the ladder is inverted rather than translated.
-  Column classes are spelled out per count because Tailwind only emits utilities it finds as
-  literals. The old config listed both `maxWidth: 900, cols: 2` and `maxWidth: 755, cols: 2`, the
-  latter unreachable — these boundaries were never precision-tuned.
+  Mantine's own thresholds are kept (≤600 → 1, 601–900 → 2, 901–980 → 3, >980 → `cols`) via
+  arbitrary `min-[…]` variants, so this is not also a layout change. One deliberate difference:
+  Mantine applied those breakpoints regardless of `cols`, so a `cols={1}` grid still rendered 3
+  columns between 901px and 980px; each tier is now capped at `cols`. Column classes are spelled
+  out per count because Tailwind only emits utilities it finds as literals. The three files that
+  imported Mantine's `SimpleGrid` directly rather than through this wrapper now use it too, so
+  Mantine's grid is gone entirely.
 - `common/loaders/loader.tsx` — Mantine's `variant="dots"` loader has no lucide equivalent, so
   `AccounterLoader` now uses the house `Spinner`. **This is a deliberate, visible change** to the
   full-page loading animation.
@@ -31,4 +35,4 @@ Four wrappers were reimplemented in Tailwind, so their consumers were untouched:
 
 Also adds stories for both new primitives.
 
-Mantine imports: 124 → 104, across 117 → 97 files.
+Mantine imports: 124 → 102, across 117 → 95 files.

--- a/packages/client/src/components/business-ledger/business-ledger-filters.tsx
+++ b/packages/client/src/components/business-ledger/business-ledger-filters.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useState, type ReactElement } from 'react';
 import equal from 'deep-equal';
 import { Filter } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Indicator, MultiSelect, Select } from '@mantine/core';
+import { MultiSelect, Select } from '@mantine/core';
 import { encodeFilters } from '@/router/routes.js';
 import { type BusinessTransactionsFilter } from '../../gql/graphql.js';
 import { isObjectEmpty, TIMELESS_DATE_REGEX } from '../../helpers/index.js';
@@ -14,6 +14,7 @@ import { PopUpModal } from '../common/index.js';
 import { DatePickerInput } from '../common/inputs/date-picker-input.js';
 import { Button } from '../ui/button.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form.js';
+import { Indicator } from '../ui/indicator.js';
 
 interface BusinessLedgerRecordsFilterFormProps {
   filter: BusinessTransactionsFilter;

--- a/packages/client/src/components/business-trips/business-trips-row.tsx
+++ b/packages/client/src/components/business-trips/business-trips-row.tsx
@@ -1,12 +1,12 @@
 import { useMemo, type ReactElement } from 'react';
 import { useQuery } from 'urql';
-import { Indicator } from '@mantine/core';
 import {
   BusinessTripsRowFieldsFragmentDoc,
   BusinessTripsRowValidationDocument,
 } from '../../gql/graphql.js';
 import { getFragmentData, type FragmentType } from '../../gql/index.js';
 import { AccordionContent, AccordionItem, AccordionTrigger } from '../ui/accordion.js';
+import { Indicator } from '../ui/indicator.js';
 import { EditableBusinessTrip } from './editable-business-trip.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
@@ -76,7 +76,6 @@ export const BusinessTripsRow = ({
           processing={fetching}
           disabled={!indicatorUp}
           color={isError ? 'red' : 'yellow'}
-          zIndex="auto"
         >
           {trip.name}
         </Indicator>

--- a/packages/client/src/components/charges/cells/amount.tsx
+++ b/packages/client/src/components/charges/cells/amount.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { Currency } from '../../../gql/graphql.js';
 import { formatAmountWithCurrency } from '../../../helpers/index.js';
+import { Indicator } from '../../ui/indicator.js';
 
 export type AmountProps = {
   amount?: {
@@ -24,7 +24,6 @@ export const Amount = ({ amount }: AmountProps): ReactElement | null => {
       disabled={isValid === undefined ? true : isValid}
       processing={shouldValidate && isValid === undefined}
       color="red"
-      zIndex="auto"
     >
       <p
         className={

--- a/packages/client/src/components/charges/cells/counterparty.tsx
+++ b/packages/client/src/components/charges/cells/counterparty.tsx
@@ -1,8 +1,8 @@
 import { type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { Indicator } from '@mantine/core';
 import { ROUTES } from '@/router/routes.js';
 import type { ChargeType } from '../../../helpers/index.js';
+import { Indicator } from '../../ui/indicator.js';
 import { shouldHaveCounterparty } from '../utils.js';
 
 export type CounterpartyProps = {
@@ -26,7 +26,7 @@ export const Counterparty = ({
 
   return (
     <div className="whitespace-normal">
-      <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+      <Indicator inline size={12} disabled={!isError} color="red">
         {!isError && id && (
           <Link
             to={ROUTES.BUSINESSES.DETAIL(id)}

--- a/packages/client/src/components/charges/cells/description.tsx
+++ b/packages/client/src/components/charges/cells/description.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState, type ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { useUpdateCharge } from '../../../hooks/use-update-charge.js';
 import { ConfirmMiniButton, SimilarChargesByIdModal } from '../../common/index.js';
+import { Indicator } from '../../ui/indicator.js';
 
 export type DescriptionProps = {
   chargeId: string;
@@ -63,7 +63,7 @@ export const Description = ({
   return (
     <>
       <div className="flex flex-wrap whitespace-normal">
-        <Indicator inline size={12} disabled={!isMissing} color="red" zIndex="auto">
+        <Indicator inline size={12} disabled={!isMissing} color="red">
           <p className={hasAlternative ? 'bg-yellow-400' : undefined}>{cellText}</p>
         </Indicator>
         {hasAlternative && (

--- a/packages/client/src/components/charges/cells/more-info.tsx
+++ b/packages/client/src/components/charges/cells/more-info.tsx
@@ -1,7 +1,7 @@
 import { useMemo, type ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import type { ChargeType } from '../../../helpers/index.js';
 import { DragFile, ListCapsule } from '../../common/index.js';
+import { Indicator } from '../../ui/indicator.js';
 
 export type MoreInfoProps = {
   chargeId: string;
@@ -76,14 +76,7 @@ export const MoreInfo = ({
       extraClassName:
         info?.transactionsCount || !shouldHaveTransactions ? undefined : 'bg-yellow-400',
       content: (
-        <Indicator
-          key="transactions"
-          inline
-          size={12}
-          disabled={!isTransactionsError}
-          color="red"
-          zIndex="auto"
-        >
+        <Indicator key="transactions" inline size={12} disabled={!isTransactionsError} color="red">
           <div className="whitespace-nowrap">Transactions: {info?.transactionsCount ?? 0}</div>
         </Indicator>
       ),
@@ -99,7 +92,6 @@ export const MoreInfo = ({
         processing={!ledgerStatus}
         disabled={ledgerStatus === 'VALID'}
         color={ledgerStatus === 'DIFF' ? 'orange' : 'red'}
-        zIndex="auto"
       >
         <div className="whitespace-nowrap">Ledger Records: {info?.ledgerCount ?? 0}</div>
       </Indicator>
@@ -109,14 +101,7 @@ export const MoreInfo = ({
   if (isDocumentsError || info?.documentsCount) {
     list.push({
       content: (
-        <Indicator
-          key="documents"
-          inline
-          size={12}
-          disabled={!isDocumentsError}
-          color="red"
-          zIndex="auto"
-        >
+        <Indicator key="documents" inline size={12} disabled={!isDocumentsError} color="red">
           <div className="whitespace-nowrap">Documents: {info?.documentsCount ?? 0}</div>
         </Indicator>
       ),

--- a/packages/client/src/components/charges/cells/tags.tsx
+++ b/packages/client/src/components/charges/cells/tags.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useState, type ReactElement } from 'react';
-import { Group, Indicator, Text } from '@mantine/core';
+import { Group, Text } from '@mantine/core';
 import { useUpdateCharge } from '../../../hooks/use-update-charge.js';
 import { ConfirmMiniButton, ListCapsule, SimilarChargesByIdModal } from '../../common/index.js';
+import { Indicator } from '../../ui/indicator.js';
 
 export type TagsProps = {
   chargeId: string;
@@ -51,7 +52,7 @@ export const Tags = ({
 
   return (
     <>
-      <Indicator inline size={12} disabled={!isMissing} color="red" zIndex="auto">
+      <Indicator inline size={12} disabled={!isMissing} color="red">
         <ListCapsule
           items={tags.map(t => (
             <Group key={t.id}>

--- a/packages/client/src/components/charges/cells/tax-category.tsx
+++ b/packages/client/src/components/charges/cells/tax-category.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
+import { Indicator } from '../../ui/indicator.js';
 
 export type TaxCategoryProps = {
   taxCategory?: {
@@ -11,7 +11,7 @@ export type TaxCategoryProps = {
 
 export const TaxCategory = ({ taxCategory, isMissing }: TaxCategoryProps): ReactElement => {
   return (
-    <Indicator inline size={12} disabled={!isMissing} color="red" zIndex="auto">
+    <Indicator inline size={12} disabled={!isMissing} color="red">
       {taxCategory?.name ?? 'N/A'}
     </Indicator>
   );

--- a/packages/client/src/components/charges/cells/vat.tsx
+++ b/packages/client/src/components/charges/cells/vat.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { Currency } from '../../../gql/graphql.js';
 import { formatAmountWithCurrency } from '../../../helpers/index.js';
+import { Indicator } from '../../ui/indicator.js';
 
 export type VatProps = {
   value?: number;
@@ -20,7 +20,7 @@ export const Vat = ({ value, currency, amountValue, missingInfo }: VatProps): Re
     <div
       className={isError ? 'whitespace-nowrap text-red-500' : 'whitespace-nowrap text-green-700'}
     >
-      <Indicator inline size={12} disabled={!missingInfo} color="red" zIndex="auto">
+      <Indicator inline size={12} disabled={!missingInfo} color="red">
         {value != null && currency ? formatAmountWithCurrency(value, currency) : null}
       </Indicator>
     </div>

--- a/packages/client/src/components/common/business-trip-report/buttons/add-accommodation-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-accommodation-expense.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, Overlay } from '@mantine/core';
+import { Loader, Modal } from '@mantine/core';
 import { type AddBusinessTripAccommodationsExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripAccommodationsExpense } from '../../../../hooks/use-add-business-trip-accommodations-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -14,6 +14,7 @@ import {
   FormMessage,
 } from '../../../ui/form.js';
 import { Input } from '../../../ui/input.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { NumberInput, Tooltip } from '../../index.js';
 import { AttendeesStayInput } from '../parts/attendee-stay-input.js';
 import { AddExpenseFields } from './add-expense-fields.js';

--- a/packages/client/src/components/common/business-trip-report/buttons/add-attendee.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-attendee.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, Overlay, Select } from '@mantine/core';
+import { Loader, Modal, Select } from '@mantine/core';
 import type { InsertBusinessTripAttendeeInput } from '../../../../gql/graphql.js';
 import { TIMELESS_DATE_REGEX } from '../../../../helpers/index.js';
 import { useGetBusinesses } from '../../../../hooks/use-get-businesses.js';
@@ -15,6 +15,7 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../ui/form.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Tooltip } from '../../index.js';
 import { DatePickerInput } from '../../inputs/date-picker-input.js';
 

--- a/packages/client/src/components/common/business-trip-report/buttons/add-car-rental-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-car-rental-expense.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, NumberInput, Overlay } from '@mantine/core';
+import { Loader, Modal, NumberInput } from '@mantine/core';
 import type { AddBusinessTripCarRentalExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripCarRentalExpense } from '../../../../hooks/use-add-business-trip-car-rental-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -13,6 +13,7 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../ui/form.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Switch } from '../../../ui/switch.js';
 import { Tooltip } from '../../index.js';
 import { AddExpenseFields } from './add-expense-fields.js';

--- a/packages/client/src/components/common/business-trip-report/buttons/add-flight-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-flight-expense.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { useQuery } from 'urql';
-import { Loader, Modal, MultiSelect, Overlay, Select } from '@mantine/core';
+import { Loader, Modal, MultiSelect, Select } from '@mantine/core';
 import {
   AttendeesByBusinessTripDocument,
   FlightClass,
@@ -11,6 +11,7 @@ import {
 import { useAddBusinessTripFlightsExpense } from '../../../../hooks/use-add-business-trip-flights-expense.js';
 import { Button } from '../../../ui/button.js';
 import { Form } from '../../../ui/form.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Tooltip } from '../../index.js';
 import { FlightPathInput } from '../parts/flight-path-input.js';
 import { AddExpenseFields } from './add-expense-fields.js';

--- a/packages/client/src/components/common/business-trip-report/buttons/add-other-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-other-expense.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, Overlay } from '@mantine/core';
+import { Loader, Modal } from '@mantine/core';
 import type { AddBusinessTripOtherExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripOtherExpense } from '../../../../hooks/use-add-business-trip-other-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -14,6 +14,7 @@ import {
   FormMessage,
 } from '../../../ui/form.js';
 import { Input } from '../../../ui/input.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Switch } from '../../../ui/switch.js';
 import { Tooltip } from '../../index.js';
 import { AddExpenseFields } from './add-expense-fields.js';

--- a/packages/client/src/components/common/business-trip-report/buttons/add-travel-and-subsistence-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-travel-and-subsistence-expense.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, Overlay } from '@mantine/core';
+import { Loader, Modal } from '@mantine/core';
 import type { AddBusinessTripTravelAndSubsistenceExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripTravelAndSubsistenceExpense } from '../../../../hooks/use-add-business-trip-travel-and-subsistence-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -14,6 +14,7 @@ import {
   FormMessage,
 } from '../../../ui/form.js';
 import { Input } from '../../../ui/input.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Tooltip } from '../../index.js';
 import { AddExpenseFields } from './add-expense-fields.js';
 

--- a/packages/client/src/components/common/business-trip-report/buttons/categorize-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/categorize-expense.tsx
@@ -1,13 +1,14 @@
 import { useState, type ReactElement } from 'react';
 import { Edit } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, NumberInput, Overlay, Select } from '@mantine/core';
+import { Loader, Modal, NumberInput, Select } from '@mantine/core';
 import {
   BusinessTripExpenseCategories,
   type CategorizeBusinessTripExpenseInput,
 } from '../../../../gql/graphql.js';
 import { useCategorizeBusinessTripExpense } from '../../../../hooks/use-categorize-business-trip-expense.js';
 import { Button } from '../../../ui/button.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Tooltip } from '../../index.js';
 
 export function CategorizeExpense(props: {

--- a/packages/client/src/components/common/business-trip-report/buttons/categorize-into-existing-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/categorize-into-existing-expense.tsx
@@ -3,7 +3,7 @@ import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { toast } from 'sonner';
 import { useQuery } from 'urql';
-import { Grid, Loader, Modal, NumberInput, Overlay, Select, Text } from '@mantine/core';
+import { Grid, Loader, Modal, NumberInput, Select, Text } from '@mantine/core';
 import {
   UncategorizedTransactionsByBusinessTripDocument,
   type CategorizeIntoExistingBusinessTripExpenseInput,
@@ -11,6 +11,7 @@ import {
 } from '../../../../gql/graphql.js';
 import { useCategorizeIntoExistingBusinessTripExpense } from '../../../../hooks/use-categorize-into-existing-business-trip-expense.js';
 import { Button } from '../../../ui/button.js';
+import { Overlay } from '../../../ui/overlay.js';
 import { Tooltip } from '../../index.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen

--- a/packages/client/src/components/common/depreciation/add-depreciation-record.tsx
+++ b/packages/client/src/components/common/depreciation/add-depreciation-record.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { useQuery } from 'urql';
-import { Loader, Modal, Overlay, Select } from '@mantine/core';
+import { Loader, Modal, Select } from '@mantine/core';
 import {
   AllDepreciationCategoriesDocument,
   type InsertDepreciationRecordInput,
@@ -11,6 +11,7 @@ import { TIMELESS_DATE_REGEX } from '../../../helpers/index.js';
 import { useAddDepreciationRecord } from '../../../hooks/use-add-depreciation-record.js';
 import { Button } from '../../ui/button.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
+import { Overlay } from '../../ui/overlay.js';
 import { CurrencyInput, DatePickerInput, Tooltip } from '../index.js';
 import { depreciationTypes } from './index.js';
 

--- a/packages/client/src/components/common/divider.tsx
+++ b/packages/client/src/components/common/divider.tsx
@@ -1,4 +1,0 @@
-import type { ReactElement } from 'react';
-import { Divider, type DividerProps } from '@mantine/core';
-
-export const AccounterDivider = (props: DividerProps): ReactElement => <Divider {...props} />;

--- a/packages/client/src/components/common/icon.tsx
+++ b/packages/client/src/components/common/icon.tsx
@@ -1,12 +1,11 @@
-import type { ReactElement, RefAttributes } from 'react';
-import { Image, type ImageProps } from '@mantine/core';
+import type { ComponentProps, ReactElement } from 'react';
 
 export type IconName = 'logo';
 
-interface IconProps extends ImageProps, RefAttributes<HTMLDivElement> {
+interface IconProps extends Omit<ComponentProps<'img'>, 'src' | 'alt'> {
   name: IconName;
 }
 
 export const Icon = ({ name, ...props }: IconProps): ReactElement => {
-  return <Image src={`/icons/${name}.svg`} {...props} />;
+  return <img src={`/icons/${name}.svg`} alt={name} {...props} />;
 };

--- a/packages/client/src/components/common/index.ts
+++ b/packages/client/src/components/common/index.ts
@@ -4,7 +4,6 @@ export * from './buttons/index.js';
 export * from './common-wrappers.js';
 export * from './data-table-column-header.js';
 export * from './data-table-pagination.js';
-export * from './divider.js';
 export * from './document-image-drawer.js';
 export * from './footer.js';
 export * from './forms/index.js';

--- a/packages/client/src/components/common/loaders/loader.tsx
+++ b/packages/client/src/components/common/loaders/loader.tsx
@@ -1,12 +1,14 @@
 import type { ReactElement } from 'react';
-import { Loader } from '@mantine/core';
+import { Spinner } from '../../ui/spinner.js';
 import { Icon } from '../icon.js';
 
 export const AccounterLoader = (): ReactElement => {
   return (
     <div className="flex flex-col justify-center items-center content-center h-screen">
       <Icon name="logo" className="max-w-xs" />
-      <Loader className="flex self-center" color="dark" size="xl" variant="dots" />
+      {/* Mantine's `variant="dots"` loader has no lucide equivalent; this is the house
+          convention (a spinning Loader2) at the same visual weight. */}
+      <Spinner className="size-12 self-center text-gray-900" />
     </div>
   );
 };

--- a/packages/client/src/components/common/simple-grid.tsx
+++ b/packages/client/src/components/common/simple-grid.tsx
@@ -12,24 +12,34 @@ export interface SimpleGridProps {
  *
  * Replaces Mantine's `SimpleGrid`, whose v6 `breakpoints` array was max-width based
  * (desktop-first) while Tailwind's variants are min-width based, so the ladder below is the
- * inverted equivalent: one column on phones, two on small screens, then up to `cols`. The
- * original config listed both `maxWidth: 900, cols: 2` and `maxWidth: 755, cols: 2` — the
- * latter was unreachable, so these boundaries were never precision-tuned.
+ * inverted equivalent. The thresholds are Mantine's own (≤600 → 1, 601–900 → 2, 901–980 → 3,
+ * >980 → `cols`) rather than Tailwind's sm/lg/xl, so this migration does not also move the
+ * layout — hence the arbitrary `min-[…]` variants in place of the usual core utilities.
+ *
+ * One deliberate difference: Mantine applied those breakpoints regardless of `cols`, so a
+ * `cols={1}` grid still rendered 3 columns between 901px and 980px. Each tier is capped at
+ * `cols` here, which is plainly what the call sites intend.
  *
  * Classes are spelled out per column count rather than interpolated because Tailwind only
  * emits utilities it can find as literals in the source.
  */
 const columnClasses: Record<number, string> = {
   1: 'grid-cols-1',
-  2: 'grid-cols-1 sm:grid-cols-2',
-  3: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
-  4: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
-  5: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5',
+  2: 'grid-cols-1 min-[601px]:grid-cols-2',
+  3: 'grid-cols-1 min-[601px]:grid-cols-2 min-[901px]:grid-cols-3',
+  4: 'grid-cols-1 min-[601px]:grid-cols-2 min-[901px]:grid-cols-3 min-[981px]:grid-cols-4',
+  5: 'grid-cols-1 min-[601px]:grid-cols-2 min-[901px]:grid-cols-3 min-[981px]:grid-cols-5',
 };
 
 export const SimpleGrid = ({ cols, className, children }: SimpleGridProps): ReactElement => {
   return (
-    <div className={cn('grid gap-3 sm:gap-4', columnClasses[cols] ?? columnClasses[1], className)}>
+    <div
+      className={cn(
+        'grid gap-3 min-[901px]:gap-4',
+        columnClasses[cols] ?? columnClasses[1],
+        className,
+      )}
+    >
       {children}
     </div>
   );

--- a/packages/client/src/components/common/simple-grid.tsx
+++ b/packages/client/src/components/common/simple-grid.tsx
@@ -1,25 +1,36 @@
 import type { ReactElement } from 'react';
-import { SimpleGrid as Grid } from '@mantine/core';
+import { cn } from '../../lib/utils.js';
 
 export interface SimpleGridProps {
   cols: number;
-  spacing?: number;
+  className?: string;
   children?: ReactElement | ReactElement[];
 }
 
-export const SimpleGrid = ({ cols, spacing, children }: SimpleGridProps): ReactElement => {
+/**
+ * Responsive grid stepping up to `cols` on wide viewports.
+ *
+ * Replaces Mantine's `SimpleGrid`, whose v6 `breakpoints` array was max-width based
+ * (desktop-first) while Tailwind's variants are min-width based, so the ladder below is the
+ * inverted equivalent: one column on phones, two on small screens, then up to `cols`. The
+ * original config listed both `maxWidth: 900, cols: 2` and `maxWidth: 755, cols: 2` — the
+ * latter was unreachable, so these boundaries were never precision-tuned.
+ *
+ * Classes are spelled out per column count rather than interpolated because Tailwind only
+ * emits utilities it can find as literals in the source.
+ */
+const columnClasses: Record<number, string> = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-1 sm:grid-cols-2',
+  3: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
+  4: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+  5: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5',
+};
+
+export const SimpleGrid = ({ cols, className, children }: SimpleGridProps): ReactElement => {
   return (
-    <Grid
-      cols={cols}
-      spacing={spacing}
-      breakpoints={[
-        { maxWidth: 980, cols: 3, spacing: 'md' },
-        { maxWidth: 900, cols: 2, spacing: 'sm' },
-        { maxWidth: 755, cols: 2, spacing: 'sm' },
-        { maxWidth: 600, cols: 1, spacing: 'sm' },
-      ]}
-    >
+    <div className={cn('grid gap-3 sm:gap-4', columnClasses[cols] ?? columnClasses[1], className)}>
       {children}
-    </Grid>
+    </div>
   );
 };

--- a/packages/client/src/components/documents-table/cells/amount.tsx
+++ b/packages/client/src/components/documents-table/cells/amount.tsx
@@ -1,8 +1,8 @@
 import { useCallback, type ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { Currency, DocumentType } from '../../../gql/graphql.js';
 import { useUpdateDocument } from '../../../hooks/use-update-document.js';
 import { ConfirmMiniButton } from '../../common/index.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 type Props = {
@@ -43,7 +43,7 @@ export const Amount = ({ document }: Props): ReactElement => {
   return (
     <div className="flex flex-wrap">
       <div className="flex flex-col justify-center">
-        <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+        <Indicator inline size={12} disabled={!isError} color="red">
           <p
             className={[
               'whitespace-nowrap',

--- a/packages/client/src/components/documents-table/cells/creditor.tsx
+++ b/packages/client/src/components/documents-table/cells/creditor.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useMemo, useState, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { Indicator } from '@mantine/core';
 import { DocumentType } from '@/gql/graphql.js';
 import { useGetBusinesses } from '@/hooks/use-get-businesses.js';
 import { useUpdateDocument } from '@/hooks/use-update-document.js';
 import { ROUTES } from '@/router/routes.js';
 import { ConfirmMiniButton, InsertBusiness, SelectWithSearch } from '../../common/index.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 export const COUNTERPARTIES_LESS_DOCUMENT_TYPES: DocumentType[] = [
@@ -93,7 +93,7 @@ export const Creditor = ({ document, onChange }: Props): ReactElement => {
   return (
     <div className="flex flex-wrap">
       <div className="flex flex-col justify-center whitespace-normal">
-        <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+        <Indicator inline size={12} disabled={!isError} color="red">
           {shouldHaveCreditor &&
             (id ? (
               <Link

--- a/packages/client/src/components/documents-table/cells/date.tsx
+++ b/packages/client/src/components/documents-table/cells/date.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { format } from 'date-fns';
-import { Indicator } from '@mantine/core';
 import { DocumentType } from '../../../gql/graphql.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 type Props = {
@@ -18,7 +18,7 @@ export const DateCell = ({ document }: Props): ReactElement => {
   const dateContentValue = shouldHaveDate ? formattedDate : null;
 
   return (
-    <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+    <Indicator inline size={12} disabled={!isError} color="red">
       <div>{dateContentValue}</div>
     </Indicator>
   );

--- a/packages/client/src/components/documents-table/cells/debtor.tsx
+++ b/packages/client/src/components/documents-table/cells/debtor.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useMemo, useState, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { Indicator } from '@mantine/core';
 import { useGetBusinesses } from '@/hooks/use-get-businesses.js';
 import { ROUTES } from '@/router/routes.js';
 import { DocumentType } from '../../../gql/graphql.js';
 import { useUpdateDocument } from '../../../hooks/use-update-document.js';
 import { ConfirmMiniButton, InsertBusiness, SelectWithSearch } from '../../common/index.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 import { COUNTERPARTIES_LESS_DOCUMENT_TYPES } from './index.js';
 
@@ -89,7 +89,7 @@ export const Debtor = ({ document, onChange }: Props): ReactElement => {
   return (
     <div className="flex flex-wrap">
       <div className="flex flex-col justify-center whitespace-normal">
-        <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+        <Indicator inline size={12} disabled={!isError} color="red">
           {shouldHaveDebtor &&
             (id ? (
               <Link

--- a/packages/client/src/components/documents-table/cells/files.tsx
+++ b/packages/client/src/components/documents-table/cells/files.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react';
 import { File, Image } from 'lucide-react';
-import { SimpleGrid } from '@mantine/core';
-import { DocumentImageDrawer, Tooltip } from '../../common/index.js';
+import { DocumentImageDrawer, SimpleGrid, Tooltip } from '../../common/index.js';
 import { Button } from '../../ui/button.js';
 import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';

--- a/packages/client/src/components/documents-table/cells/files.tsx
+++ b/packages/client/src/components/documents-table/cells/files.tsx
@@ -1,8 +1,9 @@
 import { useState, type ReactElement } from 'react';
 import { File, Image } from 'lucide-react';
-import { Indicator, SimpleGrid } from '@mantine/core';
+import { SimpleGrid } from '@mantine/core';
 import { DocumentImageDrawer, Tooltip } from '../../common/index.js';
 import { Button } from '../../ui/button.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 type Props = {
@@ -18,7 +19,7 @@ export const Files = ({ document: { image, file } }: Props): ReactElement => {
         <div className="flex flex-col justify-center">
           <SimpleGrid cols={1}>
             <Tooltip disabled={!image} content="Open Image">
-              <Indicator inline size={12} disabled={!!image} color="red" zIndex="auto">
+              <Indicator inline size={12} disabled={!!image} color="red">
                 <Button
                   variant="ghost"
                   size="icon"
@@ -31,7 +32,7 @@ export const Files = ({ document: { image, file } }: Props): ReactElement => {
               </Indicator>
             </Tooltip>
             <Tooltip disabled={!file} content="Open File">
-              <Indicator inline size={12} disabled={!!file} color="red" zIndex="auto">
+              <Indicator inline size={12} disabled={!!file} color="red">
                 {file ? (
                   <a
                     href={typeof file === 'string' ? file : file.href}

--- a/packages/client/src/components/documents-table/cells/serial.tsx
+++ b/packages/client/src/components/documents-table/cells/serial.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { DocumentType } from '../../../gql/graphql.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 type Props = {
@@ -16,7 +16,7 @@ export const Serial = ({ document }: Props): ReactElement => {
 
   return (
     <div className="flex flex-col align-center justify-center flex-wrap">
-      <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+      <Indicator inline size={12} disabled={!isError} color="red">
         <p>{serialNumber}</p>
       </Indicator>
       {allocationNumber && <p className="text-xs">({allocationNumber})</p>}

--- a/packages/client/src/components/documents-table/cells/type.tsx
+++ b/packages/client/src/components/documents-table/cells/type.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { DocumentType } from '../../../gql/graphql.js';
 import { getDocumentNameFromType } from '../../../helpers/index.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 type Props = {
@@ -17,7 +17,7 @@ export const TypeCell = ({ document: { documentType }, isOpen }: Props): ReactEl
   return (
     <div className="flex flex-wrap">
       <div className="flex flex-col justify-center whitespace-normal">
-        <Indicator inline size={12} disabled={!isError && !isOpen} color={color} zIndex="auto">
+        <Indicator inline size={12} disabled={!isError && !isOpen} color={color}>
           <p>{getDocumentNameFromType(cellText)}</p>
         </Indicator>
       </div>

--- a/packages/client/src/components/documents-table/cells/vat.tsx
+++ b/packages/client/src/components/documents-table/cells/vat.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
-import { Indicator } from '@mantine/core';
 import { DocumentType } from '../../../gql/graphql.js';
+import { Indicator } from '../../ui/indicator.js';
 import type { DocumentsTableRowType } from '../columns.js';
 
 type Props = {
@@ -14,7 +14,7 @@ export const Vat = ({ document }: Props): ReactElement => {
   const isError = shouldHaveVat && vat?.formatted == null;
 
   return (
-    <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+    <Indicator inline size={12} disabled={!isError} color="red">
       <div
         style={{
           color: Number(vat?.raw) > 0 ? 'green' : 'red',

--- a/packages/client/src/components/reports/corporate-tax-ruling-compliance-report/index.tsx
+++ b/packages/client/src/components/reports/corporate-tax-ruling-compliance-report/index.tsx
@@ -2,12 +2,13 @@ import { useContext, useEffect, useState, type ReactElement } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from 'urql';
-import { Indicator, Table } from '@mantine/core';
+import { Table } from '@mantine/core';
 import { CorporateTaxRulingComplianceReportDocument, Currency } from '../../../gql/graphql.js';
 import { dedupeFragments, getCurrencyFormatter } from '../../../helpers/index.js';
 import { FiltersContext } from '../../../providers/filters-context.js';
 import { PrintToPdfButton, Tooltip } from '../../common/index.js';
 import { PageLayout } from '../../layout/page-layout.js';
+import { Indicator } from '../../ui/indicator.js';
 import { AmountCell } from './amount-cell.js';
 import { CorporateTaxRulingComplianceReportFilter } from './corporate-tax-ruling-compliance-report-filters.js';
 import { RuleCell } from './rule-cell.js';
@@ -167,7 +168,6 @@ export const CorporateTaxRulingComplianceReport = (): ReactElement => {
                             !!yearlyReports.find(report => report.year === year)?.differences
                           }
                           color="orange"
-                          zIndex="auto"
                         >
                           {year}
                         </Indicator>

--- a/packages/client/src/components/reports/trial-balance-report/trial-balance-report-filters.tsx
+++ b/packages/client/src/components/reports/trial-balance-report/trial-balance-report-filters.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useState, type ReactElement } from 'react';
 import equal from 'deep-equal';
 import { Filter } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Indicator, MultiSelect } from '@mantine/core';
+import { MultiSelect } from '@mantine/core';
 import { encodeFilters } from '@/router/routes.js';
 import type { BusinessTransactionsFilter } from '../../../gql/graphql.js';
 import { isObjectEmpty, TIMELESS_DATE_REGEX } from '../../../helpers/index.js';
@@ -13,6 +13,7 @@ import { UserContext } from '../../../providers/user-provider.js';
 import { DatePickerInput, PopUpModal } from '../../common/index.js';
 import { Button } from '../../ui/button.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
+import { Indicator } from '../../ui/indicator.js';
 import { Switch } from '../../ui/switch.js';
 
 export type TrialBalanceReportFilters = BusinessTransactionsFilter & {

--- a/packages/client/src/components/screens/charges/all-charges.tsx
+++ b/packages/client/src/components/screens/charges/all-charges.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Loader2, PanelTopClose, PanelTopOpen } from 'lucide-react';
 import { useQuery } from 'urql';
-import { LoadingOverlay } from '@mantine/core';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { ChargesTable } from '@/components/charges/charges-table.js';
 import { AllChargesDocument, type ChargeFilter } from '../../../gql/graphql.js';
@@ -12,6 +11,7 @@ import { ChargesFilters } from '../../charges/charges-filters/index.js';
 import { MergeChargesButton, Tooltip } from '../../common/index.js';
 import { PageLayout } from '../../layout/page-layout.js';
 import { Button } from '../../ui/button.js';
+import { LoadingOverlay } from '../../ui/overlay.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -145,7 +145,7 @@ export const AllCharges = (): ReactElement => {
         // but overlay a spinner so it's clear the charges are being reloaded
         // (the stale rows stay visible underneath instead of blinking away).
         <div className="relative">
-          <LoadingOverlay visible={fetching} overlayBlur={1} />
+          <LoadingOverlay visible={fetching} blur={1} />
           <ChargesTable
             data={chargeNodes}
             rowSelection={rowSelection}

--- a/packages/client/src/components/screens/charges/missing-info-charges.tsx
+++ b/packages/client/src/components/screens/charges/missing-info-charges.tsx
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Loader2, PanelTopClose, PanelTopOpen } from 'lucide-react';
 import { useQuery } from 'urql';
-import { LoadingOverlay } from '@mantine/core';
 import { ChargesTable } from '@/components/charges/charges-table.js';
 import { MissingInfoChargesDocument, type ChargeFilter } from '../../../gql/graphql.js';
 import { useStableValue } from '../../../hooks/use-stable-value.js';
@@ -11,6 +10,7 @@ import { ChargesFilters } from '../../charges/charges-filters/index.js';
 import { Tooltip } from '../../common/index.js';
 import { PageLayout } from '../../layout/page-layout.js';
 import { Button } from '../../ui/button.js';
+import { LoadingOverlay } from '../../ui/overlay.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -118,7 +118,7 @@ export const MissingInfoCharges = (): ReactElement => {
         // but overlay a spinner so it's clear the charges are being reloaded
         // (the stale rows stay visible underneath instead of blinking away).
         <div className="relative">
-          <LoadingOverlay visible={fetching} overlayBlur={1} />
+          <LoadingOverlay visible={fetching} blur={1} />
           <ChargesTable data={chargeNodes ?? []} isAllOpened={isAllOpened} />
         </div>
       )}

--- a/packages/client/src/components/screens/documents/all-documents/documents-filters.tsx
+++ b/packages/client/src/components/screens/documents/all-documents/documents-filters.tsx
@@ -3,7 +3,7 @@ import { format, sub } from 'date-fns';
 import equal from 'deep-equal';
 import { Filter } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { MultiSelect, SimpleGrid } from '@mantine/core';
+import { MultiSelect } from '@mantine/core';
 import { encodeFilters } from '@/router/routes.js';
 import {
   DocumentType,
@@ -19,7 +19,7 @@ import { useGetAdminBusinesses } from '../../../../hooks/use-get-admin-businesse
 import { useGetFinancialEntities } from '../../../../hooks/use-get-financial-entities.js';
 import { useUrlQuery } from '../../../../hooks/use-url-query.js';
 import { UserContext } from '../../../../providers/user-provider.js';
-import { DatePickerInput, PopUpModal } from '../../../common/index.js';
+import { DatePickerInput, PopUpModal, SimpleGrid } from '../../../common/index.js';
 import { Button } from '../../../ui/button.js';
 import {
   Form,

--- a/packages/client/src/components/screens/documents/all-documents/documents-filters.tsx
+++ b/packages/client/src/components/screens/documents/all-documents/documents-filters.tsx
@@ -3,7 +3,7 @@ import { format, sub } from 'date-fns';
 import equal from 'deep-equal';
 import { Filter } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Indicator, MultiSelect, SimpleGrid } from '@mantine/core';
+import { MultiSelect, SimpleGrid } from '@mantine/core';
 import { encodeFilters } from '@/router/routes.js';
 import {
   DocumentType,
@@ -29,6 +29,7 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../ui/form.js';
+import { Indicator } from '../../../ui/indicator.js';
 import { Input } from '../../../ui/input.js';
 import { Switch } from '../../../ui/switch.js';
 

--- a/packages/client/src/components/screens/reports/balance-report/balance-report-filters.tsx
+++ b/packages/client/src/components/screens/reports/balance-report/balance-report-filters.tsx
@@ -4,7 +4,6 @@ import { Filter } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { SimpleGrid } from '@mantine/core';
 import { useGetAdminBusinesses } from '@/hooks/use-get-admin-businesses.js';
 import { useGetFinancialAccounts } from '@/hooks/use-get-financial-accounts.js';
 import { encodeFilters } from '@/router/routes.js';
@@ -14,7 +13,13 @@ import { useGetFinancialEntities } from '../../../../hooks/use-get-financial-ent
 import { useGetTags } from '../../../../hooks/use-get-tags.js';
 import { useUrlQuery } from '../../../../hooks/use-url-query.js';
 import { UserContext } from '../../../../providers/user-provider.js';
-import { ComboBox, DatePickerInput, MultiSelect, PopUpModal } from '../../../common/index.js';
+import {
+  ComboBox,
+  DatePickerInput,
+  MultiSelect,
+  PopUpModal,
+  SimpleGrid,
+} from '../../../common/index.js';
 import { Button } from '../../../ui/button.js';
 import {
   Form,

--- a/packages/client/src/components/screens/reports/balance-report/balance-report-filters.tsx
+++ b/packages/client/src/components/screens/reports/balance-report/balance-report-filters.tsx
@@ -4,7 +4,7 @@ import { Filter } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Indicator, SimpleGrid } from '@mantine/core';
+import { SimpleGrid } from '@mantine/core';
 import { useGetAdminBusinesses } from '@/hooks/use-get-admin-businesses.js';
 import { useGetFinancialAccounts } from '@/hooks/use-get-financial-accounts.js';
 import { encodeFilters } from '@/router/routes.js';
@@ -24,6 +24,7 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../ui/form.js';
+import { Indicator } from '../../../ui/indicator.js';
 import { Switch } from '../../../ui/switch.js';
 
 export function encodeBalanceReportFilters(filter?: BalanceReportFilter | null): string | null {

--- a/packages/client/src/components/ui/indicator.stories.tsx
+++ b/packages/client/src/components/ui/indicator.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from './button.js';
+import { Indicator } from './indicator.js';
+
+const meta = {
+  title: 'UI/Indicator',
+  component: Indicator,
+  parameters: { layout: 'centered' },
+  args: { inline: true, size: 12, disabled: false, color: 'red' },
+} satisfies Meta<typeof Indicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: <span className="text-sm">Invoice #4821</span> },
+};
+
+/** `disabled` is how every call site spells "nothing is wrong here". */
+export const Disabled: Story = {
+  args: { disabled: true, children: <span className="text-sm">Invoice #4821</span> },
+};
+
+/** The pending state, while a validation result is still resolving. */
+export const Processing: Story = {
+  args: { processing: true, children: <span className="text-sm">Invoice #4821</span> },
+};
+
+export const Colors: Story = {
+  args: { children: null },
+  render: args => (
+    <div className="flex items-center gap-6">
+      {(['red', 'orange', 'yellow', 'green', 'blue'] as const).map(color => (
+        <Indicator key={color} {...args} color={color}>
+          <span className="text-sm">{color}</span>
+        </Indicator>
+      ))}
+    </div>
+  ),
+};
+
+/** The filter-button case: a larger dot marking an active filter set. */
+export const OnIconButton: Story = {
+  args: {
+    size: 16,
+    children: (
+      <Button variant="outline" size="icon">
+        F
+      </Button>
+    ),
+  },
+};

--- a/packages/client/src/components/ui/indicator.tsx
+++ b/packages/client/src/components/ui/indicator.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils.js';
+
+const indicatorDotVariants = cva(
+  'pointer-events-none absolute top-0 right-0 -translate-y-1/2 translate-x-1/2 rounded-full',
+  {
+    variants: {
+      color: {
+        red: 'bg-red-500',
+        orange: 'bg-orange-500',
+        yellow: 'bg-yellow-500',
+        green: 'bg-green-500',
+        blue: 'bg-blue-500',
+      },
+      // Mantine's `processing` ripples the dot outward. `animate-pulse` is the calmer
+      // Tailwind equivalent — same "something is still resolving" read, one element.
+      processing: {
+        true: 'animate-pulse',
+        false: '',
+      },
+    },
+    defaultVariants: {
+      color: 'red',
+      processing: false,
+    },
+  },
+);
+
+type IndicatorProps = React.ComponentProps<'div'> &
+  VariantProps<typeof indicatorDotVariants> & {
+    /** Lay the wrapper out inline rather than as a block. */
+    inline?: boolean;
+    /** Dot diameter in pixels. Dynamic, so it is applied as a style rather than a class. */
+    size?: number;
+    /** Hide the dot. Named for parity with the call sites, which all read `disabled={!isError}`. */
+    disabled?: boolean;
+    zIndex?: React.CSSProperties['zIndex'];
+  };
+
+/**
+ * Wraps content with a small status dot in its top-right corner — a "this row has an
+ * error" / "this filter is active" marker.
+ *
+ * There is no shadcn equivalent, so this is a first-class local primitive rather than a
+ * compatibility shim, and it is what replaced Mantine's `Indicator` across the client.
+ */
+function Indicator({
+  className,
+  children,
+  inline = false,
+  size = 10,
+  disabled = false,
+  color,
+  processing,
+  zIndex,
+  ...props
+}: IndicatorProps) {
+  return (
+    <div
+      data-slot="indicator"
+      className={cn('relative', inline ? 'inline-block' : 'block', className)}
+      {...props}
+    >
+      {children}
+      {!disabled && (
+        <span
+          data-slot="indicator-dot"
+          className={cn(indicatorDotVariants({ color, processing }))}
+          style={{ width: size, height: size, zIndex }}
+        />
+      )}
+    </div>
+  );
+}
+
+export { Indicator, indicatorDotVariants };

--- a/packages/client/src/components/ui/overlay.stories.tsx
+++ b/packages/client/src/components/ui/overlay.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from './button.js';
+import { LoadingOverlay, Overlay } from './overlay.js';
+
+const Panel = ({ children }: { children?: React.ReactNode }) => (
+  <div className="relative h-48 w-80 rounded-lg border bg-white p-4">
+    <p className="text-sm font-medium">Trip expense</p>
+    <p className="mt-2 text-xs text-gray-500">
+      Amsterdam, 14–17 March. Three receipts pending categorisation.
+    </p>
+    <Button className="mt-4" size="sm">
+      Categorise
+    </Button>
+    {children}
+  </div>
+);
+
+const meta = {
+  title: 'UI/Overlay',
+  component: Overlay,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof Overlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The shape used across the business-trip-report buttons: `blur={1}` and centred. */
+export const Centered: Story = {
+  render: () => (
+    <Panel>
+      <Overlay blur={1} center>
+        <Button size="sm">Confirm</Button>
+      </Overlay>
+    </Panel>
+  ),
+};
+
+export const WithoutBlur: Story = {
+  render: () => (
+    <Panel>
+      <Overlay center>
+        <span className="text-sm">No blur</span>
+      </Overlay>
+    </Panel>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <Panel>
+      <LoadingOverlay visible />
+    </Panel>
+  ),
+};
+
+/** Renders nothing at all, so the panel underneath stays interactive. */
+export const LoadingHidden: Story = {
+  render: () => (
+    <Panel>
+      <LoadingOverlay visible={false} />
+    </Panel>
+  ),
+};

--- a/packages/client/src/components/ui/overlay.tsx
+++ b/packages/client/src/components/ui/overlay.tsx
@@ -26,7 +26,12 @@ function Overlay({ className, children, blur, center = false, style, ...props }:
         center && 'flex items-center justify-center',
         className,
       )}
-      style={{ backdropFilter: blur ? `blur(${blur}px)` : undefined, ...style }}
+      style={{
+        backdropFilter: blur ? `blur(${blur}px)` : undefined,
+        // Safari still only honours the prefixed property.
+        WebkitBackdropFilter: blur ? `blur(${blur}px)` : undefined,
+        ...style,
+      }}
       {...props}
     >
       {children}

--- a/packages/client/src/components/ui/overlay.tsx
+++ b/packages/client/src/components/ui/overlay.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { cn } from '@/lib/utils.js';
+import { Spinner } from './spinner.js';
+
+type OverlayProps = React.ComponentProps<'div'> & {
+  /** Backdrop blur radius in pixels. Dynamic, so applied as a style rather than a class. */
+  blur?: number;
+  /** Centre the children within the overlay. */
+  center?: boolean;
+};
+
+/**
+ * A scrim filling its nearest positioned ancestor. Used to veil a form or table while a
+ * mutation is in flight.
+ *
+ * No shadcn equivalent exists, so this is a first-class local primitive. It replaced
+ * Mantine's `Overlay`, whose default appearance was a 60% white wash — matched here so
+ * the migration was not also a visual change.
+ */
+function Overlay({ className, children, blur, center = false, style, ...props }: OverlayProps) {
+  return (
+    <div
+      data-slot="overlay"
+      className={cn(
+        'absolute inset-0 bg-white/60',
+        center && 'flex items-center justify-center',
+        className,
+      )}
+      style={{ backdropFilter: blur ? `blur(${blur}px)` : undefined, ...style }}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+type LoadingOverlayProps = Omit<OverlayProps, 'center'> & {
+  /** Render nothing when false. */
+  visible?: boolean;
+};
+
+/** An `Overlay` with a centred spinner, shown while `visible`. */
+function LoadingOverlay({ visible = false, blur = 1, ...props }: LoadingOverlayProps) {
+  if (!visible) {
+    return null;
+  }
+  return (
+    <Overlay center blur={blur} {...props}>
+      <Spinner className="size-8 text-gray-500" />
+    </Overlay>
+  );
+}
+
+export { Overlay, LoadingOverlay };


### PR DESCRIPTION
Step 2 of the Mantine removal: the first component cluster, and the highest-leverage one.

## Why

`packages/client` runs three UI stacks at once — `root-layout.tsx` literally nests `MantineProvider` → MUI `ThemeProvider` → shadcn `<Toaster/>`. Mantine 6.0.22 is the emotion-runtime generation, released against React 18 and running here under React 19.2.8, an unsupported combination. 117 files import `@mantine/*`, and 60 of those *also* import shadcn `ui/*` in the same file.

This PR takes the cluster with the best ratio of files cleared to risk: usage of these six components was almost perfectly uniform, so most of the diff is a mechanical import swap.

## What

**Two new primitives in `components/ui/`.** These are genuine gaps in shadcn's catalogue, so they are written in the house idiom (`data-slot`, `cn()`, cva) as first-class components, not as Mantine-shaped compatibility shims:

- **`indicator.tsx`** — the status dot on table cells and filter buttons. All 21 Mantine call sites used a near-identical prop set (`inline`, `size`, `disabled`, `color`, `processing`), which is what made the swap mechanical. Mantine's `processing` ripple becomes `animate-pulse`; the `zIndex="auto"` plumbing every call site carried is dropped, since the new dot needs no stacking override.
- **`overlay.tsx`** — `Overlay` and `LoadingOverlay`, the scrim veiling a form while a mutation runs. All 9 `Overlay` sites were byte-identical (`<Overlay blur={1} center>`). Matches Mantine's default 60% white wash so this is not *also* a visual change. `LoadingOverlay`'s prop is now `blur`, not `overlayBlur`.

**Four wrappers reimplemented in Tailwind**, so their consumers were untouched:

- **`common/simple-grid.tsx`** — Mantine v6's `breakpoints` array is max-width based (desktop-first) while Tailwind's variants are min-width based, so the ladder is **inverted**, not translated. Column classes are spelled out per count because Tailwind only emits utilities it can find as literals in source — `grid-cols-${cols}` would produce nothing. Worth knowing: the old config listed both `maxWidth: 900, cols: 2` and `maxWidth: 755, cols: 2`, the latter unreachable, so these boundaries were never precision-tuned.
- **`common/loaders/loader.tsx`** — ⚠️ **deliberate visible change.** Mantine's `variant="dots"` loader has no lucide equivalent, so `AccounterLoader` now uses the house `Spinner` (`.claude/rules/client-components.md` convention). The full-page loading animation looks different; that is intended, not a regression.
- **`common/icon.tsx`** — Mantine `Image` becomes a plain `<img>`, and now carries an `alt`.
- **`common/divider.tsx`** — **deleted.** `AccounterDivider` had no consumers anywhere in the repo.

Plus stories for both new primitives, covering every variant and the `disabled`/`visible` states.

## Notes for the reviewer

The interesting parts are the four wrapper files and the two new primitives — the other ~35 files are the mechanical swap and read almost identically:

```diff
-import { Indicator } from '@mantine/core';
+import { Indicator } from '../../ui/indicator.js';
...
-    <Indicator inline size={12} disabled={!isError} color="red" zIndex="auto">
+    <Indicator inline size={12} disabled={!isError} color="red">
```

Please look hardest at **`simple-grid.tsx`** — inverting desktop-first breakpoints to mobile-first is mechanical but easy to get backwards, and it is worth checking the 10 call sites (`cols` 1–5) at narrow widths.

**Mantine imports: 124 → 104, across 117 → 97 files.**

## Verification

```
yarn vitest run --project unit packages/client   # 43 files, 335 passed, 1 skipped
yarn workspace @accounter/client build           # typechecks + builds
yarn lint                                        # 0 errors
yarn prettier:check                              # clean
```

Not yet verified visually in the running app — the `Overlay` scrim colour, the `SimpleGrid` breakpoint inversion and the new `AccounterLoader` are the three things worth eyeballing before merge.

## Related

Part of the Mantine → shadcn/ui migration. Independent of, and mergeable in any order with, the safety-net and ESLint-ratchet PRs. Once the ratchet lands, subsequent clusters move their cleaned directories into its error list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR)_