### PR TITLE
feat(client): replace Mantine Modal with shadcn Dialog behind PopUpModal

### DIFF
--- a/.changeset/mantine-popup-modal-dialog.md
+++ b/.changeset/mantine-popup-modal-dialog.md
@@ -26,6 +26,12 @@ Notes:
 - Mantine's `centered` and `withinPortal` props are dropped: Radix dialogs are centred and portaled
   by default.
 
+The dialog now carries `max-h-[90vh] overflow-y-auto`, matching the 17 other `DialogContent` sites
+that do — several filter forms are taller than the viewport, and Mantine's `Modal` scrolled its body
+by default. `merge-businesses` gains an explicit title so it is not announced as "Filters", and
+`edit-tag-modal`'s title is corrected from "Insert Business Trip" (a pre-existing mislabel) to
+"Edit Tag".
+
 Mantine imports: 101 → 97, across 94 → 90 files. The remaining `Modal` users all sit in
 `business-trip-report/buttons/` and `depreciation/`, which carry other Mantine imports too and
 belong to their own cluster.

--- a/.changeset/mantine-popup-modal-dialog.md
+++ b/.changeset/mantine-popup-modal-dialog.md
@@ -26,6 +26,18 @@ Notes:
 - Mantine's `centered` and `withinPortal` props are dropped: Radix dialogs are centred and portaled
   by default.
 
+`PopUpModal` takes its body as `children` only — the old wrapper declared both `content` and
+`children`, which were two names for the same slot (and `children` was never actually rendered). All
+thirteen call sites now pass children.
+
+**Nested dialogs restack correctly.** Radix's `DialogContent` sits at `z-1001` while Mantine v6's
+`Modal` defaults far below it, so any Mantine modal opened *from inside* a converted dialog rendered
+behind it. That affected the Depreciation dialog, whose `AddDepreciationRecord` child is a Mantine
+`Modal` — it is now a `PopUpModal` too, and nested Radix dialogs stack by portal order. The same
+applies to Mantine dropdowns portaled to the body: the four `withinPortal` `Select`s under
+`common/depreciation/` now pass `zIndex={1002}`, matching the fix already present in
+`charge-spread-input.tsx`.
+
 The dialog now carries `max-h-[90vh] overflow-y-auto`, matching the 17 other `DialogContent` sites
 that do — several filter forms are taller than the viewport, and Mantine's `Modal` scrolled its body
 by default. `merge-businesses` gains an explicit title so it is not announced as "Filters", and

--- a/.changeset/mantine-popup-modal-dialog.md
+++ b/.changeset/mantine-popup-modal-dialog.md
@@ -1,0 +1,31 @@
+---
+'@accounter/client': patch
+---
+
+Replace Mantine's `Modal` with the shadcn `Dialog` behind `PopUpModal`, migrating all twelve filter
+dialogs plus three screens that used Mantine's `Modal` directly.
+
+`common/modals/modal.tsx` now wraps `ui/dialog.tsx`. Because every `*-filters.tsx` screen goes
+through this wrapper, one file change moves all twelve; the three direct users
+(`charges/charge-actions-menu.tsx` with two dialogs, `common/modals/edit-tag-modal.tsx`,
+`common/merge-businesses/index.tsx`) now go through it too, which clears Mantine from those files
+entirely.
+
+Notes:
+
+- **Dismissal was the risk, and is preserved.** `withCloseButton` defaults to `false`, so most
+  filter dialogs offer no visible close control and rely on Escape and outside-click — both of which
+  Radix's `Dialog` provides. The prop maps onto `DialogContent`'s existing `showCloseButton`.
+- **Radix requires an accessible name.** No call site passes a title, and an unnamed dialog makes
+  Radix warn at runtime, so the wrapper renders an `sr-only` header when no `title` is given.
+- `modalSize` is kept and translated from Mantine's size vocabulary to a max-width class
+  (`xl` → `sm:max-w-3xl`, `auto`/`fit-content` → `sm:max-w-fit`). Three filter dialogs use `xl`.
+- The wrapper gains `children`, `onClick` and `description`. `children` was previously declared but
+  never rendered — the three newly-migrated files pass children rather than `content`, and
+  `charge-actions-menu.tsx` needs `onClick` to stop click-through to the row beneath.
+- Mantine's `centered` and `withinPortal` props are dropped: Radix dialogs are centred and portaled
+  by default.
+
+Mantine imports: 101 → 97, across 94 → 90 files. The remaining `Modal` users all sit in
+`business-trip-report/buttons/` and `depreciation/`, which carry other Mantine imports too and
+belong to their own cluster.

--- a/packages/client/src/components/business-ledger/business-ledger-filters.tsx
+++ b/packages/client/src/components/business-ledger/business-ledger-filters.tsx
@@ -272,18 +272,14 @@ export function BusinessLedgerRecordsFilters({
 
   return (
     <>
-      <PopUpModal
-        opened={opened}
-        onClose={(): void => setOpened(false)}
-        content={
-          <BusinessLedgerRecordsFilterForm
-            single
-            filter={filter}
-            setFilter={onSetFilter}
-            closeModal={(): void => setOpened(false)}
-          />
-        }
-      />
+      <PopUpModal opened={opened} onClose={(): void => setOpened(false)}>
+        <BusinessLedgerRecordsFilterForm
+          single
+          filter={filter}
+          setFilter={onSetFilter}
+          closeModal={(): void => setOpened(false)}
+        />
+      </PopUpModal>
       <Indicator inline size={16} disabled={!isFiltered}>
         <Button
           variant="outline"

--- a/packages/client/src/components/charges/charge-actions-menu.tsx
+++ b/packages/client/src/components/charges/charge-actions-menu.tsx
@@ -8,7 +8,6 @@ import {
   MoreVertical,
   Trash,
 } from 'lucide-react';
-import { Modal } from '@mantine/core';
 import type { ChargeType } from '@/helpers/index.js';
 import { ROUTES } from '@/router/routes.js';
 import { writeToClipboard } from '../../helpers/index.js';
@@ -23,6 +22,7 @@ import {
   UploadDocumentsModal,
   UploadPayrollFile,
 } from '../common/index.js';
+import { PopUpModal } from '../common/modals/modal.js';
 import { Button } from '../ui/button.js';
 import { Dialog, DialogContent } from '../ui/dialog.js';
 import {
@@ -170,13 +170,12 @@ export function ChargeActionsMenu({
         onConfirm={handleDelete}
         title="Are you sure you want to delete this charge?"
       />
-      <Modal
-        withinPortal
-        size="xl"
-        centered
+      <PopUpModal
+        modalSize="xl"
         opened={depreciationOpened}
         onClose={closeDepreciation}
         title="Depreciation"
+        withCloseButton
         onClick={event => event.stopPropagation()}
       >
         <Depreciation
@@ -186,7 +185,7 @@ export function ChargeActionsMenu({
             onChange?.();
           }}
         />
-      </Modal>
+      </PopUpModal>
       <Dialog open={miscExpensesOpened} onOpenChange={setMiscExpensesOpened}>
         <DialogContent className="sm:max-w-[425px]" onClick={event => event.stopPropagation()}>
           <InsertMiscExpense
@@ -198,11 +197,11 @@ export function ChargeActionsMenu({
           />
         </DialogContent>
       </Dialog>
-      <Modal
-        centered
+      <PopUpModal
         opened={uploadSalariesOpened}
         onClose={closeUploadSalaries}
         title="Upload Payroll File"
+        withCloseButton
         onClick={event => event.stopPropagation()}
       >
         <UploadPayrollFile
@@ -212,7 +211,7 @@ export function ChargeActionsMenu({
           }}
           chargeId={chargeId}
         />
-      </Modal>
+      </PopUpModal>
       <UploadDocumentsModal
         open={uploadDocumentsOpen}
         onOpenChange={setUploadDocumentsOpen}

--- a/packages/client/src/components/charts/chart-filters.tsx
+++ b/packages/client/src/components/charts/chart-filters.tsx
@@ -151,17 +151,13 @@ export function ChargeFilterFilter({ filter, setFilter }: ChargeFilterProps): Re
 
   return (
     <>
-      <PopUpModal
-        opened={opened}
-        onClose={(): void => setOpened(false)}
-        content={
-          <ChargeFilterForm
-            filter={filter}
-            setFilter={onSetFilter}
-            closeModal={(): void => setOpened(false)}
-          />
-        }
-      />
+      <PopUpModal opened={opened} onClose={(): void => setOpened(false)}>
+        <ChargeFilterForm
+          filter={filter}
+          setFilter={onSetFilter}
+          closeModal={(): void => setOpened(false)}
+        />
+      </PopUpModal>
       <Button
         variant="outline"
         size="icon"

--- a/packages/client/src/components/charts/monthly-income-expense/chart-filter.tsx
+++ b/packages/client/src/components/charts/monthly-income-expense/chart-filter.tsx
@@ -139,17 +139,13 @@ export function ChartFilter({ filter, setFilter }: ChargeFilterProps): ReactElem
 
   return (
     <>
-      <PopUpModal
-        opened={opened}
-        onClose={(): void => setOpened(false)}
-        content={
-          <ChartFilterForm
-            filter={filter}
-            setFilter={onSetFilter}
-            closeModal={(): void => setOpened(false)}
-          />
-        }
-      />
+      <PopUpModal opened={opened} onClose={(): void => setOpened(false)}>
+        <ChartFilterForm
+          filter={filter}
+          setFilter={onSetFilter}
+          closeModal={(): void => setOpened(false)}
+        />
+      </PopUpModal>
       <Button
         variant="outline"
         size="icon"

--- a/packages/client/src/components/common/depreciation/add-depreciation-record.tsx
+++ b/packages/client/src/components/common/depreciation/add-depreciation-record.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { useQuery } from 'urql';
-import { Loader, Modal, Select } from '@mantine/core';
+import { Loader, Select } from '@mantine/core';
 import {
   AllDepreciationCategoriesDocument,
   type InsertDepreciationRecordInput,
@@ -13,6 +13,7 @@ import { Button } from '../../ui/button.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { Overlay } from '../../ui/overlay.js';
 import { CurrencyInput, DatePickerInput, Tooltip } from '../index.js';
+import { PopUpModal } from '../modals/modal.js';
 import { depreciationTypes } from './index.js';
 
 export function AddDepreciationRecord(props: {
@@ -88,9 +89,8 @@ function ModalContent({ chargeId, opened, close, onAdd }: ModalProps): ReactElem
   }, [fetchingCategories, addingInProcess]);
 
   return (
-    <Modal opened={opened} onClose={close} centered lockScroll>
-      <Modal.Title>Add Depreciation Record</Modal.Title>
-      <Modal.Body>
+    <PopUpModal opened={opened} onClose={close} title="Add Depreciation Record" withCloseButton>
+      <div>
         <Form {...form}>
           <form onSubmit={handleSubmit(onSubmit)}>
             <FormField
@@ -157,6 +157,7 @@ function ModalContent({ chargeId, opened, close, onAdd }: ModalProps): ReactElem
                   searchable
                   error={fieldState.error?.message}
                   withinPortal
+                  zIndex={1002}
                 />
               )}
             />
@@ -174,6 +175,7 @@ function ModalContent({ chargeId, opened, close, onAdd }: ModalProps): ReactElem
                   searchable
                   error={fieldState.error?.message}
                   withinPortal
+                  zIndex={1002}
                 />
               )}
             />
@@ -188,12 +190,12 @@ function ModalContent({ chargeId, opened, close, onAdd }: ModalProps): ReactElem
             </div>
           </form>
         </Form>
-      </Modal.Body>
+      </div>
       {(addingInProcess || fetching) && (
         <Overlay blur={1} center>
           <Loader />
         </Overlay>
       )}
-    </Modal>
+    </PopUpModal>
   );
 }

--- a/packages/client/src/components/common/depreciation/depreciation-row.tsx
+++ b/packages/client/src/components/common/depreciation/depreciation-row.tsx
@@ -202,6 +202,7 @@ export const DepreciationRow = ({ data, onChange }: Props): ReactElement => {
                       searchable
                       error={fieldState.error?.message}
                       withinPortal
+                      zIndex={1002}
                     />
                   </FormControl>
                   <FormMessage />
@@ -233,6 +234,7 @@ export const DepreciationRow = ({ data, onChange }: Props): ReactElement => {
                       searchable
                       error={fieldState.error?.message}
                       withinPortal
+                      zIndex={1002}
                     />
                   </FormControl>
                   <FormMessage />

--- a/packages/client/src/components/common/merge-businesses/index.tsx
+++ b/packages/client/src/components/common/merge-businesses/index.tsx
@@ -34,7 +34,13 @@ export function MergeBusinessesButton(props: {
       >
         <Merge className="size-5" />
       </Button>
-      <PopUpModal opened={opened} onClose={close} modalSize="auto" withCloseButton>
+      <PopUpModal
+        opened={opened}
+        onClose={close}
+        modalSize="auto"
+        title="Merge Businesses"
+        withCloseButton
+      >
         <MergeBusinessesSelectionForm
           businessIds={Array.from(distinctIDs)}
           onDone={onDone}

--- a/packages/client/src/components/common/merge-businesses/index.tsx
+++ b/packages/client/src/components/common/merge-businesses/index.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useState, type ReactElement } from 'react';
 import { Merge } from 'lucide-react';
-import { Modal } from '@mantine/core';
 import { cn } from '../../../lib/utils.js';
 import { Button } from '../../ui/button.js';
+import { PopUpModal } from '../modals/modal.js';
 import { MergeBusinessesSelectionForm } from './merge-businesses-selection-form.js';
 
 export function MergeBusinessesButton(props: {
@@ -34,13 +34,13 @@ export function MergeBusinessesButton(props: {
       >
         <Merge className="size-5" />
       </Button>
-      <Modal opened={opened} onClose={close} size="auto" centered>
+      <PopUpModal opened={opened} onClose={close} modalSize="auto" withCloseButton>
         <MergeBusinessesSelectionForm
           businessIds={Array.from(distinctIDs)}
           onDone={onDone}
           resetMerge={resetMerge}
         />
-      </Modal>
+      </PopUpModal>
     </>
   );
 }

--- a/packages/client/src/components/common/modals/edit-tag-modal.tsx
+++ b/packages/client/src/components/common/modals/edit-tag-modal.tsx
@@ -26,7 +26,7 @@ export const EditTagModal = ({ onDone, data }: Props): ReactElement => {
           <Edit className="size-5" />
         </Button>
       </Tooltip>
-      <PopUpModal opened={opened} onClose={close} title="Insert Business Trip" withCloseButton>
+      <PopUpModal opened={opened} onClose={close} title="Edit Tag" withCloseButton>
         <EditTag close={close} onDone={onEditDone} data={data} />
       </PopUpModal>
     </>

--- a/packages/client/src/components/common/modals/edit-tag-modal.tsx
+++ b/packages/client/src/components/common/modals/edit-tag-modal.tsx
@@ -1,10 +1,10 @@
 import { useState, type ReactElement } from 'react';
 import { Edit } from 'lucide-react';
-import { Modal } from '@mantine/core';
 import { EditTagFieldsFragmentDoc } from '../../../gql/graphql.js';
 import type { FragmentType } from '../../../gql/index.js';
 import { Button } from '../../ui/button.js';
 import { EditTag, Tooltip } from '../index.js';
+import { PopUpModal } from './modal.js';
 
 interface Props {
   data: FragmentType<typeof EditTagFieldsFragmentDoc>;
@@ -26,9 +26,9 @@ export const EditTagModal = ({ onDone, data }: Props): ReactElement => {
           <Edit className="size-5" />
         </Button>
       </Tooltip>
-      <Modal centered opened={opened} onClose={close} title="Insert Business Trip">
+      <PopUpModal opened={opened} onClose={close} title="Insert Business Trip" withCloseButton>
         <EditTag close={close} onDone={onEditDone} data={data} />
-      </Modal>
+      </PopUpModal>
     </>
   );
 };

--- a/packages/client/src/components/common/modals/modal.stories.tsx
+++ b/packages/client/src/components/common/modals/modal.stories.tsx
@@ -27,20 +27,19 @@ function Harness({
         withCloseButton={withCloseButton}
         modalSize={modalSize}
         title={title}
-        content={
-          <div className="flex flex-col gap-3">
-            <p className="text-sm text-gray-600">
-              Escape and clicking outside should both close this.
-            </p>
-            <div className="flex justify-center gap-3">
-              <Button onClick={() => setOpened(false)}>Apply</Button>
-              <Button variant="outline" onClick={() => setOpened(false)}>
-                Cancel
-              </Button>
-            </div>
+      >
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-gray-600">
+            Escape and clicking outside should both close this.
+          </p>
+          <div className="flex justify-center gap-3">
+            <Button onClick={() => setOpened(false)}>Apply</Button>
+            <Button variant="outline" onClick={() => setOpened(false)}>
+              Cancel
+            </Button>
           </div>
-        }
-      />
+        </div>
+      </PopUpModal>
     </div>
   );
 }

--- a/packages/client/src/components/common/modals/modal.stories.tsx
+++ b/packages/client/src/components/common/modals/modal.stories.tsx
@@ -1,0 +1,65 @@
+import { useState, type ReactElement } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from '../../ui/button.js';
+import { PopUpModal } from './modal.js';
+
+/**
+ * The filter dialog behind all twelve `*-filters.tsx` screens. These stories exist mainly to
+ * check dismissal: `withCloseButton` defaults to false, so most call sites rely on Escape and
+ * outside-click as the only way out — the behaviour most at risk in the Mantine → Radix swap.
+ */
+function Harness({
+  withCloseButton = false,
+  modalSize,
+  title,
+}: {
+  withCloseButton?: boolean;
+  modalSize?: string;
+  title?: string;
+}): ReactElement {
+  const [opened, setOpened] = useState(true);
+  return (
+    <div className="p-6">
+      <Button onClick={() => setOpened(true)}>Open filters</Button>
+      <PopUpModal
+        opened={opened}
+        onClose={() => setOpened(false)}
+        withCloseButton={withCloseButton}
+        modalSize={modalSize}
+        title={title}
+        content={
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-gray-600">
+              Escape and clicking outside should both close this.
+            </p>
+            <div className="flex justify-center gap-3">
+              <Button onClick={() => setOpened(false)}>Apply</Button>
+              <Button variant="outline" onClick={() => setOpened(false)}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        }
+      />
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Modals/PopUpModal',
+  component: Harness,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The common case: no close button, dismissed by Escape or outside-click only. */
+export const Default: Story = { args: {} };
+
+export const WithCloseButton: Story = { args: { withCloseButton: true } };
+
+/** `modalSize="xl"` — the wide filter dialogs (salaries, balance report, documents). */
+export const Wide: Story = { args: { modalSize: 'xl', withCloseButton: true } };
+
+export const WithTitle: Story = { args: { title: 'Depreciation', withCloseButton: true } };

--- a/packages/client/src/components/common/modals/modal.tsx
+++ b/packages/client/src/components/common/modals/modal.tsx
@@ -63,7 +63,13 @@ export const PopUpModal = ({
       <DialogContent
         showCloseButton={withCloseButton}
         onClick={onClick}
-        className={cn(modalSize && modalSizeClasses[modalSize], className)}
+        className={cn(
+          // Several filter forms are taller than the viewport; 17 other DialogContent sites
+          // use this same pairing.
+          'max-h-[90vh] overflow-y-auto',
+          modalSize && modalSizeClasses[modalSize],
+          className,
+        )}
       >
         <DialogHeader className={title || description ? undefined : 'sr-only'}>
           <DialogTitle>{title ?? 'Filters'}</DialogTitle>

--- a/packages/client/src/components/common/modals/modal.tsx
+++ b/packages/client/src/components/common/modals/modal.tsx
@@ -1,35 +1,77 @@
-import type { ReactElement, ReactNode } from 'react';
-import { Modal } from '@mantine/core';
+import type { MouseEventHandler, ReactElement, ReactNode } from 'react';
+import { cn } from '../../../lib/utils.js';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../../ui/dialog.js';
+
+/**
+ * Mantine's `size` vocabulary, translated to the dialog's max width. `xl` is the only named
+ * size any call site uses; `fit-content` and `auto` came from the drawer's copy of this prop.
+ */
+const modalSizeClasses: Record<string, string> = {
+  sm: 'sm:max-w-sm',
+  md: 'sm:max-w-md',
+  lg: 'sm:max-w-2xl',
+  xl: 'sm:max-w-3xl',
+  auto: 'sm:max-w-fit',
+  'fit-content': 'sm:max-w-fit',
+};
 
 export interface ModalProps {
   content?: ReactNode;
-  title?: ReactElement;
-  modalSize?: string;
+  /** Heading for the dialog. When omitted, an accessible name is still provided. */
+  title?: ReactNode;
+  description?: ReactNode;
   opened?: boolean;
   onClose?: () => void;
-  children?: ReactElement | ReactElement[];
+  /** Mirrors the old Mantine prop; maps onto `DialogContent`'s `showCloseButton`. */
   withCloseButton?: boolean;
+  /** Mantine size name, translated to a max-width class. */
+  modalSize?: string;
+  children?: ReactNode;
+  onClick?: MouseEventHandler<HTMLDivElement>;
+  className?: string;
 }
 
+/**
+ * The filter dialog used across the reports and charts screens. Replaces Mantine's `Modal`.
+ *
+ * Radix requires every dialog to have a title for assistive tech, and none of the call sites
+ * pass one, so an `sr-only` fallback is rendered instead of leaving the dialog unnamed (which
+ * Radix warns about at runtime).
+ */
 export const PopUpModal = ({
   content,
   title,
+  description,
   opened = false,
   onClose = (): void => {
     return;
   },
-  modalSize,
   withCloseButton = false,
+  modalSize,
+  children,
+  onClick,
+  className,
 }: ModalProps): ReactElement => {
   return (
-    <Modal
-      size={modalSize}
-      opened={opened}
-      onClose={onClose}
-      title={title}
-      withCloseButton={withCloseButton}
-    >
-      {content}
-    </Modal>
+    <Dialog open={opened} onOpenChange={next => !next && onClose()}>
+      <DialogContent
+        showCloseButton={withCloseButton}
+        onClick={onClick}
+        className={cn(modalSize && modalSizeClasses[modalSize], className)}
+      >
+        <DialogHeader className={title || description ? undefined : 'sr-only'}>
+          <DialogTitle>{title ?? 'Filters'}</DialogTitle>
+          {description ? <DialogDescription>{description}</DialogDescription> : null}
+        </DialogHeader>
+        {content}
+        {children}
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/packages/client/src/components/common/modals/modal.tsx
+++ b/packages/client/src/components/common/modals/modal.tsx
@@ -22,7 +22,6 @@ const modalSizeClasses: Record<string, string> = {
 };
 
 export interface ModalProps {
-  content?: ReactNode;
   /** Heading for the dialog. When omitted, an accessible name is still provided. */
   title?: ReactNode;
   description?: ReactNode;
@@ -45,7 +44,6 @@ export interface ModalProps {
  * Radix warns about at runtime).
  */
 export const PopUpModal = ({
-  content,
   title,
   description,
   opened = false,
@@ -75,7 +73,6 @@ export const PopUpModal = ({
           <DialogTitle>{title ?? 'Filters'}</DialogTitle>
           {description ? <DialogDescription>{description}</DialogDescription> : null}
         </DialogHeader>
-        {content}
         {children}
       </DialogContent>
     </Dialog>

--- a/packages/client/src/components/reports/corporate-tax-ruling-compliance-report/corporate-tax-ruling-compliance-report-filters.tsx
+++ b/packages/client/src/components/reports/corporate-tax-ruling-compliance-report/corporate-tax-ruling-compliance-report-filters.tsx
@@ -17,22 +17,17 @@ export function CorporateTaxRulingComplianceReportFilter({
 
   return (
     <>
-      <PopUpModal
-        opened={opened}
-        onClose={(): void => setOpened(false)}
-        withCloseButton
-        content={
-          <YearPickerInput
-            type="multiple"
-            label="Pick years"
-            value={years?.map(year => new Date(year, 0, 1))}
-            onChange={date => setYears(date.map(date => date.getFullYear()))}
-            popoverProps={{ withinPortal: true }}
-            minDate={new Date(2010, 0, 1)}
-            maxDate={new Date()}
-          />
-        }
-      />
+      <PopUpModal opened={opened} onClose={(): void => setOpened(false)} withCloseButton>
+        <YearPickerInput
+          type="multiple"
+          label="Pick years"
+          value={years?.map(year => new Date(year, 0, 1))}
+          onChange={date => setYears(date.map(date => date.getFullYear()))}
+          popoverProps={{ withinPortal: true }}
+          minDate={new Date(2010, 0, 1)}
+          maxDate={new Date()}
+        />
+      </PopUpModal>
       <Button
         variant="outline"
         size="icon"

--- a/packages/client/src/components/reports/profit-and-loss-report/profit-and-loss-report-filters.tsx
+++ b/packages/client/src/components/reports/profit-and-loss-report/profit-and-loss-report-filters.tsx
@@ -21,36 +21,31 @@ export function ProfitAndLossReportFilter({
 
   return (
     <>
-      <PopUpModal
-        opened={opened}
-        onClose={(): void => setOpened(false)}
-        withCloseButton
-        content={
-          <>
-            <YearPickerInput
-              label="Change report year"
-              value={new Date(year, 0, 1)}
-              onChange={date => date && setYear(date?.getFullYear())}
-              popoverProps={{ withinPortal: true }}
-              minDate={new Date(2010, 0, 1)}
-              maxDate={new Date()}
-            />
-            <YearPickerInput
-              type="multiple"
-              label="Pick reference years"
-              value={referenceYears?.map(year => new Date(year, 0, 1))}
-              onChange={date =>
-                setReferenceYears(
-                  date.map(date => date.getFullYear()).filter(refYear => year !== refYear),
-                )
-              }
-              popoverProps={{ withinPortal: true }}
-              minDate={new Date(2010, 0, 1)}
-              maxDate={new Date()}
-            />
-          </>
-        }
-      />
+      <PopUpModal opened={opened} onClose={(): void => setOpened(false)} withCloseButton>
+        <>
+          <YearPickerInput
+            label="Change report year"
+            value={new Date(year, 0, 1)}
+            onChange={date => date && setYear(date?.getFullYear())}
+            popoverProps={{ withinPortal: true }}
+            minDate={new Date(2010, 0, 1)}
+            maxDate={new Date()}
+          />
+          <YearPickerInput
+            type="multiple"
+            label="Pick reference years"
+            value={referenceYears?.map(year => new Date(year, 0, 1))}
+            onChange={date =>
+              setReferenceYears(
+                date.map(date => date.getFullYear()).filter(refYear => year !== refYear),
+              )
+            }
+            popoverProps={{ withinPortal: true }}
+            minDate={new Date(2010, 0, 1)}
+            maxDate={new Date()}
+          />
+        </>
+      </PopUpModal>
       <Button
         variant="outline"
         size="icon"

--- a/packages/client/src/components/reports/tax-report/tax-report-filters.tsx
+++ b/packages/client/src/components/reports/tax-report/tax-report-filters.tsx
@@ -21,36 +21,31 @@ export function TaxReportFilter({
 
   return (
     <>
-      <PopUpModal
-        opened={opened}
-        onClose={(): void => setOpened(false)}
-        withCloseButton
-        content={
-          <>
-            <YearPickerInput
-              label="Change report year"
-              value={new Date(year, 0, 1)}
-              onChange={date => date && setYear(date?.getFullYear())}
-              popoverProps={{ withinPortal: true }}
-              minDate={new Date(2010, 0, 1)}
-              maxDate={new Date()}
-            />
-            <YearPickerInput
-              type="multiple"
-              label="Pick reference years"
-              value={referenceYears?.map(year => new Date(year, 0, 1))}
-              onChange={date =>
-                setReferenceYears(
-                  date.map(date => date.getFullYear()).filter(refYear => year !== refYear),
-                )
-              }
-              popoverProps={{ withinPortal: true }}
-              minDate={new Date(2010, 0, 1)}
-              maxDate={new Date()}
-            />
-          </>
-        }
-      />
+      <PopUpModal opened={opened} onClose={(): void => setOpened(false)} withCloseButton>
+        <>
+          <YearPickerInput
+            label="Change report year"
+            value={new Date(year, 0, 1)}
+            onChange={date => date && setYear(date?.getFullYear())}
+            popoverProps={{ withinPortal: true }}
+            minDate={new Date(2010, 0, 1)}
+            maxDate={new Date()}
+          />
+          <YearPickerInput
+            type="multiple"
+            label="Pick reference years"
+            value={referenceYears?.map(year => new Date(year, 0, 1))}
+            onChange={date =>
+              setReferenceYears(
+                date.map(date => date.getFullYear()).filter(refYear => year !== refYear),
+              )
+            }
+            popoverProps={{ withinPortal: true }}
+            minDate={new Date(2010, 0, 1)}
+            maxDate={new Date()}
+          />
+        </>
+      </PopUpModal>
       <Button
         variant="outline"
         size="icon"

--- a/packages/client/src/components/reports/trial-balance-report/trial-balance-report-filters.tsx
+++ b/packages/client/src/components/reports/trial-balance-report/trial-balance-report-filters.tsx
@@ -267,17 +267,13 @@ export function TrialBalanceReportFilters({
 
   return (
     <>
-      <PopUpModal
-        opened={opened}
-        onClose={(): void => setOpened(false)}
-        content={
-          <TrialBalanceReportFilterForm
-            filter={filter}
-            setFilter={onSetFilter}
-            closeModal={(): void => setOpened(false)}
-          />
-        }
-      />
+      <PopUpModal opened={opened} onClose={(): void => setOpened(false)}>
+        <TrialBalanceReportFilterForm
+          filter={filter}
+          setFilter={onSetFilter}
+          closeModal={(): void => setOpened(false)}
+        />
+      </PopUpModal>
       <Indicator inline size={16} disabled={!isFiltered}>
         <Button variant="outline" onClick={(): void => setOpened(true)} className="p-2">
           <Filter size={20} />

--- a/packages/client/src/components/reports/validations/validate-reports-filter.tsx
+++ b/packages/client/src/components/reports/validations/validate-reports-filter.tsx
@@ -137,17 +137,13 @@ export function ValidateReportsFilter({
 
   return (
     <>
-      <PopUpModal
-        opened={opened}
-        onClose={(): void => setOpened(false)}
-        content={
-          <ValidateReportsFilterForm
-            filter={filter}
-            setFilter={onSetFilter}
-            closeModal={(): void => setOpened(false)}
-          />
-        }
-      />
+      <PopUpModal opened={opened} onClose={(): void => setOpened(false)}>
+        <ValidateReportsFilterForm
+          filter={filter}
+          setFilter={onSetFilter}
+          closeModal={(): void => setOpened(false)}
+        />
+      </PopUpModal>
       <Button
         variant="outline"
         size="icon"

--- a/packages/client/src/components/reports/vat-monthly-report/vat-monthly-report-filters.tsx
+++ b/packages/client/src/components/reports/vat-monthly-report/vat-monthly-report-filters.tsx
@@ -168,17 +168,13 @@ export function VatMonthlyReportFilter({
 
   return (
     <>
-      <PopUpModal
-        opened={opened}
-        onClose={(): void => setOpened(false)}
-        content={
-          <VatMonthlyReportFilterForm
-            filter={filter}
-            setFilter={onSetFilter}
-            closeModal={(): void => setOpened(false)}
-          />
-        }
-      />
+      <PopUpModal opened={opened} onClose={(): void => setOpened(false)}>
+        <VatMonthlyReportFilterForm
+          filter={filter}
+          setFilter={onSetFilter}
+          closeModal={(): void => setOpened(false)}
+        />
+      </PopUpModal>
       <Button
         variant="outline"
         size="icon"

--- a/packages/client/src/components/salaries/salaries-filters.tsx
+++ b/packages/client/src/components/salaries/salaries-filters.tsx
@@ -206,18 +206,13 @@ export function SalariesFilters({ filter, setFilter }: SalariesFiltersProps): Re
 
   return (
     <div className="flex flex-row gap-5 items-center">
-      <PopUpModal
-        opened={opened}
-        onClose={(): void => setOpened(false)}
-        content={
-          <SalariesFiltersForm
-            filter={filter}
-            setFilter={onSetFilter}
-            closeModal={(): void => setOpened(false)}
-          />
-        }
-        modalSize="xl"
-      />
+      <PopUpModal opened={opened} onClose={(): void => setOpened(false)} modalSize="xl">
+        <SalariesFiltersForm
+          filter={filter}
+          setFilter={onSetFilter}
+          closeModal={(): void => setOpened(false)}
+        />
+      </PopUpModal>
       <Button
         variant="outline"
         size="icon"

--- a/packages/client/src/components/screens/documents/all-documents/documents-filters.tsx
+++ b/packages/client/src/components/screens/documents/all-documents/documents-filters.tsx
@@ -342,18 +342,13 @@ export function DocumentsFilters({
 
   return (
     <div className="flex flex-row gap-5 items-center">
-      <PopUpModal
-        opened={opened}
-        onClose={(): void => setOpened(false)}
-        content={
-          <DocumentsFiltersForm
-            filter={filter}
-            setFilter={onSetFilter}
-            closeModal={(): void => setOpened(false)}
-          />
-        }
-        modalSize="xl"
-      />
+      <PopUpModal opened={opened} onClose={(): void => setOpened(false)} modalSize="xl">
+        <DocumentsFiltersForm
+          filter={filter}
+          setFilter={onSetFilter}
+          closeModal={(): void => setOpened(false)}
+        />
+      </PopUpModal>
       <Indicator inline size={16} disabled={!isFiltered}>
         <Button
           variant="outline"

--- a/packages/client/src/components/screens/reports/balance-report/balance-report-filters.tsx
+++ b/packages/client/src/components/screens/reports/balance-report/balance-report-filters.tsx
@@ -465,18 +465,13 @@ export function BalanceReportFilters({
 
   return (
     <div className="flex flex-row gap-5 items-center">
-      <PopUpModal
-        opened={opened}
-        onClose={(): void => setOpened(false)}
-        content={
-          <BalanceReportFiltersForm
-            filter={filter}
-            setFilter={onSetFilter}
-            closeModal={(): void => setOpened(false)}
-          />
-        }
-        modalSize="xl"
-      />
+      <PopUpModal opened={opened} onClose={(): void => setOpened(false)} modalSize="xl">
+        <BalanceReportFiltersForm
+          filter={filter}
+          setFilter={onSetFilter}
+          closeModal={(): void => setOpened(false)}
+        />
+      </PopUpModal>
       <Indicator inline size={16} disabled={!isFiltered}>
         <Button
           variant="outline"


### PR DESCRIPTION
Step 4 of the Mantine removal. High leverage for a small diff: one wrapper file moves twelve screens.

## What

`common/modals/modal.tsx` now wraps `ui/dialog.tsx` instead of Mantine's `Modal`. Every `*-filters.tsx` screen goes through this wrapper, so changing it migrates all twelve filter dialogs without touching them.

Three screens used Mantine's `Modal` **directly**, bypassing the wrapper — they now go through it too, which clears Mantine from those files entirely:

- `charges/charge-actions-menu.tsx` (two dialogs: Depreciation, Upload Payroll File)
- `common/modals/edit-tag-modal.tsx`
- `common/merge-businesses/index.tsx`

## Worth a reviewer's attention

**Dismissal was the real risk here, and it's preserved.** `withCloseButton` defaults to `false`, so most of these dialogs render *no visible close control* — Escape and outside-click are the only way out. Radix's `Dialog` provides both, and the prop maps cleanly onto `DialogContent`'s existing `showCloseButton`. `modal.stories.tsx` exists mainly to make this checkable by hand.

**Radix requires an accessible name.** No call site passes a title, and an unnamed dialog makes Radix warn at runtime, so the wrapper renders an `sr-only` header when `title` is absent rather than leaving it unnamed.

**Prop translation:**

- `modalSize` kept, mapped from Mantine's size vocabulary to a max-width class (`xl` → `sm:max-w-3xl`, `auto`/`fit-content` → `sm:max-w-fit`). Three filter dialogs pass `xl`.
- The wrapper gains `children`, `onClick` and `description`. `children` was previously *declared but never rendered* — a latent bug; the three newly-migrated files pass children rather than `content`, and `charge-actions-menu.tsx` needs `onClick` to stop click-through to the charge row beneath.
- Mantine's `centered` and `withinPortal` are dropped: Radix dialogs are centred and portaled by default.

## Scope

The remaining Mantine `Modal` users all sit in `business-trip-report/buttons/` (8 files) and `depreciation/`, and carry `Loader`, `Select`, `NumberInput` and friends alongside. Migrating only their `Modal` would leave them just as Mantine-dependent, so they stay with their own cluster rather than bloating this one.

## Verification

```
yarn test:client                                  # 44 files, 342 passed, 1 skipped
yarn workspace @accounter/client build            # typechecks + builds
yarn workspace @accounter/client storybook:build  # completes
yarn lint                                         # 0 errors
yarn prettier:check                               # clean
```

Worth clicking through before merge: open each filter dialog and confirm Escape and outside-click still dismiss it, and that the Depreciation dialog in the charges row menu doesn't trigger the row underneath.

**Mantine imports: 101 → 97, across 94 → 90 files.**

## Related

Follows #4403, #4404, #4405 and #4407. Independent of #4407 — both touch `*-filters.tsx` files but in different regions, so they merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR)_