### PR TITLE
ci: trigger server tests for every change the job actually tests

### DIFF
--- a/.changeset/@accounter_client-4409-dependencies.md
+++ b/.changeset/@accounter_client-4409-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Removed dependency [`@mantine/dates@6.0.22` ↗︎](https://www.npmjs.com/package/@mantine/dates/v/6.0.22) (from `dependencies`)

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -1,13 +1,31 @@
 name: Server Tests
 
 on:
+  # Allow running the suite on demand, e.g. against a branch whose PR the path
+  # filter below skipped, or to re-run after a flake without an empty commit.
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
     paths:
-      - 'packages/server/**'
-      - 'packages/migrations/**'
-      - 'packages/email-ingestion-gateway/**'
+      # Every workspace package, because this job runs the whole suite: its
+      # `yarn test:integration` covers the unit, client and integration projects, and
+      # it is currently the only workflow that runs vitest at all. Listing individual
+      # packages here reads as a scope this job does not actually have, and each
+      # omission fails silently — an unmatched PR skips the job instead of failing it.
+      - 'packages/**'
+      # Root files that decide what these tests are and how they run: dependency
+      # versions, the vitest projects/setup this job invokes, the codegen that
+      # produces the types under test, and the toolchain they run on.
+      - 'package.json'
+      - 'yarn.lock'
+      - 'vitest.config.ts'
+      - 'scripts/vitest-*.ts'
+      - 'codegen.ts'
+      - 'graphql.config.js'
+      - 'tsconfig.json'
+      - '.node-version'
+      - 'docker/pgconfig.json'
       - '.github/workflows/server-tests.yml'
 
 jobs:
@@ -111,7 +129,7 @@ jobs:
         run: yarn generate:sql
 
       - name: Run Server Tests (Integration)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
         env:
           POSTGRES_HOST: 127.0.0.1
           POSTGRES_PORT: 5432
@@ -136,7 +154,7 @@ jobs:
           ALLOW_DEMO_SEED: '1'
           DEBUG: ''
         run: |
-          yarn vitest run --project unit --project integration --project demo-seed --reporter=default --coverage
+          yarn vitest run --project unit --project client --project integration --project demo-seed --reporter=default --coverage
 
       - name: Upload Coverage
         if: always()

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -14,13 +14,17 @@ on:
       # packages here reads as a scope this job does not actually have, and each
       # omission fails silently — an unmatched PR skips the job instead of failing it.
       - 'packages/**'
+      # Every root script, because this job runs several of them directly: the vitest
+      # setup/globalSetup, the migration verification below, and its ESM loader. It also
+      # runs the guard test in scripts/__tests__, which must not be editable without CI
+      # exercising it.
+      - 'scripts/**'
       # Root files that decide what these tests are and how they run: dependency
-      # versions, the vitest projects/setup this job invokes, the codegen that
-      # produces the types under test, and the toolchain they run on.
+      # versions, the vitest projects this job invokes, the codegen that produces the
+      # types under test, and the toolchain they run on.
       - 'package.json'
       - 'yarn.lock'
       - 'vitest.config.ts'
-      - 'scripts/vitest-*.ts'
       - 'codegen.ts'
       - 'graphql.config.js'
       - 'tsconfig.json'

--- a/scripts/__tests__/server-tests-workflow.test.ts
+++ b/scripts/__tests__/server-tests-workflow.test.ts
@@ -20,9 +20,15 @@ function readPullRequestPaths(): string[] {
   const workflow = readFileSync(join(repoRoot, workflowPath), 'utf8');
 
   // The filter is the only `paths:` block in this workflow, and it ends where the
-  // top-level `jobs:` key begins.
-  const block = workflow.slice(workflow.indexOf('    paths:'), workflow.indexOf('\njobs:'));
-  expect(block, `no pull_request paths block found in ${workflowPath}`).not.toBe('');
+  // top-level `jobs:` key begins. Both offsets are checked: a missing marker returns -1
+  // from indexOf, and slice() would happily turn that into a plausible-looking but wrong
+  // block, letting these tests pass against something that is not the filter.
+  const start = workflow.indexOf('    paths:');
+  const end = workflow.indexOf('\njobs:');
+  expect(start, `no pull_request 'paths:' block found in ${workflowPath}`).toBeGreaterThan(-1);
+  expect(end, `no top-level 'jobs:' key found in ${workflowPath}`).toBeGreaterThan(start);
+
+  const block = workflow.slice(start, end);
 
   return [...block.matchAll(/^\s+- '(?<path>[^']+)'$/gm)].map(match => match.groups!['path']!);
 }

--- a/scripts/__tests__/server-tests-workflow.test.ts
+++ b/scripts/__tests__/server-tests-workflow.test.ts
@@ -1,0 +1,127 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The Server Tests workflow is filtered by `paths`, so a PR that touches none of them
+ * silently skips the job rather than failing it — an omission never shows up as a red
+ * check. That job is also the only workflow that runs vitest, so anything it does not
+ * trigger on is simply untested.
+ *
+ * These tests assert what the filter *matches*, not how it is written, so narrowing it
+ * to an enumerated list still has to cover everything the job tests.
+ */
+
+const repoRoot = join(import.meta.dirname, '../..');
+const workflowPath = '.github/workflows/server-tests.yml';
+
+/** The `paths:` entries of the workflow's `pull_request` trigger. */
+function readPullRequestPaths(): string[] {
+  const workflow = readFileSync(join(repoRoot, workflowPath), 'utf8');
+
+  // The filter is the only `paths:` block in this workflow, and it ends where the
+  // top-level `jobs:` key begins.
+  const block = workflow.slice(workflow.indexOf('    paths:'), workflow.indexOf('\njobs:'));
+  expect(block, `no pull_request paths block found in ${workflowPath}`).not.toBe('');
+
+  return [...block.matchAll(/^\s+- '(?<path>[^']+)'$/gm)].map(match => match.groups!['path']!);
+}
+
+/**
+ * GitHub's path-filter globbing: `**` crosses directory separators, `*` does not.
+ * Mirrored here so the tests below check the filter the way Actions evaluates it.
+ */
+function matches(pattern: string, filePath: string): boolean {
+  let source = '';
+  for (let i = 0; i < pattern.length; ) {
+    if (pattern.startsWith('**/', i)) {
+      source += '(?:.*/)?';
+      i += 3;
+    } else if (pattern.startsWith('**', i)) {
+      source += '.*';
+      i += 2;
+    } else if (pattern[i] === '*') {
+      source += '[^/]*';
+      i += 1;
+    } else {
+      source += pattern[i]!.replace(/[.*+?^${}()|[\]\\]/, String.raw`\$&`);
+      i += 1;
+    }
+  }
+  return new RegExp(`^${source}$`).test(filePath);
+}
+
+/** Workspace package name -> directory name under `packages/`. */
+function readWorkspacePackages(): Map<string, string> {
+  const packages = new Map<string, string>();
+  for (const dir of readdirSync(join(repoRoot, 'packages'), { withFileTypes: true })) {
+    if (!dir.isDirectory()) continue;
+    try {
+      const manifest = readFileSync(join(repoRoot, 'packages', dir.name, 'package.json'), 'utf8');
+      packages.set(JSON.parse(manifest).name, dir.name);
+    } catch {
+      // Not a workspace package (no manifest) — ignore.
+    }
+  }
+  return packages;
+}
+
+describe('server-tests workflow path filter', () => {
+  const paths = readPullRequestPaths();
+  const triggers = (filePath: string) => paths.some(pattern => matches(pattern, filePath));
+
+  const workspacePackages = readWorkspacePackages();
+  const serverManifest = JSON.parse(
+    readFileSync(join(repoRoot, 'packages/server/package.json'), 'utf8'),
+  );
+  const serverWorkspaceDeps = Object.keys(serverManifest.dependencies ?? {})
+    .filter(name => workspacePackages.has(name))
+    .map(name => workspacePackages.get(name)!);
+
+  it('finds the workflow and the server dependency graph', () => {
+    expect(paths.length).toBeGreaterThan(0);
+    // Guards against the parsing above silently returning nothing if the manifest moves.
+    expect(serverWorkspaceDeps.length).toBeGreaterThan(0);
+  });
+
+  it('covers every workspace package the server depends on', () => {
+    const uncovered = serverWorkspaceDeps.filter(dir => !triggers(`packages/${dir}/src/index.ts`));
+
+    expect(
+      uncovered,
+      `packages/server depends on these workspace packages, but a change to them would not ` +
+        `trigger ${workflowPath}. Add 'packages/<name>/**' to its pull_request paths:\n` +
+        uncovered.map(dir => `  - 'packages/${dir}/**'`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('covers every package whose tests this job runs', () => {
+    // `yarn test:integration` runs the unit, client and integration projects, which span
+    // the whole monorepo — so any package holding tests must be able to trigger the job.
+    const uncovered = [...workspacePackages.values()].filter(
+      dir => !triggers(`packages/${dir}/src/example.test.ts`),
+    );
+
+    expect(
+      uncovered,
+      `this job runs the tests in these packages, but a change to them would not trigger ` +
+        `${workflowPath}, so their tests would not run on such a PR:\n` +
+        uncovered.map(dir => `  - packages/${dir}`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('covers the root files that define the test run', () => {
+    // A dependency bump or a change to the vitest projects this job invokes must not
+    // skip it — that is exactly how a Vitest major landed without server tests running.
+    for (const file of ['package.json', 'yarn.lock', 'vitest.config.ts', workflowPath]) {
+      expect(triggers(file), `a change to ${file} would not trigger ${workflowPath}`).toBe(true);
+    }
+  });
+
+  it('does not trigger on documentation-only changes', () => {
+    // The filter should stay a filter: widening it to everything would make the guarantee
+    // above trivial and run the full suite on every README edit.
+    expect(triggers('README.md')).toBe(false);
+    expect(triggers('docs/architecture/authentication.md')).toBe(false);
+  });
+});

--- a/scripts/__tests__/server-tests-workflow.test.ts
+++ b/scripts/__tests__/server-tests-workflow.test.ts
@@ -124,6 +124,12 @@ describe('server-tests workflow path filter', () => {
     }
   });
 
+  it('covers its own guard test', () => {
+    // If a change to this file cannot trigger the job that runs it, the safety net can be
+    // weakened or deleted without CI ever exercising it.
+    expect(triggers('scripts/__tests__/server-tests-workflow.test.ts')).toBe(true);
+  });
+
   it('does not trigger on documentation-only changes', () => {
     // The filter should stay a filter: widening it to everything would make the guarantee
     // above trivial and run the full suite on every README edit.


### PR DESCRIPTION
Fixes a `paths` filter that had drifted far behind what the Server Tests job runs, so whole classes of change were skipping CI silently.

## Why this was invisible

A PR matching none of a workflow's `paths` entries **skips** the job rather than failing it. There is no red check, no annotation — the job simply never appears. Every omission in the filter is therefore silent by construction.

## What was falling through

**Root files that decide what the job runs.** The job's `yarn test:integration` is defined in `package.json` and resolved through `yarn.lock` and `vitest.config.ts`. None were listed. The Vitest 4 → 5 major (#4374) touched only those files plus four package manifests, and did not trigger this workflow at all.

**Client tests — 45 files that no workflow could trigger.** `test:integration` now covers the `unit`, `client` and `integration` projects, and `server-tests.yml` is currently the only workflow that runs vitest anywhere in the repo. With `packages/client/**` absent from the filter, a client-only PR ran **zero** tests.

**Scripts the job executes directly.** `scripts/register-esm.js` and `scripts/verify-migrations.ts` run in the final step; only `scripts/vitest-*.ts` was listed.

**Workspace packages the server depends on.** `green-invoice-graphql`, `pcn874-generator`, `shaam-uniform-format-generator` and `shaam6111-generator` are imported directly by `packages/server/src`, so any of them can break the server without touching `packages/server/**`.

## Changes

- **Filter matched to what the job runs**: `packages/**`, `scripts/**`, plus the root files the run depends on. Enumerating individual packages described a scope this job does not have — it runs the whole suite — and each omission failed silently.
- **`workflow_dispatch` added**, so the suite can be run on demand. Both test steps were gated on `pull_request` or `push`, so a manual run would have set up Postgres, migrations and codegen and then executed no tests; the integration step now accepts it too.
- **`--project client` added to the main-push step**, which ran `unit`, `integration` and `demo-seed` but not the client project added alongside those tests.
- **A guard test** (`scripts/__tests__/server-tests-workflow.test.ts`) pinning the filter to the dependency graph, so this cannot rot again. It asserts what the filter *matches* — mirroring GitHub's glob semantics — rather than how it is written, so narrowing it back to an explicit list is fine as long as the list still covers every package holding tests and the server's own dependencies. It also pins the filter to stay a filter: documentation-only changes must not run the suite.

## Verification

- Simulated GitHub's path matching against the Vitest 5 PR's real file list: the old filter matched **nothing**; the new one matches five of its files.
- Guard test verified to fail correctly — reverting to the old enumerated list reports `packages/client`, `packages/mcp-server` and the rest as uncovered.
- `yarn test`: 4088 passed, 6 skipped.
- The `test` job running on this PR is itself the fix working: under the old filter, a change to these files would not have triggered it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191S3xcoFQeasHywMBb5CnH