### PR TITLE
feat(client): replace Mantine display primitives with Tailwind

### DIFF
--- a/.changeset/mantine-display-primitives.md
+++ b/.changeset/mantine-display-primitives.md
@@ -1,0 +1,25 @@
+---
+'@accounter/client': patch
+---
+
+Replace Mantine's display primitives — `Text`, `Group`, `ThemeIcon`, `Mark`, `Progress` and the last
+`Loader` — with plain Tailwind and shadcn equivalents, clearing Mantine from six files.
+
+These have no state or behaviour, so each is a direct markup substitution rather than a component
+swap:
+
+- `Text` → `<div>` with `text-xs` / `text-sm`. Mantine v6's `Text` renders a `div`, not a `span`, so
+  the replacement keeps it block-level — using a `span` would have run the tag name and its path
+  together on one line in the tag cells.
+- `Group` → `flex items-center gap-4`.
+- `ThemeIcon radius="xl" size="xl"` → an `inline-flex size-11 … rounded-full` span. Mantine's `xl`
+  size is 44px, which is `size-11`.
+- `Mark` → the native `<mark>` element with an explicit `bg-green-200` / `bg-red-200`.
+- `Progress` → `ui/progress.tsx`. Mantine's version renders its own `label`; the shadcn one does
+  not, so the percentage is now a sibling `span`.
+
+Files cleared: `charges/cells/{tags,type}.tsx`, `charge-matches/cells/{tags,type}.tsx`,
+`business-ledger/business-ledger-single.tsx`, `charges-ledger-validation.tsx`. That makes
+`components/charge-matches` Mantine-free, so it joins the ESLint rule's `error` list.
+
+Mantine imports: 101 → 95, across 94 → 88 files.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -303,6 +303,7 @@ export default [
       'packages/client/src/components/business/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/businesses/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/charge-matching/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/charge-matches/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/clients/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/financial-accounts/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/landing/**/*.{,c,m}{j,t}s{,x}',

--- a/packages/client/src/components/business-ledger/business-ledger-single.tsx
+++ b/packages/client/src/components/business-ledger/business-ledger-single.tsx
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useState, type ReactElement, type ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from 'urql';
-import { Mark } from '@mantine/core';
 import {
   BusinessLedgerRecordsSummeryDocument,
   Currency,
@@ -84,7 +83,9 @@ export const BusinessLedgerRecordsSingle = ({ businessId }: Props): ReactElement
           title: 'Total',
           value: data =>
             data.total.raw && (data.total.raw < -0.0001 || data.total.raw > 0.0001) ? (
-              <Mark color={data.total.raw > 0 ? 'green' : 'red'}>{data.total.formatted}</Mark>
+              <mark className={data.total.raw > 0 ? 'bg-green-200' : 'bg-red-200'}>
+                {data.total.formatted}
+              </mark>
             ) : (
               data.total.formatted
             ),
@@ -132,9 +133,9 @@ function getCurrencyCells(currency: Currency): CellInfo[] {
         const currencyData = data.foreignCurrenciesSum.find(c => c.currency === currency);
         return currencyData?.total?.raw &&
           (currencyData.total.raw < -0.0001 || currencyData.total.raw > 0.0001) ? (
-          <Mark color={currencyData.total.raw > 0 ? 'green' : 'red'}>
+          <mark className={currencyData.total.raw > 0 ? 'bg-green-200' : 'bg-red-200'}>
             {currencyData.total.formatted}
-          </Mark>
+          </mark>
         ) : (
           currencyData?.total?.formatted
         );

--- a/packages/client/src/components/charge-matches/cells/tags.tsx
+++ b/packages/client/src/components/charge-matches/cells/tags.tsx
@@ -1,5 +1,4 @@
 import { type ReactElement } from 'react';
-import { Group, Text } from '@mantine/core';
 import { ListCapsule } from '../../common/index.js';
 
 type Props = {
@@ -14,16 +13,14 @@ export const Tags = ({ tags }: Props): ReactElement => {
   return (
     <ListCapsule
       items={tags.map(t => (
-        <Group key={t.id}>
+        <div key={t.id} className="flex items-center gap-4">
           <div>
             {t.namePath && (
-              <Text size="xs" opacity={0.65}>
-                {`${t.namePath.join(' > ')} >`}
-              </Text>
+              <div className="text-xs opacity-65">{`${t.namePath.join(' > ')} >`}</div>
             )}
-            <Text size="sm">{t.name}</Text>
+            <div className="text-sm">{t.name}</div>
           </div>
-        </Group>
+        </div>
       ))}
     />
   );

--- a/packages/client/src/components/charge-matches/cells/type.tsx
+++ b/packages/client/src/components/charge-matches/cells/type.tsx
@@ -1,5 +1,4 @@
 import { useMemo, type ReactElement } from 'react';
-import { ThemeIcon } from '@mantine/core';
 import { getChargeTypeIcon, getChargeTypeName, type ChargeType } from '../../../helpers/index.js';
 
 type Props = {
@@ -20,9 +19,9 @@ export const TypeCell = ({ type }: Props): ReactElement => {
   return (
     <>
       <div>{text}</div>
-      <ThemeIcon radius="xl" size="xl">
+      <span className="inline-flex size-11 items-center justify-center rounded-full bg-blue-500 text-white">
         {icon}
-      </ThemeIcon>
+      </span>
     </>
   );
 };

--- a/packages/client/src/components/charges-ledger-validation.tsx
+++ b/packages/client/src/components/charges-ledger-validation.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useContext, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { Check, Loader2, PanelTopClose, PanelTopOpen } from 'lucide-react';
 import { useQuery } from 'urql';
-import { Loader, Progress, ThemeIcon } from '@mantine/core';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { encodeFilters, ROUTES } from '@/router/routes.js';
 import { ChargesLedgerValidationDocument, type ChargeFilter } from '../gql/graphql.js';
@@ -12,6 +11,7 @@ import { ChargesTable } from './charges/charges-table.js';
 import { MergeChargesButton, Tooltip } from './common/index.js';
 import { PageLayout } from './layout/page-layout.js';
 import { Button } from './ui/button.js';
+import { Progress } from './ui/progress.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -109,13 +109,10 @@ export const ChargesLedgerValidation = (): ReactElement => {
   useEffect(() => {
     setFiltersContext(
       <div className="flex flex-row gap-x-5 items-center">
-        <Progress
-          value={progress}
-          label={`${progress?.toFixed(2)}%`}
-          size="xl"
-          animate={progress < 100}
-          className="min-w-52"
-        />
+        <div className="flex min-w-52 items-center gap-2">
+          <Progress value={progress} className="h-4 flex-1" />
+          <span className="text-xs tabular-nums">{`${progress?.toFixed(2)}%`}</span>
+        </div>
         <ChargesFilters
           filter={filter}
           setFilter={onFilterChange}
@@ -168,12 +165,12 @@ export const ChargesLedgerValidation = (): ReactElement => {
             isAllOpened={isAllOpened}
           />
           <div className="flex flex-row justify-center my-2">
-            {progress > 0 && progress < 100 && <Loader />}
+            {progress > 0 && progress < 100 && <Loader2 className="size-6 animate-spin" />}
             {progress === 100 &&
               !data?.chargesWithLedgerChanges.filter(res => !!res.charge).length && (
-                <ThemeIcon radius="xl" size="xl" color="green">
+                <span className="inline-flex size-11 items-center justify-center rounded-full bg-green-500 text-white">
                   <Check />
-                </ThemeIcon>
+                </span>
               )}
           </div>
         </>

--- a/packages/client/src/components/charges/cells/tags.tsx
+++ b/packages/client/src/components/charges/cells/tags.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useState, type ReactElement } from 'react';
-import { Group, Text } from '@mantine/core';
 import { useUpdateCharge } from '../../../hooks/use-update-charge.js';
 import { ConfirmMiniButton, ListCapsule, SimilarChargesByIdModal } from '../../common/index.js';
 import { Indicator } from '../../ui/indicator.js';
@@ -55,16 +54,14 @@ export const Tags = ({
       <Indicator inline size={12} disabled={!isMissing} color="red">
         <ListCapsule
           items={tags.map(t => (
-            <Group key={t.id}>
+            <div key={t.id} className="flex items-center gap-4">
               <div>
                 {t.namePath && (
-                  <Text size="xs" opacity={0.65}>
-                    {`${t.namePath.join(' > ')} >`}
-                  </Text>
+                  <div className="text-xs opacity-65">{`${t.namePath.join(' > ')} >`}</div>
                 )}
-                <Text size="sm">{t.name}</Text>
+                <div className="text-sm">{t.name}</div>
               </div>
-            </Group>
+            </div>
           ))}
           extraClassName={hasAlternative ? 'bg-yellow-400' : undefined}
         />

--- a/packages/client/src/components/charges/cells/type.tsx
+++ b/packages/client/src/components/charges/cells/type.tsx
@@ -1,5 +1,4 @@
 import { useMemo, type ReactElement } from 'react';
-import { ThemeIcon } from '@mantine/core';
 import { getChargeTypeIcon, getChargeTypeName, type ChargeType } from '../../../helpers/index.js';
 import { Tooltip } from '../../common/index.js';
 
@@ -20,9 +19,9 @@ export const TypeCell = ({ type }: Props): ReactElement => {
   );
   return (
     <Tooltip content={text}>
-      <ThemeIcon radius="xl" size="xl">
+      <span className="inline-flex size-11 items-center justify-center rounded-full bg-blue-500 text-white">
         {icon}
-      </ThemeIcon>
+      </span>
     </Tooltip>
   );
 };


### PR DESCRIPTION
Step 5 of the Mantine removal: the pure-markup primitives — `Text`, `Group`, `ThemeIcon`, `Mark`, `Progress` and the last bare `Loader`.

## What

These carry no state or behaviour, so every change is a markup substitution rather than a component swap:

| Mantine | Replacement | Note |
|---|---|---|
| `Text` | `<div>` + `text-xs` / `text-sm` | see below |
| `Group` | `flex items-center gap-4` | |
| `ThemeIcon radius="xl" size="xl"` | `inline-flex size-11 … rounded-full` span | Mantine's `xl` is 44px = `size-11` |
| `Mark` | native `<mark>` + explicit `bg-green-200` / `bg-red-200` | |
| `Progress` | `ui/progress.tsx` | |

**The `Text` substitution is the one with a trap.** Mantine v6's `Text` renders a **`div`**, not a `span` (v6 has a `span` boolean prop, which is the giveaway). Substituting a `span` would have made the tag name and its `namePath` run together on one line in both tag cells, instead of stacking. So the replacement is a `div`.

**`Progress` needed restructuring, not just a swap.** Mantine's renders its own `label` inside the bar; the shadcn one has no label concept. The percentage is now a sibling `span` next to the bar.

## Scope

Six files, all fully cleared of Mantine:

- `charges/cells/{tags,type}.tsx`
- `charge-matches/cells/{tags,type}.tsx`
- `business-ledger/business-ledger-single.tsx`
- `charges-ledger-validation.tsx`

That makes `components/charge-matches` Mantine-free, so it joins the ESLint rule's `error` list.

Deliberately left alone: `documents-gallery.tsx` (`Badge` sits next to `Carousel`, which is the long-tail cluster), `charges/extended-info/conversion-info.tsx` and `charge-errors.tsx` (`Card`/`Grid`/`List`/`Paper` belong with the reports-tables cluster), and `business-ledger/index.tsx` (its `Table` is that same cluster). Migrating just their display primitives would leave them equally Mantine-bound.

## Verification

```
yarn test:client                       # 44 files, 341 passed, 1 skipped
yarn workspace @accounter/client build # typechecks + builds
yarn lint                              # 0 errors
yarn prettier:check                    # clean
```

No new stories: these are leaf cells with no interactive behaviour, and they render inside tables that stories would have to reconstruct wholesale to show anything. Worth a glance in the app at the charges and charge-matches tables — specifically that tag paths still stack above tag names, and the charge-type icons keep their circle.

**Mantine imports: 101 → 95, across 94 → 88 files.**

## Related

Follows #4403, #4404, #4405, #4407, #4408. No overlap with the two open PRs — they touch `*-filters.tsx` and the modal wrapper, this touches cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR)_