### PR TITLE
feat(client): document wildcard email patterns in business configurations

### DIFF
--- a/.changeset/business-email-wildcard-hint.md
+++ b/.changeset/business-email-wildcard-hint.md
@@ -1,0 +1,18 @@
+---
+'@accounter/client': patch
+---
+
+Surface wildcard support in the business "Email Addresses" recognition field.
+
+Business recognition emails (`suggestion_data.emails`) already accept wildcard patterns such as
+`*@cloudflare.com`, for suppliers that send each invoice from a unique address — both the write-side
+schema and the email-ingestion issuer lookup support it — but nothing in the UI said so.
+
+An info icon next to the "Email Addresses" label now carries a tooltip explaining the `*` semantics,
+the concrete example, and the concrete-label requirement that rejects an over-broad pattern like
+`*@*.com`.
+
+The entry input also moves from `type="email"` to `type="text"`. A valid wildcard entry may carry `*`
+in the domain (e.g. `*@*.cloudflare.com`), which fails the browser's built-in email constraint
+validation — so while the input sat inside the form, it blocked saving the very patterns the tooltip
+now advertises.

--- a/packages/client/src/components/business/configurations-section.tsx
+++ b/packages/client/src/components/business/configurations-section.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useEffect, useState } from 'react';
-import { Plus, Save, X } from 'lucide-react';
+import { Info, Plus, Save, X } from 'lucide-react';
 import { useForm, type UseFormReturn } from 'react-hook-form';
 import { Badge } from '@/components/ui/badge.js';
 import { Button } from '@/components/ui/button.js';
@@ -30,6 +30,7 @@ import {
 } from '@/components/ui/select.js';
 import { Separator } from '@/components/ui/separator.js';
 import { Switch } from '@/components/ui/switch.js';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip.js';
 import {
   BusinessConfigurationSectionFragmentDoc,
   EmailAttachmentType,
@@ -711,11 +712,34 @@ function AutoMatchingConfigurationSubSection({ form }: SubSectionProps) {
         name="emails"
         render={({ field, fieldState }) => (
           <FormItem>
-            <FormLabel>Email Addresses</FormLabel>
+            <div className="flex items-center gap-1.5">
+              <FormLabel>Email Addresses</FormLabel>
+              {/* The tooltip hangs off an icon rather than the label: recognition
+                  entries accept wildcards, which is not discoverable otherwise. */}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button type="button" aria-label="About email addresses" className="flex">
+                    <Info className="size-3.5 text-muted-foreground" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-72">
+                  <p>
+                    An entry can be a plain address, or a wildcard pattern where <code>*</code>{' '}
+                    matches any run of characters — e.g. <code>*@cloudflare.com</code> matches every
+                    sender on that domain. Useful for suppliers that send each invoice from a
+                    different address. The domain must still contain a concrete label, so an
+                    over-broad pattern like <code>*@*.com</code> is rejected.
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
             <div className="flex gap-2">
               <Input
-                type="email"
-                placeholder="Add email..."
+                // Deliberately not type="email": a wildcard pattern such as
+                // `*@*.cloudflare.com` is a valid recognition entry but fails the
+                // browser's built-in email constraint validation.
+                type="text"
+                placeholder="Add email or wildcard pattern..."
                 value={newEmail}
                 onChange={e => setNewEmail(e.target.value)}
                 onKeyDown={e => {


### PR DESCRIPTION
## Problem

Business recognition emails (`suggestion_data.emails`) already accept **wildcard patterns** such as `*@cloudflare.com`, for suppliers that send each invoice from a unique address. Both ends support it:

- write side — `packages/server/src/modules/financial-entities/helpers/business-suggestion-data-schema.helper.ts#L7-L12`, where `recognitionEmail` accepts a plain address *or* `isValidWildcardEmailPattern`
- read side — `packages/server/src/modules/email-ingestion/providers/email-ingestion-control.provider.ts#L66-L82`, where the issuer lookup translates `*` to a `LIKE` wildcard

Nothing in the UI mentions this, so the feature is effectively undiscoverable.

## Changes

**1. Info icon + tooltip** next to the "Email Addresses" label in the Auto-matching Configuration sub-section of `configurations-section.tsx`. The copy covers exactly what the server enforces, per `email-pattern.helper.ts`:

- an entry is a plain address, or a wildcard pattern where `*` matches any run of characters
- `*@cloudflare.com` as the worked example, with the "unique address per invoice" rationale
- the domain must still contain a concrete label, so an over-broad pattern like `*@*.com` is rejected

It follows the existing idiom from `charges-filters/sections/completeness-section.tsx` — the tooltip hangs off an icon in a `type="button"` wrapper with an `aria-label`, rather than wrapping the label itself.

**2. `type="email"` → `type="text"`** on the entry input.

This wasn't part of the original ask, so flagging it explicitly. `isValidWildcardEmailPattern` accepts `*` in the domain — `*@*.cloudflare.com` is valid, since the rule only requires *some* concrete label before the TLD. But `*` in the domain fails the browser's built-in email constraint validation, and the input sits inside the `<form>`, so it would have blocked Save on exactly the patterns the new tooltip advertises. The placeholder is updated to match.

## Verification

Run against this branch's base (`main`), after a fresh `yarn install`:

- `yarn generate` — clean
- `tsc --noEmit` (client) — no errors
- `yarn eslint <file>` — 0 errors; one pre-existing `react-hooks/incompatible-library` warning at line 272 (`form.watch`), untouched by this change
- `yarn prettier --check` — passes
- `yarn test:client` — 45 files, 346 passed / 1 skipped

## Not included

There's still no client-side validation before an entry is added to the badge list, so an invalid pattern fails server-side on save rather than at the input. Mirroring `isValidWildcardEmailPattern` into the client would close that gap, but it's a behavior change beyond documenting the feature — happy to add it in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEMgHaKYvWtzkzhMdgf1CM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEMgHaKYvWtzkzhMdgf1CM)_