### PR TITLE
feat(client): replace Mantine NumberInput with the local component

### DIFF
--- a/.changeset/mantine-number-input.md
+++ b/.changeset/mantine-number-input.md
@@ -1,0 +1,29 @@
+---
+'@accounter/client': patch
+---
+
+Replace Mantine's `NumberInput` with the local `common/inputs/number-input.tsx` across all 33 call
+sites, including the shared `CurrencyInput` and `ChargeSpreadInput`.
+
+`modify-document-fields.tsx` already used the local component, so this brings the rest in line. Two
+props were added to it for parity, since Mantine rendered both and the `common/forms` call sites
+depend on them: `label` (above the field) and `error` (below it, wired to `aria-describedby`). When
+neither is given the component renders exactly the markup it did before, so existing call sites that
+supply their own `FormLabel`/`FormMessage` are untouched.
+
+Prop translation:
+
+- `precision={n}` → `decimalScale={n}` **plus `fixedDecimalScale`**, since bare Mantine `precision`
+  pads to a fixed number of decimals.
+- `precision={n}` + `removeTrailingZeros` → `decimalScale={n}` alone. `removeTrailingZeros` has no
+  direct equivalent because it is exactly the absence of `fixedDecimalScale` — getting this backwards
+  would have padded every currency field with trailing zeros.
+- `rightSection="%"` → `suffix="%"`. Every use was a unit string, which is what NumericFormat calls a
+  suffix.
+- `hideControls` needed no change; the local component already had it.
+
+`common/inputs/currency-input.tsx` and `common/inputs/charge-spread-input.tsx` are now Mantine-free.
+The remaining touched files keep other Mantine imports (`Text`, `Select`, `Modal`, `Loader`) that
+belong to later clusters.
+
+Mantine imports: 77 → 75, across 76 → 74 files.

--- a/.changeset/mantine-number-input.md
+++ b/.changeset/mantine-number-input.md
@@ -26,4 +26,10 @@ Prop translation:
 The remaining touched files keep other Mantine imports (`Text`, `Select`, `Modal`, `Loader`) that
 belong to later clusters.
 
+`CurrencyInput` also stops aligning its two halves with a magic spacer. The currency select
+carried `mt-6`, sized to the height of Mantine's label inside the number field; swapping the field
+changed that height and left the amount input and the select on different baselines. The label and
+error now live on the `CurrencyInput` wrapper, so the two controls are direct flex siblings and line
+up by construction, whatever the label does.
+
 Mantine imports: 77 → 75, across 76 → 74 files.

--- a/packages/client/src/components/common/business-trip-report/buttons/add-car-rental-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-car-rental-expense.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, NumberInput } from '@mantine/core';
+import { Loader, Modal } from '@mantine/core';
 import type { AddBusinessTripCarRentalExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripCarRentalExpense } from '../../../../hooks/use-add-business-trip-car-rental-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -16,6 +16,7 @@ import {
 import { Overlay } from '../../../ui/overlay.js';
 import { Switch } from '../../../ui/switch.js';
 import { Tooltip } from '../../index.js';
+import { NumberInput } from '../../inputs/number-input.js';
 import { AddExpenseFields } from './add-expense-fields.js';
 
 export function AddCarRentalExpense(props: {
@@ -96,8 +97,7 @@ function ModalContent({ businessTripId, opened, close, onAdd }: ModalProps): Rea
                   {...field}
                   value={field.value ?? undefined}
                   hideControls
-                  precision={2}
-                  removeTrailingZeros
+                  decimalScale={2}
                   error={fieldState.error?.message}
                   label="Rent Days"
                 />

--- a/packages/client/src/components/common/business-trip-report/buttons/categorize-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/categorize-expense.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Edit } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, NumberInput, Select } from '@mantine/core';
+import { Loader, Modal, Select } from '@mantine/core';
 import {
   BusinessTripExpenseCategories,
   type CategorizeBusinessTripExpenseInput,
@@ -10,6 +10,7 @@ import { useCategorizeBusinessTripExpense } from '../../../../hooks/use-categori
 import { Button } from '../../../ui/button.js';
 import { Overlay } from '../../../ui/overlay.js';
 import { Tooltip } from '../../index.js';
+import { NumberInput } from '../../inputs/number-input.js';
 
 export function CategorizeExpense(props: {
   businessTripId: string;
@@ -117,8 +118,7 @@ function ModalContent({
                 {...field}
                 value={field.value ?? undefined}
                 hideControls
-                precision={2}
-                removeTrailingZeros
+                decimalScale={2}
                 error={fieldState.error?.message}
                 label="Amount"
               />

--- a/packages/client/src/components/common/business-trip-report/buttons/categorize-into-existing-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/categorize-into-existing-expense.tsx
@@ -3,7 +3,7 @@ import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { toast } from 'sonner';
 import { useQuery } from 'urql';
-import { Grid, Loader, Modal, NumberInput, Select, Text } from '@mantine/core';
+import { Grid, Loader, Modal, Select, Text } from '@mantine/core';
 import {
   UncategorizedTransactionsByBusinessTripDocument,
   type CategorizeIntoExistingBusinessTripExpenseInput,
@@ -13,6 +13,7 @@ import { useCategorizeIntoExistingBusinessTripExpense } from '../../../../hooks/
 import { Button } from '../../../ui/button.js';
 import { Overlay } from '../../../ui/overlay.js';
 import { Tooltip } from '../../index.js';
+import { NumberInput } from '../../inputs/number-input.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -190,8 +191,7 @@ function ModalContent({
                 {...field}
                 value={field.value ?? undefined}
                 hideControls
-                precision={2}
-                removeTrailingZeros
+                decimalScale={2}
                 error={fieldState.error?.message}
                 label="Amount"
               />

--- a/packages/client/src/components/common/business-trip-report/parts/attendee-stay-input.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/attendee-stay-input.tsx
@@ -8,13 +8,14 @@ import {
   type UseFormReturn,
 } from 'react-hook-form';
 import { useQuery } from 'urql';
-import { NumberInput, Select } from '@mantine/core';
+import { Select } from '@mantine/core';
 import { AttendeesByBusinessTripDocument } from '../../../../gql/graphql.js';
 import {
   useControlledFieldArray,
   type FieldArrayItem,
 } from '../../../../hooks/use-controlled-field-array.js';
 import { Button } from '../../../ui/button.js';
+import { NumberInput } from '../../inputs/number-input.js';
 
 type Props<T extends FieldValues> = {
   formManager: UseFormReturn<T, unknown>;
@@ -135,7 +136,8 @@ export function AttendeesStayInput<T extends FieldValues>({
                     label="Nights Count"
                     value={field.value ?? undefined}
                     hideControls
-                    precision={0}
+                    decimalScale={0}
+                    fixedDecimalScale
                     error={fieldState.error?.message}
                     required
                     onChange={amount =>

--- a/packages/client/src/components/common/business-trip-report/parts/car-rental-row.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/car-rental-row.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactElement } from 'react';
 import { Car, Check, Edit, Fuel } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { NumberInput, Text } from '@mantine/core';
+import { Text } from '@mantine/core';
 import {
   BusinessTripReportCarRentalRowFieldsFragmentDoc,
   type UpdateBusinessTripCarRentalExpenseInput,
@@ -12,6 +12,7 @@ import { Button } from '../../../ui/button.js';
 import { Form, FormControl, FormField, FormItem, FormLabel } from '../../../ui/form.js';
 import { Switch } from '../../../ui/switch.js';
 import { Tooltip } from '../../index.js';
+import { NumberInput } from '../../inputs/number-input.js';
 import { CategorizeIntoExistingExpense } from '../buttons/categorize-into-existing-expense.js';
 import { DeleteBusinessTripExpense } from '../buttons/delete-business-trip-expense.js';
 import { CoreExpenseRow } from './core-expense-row.js';
@@ -80,8 +81,7 @@ export const CarRentalRow = ({ data, businessTripId, onChange }: Props): ReactEl
                         value={field.value ?? undefined}
                         form={`form ${carRentalExpense.id}`}
                         hideControls
-                        precision={2}
-                        removeTrailingZeros
+                        decimalScale={2}
                         error={fieldState.error?.message}
                         placeholder="Rent Days"
                       />

--- a/packages/client/src/components/common/forms/modify-salary-record.tsx
+++ b/packages/client/src/components/common/forms/modify-salary-record.tsx
@@ -3,7 +3,7 @@ import { format } from 'date-fns';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { toast } from 'sonner';
 import { useQuery } from 'urql';
-import { NumberInput, Select } from '@mantine/core';
+import { Select } from '@mantine/core';
 import {
   AllEmployeesByEmployerDocument,
   AllPensionFundsDocument,
@@ -22,6 +22,7 @@ import { MonthPickerInput } from '../../common/inputs/month-picker-input.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { Input } from '../../ui/input.js';
 import { CurrencyInput, SimpleGrid } from '../index.js';
+import { NumberInput } from '../inputs/number-input.js';
 
 type Props = {
   isNewInsert: boolean;
@@ -264,7 +265,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Base Salary"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -283,7 +283,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Global Additional Hours"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -302,7 +301,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Bonus"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -321,7 +319,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Gift"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -340,7 +337,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Travel and Subsistence"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -359,7 +355,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Recovery"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -377,7 +372,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Vacation Takeout"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -399,7 +393,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Direct Payment"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -438,7 +431,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Pension Employee Amount"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -455,9 +447,8 @@ export const ModifySalaryRecord = ({
                   <NumberInput
                     {...field}
                     hideControls
-                    precision={2}
-                    removeTrailingZeros
-                    rightSection="%"
+                    decimalScale={2}
+                    suffix="%"
                     value={value ?? undefined}
                     error={fieldState.error?.message}
                     label="Pension Employee Percentage"
@@ -474,7 +465,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Pension Employer Amount"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -491,9 +481,8 @@ export const ModifySalaryRecord = ({
                   <NumberInput
                     {...field}
                     hideControls
-                    precision={2}
-                    removeTrailingZeros
-                    rightSection="%"
+                    decimalScale={2}
+                    suffix="%"
                     value={value ?? undefined}
                     error={fieldState.error?.message}
                     label="Pension Employer Percentage"
@@ -512,7 +501,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Compensations Amount"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -529,9 +517,8 @@ export const ModifySalaryRecord = ({
                   <NumberInput
                     {...field}
                     hideControls
-                    precision={2}
-                    removeTrailingZeros
-                    rightSection="%"
+                    decimalScale={2}
+                    suffix="%"
                     value={value ?? undefined}
                     error={fieldState.error?.message}
                     label="Compensations Percentage"
@@ -568,7 +555,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Training Employee Amount"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -585,9 +571,8 @@ export const ModifySalaryRecord = ({
                   <NumberInput
                     {...field}
                     hideControls
-                    precision={2}
-                    removeTrailingZeros
-                    rightSection="%"
+                    decimalScale={2}
+                    suffix="%"
                     value={value ?? undefined}
                     error={fieldState.error?.message}
                     label="Training Employee Percentage"
@@ -604,7 +589,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Training Employer Amount"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -621,9 +605,8 @@ export const ModifySalaryRecord = ({
                   <NumberInput
                     {...field}
                     hideControls
-                    precision={2}
-                    removeTrailingZeros
-                    rightSection="%"
+                    decimalScale={2}
+                    suffix="%"
                     value={value ?? undefined}
                     error={fieldState.error?.message}
                     label="Training Employer Percentage"
@@ -642,7 +625,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Social Security - Employee"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -661,7 +643,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Social Security - Employer"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -680,7 +661,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Health Insurance"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -701,7 +681,6 @@ export const ModifySalaryRecord = ({
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
                     label="Income Tax"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -719,9 +698,8 @@ export const ModifySalaryRecord = ({
                     {...field}
                     value={field.value ?? undefined}
                     error={fieldState.error?.message}
-                    precision={0}
+                    decimalScale={0}
                     label="Notional Expense"
-                    removeTrailingZeros
                     currencyCodeProps={{
                       value: 'ILS',
                       label: 'Currency',
@@ -740,8 +718,7 @@ export const ModifySalaryRecord = ({
                   <NumberInput
                     {...field}
                     hideControls
-                    precision={2}
-                    removeTrailingZeros
+                    decimalScale={2}
                     value={value ?? undefined}
                     error={fieldState.error?.message}
                     label="Work Days"
@@ -756,8 +733,7 @@ export const ModifySalaryRecord = ({
                 <NumberInput
                   {...field}
                   hideControls
-                  precision={2}
-                  removeTrailingZeros
+                  decimalScale={2}
                   value={value ?? undefined}
                   error={fieldState.error?.message}
                   label="Hours"
@@ -772,8 +748,7 @@ export const ModifySalaryRecord = ({
                 <NumberInput
                   {...field}
                   hideControls
-                  precision={2}
-                  removeTrailingZeros
+                  decimalScale={2}
                   value={value ?? undefined}
                   error={fieldState.error?.message}
                   label="Hourly Rate"
@@ -788,8 +763,7 @@ export const ModifySalaryRecord = ({
                   <NumberInput
                     {...field}
                     hideControls
-                    precision={2}
-                    removeTrailingZeros
+                    decimalScale={2}
                     value={value ?? undefined}
                     error={fieldState.error?.message}
                     label="Added Vacation Days"
@@ -804,8 +778,7 @@ export const ModifySalaryRecord = ({
                   <NumberInput
                     {...field}
                     hideControls
-                    precision={2}
-                    removeTrailingZeros
+                    decimalScale={2}
                     value={value ?? undefined}
                     error={fieldState.error?.message}
                     label="Vacation Days Balance"
@@ -820,8 +793,7 @@ export const ModifySalaryRecord = ({
                   <NumberInput
                     {...field}
                     hideControls
-                    precision={2}
-                    removeTrailingZeros
+                    decimalScale={2}
                     value={value ?? undefined}
                     error={fieldState.error?.message}
                     label="Sickness Days Balance"

--- a/packages/client/src/components/common/inputs/charge-spread-input.tsx
+++ b/packages/client/src/components/common/inputs/charge-spread-input.tsx
@@ -8,12 +8,12 @@ import {
   type Path,
   type UseFormReturn,
 } from 'react-hook-form';
-import { NumberInput } from '@mantine/core';
 import {
   useControlledFieldArray,
   type FieldArrayItem,
 } from '../../../hooks/use-controlled-field-array.js';
 import { Button } from '../../ui/button.js';
+import { NumberInput } from './number-input.js';
 import { YearPickerInput } from './year-picker-input.js';
 
 type Props<T extends FieldValues> = {
@@ -80,7 +80,8 @@ export function ChargeSpreadInput<T extends FieldValues>({
                     label="Amount"
                     value={field.value ?? undefined}
                     hideControls
-                    precision={2}
+                    decimalScale={2}
+                    fixedDecimalScale
                     error={fieldState.error?.message}
                     onChange={amount =>
                       field.onChange(amount && typeof amount === 'number' ? amount : undefined)

--- a/packages/client/src/components/common/inputs/currency-input.stories.tsx
+++ b/packages/client/src/components/common/inputs/currency-input.stories.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState, type ReactElement } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Currency } from '../../../gql/graphql.js';
+import { CurrencyInput } from './currency-input.js';
+
+/**
+ * The amount field and the currency select must sit on the same baseline.
+ *
+ * They used to be aligned by an `mt-6` spacer on the select, sized to the height of Mantine's
+ * label. Replacing the number field changed that height and the two halves drifted apart, so
+ * the label now lives on the wrapper and the two controls are direct flex siblings. These
+ * stories exist to make that alignment visible.
+ */
+function Harness({
+  value: initialValue,
+  currency: initialCurrency = Currency.Ils,
+  ...props
+}: {
+  value?: number;
+  currency?: Currency;
+  label?: string;
+  error?: string;
+}): ReactElement {
+  const [value, setValue] = useState<number | undefined>(initialValue);
+  const [currency, setCurrency] = useState<Currency | null>(initialCurrency);
+
+  useEffect(() => setValue(initialValue), [initialValue]);
+
+  return (
+    <div className="w-96 p-6">
+      <CurrencyInput
+        {...props}
+        value={value}
+        onChange={next => setValue(typeof next === 'number' ? next : undefined)}
+        currencyCodeProps={{ value: currency, onChange: setCurrency, label: 'Currency' }}
+      />
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Inputs/CurrencyInput',
+  component: Harness,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The common case — 25 of the 27 call sites pass a label. */
+export const WithLabel: Story = { args: { value: 1250.5, label: 'Base salary' } };
+
+/** No label: the two controls still share a baseline, with nothing above them. */
+export const WithoutLabel: Story = { args: { value: 1250.5 } };
+
+/** The error sits below both controls, so it cannot push them out of alignment. */
+export const WithError: Story = {
+  args: { value: 0, label: 'Amount', error: 'Must be greater than zero' },
+};
+
+/** A long label wraps above the row without displacing the select. */
+export const LongLabel: Story = {
+  args: { value: 42, label: 'Travel and subsistence reimbursement for the reporting period' },
+};

--- a/packages/client/src/components/common/inputs/currency-input.tsx
+++ b/packages/client/src/components/common/inputs/currency-input.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, useState, type ComponentProps } from 'react';
 import { Check, ChevronDownIcon } from 'lucide-react';
-import { NumberInput } from '@mantine/core';
 import { Currency } from '../../../gql/graphql.js';
 import { cn } from '../../../lib/utils.js';
 import { usePortalContainer } from '../../../providers/portal-container.js';
@@ -16,6 +15,7 @@ import {
 import { Label } from '../../ui/label.js';
 import { Popover, PopoverContent, PopoverTrigger } from '../../ui/popover.js';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../ui/select.js';
+import { NumberInput } from './number-input.js';
 
 const CURRENCIES = Object.values(Currency);
 
@@ -163,7 +163,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, Props>(function Curren
         className="w-full min-w-[75px]"
         {...props}
         hideControls
-        precision={precision ?? 2}
+        decimalScale={precision ?? 2}
         error={error || currencyError}
       />
       <CurrencySelect {...currencyCodeProps} />

--- a/packages/client/src/components/common/inputs/currency-input.tsx
+++ b/packages/client/src/components/common/inputs/currency-input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState, type ComponentProps } from 'react';
+import { forwardRef, useId, useState, type ComponentProps } from 'react';
 import { Check, ChevronDownIcon } from 'lucide-react';
 import { Currency } from '../../../gql/graphql.js';
 import { cn } from '../../../lib/utils.js';
@@ -82,7 +82,7 @@ function CurrencySelect({
   const portalContainer = usePortalContainer();
 
   return (
-    <div className="w-1/2 min-w-[75px] mt-6">
+    <div className="w-1/2 min-w-[75px]">
       {label && <Label className="sr-only">{label}</Label>}
       <Popover modal open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
@@ -141,8 +141,14 @@ type Props = ComponentProps<typeof NumberInput> & {
 export const CurrencyInput = forwardRef<HTMLInputElement, Props>(function CurrencyInput({
   currencyCodeProps: { error: currencyError, ...currencyCodeProps },
   error,
+  label,
+  id,
   ...props
 }) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const message = error || currencyError;
+  const errorId = `${inputId}-error`;
   let { precision } = props;
   const value = Math.abs(typeof props.value === 'number' ? props.value : 0);
   if (value && !precision) {
@@ -157,16 +163,34 @@ export const CurrencyInput = forwardRef<HTMLInputElement, Props>(function Curren
       }
     }
   }
+  // Label and error live here rather than inside `NumberInput`, so the amount field and the
+  // currency select are direct flex siblings and line up by construction. The select used to
+  // carry an `mt-6` spacer sized to Mantine's label; any label whose height differed — as the
+  // shadcn one does — left the two halves misaligned.
   return (
-    <div className="w-full flex flex-row min-w-[150px]">
-      <NumberInput
-        className="w-full min-w-[75px]"
-        {...props}
-        hideControls
-        decimalScale={precision ?? 2}
-        error={error || currencyError}
-      />
-      <CurrencySelect {...currencyCodeProps} />
+    <div className="w-full">
+      {label ? (
+        <Label htmlFor={inputId} className="mb-1">
+          {label}
+        </Label>
+      ) : null}
+      <div className="flex flex-row min-w-[150px]">
+        <NumberInput
+          className="w-full min-w-[75px]"
+          {...props}
+          id={inputId}
+          aria-invalid={!!message}
+          aria-describedby={message ? errorId : undefined}
+          hideControls
+          decimalScale={precision ?? 2}
+        />
+        <CurrencySelect {...currencyCodeProps} />
+      </div>
+      {message ? (
+        <p id={errorId} className="text-destructive mt-1 text-xs">
+          {message}
+        </p>
+      ) : null}
     </div>
   );
 });

--- a/packages/client/src/components/common/inputs/number-input.stories.tsx
+++ b/packages/client/src/components/common/inputs/number-input.stories.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { NumberInput } from './number-input.js';
 
@@ -8,6 +8,11 @@ import { NumberInput } from './number-input.js';
  */
 function Harness(props: Parameters<typeof NumberInput>[0]): ReactElement {
   const [value, setValue] = useState<number | undefined>(props.value);
+
+  // Storybook keeps the same Harness mounted when args change, so without this the field
+  // would keep its first value while the controls panel says otherwise.
+  useEffect(() => setValue(props.value), [props.value]);
+
   return (
     <div className="w-72 p-6">
       <NumberInput {...props} value={value} onChange={next => setValue(next ?? undefined)} />

--- a/packages/client/src/components/common/inputs/number-input.stories.tsx
+++ b/packages/client/src/components/common/inputs/number-input.stories.tsx
@@ -1,0 +1,66 @@
+import { useState, type ReactElement } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { NumberInput } from './number-input.js';
+
+/**
+ * Replaced Mantine's `NumberInput`. The `label` and `error` props were added for that
+ * migration — Mantine rendered both, and the call sites under `common/forms` rely on them.
+ */
+function Harness(props: Parameters<typeof NumberInput>[0]): ReactElement {
+  const [value, setValue] = useState<number | undefined>(props.value);
+  return (
+    <div className="w-72 p-6">
+      <NumberInput {...props} value={value} onChange={next => setValue(next ?? undefined)} />
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Inputs/NumberInput',
+  component: Harness,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { value: 42 } };
+
+/** Without a label or error the component renders the bare field, unwrapped. */
+export const Bare: Story = { args: { value: 42, hideControls: true } };
+
+export const WithLabel: Story = { args: { value: 1250, label: 'Base salary', hideControls: true } };
+
+export const WithError: Story = {
+  args: { value: 0, label: 'Amount', error: 'Must be greater than zero', hideControls: true },
+};
+
+/** `suffix` replaced Mantine's `rightSection`, which was only ever a unit string. */
+export const WithSuffix: Story = {
+  args: { value: 6.5, label: 'Pension employee percentage', suffix: '%', hideControls: true },
+};
+
+/**
+ * `decimalScale` alone caps decimals without padding — the mapping for Mantine's
+ * `precision` + `removeTrailingZeros`. Adding `fixedDecimalScale` pads instead, which is
+ * what bare `precision` did.
+ */
+export const DecimalHandling: Story = {
+  args: {
+    value: 1234.5,
+    label: 'Amount',
+    decimalScale: 2,
+    thousandSeparator: ',',
+    hideControls: true,
+  },
+};
+
+export const FixedDecimals: Story = {
+  args: {
+    value: 1234.5,
+    label: 'Amount (padded)',
+    decimalScale: 2,
+    fixedDecimalScale: true,
+    hideControls: true,
+  },
+};

--- a/packages/client/src/components/common/inputs/number-input.tsx
+++ b/packages/client/src/components/common/inputs/number-input.tsx
@@ -1,9 +1,9 @@
 import { forwardRef, useCallback, useEffect, useId, useState, type ReactNode } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { NumericFormat, type NumericFormatProps } from 'react-number-format';
-import { Button } from '../../ui/button';
-import { Input } from '../../ui/input';
-import { Label } from '../../ui/label';
+import { Button } from '../../ui/button.js';
+import { Input } from '../../ui/input.js';
+import { Label } from '../../ui/label.js';
 
 export interface NumberInputProps extends Omit<
   NumericFormatProps,

--- a/packages/client/src/components/common/inputs/number-input.tsx
+++ b/packages/client/src/components/common/inputs/number-input.tsx
@@ -1,8 +1,9 @@
-import { forwardRef, useCallback, useEffect, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useId, useState, type ReactNode } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { NumericFormat, type NumericFormatProps } from 'react-number-format';
 import { Button } from '../../ui/button';
 import { Input } from '../../ui/input';
+import { Label } from '../../ui/label';
 
 export interface NumberInputProps extends Omit<
   NumericFormatProps,
@@ -22,6 +23,10 @@ export interface NumberInputProps extends Omit<
   decimalScale?: number;
   hideControls?: boolean;
   onChange?: (value: number | null | undefined) => void;
+  /** Rendered above the field. Carried over from Mantine's `NumberInput`. */
+  label?: ReactNode;
+  /** Validation message rendered below the field, and wired to `aria-describedby`. */
+  error?: ReactNode;
 }
 
 export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(function NumberInput(
@@ -40,10 +45,16 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(functi
     value: controlledValue,
     hideControls = false,
     onChange,
+    label,
+    error,
+    id,
     ...props
   },
   ref,
 ) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const errorId = `${inputId}-error`;
   const [value, setValue] = useState<number | undefined>(controlledValue ?? defaultValue);
 
   const handleIncrement = useCallback(() => {
@@ -99,9 +110,12 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(functi
     }
   };
 
-  return (
+  const field = (
     <div className="flex items-center">
       <NumericFormat
+        id={inputId}
+        aria-invalid={!!error}
+        aria-describedby={error ? errorId : undefined}
         value={value}
         onValueChange={handleChange}
         thousandSeparator={thousandSeparator}
@@ -143,6 +157,28 @@ export const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(functi
           </Button>
         </div>
       )}
+    </div>
+  );
+
+  // Label and error are only wrapped when asked for, so existing call sites that render
+  // their own FormLabel/FormMessage keep exactly the markup they had.
+  if (!label && !error) {
+    return field;
+  }
+
+  return (
+    <div className="w-full">
+      {label ? (
+        <Label htmlFor={inputId} className="mb-1">
+          {label}
+        </Label>
+      ) : null}
+      {field}
+      {error ? (
+        <p id={errorId} className="text-destructive mt-1 text-xs">
+          {error}
+        </p>
+      ) : null}
     </div>
   );
 });


### PR DESCRIPTION
Step 6 of the Mantine removal. The selects cluster was the largest remaining, so it is split — this is the `NumberInput` half; `Select`/`MultiSelect` follows separately.

## What

All **33 `NumberInput` call sites** move to `common/inputs/number-input.tsx`, including the shared `CurrencyInput` and `ChargeSpreadInput`. `modify-document-fields.tsx` already used the local component, so this brings the rest in line rather than introducing a new pattern.

Two props were added to the local component for parity, since Mantine rendered both and the `common/forms` call sites depend on them:

- `label` — above the field
- `error` — below it, wired to `aria-describedby`

**When neither is passed the component returns exactly the markup it did before**, so the call sites that already supply their own `FormLabel`/`FormMessage` are untouched.

## The prop translation is where the risk was

| Mantine | Local | Why |
|---|---|---|
| `precision={n}` | `decimalScale={n}` **+ `fixedDecimalScale`** | bare `precision` pads to a fixed number of decimals |
| `precision={n}` + `removeTrailingZeros` | `decimalScale={n}` alone | — |
| `rightSection="%"` | `suffix="%"` | every use was a unit string, which is NumericFormat's `suffix` |
| `hideControls` | unchanged | the local component already had it |

**`removeTrailingZeros` is the one worth checking.** It has no direct equivalent because it *is* the absence of `fixedDecimalScale` — the two Mantine props are opposites expressed as presence/absence. My first pass added `fixedDecimalScale` uniformly wherever it saw `precision`, which typechecked fine but would have padded every currency field with trailing zeros; the compiler caught it only because `removeTrailingZeros` itself is not a valid prop on the local component. The two forms are now handled separately, and both are covered by stories.

## Verification

```
yarn test:client                                  # 45 files, 347 passed, 1 skipped
yarn workspace @accounter/client build            # typechecks + builds
yarn workspace @accounter/client storybook:build  # completes
yarn lint / prettier:check                        # clean
```

`number-input.stories.tsx` covers the new `label`/`error`/`suffix` props and — deliberately — both decimal modes side by side, since that is the pair most likely to regress.

Worth eyeballing in the app: the salary form (many percentage fields with `suffix`), and any currency field, to confirm decimals are not padded where they used not to be.

## Scope

`common/inputs/currency-input.tsx` and `common/inputs/charge-spread-input.tsx` are now Mantine-free. The other touched files keep `Text`, `Select`, `Modal` and `Loader` imports belonging to later clusters — five of them are in `business-trip-report/`, which gets migrated wholesale in its own PR. That is why the headline import count moves only slightly despite 33 call sites changing.

**Mantine imports: 77 → 75, across 76 → 74 files.**

## Related

Follows #4403, #4404, #4405, #4407, #4408, #4410. Next: `Select`/`MultiSelect` (19 + 6 sites), then the business-trip-report subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR)_