### PR TITLE
refactor(server): drop `tsc-alias`, resolve remaining path aliases natively

### DIFF
--- a/.changeset/drop-tsc-alias-from-server-build.md
+++ b/.changeset/drop-tsc-alias-from-server-build.md
@@ -1,0 +1,19 @@
+---
+'@accounter/server': patch
+---
+
+Resolve the server's remaining tsconfig path aliases natively and drop `tsc-alias`.
+
+`build` is now a single `tsc -p tsconfig.build.json` pass with no post-processing step. The four
+`@accounter/*` generator packages resolve through the workspace `node_modules` symlinks and their
+own `exports` instead of being co-compiled from source, so the server's tsc program no longer
+includes four already-built sibling packages.
+
+The emitted tree is now flat, mirroring `src`: the entry points move from
+`dist/server/src/index.js` and `dist/server/src/bootstrap-telemetry.js` to `dist/index.js` and
+`dist/bootstrap-telemetry.js`. Anything referencing the old layout (the package `main`, `start`,
+deploy or debug configuration) needs updating.
+
+`yarn workspace @accounter/server build` now requires the four generator packages to be built
+first. Every pipeline already orders this correctly; a hand-run build in a fresh clone needs
+`yarn build:tools` first.

--- a/.changeset/drop-tsc-alias-from-server-build.md
+++ b/.changeset/drop-tsc-alias-from-server-build.md
@@ -14,6 +14,10 @@ The emitted tree is now flat, mirroring `src`: the entry points move from
 `dist/bootstrap-telemetry.js`. Anything referencing the old layout (the package `main`, `start`,
 deploy or debug configuration) needs updating.
 
-`yarn workspace @accounter/server build` now requires the four generator packages to be built
-first. Every pipeline already orders this correctly; a hand-run build in a fresh clone needs
-`yarn build:tools` first.
+Both `yarn workspace @accounter/server build` and the new `yarn workspace @accounter/server
+typecheck` now require the four generator packages to be built first, since they share the same
+module resolution. Every pipeline already orders this correctly; a hand-run build or typecheck in a
+fresh clone needs `yarn build:tools` first.
+
+`yarn dev` now also watches the four generators' `dist` directories, so rebuilding a generator
+restarts the server without touching a server file.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node",
       "request": "launch",
       "name": "Launch Server",
-      "program": "${workspaceFolder}/packages/server/dist/server/src/index.js",
+      "program": "${workspaceFolder}/packages/server/dist/index.js",
       "console": "integratedTerminal",
       "runtimeArgs": []
     }

--- a/packages/server/CLAUDE.md
+++ b/packages/server/CLAUDE.md
@@ -62,8 +62,8 @@ Charge-mutating ops (documents, transactions, misc-expenses, ledger, charge upda
 
 ```bash
 yarn build:tools                           # Build the four workspace generators the server imports
-yarn workspace @accounter/server build     # Build server (plain tsc, needs build:tools first)
-yarn workspace @accounter/server typecheck # Typecheck src including tests
+yarn workspace @accounter/server build     # Build server (plain tsc; needs build:tools first)
+yarn workspace @accounter/server typecheck # Typecheck src incl. tests (also needs build:tools)
 yarn seed:admin-context                    # Seed admin context
 yarn generate                              # Regenerate types after schema changes
 ```

--- a/packages/server/CLAUDE.md
+++ b/packages/server/CLAUDE.md
@@ -61,7 +61,12 @@ Charge-mutating ops (documents, transactions, misc-expenses, ledger, charge upda
 ## Commands
 
 ```bash
-yarn workspace @accounter/server build # Build server
-yarn seed:admin-context                # Seed admin context
-yarn generate                          # Regenerate types after schema changes
+yarn build:tools                           # Build the four workspace generators the server imports
+yarn workspace @accounter/server build     # Build server (plain tsc, needs build:tools first)
+yarn workspace @accounter/server typecheck # Typecheck src including tests
+yarn seed:admin-context                    # Seed admin context
+yarn generate                              # Regenerate types after schema changes
 ```
+
+Build output is flat: `dist/index.js`, `dist/bootstrap-telemetry.js`. See
+[README - Building](./README.md#building) for why there are two tsconfigs.

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,5 +1,47 @@
 # @accounter-helper/server
 
+## Building
+
+```bash
+yarn workspace @accounter/server build
+```
+
+`build` is a single `tsc -p tsconfig.build.json` pass — there is no post-processing step. The
+emitted tree mirrors `src`, so the entry points are `dist/index.js` and
+`dist/bootstrap-telemetry.js`.
+
+Two tsconfigs, on purpose:
+
+| File                  | Used by                   | Program                                      |
+| --------------------- | ------------------------- | -------------------------------------------- |
+| `tsconfig.json`       | editors, `yarn typecheck` | all of `src`, tests included                 |
+| `tsconfig.build.json` | `yarn build`              | `src` minus tests, `rootDir` pinned to `src` |
+
+The build config exists because the test helpers under `src/__tests__` import
+`packages/migrations/src` directly. Any file outside `src` in the program pushes `rootDir` up to
+`packages/`, which is what used to bury the entry point at `dist/server/src/index.js`.
+
+### Build the workspace generators first
+
+The server imports four sibling packages by name:
+
+- `@accounter/green-invoice-graphql`
+- `@accounter/pcn874-generator`
+- `@accounter/shaam6111-generator`
+- `@accounter/shaam-uniform-format-generator`
+
+These resolve through the workspace `node_modules` symlinks and each package's own `exports`, so
+**their `dist` has to exist before the server compiles.** A bare server build against unbuilt
+generators fails with `TS2307: Cannot find module '@accounter/...'`.
+
+Every pipeline already orders this correctly — root `yarn build` runs `build:tools` before
+`build:main`, and `yarn workspace @accounter/server server:build:prod` builds the four explicitly.
+Only a hand-run `yarn workspace @accounter/server build` in a fresh clone needs care:
+
+```bash
+yarn build:tools && yarn workspace @accounter/server build
+```
+
 ## Super-Admin & Client Onboarding
 
 Super-admins are platform operators identified by their Auth0 user ID in the `super_admins` DB

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -30,17 +30,44 @@ The server imports four sibling packages by name:
 - `@accounter/shaam6111-generator`
 - `@accounter/shaam-uniform-format-generator`
 
-These resolve through the workspace `node_modules` symlinks and each package's own `exports`, so
-**their `dist` has to exist before the server compiles.** A bare server build against unbuilt
-generators fails with `TS2307: Cannot find module '@accounter/...'`.
+These resolve through the workspace `node_modules` symlinks and each package's own `exports`, whose
+`types` and `import` conditions both point into `dist`. So **their `dist` has to exist before the
+server type-resolves at all** — this applies equally to `yarn build` and `yarn typecheck`, since
+both read the same module resolution. Either one, run against unbuilt generators, fails with
+`TS2307: Cannot find module '@accounter/...'` (plus knock-on `TS7006`s wherever an inferred type
+came from a generator).
 
 Every pipeline already orders this correctly — root `yarn build` runs `build:tools` before
 `build:main`, and `yarn workspace @accounter/server server:build:prod` builds the four explicitly.
-Only a hand-run `yarn workspace @accounter/server build` in a fresh clone needs care:
+Only hand-run commands in a fresh clone need care:
 
 ```bash
-yarn build:tools && yarn workspace @accounter/server build
+yarn build:tools # once, before either of the next two
+yarn workspace @accounter/server build
+yarn workspace @accounter/server typecheck
 ```
+
+### The dev loop and the generators
+
+`yarn dev` watches the server's own `src` **and** the four generators' `dist` directories, so the
+loop differs depending on what you edit:
+
+| You edit                 | What happens                                                            |
+| ------------------------ | ----------------------------------------------------------------------- |
+| `packages/server/src/**` | nodemon rebuilds and restarts the server                                |
+| a generator's `src/**`   | nothing — until you build that generator, which then triggers the above |
+
+```bash
+yarn workspace @accounter/pcn874-generator build # server rebuilds and restarts on its own
+```
+
+There is no watch on the generators' _source_: `bob build` has no watch mode, and rebuilding all
+four on every server-source save would cost more than it saves. Watching their build output instead
+means one explicit generator build is all it takes.
+
+Note that nodemon's `--ignore` patterns are **not** anchored to the package directory — an
+`--ignore 'dist/**'` here would also silently swallow `../<generator>/dist/**` and break these
+watches. The server's own `dist` needs no ignore rule, as it is not under any `--watch` path.
 
 ## Super-Admin & Client Onboarding
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,9 +14,9 @@
   },
   "author": "Gil Gardosh <gilgardosh@gmail.com>",
   "license": "MIT",
-  "main": "dist/server/src/index.js",
+  "main": "dist/index.js",
   "scripts": {
-    "build": "tsc && tsc-alias",
+    "build": "tsc -p tsconfig.build.json",
     "cleanup:expired-invitations": "tsx src/scripts/run-invitation-cleanup.ts",
     "dev": "nodemon --exec \"yarn build && yarn start | pino-pretty\" --ignore dist --watch 'src/**/*' -e ts,tsx,mts",
     "generate": "yarn generate:all",
@@ -30,7 +30,8 @@
     "server:build": "yarn build",
     "server:build:prod": "yarn generate && yarn workspaces foreach --all --parallel --include @accounter/green-invoice-graphql --include @accounter/pcn874-generator --include @accounter/shaam-uniform-format-generator --include @accounter/shaam6111-generator run build && yarn build",
     "server:dev": "yarn dev",
-    "start": "node --import ./dist/server/src/bootstrap-telemetry.js dist/server/src/index.js",
+    "start": "node --import ./dist/bootstrap-telemetry.js dist/index.js",
+    "typecheck": "tsc --noEmit",
     "validate:demo": "tsx src/demo-fixtures/validate-demo-data.ts"
   },
   "dependencies": {
@@ -93,7 +94,6 @@
     "pino-pretty": "13.1.3",
     "rimraf": "6.1.3",
     "slonik": "49.10.9",
-    "tsc-alias": "1.9.0",
     "tsx": "4.23.13",
     "typescript": "6.0.3"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "cleanup:expired-invitations": "tsx src/scripts/run-invitation-cleanup.ts",
-    "dev": "nodemon --exec \"yarn build && yarn start | pino-pretty\" --ignore dist --watch 'src/**/*' -e ts,tsx,mts",
+    "dev": "nodemon --exec \"yarn build && yarn start | pino-pretty\" --watch 'src/**/*' --watch '../green-invoice-graphql/dist/**' --watch '../pcn874-generator/dist/**' --watch '../shaam6111-generator/dist/**' --watch '../shaam-uniform-format-generator/dist/**' --delay 1 -e ts,tsx,mts,js",
     "generate": "yarn generate:all",
     "generate:sql": "dotenv -e ../../.env yarn pgtyped",
     "generate:sql:watch": "dotenv -e ../../.env yarn pgtyped:watch",

--- a/packages/server/src/modules/charges-matcher/__tests__/single-match-integration.test.ts
+++ b/packages/server/src/modules/charges-matcher/__tests__/single-match-integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Mock merge-charges helper before importing providers that use it
-vi.mock('@modules/charges/helpers/merge-charges.helper.js', () => ({
+vi.mock('../../charges/helpers/merge-charges.helper.js', () => ({
   mergeChargesExecutor: vi.fn(),
 }));
 

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -1,0 +1,26 @@
+{
+  // Emit configuration: `yarn build` is `tsc -p tsconfig.build.json`.
+  //
+  // Split out from `tsconfig.json` so the emitted program is server-only. The test helpers
+  // under `src/__tests__` import `packages/migrations/src` directly, and any such file in the
+  // program forces `rootDir` back up to `packages/` — which is what used to bury the entry
+  // point at `dist/server/src/index.js`.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    // Pinned rather than inferred, so a future import that escapes `src` fails loudly with
+    // TS6059 instead of silently re-nesting the whole of `dist`.
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": [
+    "**/__generated__",
+    "**/dist/**",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/test-utils/**",
+    "src/demo-fixtures/**"
+  ]
+}

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,26 +1,26 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist",
+    // Type-checking program only — `tsconfig.build.json` is what emits.
+    "noEmit": true,
+    // This program deliberately covers the tests too, and the helpers under `src/__tests__`
+    // import `packages/migrations/src` directly, so the root has to span `packages/`. tsc
+    // validates `rootDir` even under `noEmit`, so it cannot be narrowed here; the build
+    // config excludes the tests instead and pins `rootDir` to `src`.
     "rootDir": "..",
     "noUnusedLocals": false,
 
     "paths": {
-      "@accounter/green-invoice-graphql": ["../green-invoice-graphql/src/index.js"],
-      "@accounter/pcn874-generator": ["../pcn874-generator/src/index.js"],
-      "@accounter/shaam6111-generator": ["../shaam6111-generator/src/index.js"],
-      "@accounter/shaam-uniform-format-generator": [
-        "../shaam-uniform-format-generator/src/index.js"
-      ],
+      // `graphql-modules` declares no `types` condition in its `exports` map and ships no
+      // `index.d.mts` beside its ESM entry, so `moduleResolution: bundler` finds no
+      // declarations for it. This points the specifier straight at `index.d.ts`.
+      //
+      // It is a type-resolution alias only: tsc emits the bare `graphql-modules` specifier
+      // verbatim (verified against the compiled output), and Node resolves that through the
+      // package's own `exports`. Nothing has to rewrite it after emit.
       "graphql-modules": ["../../node_modules/graphql-modules/index"]
     }
   },
-  "include": [
-    "src",
-    "../green-invoice-graphql/src",
-    "../pcn874-generator/src",
-    "../shaam6111-generator/src",
-    "../shaam-uniform-format-generator/src"
-  ],
+  "include": ["src"],
   "exclude": ["**/__generated__", "**/dist/**"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,7 +424,6 @@ __metadata:
     rimraf: "npm:6.1.3"
     slonik: "npm:49.10.9"
     strip-indent: "npm:4.1.1"
-    tsc-alias: "npm:1.9.0"
     tsx: "npm:4.23.13"
     typescript: "npm:6.0.3"
     zod: "npm:4.5.4"
@@ -12921,7 +12920,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.5.2, chokidar@npm:^3.5.3":
+"chokidar@npm:^3.5.2":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -13284,13 +13283,6 @@ __metadata:
   version: 5.1.0
   resolution: "commander@npm:5.1.0"
   checksum: 10c0/da9d71dbe4ce039faf1fe9eac3771dca8c11d66963341f62602f7b66e36d2a3f8883407af4f9a37b1db1a55c59c0c1325f186425764c2e963dc1d67aec2a4b6d
-  languageName: node
-  linkType: hard
-
-"commander@npm:^9.0.0":
-  version: 9.5.0
-  resolution: "commander@npm:9.5.0"
-  checksum: 10c0/5f7784fbda2aaec39e89eb46f06a999e00224b3763dc65976e05929ec486e174fe9aac2655f03ba6a5e83875bd173be5283dc19309b7c65954701c02025b3c1d
   languageName: node
   linkType: hard
 
@@ -16814,7 +16806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.3, globby@npm:^11.0.4, globby@npm:^11.1.0":
+"globby@npm:^11.0.3, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -20578,13 +20570,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mylas@npm:^2.1.9":
-  version: 2.1.14
-  resolution: "mylas@npm:2.1.14"
-  checksum: 10c0/2f30cee712c497a8f5c2a7218b6644efd67babf9fa7f8442f8536e2c95e4fded44b7117aea61cb1616c8ce0cdcfd9de329d6fa16d81818141267942b4eadb711
-  languageName: node
-  linkType: hard
-
 "mz@npm:^2.7.0":
   version: 2.7.0
   resolution: "mz@npm:2.7.0"
@@ -22172,15 +22157,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"plimit-lit@npm:^1.2.6":
-  version: 1.6.1
-  resolution: "plimit-lit@npm:1.6.1"
-  dependencies:
-    queue-lit: "npm:^1.5.1"
-  checksum: 10c0/af5d351bb55afe1eaa84b27c2b329699e150e4cf70464f3d474f5eabe9bdb9f48ed378ada1498d3b893f68ee7da2423ba6d9a4d88b1429d3b0aea22afcf5292b
-  languageName: node
-  linkType: hard
-
 "pluralize@npm:^8.0.0":
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
@@ -22712,13 +22688,6 @@ __metadata:
   version: 0.2.1
   resolution: "querystring-es3@npm:0.2.1"
   checksum: 10c0/476938c1adb45c141f024fccd2ffd919a3746e79ed444d00e670aad68532977b793889648980e7ca7ff5ffc7bfece623118d0fbadcaf217495eeb7059ae51580
-  languageName: node
-  linkType: hard
-
-"queue-lit@npm:^1.5.1":
-  version: 1.5.2
-  resolution: "queue-lit@npm:1.5.2"
-  checksum: 10c0/8aa838b2c939aeaa6cd272b5b6b172379a3fa1d9193b2a3e687643c68c0efee3cd3493af4f1f8a11ff79b8207e4d00cc5d0b072f6e4bbeaaa27ee01f567ec4ac
   languageName: node
   linkType: hard
 
@@ -25811,23 +25780,6 @@ __metadata:
   dependencies:
     mongodb-uri: "npm:^0.9.7"
   checksum: 10c0/dbbb5968c43f66283de89d030eec6d7fbd058f284486795a3e04f56bd203aa34313b3615bfc3eb0b9fbee12d02771300d9f9e0e7f9e10801288e896fabe8d938
-  languageName: node
-  linkType: hard
-
-"tsc-alias@npm:1.9.0":
-  version: 1.9.0
-  resolution: "tsc-alias@npm:1.9.0"
-  dependencies:
-    chokidar: "npm:^3.5.3"
-    commander: "npm:^9.0.0"
-    get-tsconfig: "npm:^4.10.0"
-    globby: "npm:^11.0.4"
-    mylas: "npm:^2.1.9"
-    normalize-path: "npm:^3.0.0"
-    plimit-lit: "npm:^1.2.6"
-  bin:
-    tsc-alias: dist/bin/index.js
-  checksum: 10c0/229ef236f4ccd3145cbb7a003b805e5c1de7ecfb563ffe88ecccb7c0c596fb4d2baf06706b8ee0b66017141beb3e8505a1e6b5e5b1c8cd7a87a640cf13b40e41
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #4415.

`packages/server` was the last workspace that needed a post-processing pass over its emitted JavaScript. `build` is now a single `tsc` invocation and `tsc-alias` is gone from the repo.

## What changed

**1. The four `@accounter/*` aliases are gone (#4415 step 1)**

Removed from `paths`, and the four sibling source trees removed from `include`. All 15 import sites are untouched — they resolve through the workspace `node_modules` symlinks and each package's own `exports`. The server's tsc program no longer contains four packages that every pipeline had already built.

**2. `dist` is flat (#4415 step 2)**

Entry points move:

| | before | after |
| --- | --- | --- |
| `main` | `dist/server/src/index.js` | `dist/index.js` |
| `start` | `node --import ./dist/server/src/bootstrap-telemetry.js dist/server/src/index.js` | `node --import ./dist/bootstrap-telemetry.js dist/index.js` |
| `.vscode/launch.json` | `packages/server/dist/server/src/index.js` | `packages/server/dist/index.js` |

There are no Docker or deploy files pinned to the old layout — `main`, `start` and the launch config were the only references in the repo.

This needed one thing the issue didn't anticipate: **removing the sibling trees from `include` is not enough to make the program server-only.** The test helpers under `src/__tests__` import `packages/migrations/src` directly (3 files), which keeps a sibling package in the program and pushes `rootDir` back up to `packages/` — the exact mechanism that buried the entry point in the first place.

So emit is split into `tsconfig.build.json` (`rootDir: "src"`, tests excluded), while `tsconfig.json` stays the typecheck/editor program and keeps the tests. A new `typecheck` script (`tsc --noEmit`, matching the convention in seven other workspaces) preserves type coverage of the tests, which a plain `exclude` would have silently dropped — vitest doesn't typecheck. `rootDir` is pinned rather than inferred in the build config, so a future import escaping `src` fails loudly with TS6059 instead of quietly re-nesting `dist`.

**3. `graphql-modules` resolved — and it stays (#4415 step 3)**

It is **not** a dedupe hack. `graphql-modules` declares no `types` condition in its `exports` map and ships no `index.d.mts` beside its ESM entry, so `moduleResolution: bundler` finds no declarations for it; the alias points the specifier straight at `index.d.ts`. Only one copy is ever installed, so a yarn `resolutions` entry would not address this.

It also meets the issue's "must not require rewriting" bar: tsc emits the bare `graphql-modules` specifier verbatim, which Node resolves through the package's own `exports`. Verified against the compiled output both before and after this change. The entry is now commented with all of the above.

**4. `tsc-alias` deleted (#4415 step 4)** — devDependency and lockfile entries removed. Last consumer in the repo.

**5. The nearby stale mock**

`single-match-integration.test.ts:4` called `vi.mock('@modules/charges/helpers/merge-charges.helper.js', …)`. `@modules/*` is defined nowhere, and `vite-tsconfig-paths` is what feeds vitest its aliases — so the mock applied to nothing. Switched to the relative specifier its sibling `auto-match-integration.test.ts` already uses; all 10 tests in the file still pass with the mock now actually in effect.

## Prerequisite: build the generators first

Both `build` and `typecheck` share module resolution, and the four generators' `exports` point `types` and `import` into `dist` — so **either command run against unbuilt generators fails** with `TS2307`, plus knock-on `TS7006`s where an inferred type came from a generator. Verified by hiding one generator's `dist`.

Every pipeline already orders this correctly (`build:tools` → `build:main`, and `server:build:prod`). Only a hand-run command in a fresh clone needs `yarn build:tools` first; documented in `packages/server/README.md` → Building and in `CLAUDE.md`.

The issue offered documenting *or* enforcing via `prebuild`. I documented it: a `prebuild` would rebuild all four generators on every server build, including inside the root pipeline that just built them — spending roughly the build time this PR saves. Happy to add one if you'd rather have the guardrail.

## Dev loop

Extending resolution to `dist` changes the dev loop for generator edits, so `dev` now watches the four generators' `dist` directories too:

| You edit | Before this PR | After |
| --- | --- | --- |
| `packages/server/src/**` | nodemon rebuilds + restarts | unchanged |
| a generator's `src/**` | no reload; next server rebuild compiled it from source | no reload; `yarn workspace @accounter/<gen> build` then restarts the server on its own |

Note nodemon's `--ignore` patterns are **not** anchored to the package directory: the old `--ignore dist` also matched `../<generator>/dist/**` and silently killed the new watches. It was a no-op for the server's own output (never under a `--watch` path), so it's dropped. Verified: one start with no self-triggered rebuild loop, and a generator build produces exactly one restart with the server serving afterwards.

## Verification

Ran against a local Postgres with migrations and codegen applied:

- `yarn build` (full root pipeline) — passes
- `yarn workspace @accounter/server typecheck` — clean
- `dist` layout — flat, no sibling or `migrations` trees; `@accounter/*` and `graphql-modules` emitted as bare package specifiers
- source maps — `dist/index.js.map` → `../src/index.ts`, nested maps resolve too
- built server boots via `yarn start` and answers GraphQL on `/graphql`
- `vitest run --project unit --project integration` — 4256 passed, 7 skipped
- `yarn dev` — no rebuild loop; generator build triggers exactly one restart
- `yarn lint` — 0 errors; `yarn prettier:check` clean

Server build: **23.8s → 17.4s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WeDxgZoSNFDNHi5GbY7KQ