### PR TITLE
perf(build): enable TypeScript incremental builds across the monorepo

### DIFF
--- a/.changeset/typescript-incremental-builds.md
+++ b/.changeset/typescript-incremental-builds.md
@@ -25,7 +25,10 @@ where the relative path resolves against the root, not the package).
   `node_modules/.cache/tsbuildinfo`, enabled for the jobs that actually run `tsc` (the forked-PR
   `compile` job and both `publish` jobs). `client-publish` doesn't use that action and wires the
   same cache up directly. The key hashes `yarn.lock` (which pins the TypeScript version) plus every
-  `tsconfig`, with a per-run suffix so cache entries can refresh, and `restore-keys` for the hit.
+  `tsconfig`, with a per-run suffix so cache entries can refresh, and `restore-keys` for the hit. The
+key prefix is computed in a step of its own so every `key`/`restore-keys` line stays a single line —
+`restore-keys` is a literal block where each newline separates two keys, so an expression wrapped to
+fit the line-length limit would put a newline inside a key.
 - **`.gitignore`** ignores `*.tsbuildinfo` as a safety net for the default locations.
 
 Measured on this repo (warm = build info present, cold = none):

--- a/.changeset/typescript-incremental-builds.md
+++ b/.changeset/typescript-incremental-builds.md
@@ -10,11 +10,14 @@ info to the root `dist/` by accident (the client inherits `outDir: "dist"` from 
 where the relative path resolves against the root, not the package).
 
 - **Root `tsconfig.json`** sets `"incremental": true`, inherited by every package that extends it.
-- **Each package** sets its own `tsBuildInfoFile` under `node_modules/.cache/tsbuildinfo/`, so the
-  whole workspace's build state lives in one already-git-ignored directory and no two projects
+- **Each tsconfig** sets its own `tsBuildInfoFile` under `node_modules/.cache/tsbuildinfo/`, so the
+  whole workspace's build state lives in one already-git-ignored directory and no two programs
   share a file. Setting the path in the root config would have done the opposite: relative paths
   from an `extends` base resolve against the base, so all packages would have written to the same
   file and invalidated each other on every build.
+- **One file per tsconfig, not per package.** Since #4417 the server has two programs —
+  `tsconfig.json` typechecks (`noEmit`, `rootDir: ".."`, tests included), `tsconfig.build.json`
+  emits (`rootDir: "src"`, tests excluded) — so they get separate files.
 - **`etana-scraper`, `etherscan-scraper` and `kraken-scraper`** don't extend the root config, so
   they get `"incremental": true` of their own.
 - **Packages built through `bob`** deliberately keep the default build-info location. `bob build`
@@ -25,30 +28,36 @@ where the relative path resolves against the root, not the package).
   `node_modules/.cache/tsbuildinfo`, enabled for the jobs that actually run `tsc` (the forked-PR
   `compile` job and both `publish` jobs). `client-publish` doesn't use that action and wires the
   same cache up directly. The key hashes `yarn.lock` (which pins the TypeScript version) plus every
-  `tsconfig`, with a per-run suffix so cache entries can refresh, and `restore-keys` for the hit. The
-key prefix is computed in a step of its own so every `key`/`restore-keys` line stays a single line —
-`restore-keys` is a literal block where each newline separates two keys, so an expression wrapped to
-fit the line-length limit would put a newline inside a key.
+  `tsconfig`, with a per-run suffix so cache entries can refresh, and `restore-keys` for the hit.
+  The key prefix is computed in a step of its own so every `key`/`restore-keys` line stays a single
+  line — `restore-keys` is a literal block where each newline separates two keys, so an expression
+  wrapped to fit the line-length limit would put a newline inside a key.
 - **`.gitignore`** ignores `*.tsbuildinfo` as a safety net for the default locations.
 
 Measured on this repo (warm = build info present, cold = none):
 
-| build                             | cold  | warm  |
-| --------------------------------- | ----- | ----- |
-| `yarn workspace @accounter/server build` | 25.5s | 4.4s  |
-| `packages/client` `tsc`           | 58.2s | 5.4s  |
-| `yarn build:main`                 | 63.7s | 12.7s |
+| build                                       | cold  | warm  |
+| ------------------------------------------- | ----- | ----- |
+| `yarn workspace @accounter/server build`     | 30.2s | 4.6s  |
+| `yarn workspace @accounter/server typecheck` | 25.8s | 4.9s  |
+| `packages/client` `tsc`                      | 79.6s | 6.1s  |
+| `yarn build:main`                            | 76.9s | 15.3s |
 
 The server dev loop is the payoff: `nodemon` reruns `yarn build` on every file save, so each save
-went from a ~25s full recompile of ~692 server sources plus four sibling generator packages to a
-~5s one.
+went from a ~30s full recompile of the whole server program to a ~5s one.
 
 Correctness was checked, not assumed: a freshly introduced type error is still reported on a warm
-build and on the build immediately after it, and disappears once fixed; `tsc-alias` remains
-idempotent when `tsc` skips emitting unchanged files, leaving no unresolved `@accounter/*`
-specifiers in `dist/`. Stale build info can only cost a full rebuild, never a wrong one —
-TypeScript invalidates it itself when a source file or a compiler option changes.
+build and on the build immediately after it, and disappears once fixed. Stale build info can only
+cost a full rebuild, never a wrong one — TypeScript invalidates it itself when a source file or a
+compiler option changes.
 
-This is step 1 of #4416. Step 2 (real project references via `tsc --build`, which would also
-eliminate the double compilation of the four generator packages) is deliberately left out: it
-overlaps with #4415 and is a much larger, less reversible change.
+The one-file-per-tsconfig rule is measured, not a precaution. Alternating `build` and `typecheck`
+on the server with separate files stays warm at 4.1-4.5s each; with both programs pointed at a
+single file, every alternation is a full rebuild — 22.1-22.4s for `build`, 27.7-28.0s for
+`typecheck`. They differ in `noEmit`, in `rootDir` and in whether the tests are in the program, so
+each invalidates the other's state.
+
+This is step 1 of #4416. Step 2 — real project references via `tsc --build` — is deliberately left
+out: it is a much larger, less reversible change. Its other stated payoff is already banked, since
+#4417 took the four generator `src` trees out of the server's program, so they are no longer
+compiled twice.

--- a/.changeset/typescript-incremental-builds.md
+++ b/.changeset/typescript-incremental-builds.md
@@ -1,0 +1,51 @@
+---
+---
+
+Turn on TypeScript's `incremental` mode across the monorepo so `tsc` reuses the previous compile's
+program state instead of typechecking from scratch on every invocation.
+
+Nothing in the repo set `incremental`, `tsBuildInfoFile` or `references` — the only related option
+anywhere was `composite: true` in `packages/client/tsconfig.json`, and even that wrote its build
+info to the root `dist/` by accident (the client inherits `outDir: "dist"` from the root config,
+where the relative path resolves against the root, not the package).
+
+- **Root `tsconfig.json`** sets `"incremental": true`, inherited by every package that extends it.
+- **Each package** sets its own `tsBuildInfoFile` under `node_modules/.cache/tsbuildinfo/`, so the
+  whole workspace's build state lives in one already-git-ignored directory and no two projects
+  share a file. Setting the path in the root config would have done the opposite: relative paths
+  from an `extends` base resolve against the base, so all packages would have written to the same
+  file and invalidated each other on every build.
+- **`etana-scraper`, `etherscan-scraper` and `kraken-scraper`** don't extend the root config, so
+  they get `"incremental": true` of their own.
+- **Packages built through `bob`** deliberately keep the default build-info location. `bob build`
+  runs `tsc` twice with different `--outDir`s and wipes `.bob/` before each build, so a fixed path
+  would just make the two runs invalidate each other. Verified that the build info stays inside
+  `.bob/` and is never copied into `dist/` — `bob` only copies `**/*.js` and `**/*.d.ts`.
+- **CI** gains an opt-in `tsBuildInfo` input on `.github/actions/setup` that caches
+  `node_modules/.cache/tsbuildinfo`, enabled for the jobs that actually run `tsc` (the forked-PR
+  `compile` job and both `publish` jobs). `client-publish` doesn't use that action and wires the
+  same cache up directly. The key hashes `yarn.lock` (which pins the TypeScript version) plus every
+  `tsconfig`, with a per-run suffix so cache entries can refresh, and `restore-keys` for the hit.
+- **`.gitignore`** ignores `*.tsbuildinfo` as a safety net for the default locations.
+
+Measured on this repo (warm = build info present, cold = none):
+
+| build                             | cold  | warm  |
+| --------------------------------- | ----- | ----- |
+| `yarn workspace @accounter/server build` | 25.5s | 4.4s  |
+| `packages/client` `tsc`           | 58.2s | 5.4s  |
+| `yarn build:main`                 | 63.7s | 12.7s |
+
+The server dev loop is the payoff: `nodemon` reruns `yarn build` on every file save, so each save
+went from a ~25s full recompile of ~692 server sources plus four sibling generator packages to a
+~5s one.
+
+Correctness was checked, not assumed: a freshly introduced type error is still reported on a warm
+build and on the build immediately after it, and disappears once fixed; `tsc-alias` remains
+idempotent when `tsc` skips emitting unchanged files, leaving no unresolved `@accounter/*`
+specifiers in `dist/`. Stale build info can only cost a full rebuild, never a wrong one —
+TypeScript invalidates it itself when a source file or a compiler option changes.
+
+This is step 1 of #4416. Step 2 (real project references via `tsc --build`, which would also
+eliminate the double compilation of the four generator packages) is deliberately left out: it
+overlaps with #4415 and is a much larger, less reversible change.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -56,6 +56,18 @@ runs:
         restore-keys: |
           eslint-cache-${{ runner.os }}-
 
+    # Resolved in a step of its own so the cache keys below stay one line each.
+    # `restore-keys` is a literal block: every newline in it separates two keys, so
+    # a `${{ }}` expression wrapped across lines to fit the line-length limit is a
+    # newline landing inside a key.
+    - name: Compute TypeScript Build Info Cache Key
+      id: tsbuildinfo-key
+      if: ${{ inputs.tsBuildInfo == 'true' }}
+      shell: bash
+      env:
+        INPUTS_HASH: ${{ hashFiles('yarn.lock', 'tsconfig.json', 'packages/*/tsconfig*.json') }}
+      run: echo "prefix=tsbuildinfo-${RUNNER_OS}-${INPUTS_HASH}" >> "$GITHUB_OUTPUT"
+
     - name: Cache TypeScript Build Info
       if: ${{ inputs.tsBuildInfo == 'true' }}
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -64,17 +76,14 @@ runs:
         # whole workspace. The key is unique per run because cache entries are
         # immutable — without it the first run of the day would pin a stale entry
         # and later runs could never refresh it. `restore-keys` is what actually
-        # produces the hit, falling back to the newest entry for the same toolchain
-        # and tsconfig set. Build info is invalidated by TypeScript itself when a
-        # source file or a compiler option changes, so a stale restore costs a full
-        # rebuild, never a wrong one.
+        # produces the hit: the same toolchain and tsconfig set first, then the
+        # newest entry for the OS. Build info is invalidated by TypeScript itself
+        # when a source file or a compiler option changes, so a stale restore costs
+        # a full rebuild, never a wrong one.
         path: node_modules/.cache/tsbuildinfo
-        key:
-          tsbuildinfo-${{ runner.os }}-${{ hashFiles('yarn.lock', 'tsconfig.json',
-          'packages/*/tsconfig*.json') }}-${{ github.run_id }}
+        key: ${{ steps.tsbuildinfo-key.outputs.prefix }}-${{ github.run_id }}
         restore-keys: |
-          tsbuildinfo-${{ runner.os }}-${{ hashFiles('yarn.lock', 'tsconfig.json',
-          'packages/*/tsconfig*.json') }}-
+          ${{ steps.tsbuildinfo-key.outputs.prefix }}-
           tsbuildinfo-${{ runner.os }}-
 
     - name: Set up Docker Buildx

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,6 +17,12 @@ inputs:
   installDependencies:
     description: Should run yarn install?
     default: 'true'
+  tsBuildInfo:
+    description: |
+      Should restore/save the TypeScript incremental build-info cache? Only worth
+      enabling for jobs that actually run `tsc` — jobs that don't would just write
+      an empty cache entry on every run.
+    default: 'false'
   workingDirectory:
     description: Working dir
     default: ${{ github.workspace }}
@@ -49,6 +55,27 @@ runs:
           'yarn.lock') }}
         restore-keys: |
           eslint-cache-${{ runner.os }}-
+
+    - name: Cache TypeScript Build Info
+      if: ${{ inputs.tsBuildInfo == 'true' }}
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        # Every package points `tsBuildInfoFile` here, so one directory covers the
+        # whole workspace. The key is unique per run because cache entries are
+        # immutable — without it the first run of the day would pin a stale entry
+        # and later runs could never refresh it. `restore-keys` is what actually
+        # produces the hit, falling back to the newest entry for the same toolchain
+        # and tsconfig set. Build info is invalidated by TypeScript itself when a
+        # source file or a compiler option changes, so a stale restore costs a full
+        # rebuild, never a wrong one.
+        path: node_modules/.cache/tsbuildinfo
+        key:
+          tsbuildinfo-${{ runner.os }}-${{ hashFiles('yarn.lock', 'tsconfig.json',
+          'packages/*/tsconfig*.json') }}-${{ github.run_id }}
+        restore-keys: |
+          tsbuildinfo-${{ runner.os }}-${{ hashFiles('yarn.lock', 'tsconfig.json',
+          'packages/*/tsconfig*.json') }}-
+          tsbuildinfo-${{ runner.os }}-
 
     - name: Set up Docker Buildx
       if: ${{ inputs.pgTyped == 'true' || inputs.localDB == 'true' }}

--- a/.github/workflows/client-publish.yml
+++ b/.github/workflows/client-publish.yml
@@ -48,6 +48,21 @@ jobs:
       - name: Generate GraphQL
         run: yarn generate:graphql
 
+      # This job doesn't go through ./.github/actions/setup, so it wires the
+      # TypeScript build-info cache up itself. See that action for why the key
+      # carries a per-run suffix.
+      - name: Cache TypeScript Build Info
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: node_modules/.cache/tsbuildinfo
+          key:
+            tsbuildinfo-${{ runner.os }}-${{ hashFiles('yarn.lock', 'tsconfig.json',
+            'packages/*/tsconfig*.json') }}-${{ github.run_id }}
+          restore-keys: |
+            tsbuildinfo-${{ runner.os }}-${{ hashFiles('yarn.lock', 'tsconfig.json',
+            'packages/*/tsconfig*.json') }}-
+            tsbuildinfo-${{ runner.os }}-
+
       - name: Build Client
         working-directory: packages/client
         env:

--- a/.github/workflows/client-publish.yml
+++ b/.github/workflows/client-publish.yml
@@ -50,17 +50,20 @@ jobs:
 
       # This job doesn't go through ./.github/actions/setup, so it wires the
       # TypeScript build-info cache up itself. See that action for why the key
-      # carries a per-run suffix.
+      # carries a per-run suffix and why the prefix is computed in its own step.
+      - name: Compute TypeScript Build Info Cache Key
+        id: tsbuildinfo-key
+        env:
+          INPUTS_HASH: ${{ hashFiles('yarn.lock', 'tsconfig.json', 'packages/*/tsconfig*.json') }}
+        run: echo "prefix=tsbuildinfo-${RUNNER_OS}-${INPUTS_HASH}" >> "$GITHUB_OUTPUT"
+
       - name: Cache TypeScript Build Info
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: node_modules/.cache/tsbuildinfo
-          key:
-            tsbuildinfo-${{ runner.os }}-${{ hashFiles('yarn.lock', 'tsconfig.json',
-            'packages/*/tsconfig*.json') }}-${{ github.run_id }}
+          key: ${{ steps.tsbuildinfo-key.outputs.prefix }}-${{ github.run_id }}
           restore-keys: |
-            tsbuildinfo-${{ runner.os }}-${{ hashFiles('yarn.lock', 'tsconfig.json',
-            'packages/*/tsconfig*.json') }}-
+            ${{ steps.tsbuildinfo-key.outputs.prefix }}-
             tsbuildinfo-${{ runner.os }}-
 
       - name: Build Client

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: setup environment
         uses: ./.github/actions/setup
+        with:
+          tsBuildInfo: 'true'
 
       - name: Build Packages
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,7 @@ jobs:
           # the email-ingestion-gateway's generated gql output.
           codegen: 'false'
           pgTyped: 'false'
+          tsBuildInfo: 'true'
 
       - name: alpha release
         id: changesets
@@ -78,6 +79,7 @@ jobs:
           # generated gql output.
           codegen: 'false'
           pgTyped: 'false'
+          tsBuildInfo: 'true'
 
       - name: Build Packages
         run: yarn build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+*.tsbuildinfo
 storybook-static/
 .env*
 !.env.template

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,16 @@ yarn seed:admin-context # Seed admin context for server
 - Generated files are git-ignored: `__generated__/`, `gql/`, `schema.graphql`.
 - NEVER manually edit generated files.
 
+# TypeScript Build Cache
+
+- Every `tsc` run is incremental. Build info lives in `node_modules/.cache/tsbuildinfo/`, one file
+  per package (`tsBuildInfoFile` in each `packages/<name>/tsconfig.json`).
+- A new package that extends the root config inherits `incremental` — give it its own
+  `tsBuildInfoFile` there so it doesn't share build state with another package. Packages built by
+  `bob` are the exception: leave `tsBuildInfoFile` unset, since `bob` runs `tsc` once per output
+  format.
+- If a build ever looks stale, delete `node_modules/.cache/tsbuildinfo/` (or run `tsc --force`).
+
 # Architecture
 
 - **GraphQL Modules**: the server uses `graphql-modules`. Each module in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,8 @@ yarn seed:admin-context # Seed admin context for server
   `tsBuildInfoFile` there so it doesn't share build state with another package. Packages built by
   `bob` are the exception: leave `tsBuildInfoFile` unset, since `bob` runs `tsc` once per output
   format.
-- If a build ever looks stale, delete `node_modules/.cache/tsbuildinfo/` (or run `tsc --force`).
+- If a build ever looks stale, delete `node_modules/.cache/tsbuildinfo/` — that forces the next
+  `tsc` run to start from scratch.
 
 # Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,11 +69,13 @@ yarn seed:admin-context # Seed admin context for server
 # TypeScript Build Cache
 
 - Every `tsc` run is incremental. Build info lives in `node_modules/.cache/tsbuildinfo/`, one file
-  per package (`tsBuildInfoFile` in each `packages/<name>/tsconfig.json`).
-- A new package that extends the root config inherits `incremental` — give it its own
-  `tsBuildInfoFile` there so it doesn't share build state with another package. Packages built by
-  `bob` are the exception: leave `tsBuildInfoFile` unset, since `bob` runs `tsc` once per output
-  format.
+  per tsconfig (`tsBuildInfoFile` in each `packages/<name>/tsconfig*.json`).
+- One file per tsconfig, not per package: `server` has two programs (`tsconfig.json` typechecks,
+  `tsconfig.build.json` emits) and they get separate build info, because they differ in options and
+  in the files they cover.
+- A new tsconfig that extends the root config inherits `incremental` — give it its own
+  `tsBuildInfoFile` so it doesn't share build state with another program. Packages built by `bob`
+  are the exception: leave `tsBuildInfoFile` unset, since `bob` runs `tsc` once per output format.
 - If a build ever looks stale, delete `node_modules/.cache/tsbuildinfo/` — that forces the next
   `tsc` run to start from scratch.
 

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/client.tsbuildinfo",
     "module": "ESNext",
     "lib": ["DOM", "ESNext"],
     "composite": true,

--- a/packages/client/tsconfig.scripts.json
+++ b/packages/client/tsconfig.scripts.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/client-scripts.tsbuildinfo",
     "composite": false
   },
   "include": [".storybook/**/*", "src/vite-env.d.ts"]

--- a/packages/email-ingestion-gateway/tsconfig.json
+++ b/packages/email-ingestion-gateway/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/email-ingestion-gateway.tsbuildinfo",
     "rootDir": "src",
     "outDir": "dist",
     "module": "ES2022",

--- a/packages/etana-scraper/tsconfig.json
+++ b/packages/etana-scraper/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/etana-scraper.tsbuildinfo",
     "rootDir": "src",
     "outDir": "dist",
     "lib": ["es2020"],

--- a/packages/etherscan-scraper/tsconfig.json
+++ b/packages/etherscan-scraper/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/etherscan-scraper.tsbuildinfo",
     "rootDir": "src",
     "outDir": "dist",
     "lib": ["es2020"],

--- a/packages/gmail-listener/tsconfig.json
+++ b/packages/gmail-listener/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/gmail-listener.tsbuildinfo",
     "rootDir": "src",
     "outDir": "dist",
     "lib": ["ES2022", "dom"],

--- a/packages/kraken-scraper/tsconfig.json
+++ b/packages/kraken-scraper/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "incremental": true,
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/kraken-scraper.tsbuildinfo",
     "rootDir": "src",
     "outDir": "dist",
     "lib": ["es2020"],

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/mcp-server.tsbuildinfo",
     "rootDir": "src",
     "outDir": "dist",
     "module": "ES2022",

--- a/packages/modern-poalim-scraper/tsconfig.json
+++ b/packages/modern-poalim-scraper/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/modern-poalim-scraper.tsbuildinfo",
     "outDir": "dist",
     "rootDir": "./src",
     "exactOptionalPropertyTypes": true,

--- a/packages/scraper-app/tsconfig.json
+++ b/packages/scraper-app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/scraper-app.tsbuildinfo",
     "jsx": "react-jsx",
     "rootDir": "src",
     "outDir": "dist",

--- a/packages/scraper-local-app/tsconfig.json
+++ b/packages/scraper-local-app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/scraper-local-app.tsbuildinfo",
     "rootDir": "src",
     "outDir": "dist",
     "paths": {

--- a/packages/scraper-local-app/tsconfig.scripts.json
+++ b/packages/scraper-local-app/tsconfig.scripts.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/scraper-local-app-scripts.tsbuildinfo",
     "noEmit": true,
     "allowImportingTsExtensions": true,
     "paths": {

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -7,6 +7,10 @@
   // point at `dist/server/src/index.js`.
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // Its own build info, not the one `tsconfig.json` sets: this program emits, pins a
+    // different `rootDir` and drops the tests, so sharing a file would make every `build`
+    // invalidate the last `typecheck` and vice versa.
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/server-build.tsbuildinfo",
     "noEmit": false,
     "outDir": "dist",
     // Pinned rather than inferred, so a future import that escapes `src` fails loudly with

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    // Type-checking program only — `tsconfig.build.json` is what emits.
+    // Type-checking program only — `tsconfig.build.json` is what emits. It carries its own
+    // `tsBuildInfoFile`: the two programs differ in options and in the files they cover, so
+    // sharing one would make each invalidate the other's state.
+    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/server.tsbuildinfo",
     "noEmit": true,
     // This program deliberately covers the tests too, and the helpers under `src/__tests__`
     // import `packages/migrations/src` directly, so the root has to span `packages/`. tsc

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,14 @@
     "sourceMap": true,
     "declaration": true,
 
+    // Reuse the previous compile's program state instead of typechecking from
+    // scratch every time. Inherited by every package that extends this config;
+    // each one sets its own `tsBuildInfoFile` so they never share build state.
+    // Packages built through `bob` deliberately leave `tsBuildInfoFile` unset:
+    // bob runs `tsc` twice with different `--outDir`s, so the default
+    // (per-outDir) location is the only correct one there.
+    "incremental": true,
+
     "noImplicitAny": true,
     "noImplicitThis": true,
     "alwaysStrict": true,


### PR DESCRIPTION
Closes #4416 (step 1).

Every `tsc` invocation in the repo was a full, from-scratch compile — nothing set `incremental`, `tsBuildInfoFile` or `references`. The only related option anywhere was `composite: true` in `packages/client/tsconfig.json`, and even that wrote its build info to the **root** `dist/` by accident: the client inherits `outDir: "dist"` from the root config, where the relative path resolves against the root, not the package.

Rebased onto main after #4417 landed. All numbers below are re-measured against that base.

## Changes

- **Root `tsconfig.json`** sets `"incremental": true`, inherited by every package that extends it.
- **Each tsconfig** sets its own `tsBuildInfoFile` under `node_modules/.cache/tsbuildinfo/`, so the whole workspace's build state lives in one already-git-ignored directory and no two programs share a file. Setting the path in the root config (as the issue sketched) would have done the opposite — relative paths from an `extends` base resolve against the base, so every package would have written to the same file and invalidated each other on every build.
- **One file per tsconfig, not per package.** Since #4417 the server has two programs — `tsconfig.json` typechecks (`noEmit`, `rootDir: ".."`, tests included) and `tsconfig.build.json` emits (`rootDir: "src"`, tests excluded). `tsconfig.build.json` extends the other, so it needs its own path or both land on `server.tsbuildinfo`. This is measured, not a precaution: see the table below.
- **`etana-scraper`, `etherscan-scraper`, `kraken-scraper`** don't extend the root config, so they get `"incremental": true` of their own.
- **Packages built through `bob`** deliberately keep the default build-info location. `bob build` runs `tsc` twice with different `--outDir`s and wipes `.bob/` before each build, so a fixed path would only make the two runs invalidate each other. Verified the build info stays inside `.bob/` and is never copied into `dist/` — bob only copies `**/*.js` and `**/*.d.ts`.
- **CI**: an opt-in `tsBuildInfo` input on `.github/actions/setup` caches `node_modules/.cache/tsbuildinfo`, enabled for the jobs that actually run `tsc` (the forked-PR `compile` job and both `publish` jobs). `client-publish` doesn't use that action and wires the same cache up directly. The key hashes `yarn.lock` (which pins the TypeScript version) plus every `tsconfig`, with a per-run suffix so entries can refresh, and `restore-keys` for the hit. The prefix is computed in a step of its own so no `${{ }}` expression has to wrap across lines inside `restore-keys`, where a newline would land in the middle of a key.
- **`.gitignore`** ignores `*.tsbuildinfo` as a safety net for the default locations.
- Short "TypeScript Build Cache" section in `CLAUDE.md` covering the convention and the escape hatch.

## Measured

Cold = no build info, warm = build info present.

| build | cold | warm |
| --- | --- | --- |
| `yarn workspace @accounter/server build` | 30.2s | 4.6s |
| `yarn workspace @accounter/server typecheck` | 25.8s | 4.9s |
| `packages/client` `tsc` | 79.6s | 6.1s |
| `yarn build:main` | 76.9s | 15.3s |

The server dev loop is the payoff: `nodemon` reruns `yarn build` on every file save, so each save went from a ~30s full recompile to a ~5s one.

**Why the server's two programs need separate files.** Alternating `build` and `typecheck` with separate build info stays warm at 4.1–4.5s each. Pointing both at a single file makes every alternation a full rebuild:

| alternating `build` ↔ `typecheck` | `build` | `typecheck` |
| --- | --- | --- |
| separate build info | 4.1s, 4.1s | 4.5s, 4.5s |
| shared build info | 22.4s, 22.1s | 28.0s, 27.7s |

## Verification

- `yarn lint` — 0 errors (943 pre-existing warnings, almost all the intentionally-`warn` `no-console` rule).
- `yarn prettier:check` — clean.
- `yarn test` — 304 files, 4098 passed / 6 skipped.
- `yarn build:tools` and `yarn build:main` both green.
- **Correctness of incremental state, checked rather than assumed:** a freshly introduced type error is still reported on a warm build and on the build immediately after it, and disappears once fixed. Stale build info can only cost a full rebuild, never a wrong one — TypeScript invalidates it itself when a source file or a compiler option changes, and CI can always force a clean build.
- **No build info escapes into published output:** after `yarn build:tools`, the only `.tsbuildinfo` files under `packages/` are inside the seven `bob` packages' git-ignored `.bob/` directories.
- The server's `dist` layout from #4417 is unchanged — a from-scratch build still emits flat (`dist/index.js`, `dist/bootstrap-telemetry.js`), with no re-nesting.

## Not in scope

Step 2 of the issue — real project references via `tsc --build` — is deliberately left out: it's a much larger, less reversible change. Its other stated payoff is already banked, since #4417 took the four generator `src` trees out of the server's program, so they are no longer compiled twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Yremga4YL3rNghz5TZbXv