### PR TITLE
feat(client): replace Mantine Select with ComboBox

### DIFF
--- a/.changeset/mantine-select-combobox.md
+++ b/.changeset/mantine-select-combobox.md
@@ -1,0 +1,35 @@
+---
+'@accounter/client': patch
+---
+
+Replace Mantine's `Select` with the existing `ComboBox` across 20 call sites in 11 files.
+
+`ComboBox` already matched Mantine's shape — same `data` / `value` / `onChange` / `error` /
+`placeholder` / `disabled` — and is always searchable, so most of this is prop removal rather than
+translation. Three props were added to it for parity:
+
+- `label`, which Mantine's `Select` rendered itself.
+- `form`, to associate the trigger with a form element rendered outside it (the depreciation rows).
+- `required`, expressed as `aria-required` since the trigger is a `<button>`.
+
+Props dropped, with reasons:
+
+- `maxDropdownHeight` — `ComboBox`'s list sizes itself.
+- `searchable` — `ComboBox` always is.
+- **`withinPortal` and `zIndex={1002}`** — `ComboBox` portals through `usePortalContainer`, so the
+  stacking workaround added when the depreciation dialog became a Radix dialog is no longer needed.
+  Those were the last `zIndex` overrides in the client.
+- `error` at sites already inside a `FormControl`, where `FormMessage` renders the message and
+  `ComboBox` would have duplicated it. The now-unused `fieldState` bindings went with it.
+
+Two call sites needed real changes rather than prop edits:
+
+- `charts/monthly-income-expense/chart-filter.tsx` passed a bare `Currency[]`; `ComboBox` takes
+  `{ value, label }`. Its `defaultValue={Currency.Usd}` moved onto the `Controller`, since
+  `ComboBox` is controlled and would otherwise have lost the default.
+- `common/forms/edit-charge.tsx` used `rightSection` to place an "insert business trip" modal beside
+  the field. `ComboBox` has no such slot, so the modal is now a sibling in a flex row.
+
+`components/charts` is Mantine-free and joins the ESLint rule's `error` list.
+
+Mantine imports: 75 → 68, across 74 → 67 files.

--- a/.changeset/mantine-select-combobox.md
+++ b/.changeset/mantine-select-combobox.md
@@ -32,4 +32,8 @@ Two call sites needed real changes rather than prop edits:
 
 `components/charts` is Mantine-free and joins the ESLint rule's `error` list.
 
+`ComboBox`'s standalone error message is also now wired up: the trigger carries `aria-invalid` and
+an `aria-describedby` pointing at the message, matching `NumberInput` and the period pickers. Inside
+`formPart` the surrounding `FormControl` already does this, which is why `error` is not passed there.
+
 Mantine imports: 75 → 68, across 74 → 67 files.

--- a/.changeset/mantine-select-combobox.md
+++ b/.changeset/mantine-select-combobox.md
@@ -36,4 +36,14 @@ Two call sites needed real changes rather than prop edits:
 an `aria-describedby` pointing at the message, matching `NumberInput` and the period pickers. Inside
 `formPart` the surrounding `FormControl` already does this, which is why `error` is not passed there.
 
+`ComboBox`'s trigger is also realigned to match the Mantine `Select` it replaces: the selected
+value sits on the left and the chevron on the right, rather than both centred together.
+
+The trigger already asked for `justify-start`, but never got it. `Trigger` left `className` inside
+`...triggerProps`, spread *after* its own `className` — and both `PopoverTrigger` and
+`DrawerTrigger` pass a `className` down through `asChild`. The trigger's layout classes were
+therefore replaced on every render, and the Button fell back to its base `justify-center`.
+`className` is now destructured and merged with `cn()`, the value renders in a truncating span so a
+long option cannot push the chevron off the edge, and the layout is covered by tests.
+
 Mantine imports: 75 → 68, across 74 → 67 files.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -302,6 +302,7 @@ export default [
       'packages/client/src/components/bank-deposits/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/business/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/businesses/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/charts/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/charge-matching/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/charge-matches/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/clients/**/*.{,c,m}{j,t}s{,x}',

--- a/packages/client/src/components/business-ledger/business-ledger-filters.tsx
+++ b/packages/client/src/components/business-ledger/business-ledger-filters.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useState, type ReactElement } from 'react';
 import equal from 'deep-equal';
 import { Filter } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { MultiSelect, Select } from '@mantine/core';
+import { MultiSelect } from '@mantine/core';
 import { encodeFilters } from '@/router/routes.js';
 import { type BusinessTransactionsFilter } from '../../gql/graphql.js';
 import { isObjectEmpty, TIMELESS_DATE_REGEX } from '../../helpers/index.js';
@@ -11,6 +11,7 @@ import { useGetBusinesses } from '../../hooks/use-get-businesses.js';
 import { useUrlQuery } from '../../hooks/use-url-query.js';
 import { UserContext } from '../../providers/user-provider.js';
 import { PopUpModal } from '../common/index.js';
+import { ComboBox } from '../common/inputs/combo-box.js';
 import { DatePickerInput } from '../common/inputs/date-picker-input.js';
 import { Button } from '../ui/button.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form.js';
@@ -183,11 +184,11 @@ function BusinessLedgerRecordsFilterForm({
               name="type"
               control={control}
               defaultValue={null}
-              render={({ field, fieldState }): ReactElement => (
+              render={({ field }): ReactElement => (
                 <FormItem>
                   <FormLabel>Type</FormLabel>
                   <FormControl>
-                    <Select
+                    <ComboBox
                       {...field}
                       onChange={value => field.onChange(value === 'NULL' ? null : value)}
                       data={[
@@ -195,7 +196,7 @@ function BusinessLedgerRecordsFilterForm({
                         { value: 'BUSINESS', label: 'Business' },
                         { value: 'TAX_CATEGORY', label: 'Tax Category' },
                       ]}
-                      error={fieldState.error?.message}
+                      formPart
                     />
                   </FormControl>
                   <FormMessage />

--- a/packages/client/src/components/charts/monthly-income-expense/chart-filter.tsx
+++ b/packages/client/src/components/charts/monthly-income-expense/chart-filter.tsx
@@ -3,12 +3,12 @@ import { format } from 'date-fns';
 import equal from 'deep-equal';
 import { Filter } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Select } from '@mantine/core';
 import { encodeFilters } from '@/router/routes.js';
 import { Currency, type IncomeExpenseChartFilters } from '../../../gql/graphql.js';
 import { TIMELESS_DATE_REGEX, type TimelessDateString } from '../../../helpers/index.js';
 import { useUrlQuery } from '../../../hooks/use-url-query.js';
 import { PopUpModal } from '../../common/index.js';
+import { ComboBox } from '../../common/inputs/combo-box.js';
 import { MonthPickerInput } from '../../common/inputs/month-picker-input.js';
 import { Button } from '../../ui/button.js';
 
@@ -77,13 +77,18 @@ function ChartFilterForm({ filter, setFilter, closeModal }: ChartFilterFormProps
       <Controller
         name="currency"
         control={control}
+        // Mantine's Select took `defaultValue` directly; ComboBox is controlled, so the
+        // default belongs to the field.
+        defaultValue={Currency.Usd}
         render={({ field, fieldState }): ReactElement => (
-          <Select
+          <ComboBox
             {...field}
             label="Currency"
-            defaultValue={Currency.Usd}
             error={fieldState.error?.message}
-            data={Object.keys(Currency).map(key => Currency[key as keyof typeof Currency])}
+            data={Object.values(Currency).map(currency => ({
+              value: currency,
+              label: currency,
+            }))}
           />
         )}
       />

--- a/packages/client/src/components/common/depreciation/add-depreciation-record.tsx
+++ b/packages/client/src/components/common/depreciation/add-depreciation-record.tsx
@@ -2,13 +2,14 @@ import { useEffect, useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { useQuery } from 'urql';
-import { Loader, Select } from '@mantine/core';
+import { Loader } from '@mantine/core';
 import {
   AllDepreciationCategoriesDocument,
   type InsertDepreciationRecordInput,
 } from '../../../gql/graphql.js';
 import { TIMELESS_DATE_REGEX } from '../../../helpers/index.js';
 import { useAddDepreciationRecord } from '../../../hooks/use-add-depreciation-record.js';
+import { ComboBox } from '../../common/inputs/combo-box.js';
 import { Button } from '../../ui/button.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { Overlay } from '../../ui/overlay.js';
@@ -147,17 +148,13 @@ function ModalContent({ chargeId, opened, close, onAdd }: ModalProps): ReactElem
               name="categoryId"
               control={control}
               render={({ field, fieldState }): ReactElement => (
-                <Select
+                <ComboBox
                   {...field}
                   disabled={fetchingCategories}
                   data={categories}
                   label="Category"
                   placeholder="Scroll to see all options"
-                  maxDropdownHeight={160}
-                  searchable
                   error={fieldState.error?.message}
-                  withinPortal
-                  zIndex={1002}
                 />
               )}
             />
@@ -165,17 +162,13 @@ function ModalContent({ chargeId, opened, close, onAdd }: ModalProps): ReactElem
               name="type"
               control={control}
               render={({ field, fieldState }): ReactElement => (
-                <Select
+                <ComboBox
                   {...field}
                   data={depreciationTypes}
                   value={field.value}
                   label="Type"
                   placeholder="Scroll to see all options"
-                  maxDropdownHeight={160}
-                  searchable
                   error={fieldState.error?.message}
-                  withinPortal
-                  zIndex={1002}
                 />
               )}
             />

--- a/packages/client/src/components/common/depreciation/depreciation-row.tsx
+++ b/packages/client/src/components/common/depreciation/depreciation-row.tsx
@@ -3,7 +3,6 @@ import { format } from 'date-fns';
 import { Check, Edit } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { useQuery } from 'urql';
-import { Select } from '@mantine/core';
 import {
   AllDepreciationCategoriesDocument,
   DepreciationRecordRowFieldsFragmentDoc,
@@ -16,6 +15,7 @@ import {
   type MakeBoolean,
 } from '../../../helpers/index.js';
 import { useUpdateDepreciationRecord } from '../../../hooks/use-update-depreciation-record.js';
+import { ComboBox } from '../../common/inputs/combo-box.js';
 import { Button } from '../../ui/button.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { CurrencyInput, DatePickerInput, Tooltip } from '../index.js';
@@ -188,21 +188,17 @@ export const DepreciationRow = ({ data, onChange }: Props): ReactElement => {
             <FormField
               name="categoryId"
               control={control}
-              render={({ field, fieldState }): ReactElement => (
+              render={({ field }): ReactElement => (
                 <FormItem>
                   <FormLabel>Category</FormLabel>
                   <FormControl>
-                    <Select
+                    <ComboBox
                       {...field}
                       form={`form ${depreciationRecord.id}`}
                       disabled={fetchingCategories}
                       data={categories ?? []}
                       placeholder="Scroll to see all options"
-                      maxDropdownHeight={160}
-                      searchable
-                      error={fieldState.error?.message}
-                      withinPortal
-                      zIndex={1002}
+                      formPart
                     />
                   </FormControl>
                   <FormMessage />
@@ -220,21 +216,17 @@ export const DepreciationRow = ({ data, onChange }: Props): ReactElement => {
             <FormField
               name="type"
               control={control}
-              render={({ field, fieldState }): ReactElement => (
+              render={({ field }): ReactElement => (
                 <FormItem>
                   <FormLabel>Type</FormLabel>
                   <FormControl>
-                    <Select
+                    <ComboBox
                       {...field}
                       form={`form ${depreciationRecord.id}`}
                       data={depreciationTypes}
                       value={field.value}
                       placeholder="Scroll to see all options"
-                      maxDropdownHeight={160}
-                      searchable
-                      error={fieldState.error?.message}
-                      withinPortal
-                      zIndex={1002}
+                      formPart
                     />
                   </FormControl>
                   <FormMessage />

--- a/packages/client/src/components/common/forms/edit-charge.tsx
+++ b/packages/client/src/components/common/forms/edit-charge.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useState, type ReactElement } from 're
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { toast } from 'sonner';
 import { useQuery } from 'urql';
-import { Select } from '@mantine/core';
 import {
   AllBusinessTripsDocument,
   type EditChargeQuery,
@@ -19,6 +18,7 @@ import {
 import { useGetTags } from '../../../hooks/use-get-tags.js';
 import { useGetTaxCategories } from '../../../hooks/use-get-tax-categories.js';
 import { useUpdateCharge } from '../../../hooks/use-update-charge.js';
+import { ComboBox } from '../../common/inputs/combo-box.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { Input } from '../../ui/input.js';
 import { Switch } from '../../ui/switch.js';
@@ -206,19 +206,17 @@ export const EditCharge = ({ charge, close, onChange }: Props): ReactElement => 
                 name="defaultTaxCategoryID"
                 control={control}
                 defaultValue={chargeInputData.defaultTaxCategoryID}
-                render={({ field, fieldState }): ReactElement => (
+                render={({ field }): ReactElement => (
                   <FormItem>
                     <FormLabel>Tax Category Override</FormLabel>
                     <FormControl>
-                      <Select
+                      <ComboBox
                         {...field}
                         data={taxCategories}
                         value={field.value}
                         disabled={fetchingTaxCategories}
                         placeholder="Scroll to see all options"
-                        maxDropdownHeight={160}
-                        searchable
-                        error={!!fieldState.error}
+                        formPart
                       />
                     </FormControl>
                     <FormMessage />
@@ -229,23 +227,21 @@ export const EditCharge = ({ charge, close, onChange }: Props): ReactElement => 
                 name="businessTripID"
                 control={control}
                 defaultValue={chargeInputData.businessTripID}
-                render={({ field, fieldState }): ReactElement => (
+                render={({ field }): ReactElement => (
                   <FormItem>
                     <FormLabel>Business Trip</FormLabel>
                     <FormControl>
-                      <Select
-                        {...field}
-                        data={businessTrips}
-                        value={field.value}
-                        disabled={fetchingBusinessTrips}
-                        placeholder="Scroll to see all options"
-                        maxDropdownHeight={160}
-                        searchable
-                        error={!!fieldState.error}
-                        rightSection={
-                          <InsertBusinessTripModal onDone={refetchBusinessTripsCallback} />
-                        }
-                      />
+                      <div className="flex flex-row items-center gap-2">
+                        <ComboBox
+                          {...field}
+                          data={businessTrips}
+                          value={field.value}
+                          disabled={fetchingBusinessTrips}
+                          placeholder="Scroll to see all options"
+                          formPart
+                        />
+                        <InsertBusinessTripModal onDone={refetchBusinessTripsCallback} />
+                      </div>
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -286,18 +282,16 @@ export const EditCharge = ({ charge, close, onChange }: Props): ReactElement => 
                 name="type"
                 control={control}
                 defaultValue={chargeInputData.type}
-                render={({ field, fieldState }): ReactElement => (
+                render={({ field }): ReactElement => (
                   <FormItem>
                     <FormLabel>Charge Type</FormLabel>
                     <FormControl>
-                      <Select
+                      <ComboBox
                         {...field}
                         data={chargeTypes}
                         value={field.value}
                         placeholder="Scroll to see all options"
-                        maxDropdownHeight={160}
-                        searchable
-                        error={!!fieldState.error}
+                        formPart
                       />
                     </FormControl>
                     <FormMessage />

--- a/packages/client/src/components/common/forms/modify-business-trip-fields.tsx
+++ b/packages/client/src/components/common/forms/modify-business-trip-fields.tsx
@@ -1,9 +1,9 @@
 import type { ReactElement } from 'react';
 import { type Control } from 'react-hook-form';
-import { Select } from '@mantine/core';
 import type { InsertBusinessTripInput } from '../../../gql/graphql.js';
 import { TIMELESS_DATE_REGEX } from '../../../helpers/consts.js';
 import { useAllCountries } from '../../../hooks/use-get-countries.js';
+import { ComboBox } from '../../common/inputs/combo-box.js';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { Input } from '../../ui/input.js';
 import { DatePickerInput } from '../index.js';
@@ -89,11 +89,11 @@ export const ModifyBusinessTripFields = ({ control }: Props): ReactElement => {
       <FormField
         name="destinationCode"
         control={control}
-        render={({ field, fieldState }): ReactElement => (
+        render={({ field }): ReactElement => (
           <FormItem>
             <FormLabel>Destination</FormLabel>
             <FormControl>
-              <Select
+              <ComboBox
                 {...field}
                 data={countries.map(country => ({
                   value: country.code,
@@ -101,9 +101,7 @@ export const ModifyBusinessTripFields = ({ control }: Props): ReactElement => {
                 }))}
                 value={field.value ?? undefined}
                 disabled={fetchingCountries}
-                maxDropdownHeight={160}
-                searchable
-                error={fieldState.error?.message}
+                formPart
               />
             </FormControl>
             <FormMessage />

--- a/packages/client/src/components/common/forms/modify-salary-record.tsx
+++ b/packages/client/src/components/common/forms/modify-salary-record.tsx
@@ -3,7 +3,6 @@ import { format } from 'date-fns';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { toast } from 'sonner';
 import { useQuery } from 'urql';
-import { Select } from '@mantine/core';
 import {
   AllEmployeesByEmployerDocument,
   AllPensionFundsDocument,
@@ -18,6 +17,7 @@ import {
 } from '../../../helpers/index.js';
 import { useGetBusinesses } from '../../../hooks/use-get-businesses.js';
 import { UserContext } from '../../../providers/user-provider.js';
+import { ComboBox } from '../../common/inputs/combo-box.js';
 import { MonthPickerInput } from '../../common/inputs/month-picker-input.js';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
 import { Input } from '../../ui/input.js';
@@ -202,15 +202,13 @@ export const ModifySalaryRecord = ({
                   required: 'Required',
                 }}
                 render={({ field, fieldState }): ReactElement => (
-                  <Select
+                  <ComboBox
                     {...field}
                     data={businesses}
                     value={field.value}
                     disabled={fetchingBusinesses}
                     label="Employer"
                     placeholder="Scroll to see all options"
-                    maxDropdownHeight={160}
-                    searchable
                     error={fieldState.error?.message}
                   />
                 )}
@@ -240,15 +238,13 @@ export const ModifySalaryRecord = ({
                   required: 'Required',
                 }}
                 render={({ field, fieldState }): ReactElement => (
-                  <Select
+                  <ComboBox
                     {...field}
                     data={employees}
                     value={field.value}
                     disabled={employeesFetching}
                     label="Employee"
                     placeholder="Scroll to see all options"
-                    maxDropdownHeight={160}
-                    searchable
                     error={fieldState.error?.message}
                   />
                 )}
@@ -408,15 +404,13 @@ export const ModifySalaryRecord = ({
                 control={control}
                 defaultValue={defaultValues?.pensionFundId}
                 render={({ field, fieldState }): ReactElement => (
-                  <Select
+                  <ComboBox
                     {...field}
                     data={pensionFunds}
                     value={field.value}
                     disabled={fetchingPensionFunds}
                     label="Pension Fund"
                     placeholder="Scroll to see all options"
-                    maxDropdownHeight={160}
-                    searchable
                     error={fieldState.error?.message}
                   />
                 )}
@@ -532,15 +526,13 @@ export const ModifySalaryRecord = ({
                 control={control}
                 defaultValue={defaultValues?.trainingFundId}
                 render={({ field, fieldState }): ReactElement => (
-                  <Select
+                  <ComboBox
                     {...field}
                     data={trainingFunds}
                     value={field.value}
                     disabled={fetchingTrainingFunds}
                     label="Training Fund"
                     placeholder="Scroll to see all options"
-                    maxDropdownHeight={160}
-                    searchable
                     error={fieldState.error?.message}
                   />
                 )}

--- a/packages/client/src/components/common/inputs/__tests__/combo-box.test.tsx
+++ b/packages/client/src/components/common/inputs/__tests__/combo-box.test.tsx
@@ -64,3 +64,34 @@ describe('ComboBox error wiring', () => {
     expect(label?.getAttribute('for')).toBe(trigger().id);
   });
 });
+
+describe('ComboBox trigger layout', () => {
+  it('lays the value out left with the chevron on the right', () => {
+    act(() => {
+      root.render(<ComboBox data={DATA} value="marketing" />);
+    });
+
+    const classes = trigger().className;
+    expect(classes).toContain('justify-between');
+    // The Button base sets justify-center; tailwind-merge must resolve in our favour.
+    expect(classes).not.toContain('justify-center');
+
+    // Value first, chevron last.
+    const [first] = [...trigger().children];
+    expect(first.tagName).toBe('SPAN');
+    expect(first.textContent).toBe('Marketing');
+    expect(trigger().lastElementChild?.tagName.toLowerCase()).toBe('svg');
+  });
+
+  it('keeps its layout classes when a parent passes className', () => {
+    // PopoverTrigger/DrawerTrigger pass `className` down via asChild. Spreading it last used
+    // to replace the trigger's own classes outright, which silently dropped the alignment.
+    act(() => {
+      root.render(<ComboBox data={DATA} value="marketing" />);
+    });
+
+    // The rendered trigger carries PopoverTrigger's width classes *and* our alignment.
+    expect(trigger().className).toContain('w-full');
+    expect(trigger().className).toContain('justify-between');
+  });
+});

--- a/packages/client/src/components/common/inputs/__tests__/combo-box.test.tsx
+++ b/packages/client/src/components/common/inputs/__tests__/combo-box.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ComboBox } from '../combo-box.js';
+
+const DATA = [
+  { value: 'rd', label: 'Research & Development' },
+  { value: 'marketing', label: 'Marketing' },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function trigger(): HTMLButtonElement {
+  const found = container.querySelector('button');
+  if (!found) {
+    throw new Error('no trigger button rendered');
+  }
+  return found;
+}
+
+describe('ComboBox error wiring', () => {
+  it('points the trigger at the error text and marks it invalid', () => {
+    act(() => {
+      root.render(<ComboBox data={DATA} value={null} error="Tax category is required" />);
+    });
+
+    const message = container.querySelector('p');
+    expect(message?.textContent).toBe('Tax category is required');
+    expect(message?.id).toBeTruthy();
+    expect(trigger().getAttribute('aria-describedby')).toBe(message?.id);
+    expect(trigger().getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('sets neither attribute when there is no error', () => {
+    act(() => {
+      root.render(<ComboBox data={DATA} value={null} />);
+    });
+
+    expect(container.querySelector('p')).toBeNull();
+    expect(trigger().getAttribute('aria-describedby')).toBeNull();
+    expect(trigger().getAttribute('aria-invalid')).toBeNull();
+  });
+
+  it('associates the label with the trigger', () => {
+    act(() => {
+      root.render(<ComboBox data={DATA} value={null} label="Tax category" />);
+    });
+
+    const label = container.querySelector('label');
+    expect(label?.textContent).toBe('Tax category');
+    expect(label?.getAttribute('for')).toBe(trigger().id);
+  });
+});

--- a/packages/client/src/components/common/inputs/combo-box.stories.tsx
+++ b/packages/client/src/components/common/inputs/combo-box.stories.tsx
@@ -1,0 +1,95 @@
+import { useState, type ReactElement } from 'react';
+import { useForm } from 'react-hook-form';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form, FormField, FormItem, FormLabel, FormMessage } from '../../ui/form.js';
+import { ComboBox } from './combo-box.js';
+
+const TAX_CATEGORIES = [
+  { value: 'rd', label: 'Research & Development' },
+  { value: 'marketing', label: 'Marketing' },
+  { value: 'travel', label: 'Travel' },
+  { value: 'salaries', label: 'Salaries' },
+  { value: 'consulting', label: 'Consulting', description: 'Income from consulting work' },
+];
+
+/**
+ * Replaced Mantine's `Select`. `label`, `form` and `required` were added for that migration:
+ * Mantine rendered a label, and the depreciation and balance-charge forms rely on `form` and
+ * `required` to associate a trigger with a form rendered outside it.
+ */
+function Harness(props: Partial<Parameters<typeof ComboBox>[0]>): ReactElement {
+  const [value, setValue] = useState<string | null>(props.value ?? null);
+  return (
+    <div className="w-80 p-6">
+      <ComboBox
+        data={TAX_CATEGORIES}
+        placeholder="Scroll to see all options"
+        {...props}
+        value={value}
+        onChange={setValue}
+      />
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Inputs/ComboBox',
+  component: Harness,
+  parameters: { layout: 'centered' },
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: {} };
+
+/** The label is the prop added for the Mantine `Select` migration. */
+export const WithLabel: Story = { args: { label: 'Tax category' } };
+
+export const WithValue: Story = { args: { label: 'Tax category', value: 'marketing' } };
+
+/** Rendered outside a form field, the error message sits below the trigger. */
+export const WithError: Story = {
+  args: { label: 'Tax category', error: 'Tax category is required' },
+};
+
+export const Disabled: Story = { args: { label: 'Tax category', disabled: true } };
+
+/**
+ * `formPart` is what the react-hook-form call sites pass: it renders the trigger inside a
+ * `FormControl` and makes it full width rather than the default fixed 150px.
+ *
+ * It therefore only works inside a form — `FormControl` calls `useFormContext()` and throws
+ * outright without one. This story wires up a real `useForm` for that reason; the portable
+ * stories test caught the version that did not.
+ */
+export const AsFormPart: Story = {
+  render: function Render() {
+    const form = useForm<{ taxCategory: string | null }>({
+      defaultValues: { taxCategory: null },
+    });
+    return (
+      <div className="w-80 p-6">
+        <Form {...form}>
+          <FormField
+            control={form.control}
+            name="taxCategory"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Tax category</FormLabel>
+                <ComboBox
+                  data={TAX_CATEGORIES}
+                  placeholder="Scroll to see all options"
+                  value={field.value}
+                  onChange={field.onChange}
+                  formPart
+                />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </Form>
+      </div>
+    );
+  },
+};

--- a/packages/client/src/components/common/inputs/combo-box.tsx
+++ b/packages/client/src/components/common/inputs/combo-box.tsx
@@ -56,6 +56,10 @@ export function ComboBox({
 }: ComboBoxProps) {
   const generatedId = React.useId();
   const triggerId = id ?? generatedId;
+  const errorId = `${triggerId}-error`;
+  // Inside `formPart` the surrounding FormControl already points the trigger at its
+  // FormMessage, so `error` is not passed there and this wiring is for standalone use.
+  const errorProps = error ? { 'aria-invalid': true, 'aria-describedby': errorId } : {};
   const [open, setOpen] = React.useState(false);
   // When the ComboBox is rendered inside a modal layer (e.g. the vaul Drawer used by PopUpDrawer),
   // the underlying Radix Dialog traps focus and blocks interaction with any element portaled to
@@ -84,6 +88,7 @@ export function ComboBox({
               placeholder={placeholder}
               form={form}
               aria-required={required || undefined}
+              {...errorProps}
               selectedOption={selectedOption}
               disabled={disabled}
               formPart={formPart}
@@ -100,7 +105,11 @@ export function ComboBox({
             />
           </PopoverContent>
         </Popover>
-        {error && <p className="text-xs text-red-500">{error}</p>}
+        {error && (
+          <p id={errorId} className="text-xs text-red-500">
+            {error}
+          </p>
+        )}
       </div>
     );
   }
@@ -115,6 +124,7 @@ export function ComboBox({
             placeholder={placeholder}
             form={form}
             aria-required={required || undefined}
+            {...errorProps}
             selectedOption={selectedOption}
             disabled={disabled}
             formPart={formPart}
@@ -133,7 +143,11 @@ export function ComboBox({
           </div>
         </DrawerContent>
       </Drawer>
-      {error && <p className="text-xs text-red-500">{error}</p>}
+      {error && (
+        <p id={errorId} className="text-xs text-red-500">
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/client/src/components/common/inputs/combo-box.tsx
+++ b/packages/client/src/components/common/inputs/combo-box.tsx
@@ -158,24 +158,24 @@ type TriggerProps = ComponentProps<typeof Button> & {
   selectedOption: Option | null;
 };
 
-function Trigger({ formPart, placeholder, selectedOption, ...triggerProps }: TriggerProps) {
-  if (formPart) {
-    return (
-      <FormControl>
-        <Button variant="outline" className="w-full justify-start" {...triggerProps}>
-          {selectedOption ? selectedOption.label : placeholder}
-          <ChevronDownIcon
-            strokeWidth={2}
-            className="shrink-0 text-gray-500/80 dark:text-gray-400/80 size-4"
-            aria-hidden="true"
-          />
-        </Button>
-      </FormControl>
-    );
-  }
-  return (
-    <Button variant="outline" className="w-[150px] justify-start" {...triggerProps}>
-      {selectedOption ? selectedOption.label : placeholder}
+function Trigger({
+  formPart,
+  placeholder,
+  selectedOption,
+  className,
+  ...triggerProps
+}: TriggerProps) {
+  // `className` is pulled out and merged rather than left in `triggerProps`: PopoverTrigger and
+  // DrawerTrigger both pass one down through `asChild`, and spreading it last silently replaced
+  // the trigger's own layout classes — which is why `justify-start` never took effect and the
+  // Button fell back to its base `justify-center`.
+  const button = (
+    <Button variant="outline" className={cn('w-full justify-between', className)} {...triggerProps}>
+      {/* The label takes the free space and truncates, so a long option cannot push the
+          chevron off the right edge. */}
+      <span className="truncate text-left">
+        {selectedOption ? selectedOption.label : placeholder}
+      </span>
       <ChevronDownIcon
         strokeWidth={2}
         className="shrink-0 text-gray-500/80 dark:text-gray-400/80 size-4"
@@ -183,6 +183,8 @@ function Trigger({ formPart, placeholder, selectedOption, ...triggerProps }: Tri
       />
     </Button>
   );
+
+  return formPart ? <FormControl>{button}</FormControl> : button;
 }
 
 function OptionsList({

--- a/packages/client/src/components/common/inputs/combo-box.tsx
+++ b/packages/client/src/components/common/inputs/combo-box.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../ui/command.js';
 import { Drawer, DrawerContent, DrawerTrigger } from '../../ui/drawer.js';
 import { FormControl } from '../../ui/form.js';
+import { Label } from '../../ui/label.js';
 import { Popover, PopoverContent, PopoverTrigger } from '../../ui/popover.js';
 
 type Option = {
@@ -31,6 +32,12 @@ type ComboBoxProps = {
   value?: string | null;
   formPart?: boolean;
   error?: string;
+  /** Rendered above the trigger. Carried over from Mantine's `Select`. */
+  label?: string;
+  id?: string;
+  /** Associates the trigger with a form element rendered outside it. */
+  form?: string;
+  required?: boolean;
 };
 
 export function ComboBox({
@@ -42,7 +49,13 @@ export function ComboBox({
   value,
   formPart,
   error,
+  label,
+  id,
+  form,
+  required,
 }: ComboBoxProps) {
+  const generatedId = React.useId();
+  const triggerId = id ?? generatedId;
   const [open, setOpen] = React.useState(false);
   // When the ComboBox is rendered inside a modal layer (e.g. the vaul Drawer used by PopUpDrawer),
   // the underlying Radix Dialog traps focus and blocks interaction with any element portaled to
@@ -63,10 +76,14 @@ export function ComboBox({
   if (isDesktop) {
     return (
       <div className="flex flex-col gap-1 w-full">
+        {label ? <Label htmlFor={triggerId}>{label}</Label> : null}
         <Popover modal open={open} onOpenChange={setOpen}>
           <PopoverTrigger asChild className="w-full min-w-40">
             <Trigger
+              id={triggerId}
               placeholder={placeholder}
+              form={form}
+              aria-required={required || undefined}
               selectedOption={selectedOption}
               disabled={disabled}
               formPart={formPart}
@@ -90,10 +107,14 @@ export function ComboBox({
 
   return (
     <div className="flex flex-col gap-1 w-full">
+      {label ? <Label htmlFor={triggerId}>{label}</Label> : null}
       <Drawer open={open} onOpenChange={setOpen}>
         <DrawerTrigger asChild>
           <Trigger
+            id={triggerId}
             placeholder={placeholder}
+            form={form}
+            aria-required={required || undefined}
             selectedOption={selectedOption}
             disabled={disabled}
             formPart={formPart}

--- a/packages/client/src/components/common/modals/balance-charge-modal.tsx
+++ b/packages/client/src/components/common/modals/balance-charge-modal.tsx
@@ -6,11 +6,12 @@ import { useFieldArray, useForm, type SubmitHandler } from 'react-hook-form';
 import { toast } from 'sonner';
 import z from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Input, Select } from '@mantine/core';
+import { Input } from '@mantine/core';
 import { Currency, type GenerateBalanceChargeMutationVariables } from '../../../gql/graphql.js';
 import { TIMELESS_DATE_REGEX, type TimelessDateString } from '../../../helpers/index.js';
 import { useGenerateBalanceCharge } from '../../../hooks/use-balance-charge.js';
 import { useGetFinancialEntities } from '../../../hooks/use-get-financial-entities.js';
+import { ComboBox } from '../../common/inputs/combo-box.js';
 import { Button } from '../../ui/button.js';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../../ui/dialog.js';
 import { Form, FormControl, FormField, FormItem, FormMessage } from '../../ui/form.js';
@@ -174,15 +175,14 @@ function BalanceChargeForm({ onOpenChange }: { onOpenChange: (open: boolean) => 
                         render={({ field }) => (
                           <FormItem>
                             <FormControl>
-                              <Select
+                              <ComboBox
                                 {...field}
                                 required
                                 data={financialEntities}
                                 value={field.value}
                                 disabled={fetchingFinancialEntities}
                                 placeholder="Creditor"
-                                maxDropdownHeight={160}
-                                searchable
+                                formPart
                               />
                             </FormControl>
                             <FormMessage />
@@ -208,15 +208,14 @@ function BalanceChargeForm({ onOpenChange }: { onOpenChange: (open: boolean) => 
                         render={({ field }) => (
                           <FormItem>
                             <FormControl>
-                              <Select
+                              <ComboBox
                                 {...field}
                                 required
                                 data={financialEntities}
                                 value={field.value}
                                 disabled={fetchingFinancialEntities}
                                 placeholder="Debtor"
-                                maxDropdownHeight={160}
-                                searchable
+                                formPart
                               />
                             </FormControl>
                             <FormMessage />

--- a/packages/client/src/components/common/modals/sync-green-invoice-documents-modal.tsx
+++ b/packages/client/src/components/common/modals/sync-green-invoice-documents-modal.tsx
@@ -1,8 +1,9 @@
 import { useEffect, type ReactElement } from 'react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Modal, Select } from '@mantine/core';
+import { Modal } from '@mantine/core';
 import { useGetAdminBusinesses } from '@/hooks/use-get-admin-businesses.js';
 import { useSyncGreenInvoiceDocuments } from '../../../hooks/use-sync-green-invoice-documents.js';
+import { ComboBox } from '../../common/inputs/combo-box.js';
 
 type ModalProps = {
   opened: boolean;
@@ -51,15 +52,13 @@ export function SyncDocumentsModal({ opened, close, setIsLoading }: ModalProps):
             control={control}
             rules={{ required: 'Owner is required' }}
             render={({ field, fieldState }): ReactElement => (
-              <Select
+              <ComboBox
                 {...field}
                 data={adminBusinesses}
                 value={soleAdminBusinessId ?? field.value}
                 disabled={fetchingAdminBusinesses || !!soleAdminBusinessId}
                 label="Owner:"
                 placeholder="Scroll to see all options"
-                maxDropdownHeight={160}
-                searchable
                 error={fieldState.error?.message}
               />
             )}

--- a/packages/client/src/components/reports/validations/validate-reports-filter.tsx
+++ b/packages/client/src/components/reports/validations/validate-reports-filter.tsx
@@ -3,7 +3,6 @@ import { format, subYears } from 'date-fns';
 import equal from 'deep-equal';
 import { Filter } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Select } from '@mantine/core';
 import { encodeFilters } from '@/router/routes.js';
 import type { ValidatePcn874ReportsQueryVariables } from '../../../gql/graphql.js';
 import { type TimelessDateString } from '../../../helpers/index.js';
@@ -11,6 +10,7 @@ import { useGetAdminBusinesses } from '../../../hooks/use-get-admin-businesses.j
 import { useUrlQuery } from '../../../hooks/use-url-query.js';
 import { UserContext } from '../../../providers/user-provider.js';
 import { PopUpModal } from '../../common/index.js';
+import { ComboBox } from '../../common/inputs/combo-box.js';
 import { MonthPickerInput } from '../../common/inputs/month-picker-input.js';
 import { Button } from '../../ui/button.js';
 
@@ -56,15 +56,13 @@ function ValidateReportsFilterForm({
           control={control}
           defaultValue={undefined}
           render={({ field, fieldState }): ReactElement => (
-            <Select
+            <ComboBox
               {...field}
               data={adminBusinesses}
               value={soleAdminBusinessId ?? field.value}
               disabled={feLoading || !!soleAdminBusinessId}
               label="Report Issuer"
               placeholder="Scroll to see all options"
-              maxDropdownHeight={160}
-              searchable
               error={fieldState.error?.message}
             />
           )}

--- a/packages/client/src/components/reports/vat-monthly-report/vat-monthly-report-filters.tsx
+++ b/packages/client/src/components/reports/vat-monthly-report/vat-monthly-report-filters.tsx
@@ -3,7 +3,6 @@ import { format } from 'date-fns';
 import equal from 'deep-equal';
 import { Filter } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Select } from '@mantine/core';
 import { encodeFilters } from '@/router/routes.js';
 import { ChargeFilterType, type VatReportFilter } from '../../../gql/graphql.js';
 import { type TimelessDateString } from '../../../helpers/index.js';
@@ -12,6 +11,7 @@ import { useUrlQuery } from '../../../hooks/use-url-query.js';
 import { UserContext } from '../../../providers/user-provider.js';
 import { chargesTypeFilterOptions } from '../../charges/charges-filters/index.js';
 import { PopUpModal } from '../../common/index.js';
+import { ComboBox } from '../../common/inputs/combo-box.js';
 import { MonthPickerInput } from '../../common/inputs/month-picker-input.js';
 import { Button } from '../../ui/button.js';
 import { getDefaultVatReportMonth } from './utils.js';
@@ -73,15 +73,13 @@ function VatMonthlyReportFilterForm({
           control={control}
           defaultValue={undefined}
           render={({ field, fieldState }): ReactElement => (
-            <Select
+            <ComboBox
               {...field}
               data={adminBusinesses}
               value={soleAdminBusinessId ?? field.value}
               disabled={feLoading || !!soleAdminBusinessId}
               label="Report Issuer (Admin Business)"
               placeholder="Scroll to see all options"
-              maxDropdownHeight={160}
-              searchable
               error={fieldState.error?.message}
             />
           )}
@@ -91,13 +89,12 @@ function VatMonthlyReportFilterForm({
           control={control}
           defaultValue={filter.chargesType}
           render={({ field, fieldState }): ReactElement => (
-            <Select
+            <ComboBox
               {...field}
               data={chargesTypeFilterOptions}
               value={field.value ?? ChargeFilterType.All}
               label="Charge Type"
               placeholder="Filter income/expense"
-              maxDropdownHeight={160}
               error={fieldState.error?.message}
             />
           )}


### PR DESCRIPTION
Step 7 of the Mantine removal: **20 `Select` call sites across 11 files** move to the existing `ComboBox`.

## Why this one was mostly subtraction

`ComboBox` already matched Mantine's shape — same `data` / `value` / `onChange` / `error` / `placeholder` / `disabled`, and always searchable — so most of the diff is removing props that no longer mean anything, not translating them.

Three props were added to `ComboBox` for parity:

| Added | Why |
|---|---|
| `label` | Mantine's `Select` rendered its own |
| `form` | associates the trigger with a form element rendered outside it (the depreciation rows) |
| `required` | as `aria-required`, since the trigger is a `<button>` |

Dropped, with reasons:

- `maxDropdownHeight` — `ComboBox`'s list sizes itself.
- `searchable` — always on.
- **`withinPortal` and `zIndex={1002}`** — see below.
- `error` at sites already inside a `FormControl`, where `FormMessage` renders the message and `ComboBox` would have rendered it a second time. The now-unused `fieldState` bindings went with it.

## The stacking workaround is gone

`ComboBox` portals through `usePortalContainer`, so the `zIndex={1002}` overrides I added in #4408 — when the depreciation dialog became a Radix dialog and its Mantine dropdowns fell behind it — are no longer needed. Converting the component removed the need for the hack rather than carrying it forward. **Those were the last `zIndex` overrides in the client.**

## Two sites needed real changes, not prop edits

- **`charts/monthly-income-expense/chart-filter.tsx`** passed a bare `Currency[]`; `ComboBox` takes `{ value, label }`. Its `defaultValue={Currency.Usd}` moved onto the `Controller` — `ComboBox` is controlled, so leaving the default on the field would have silently lost it.
- **`common/forms/edit-charge.tsx`** used `rightSection` to place an "insert business trip" modal beside the field. `ComboBox` has no such slot, so the modal is now a sibling in a flex row rather than adding a one-use slot to a shared component.

## Scope

`MultiSelect` is **not** in this PR, and the split is on a real API gap rather than size: the local `MultiSelect` is **uncontrolled** — `defaultValue` with `useState(defaultValue)` and no sync effect. Several Mantine `MultiSelect`s are externally driven (`documents-filters.tsx` forces a value from `soleAdminBusinessId`), so a mechanical swap would break them. It needs controlled support added first, which is its own PR.

The 8 `business-trip-report/` files also keep their `Select`s; that subtree gets migrated wholesale.

## Verification

```
yarn test:client                                  # 45 files, 349 passed, 1 skipped
yarn workspace @accounter/client build            # typechecks + builds
yarn workspace @accounter/client storybook:build  # completes
yarn lint / prettier:check                        # clean
```

`combo-box.stories.tsx` covers the new props. Worth noting: **the portable-stories test caught a bug in my own story** — `formPart` renders a `FormControl`, which calls `useFormContext()` and throws outright outside a form. The `AsFormPart` story now wires up a real `useForm`, and the constraint is documented there.

Worth eyeballing: the depreciation dialog's Category/Type dropdowns (the ones that had the z-index hack), and the business-trip field in Edit Charge where the modal moved.

**Mantine imports: 75 → 68, across 74 → 67 files.** `components/charts` is Mantine-free and joins the ESLint `error` list.

## Related

Follows #4403, #4404, #4405, #4407, #4408, #4410, #4414. Next: `MultiSelect` (needs controlled support), then the business-trip-report subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR)_