### PR TITLE
fix(build): keep emitting programs' tsbuildinfo inside outDir

### DIFF
--- a/.changeset/tsbuildinfo-inside-outdir.md
+++ b/.changeset/tsbuildinfo-inside-outdir.md
@@ -1,0 +1,52 @@
+---
+'@accounter/server': patch
+'@accounter/mcp-server': patch
+'@accounter/email-ingestion-gateway': patch
+'@accounter/modern-poalim-scraper': patch
+---
+
+Fix a green build that emits nothing: move every emitting program's TypeScript build info inside
+its own `outDir`.
+
+Staging stopped booting after #4418 with a build that reported success:
+
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module
+  '/opt/render/project/src/packages/server/dist/bootstrap-telemetry.js'
+```
+
+`tsc` trusts its build info without ever checking that the output it describes is still on disk. If
+the build info outlives its `dist`, the next build decides everything is up to date, skips the emit
+and **exits 0 having produced nothing at all** — not a stale `dist`, an absent one. #4418 put the
+build info under `node_modules/.cache/tsbuildinfo/`, which is precisely the arrangement that pulls
+the two apart on a deploy: the platform restores a cached `node_modules` (build info intact) over a
+fresh checkout that has no git-ignored `dist`.
+
+Reproduced end-to-end against `packages/server` before the fix — a cold build emits 22 files, and
+the very next build, with only `dist` removed, exits 0 and leaves `dist` with **0 entries**.
+
+The four programs that emit via `tsc` now keep their build info at `dist/.tsbuildinfo`, so output
+and build info are created and discarded together:
+
+- `packages/server/tsconfig.build.json`
+- `packages/mcp-server/tsconfig.json`
+- `packages/email-ingestion-gateway/tsconfig.json`
+- `packages/modern-poalim-scraper/tsconfig.json`
+
+The `--noEmit` type-checking programs (`server` `tsconfig.json`, `client`, and the `typecheck`
+scripts of the `tsup`-built packages) stay under `node_modules/.cache/tsbuildinfo/`: they produce no
+output that can fall out of sync, and that is where the measured typecheck speedups came from, so
+the CI cache keeps covering them.
+
+CI had the same latent defect, and it was worse there than on staging: both `publish` jobs restore
+that cache and then run `yarn build`, so a cache hit could have published `@accounter/server` and
+`@accounter/modern-poalim-scraper` with no compiled output. The cache comment in
+`.github/actions/setup` claimed a stale restore "costs a full rebuild, never a wrong one" — true
+only for the `--noEmit` programs still cached there, and now scoped to say so.
+
+`scripts/__tests__/tsbuildinfo-placement.test.ts` guards the rule: it walks each package's `build`
+script, resolves which tsconfig every `tsc` invocation actually uses (following `yarn <script>`
+chains and `extends` for `noEmit`/`outDir`/`tsBuildInfoFile`), and fails if an emitting program
+points its build info outside its `outDir`. It rediscovers exactly the four configs above from the
+build scripts rather than a hardcoded list, so a fifth emitting package is covered the day it is
+added.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -72,14 +72,19 @@ runs:
       if: ${{ inputs.tsBuildInfo == 'true' }}
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        # Every package points `tsBuildInfoFile` here, so one directory covers the
-        # whole workspace. The key is unique per run because cache entries are
-        # immutable — without it the first run of the day would pin a stale entry
-        # and later runs could never refresh it. `restore-keys` is what actually
-        # produces the hit: the same toolchain and tsconfig set first, then the
-        # newest entry for the OS. Build info is invalidated by TypeScript itself
-        # when a source file or a compiler option changes, so a stale restore costs
-        # a full rebuild, never a wrong one.
+        # Every type-checking program points `tsBuildInfoFile` here, so one directory
+        # covers them all. Programs that *emit* deliberately keep their build info
+        # inside their own `outDir` and are not cached here: `tsc` trusts build info
+        # without checking that the output it describes still exists, so restoring
+        # build info over a fresh checkout (which has no git-ignored `dist`) would
+        # make those builds skip the emit and exit 0 with nothing in `dist`.
+        #
+        # The key is unique per run because cache entries are immutable — without it
+        # the first run of the day would pin a stale entry and later runs could never
+        # refresh it. `restore-keys` is what actually produces the hit: the same
+        # toolchain and tsconfig set first, then the newest entry for the OS. For the
+        # `--noEmit` programs cached here there is no output to go stale, so a stale
+        # restore costs a full typecheck, never a wrong one.
         path: node_modules/.cache/tsbuildinfo
         key: ${{ steps.tsbuildinfo-key.outputs.prefix }}-${{ github.run_id }}
         restore-keys: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,16 +68,23 @@ yarn seed:admin-context # Seed admin context for server
 
 # TypeScript Build Cache
 
-- Every `tsc` run is incremental. Build info lives in `node_modules/.cache/tsbuildinfo/`, one file
-  per tsconfig (`tsBuildInfoFile` in each `packages/<name>/tsconfig*.json`).
+- Every `tsc` run is incremental, and where the build info lives depends on whether the program
+  emits. **Programs that emit put it inside their own `outDir`** (`dist/.tsbuildinfo`); **`--noEmit`
+  type-checking programs put it in `node_modules/.cache/tsbuildinfo/`**, one file per tsconfig.
+- That split is load-bearing, not cosmetic. `tsc` trusts its build info without checking that the
+  output it describes is still on disk: if the build info outlives its `dist`, the next build skips
+  the emit and exits 0 having produced nothing. Deploys and CI hit exactly that — a fresh checkout
+  has no (git-ignored) `dist`, but a restored `node_modules` cache would still have the build info.
+  Keeping the two in one directory means they are always created and discarded together.
 - One file per tsconfig, not per package: `server` has two programs (`tsconfig.json` typechecks,
   `tsconfig.build.json` emits) and they get separate build info, because they differ in options and
   in the files they cover.
 - A new tsconfig that extends the root config inherits `incremental` — give it its own
-  `tsBuildInfoFile` so it doesn't share build state with another program. Packages built by `bob`
-  are the exception: leave `tsBuildInfoFile` unset, since `bob` runs `tsc` once per output format.
-- If a build ever looks stale, delete `node_modules/.cache/tsbuildinfo/` — that forces the next
-  `tsc` run to start from scratch.
+  `tsBuildInfoFile` so it doesn't share build state with another program, placed per the rule above.
+  Packages built by `bob` are the exception: leave `tsBuildInfoFile` unset, since `bob` runs `tsc`
+  once per output format (the default location is already inside the output dir).
+- If a build ever looks stale, delete `node_modules/.cache/tsbuildinfo/` and the package's `dist/` —
+  that forces the next `tsc` run to start from scratch.
 
 # Architecture
 

--- a/packages/email-ingestion-gateway/tsconfig.json
+++ b/packages/email-ingestion-gateway/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/email-ingestion-gateway.tsbuildinfo",
+    // Inside `outDir` on purpose: `tsc` trusts its build info without checking that the
+    // output is still on disk, so build info that outlives `dist` makes the emit a no-op
+    // that exits 0 and produces nothing. Co-locating them means they share a fate.
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
     "rootDir": "src",
     "outDir": "dist",
     "module": "ES2022",

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/mcp-server.tsbuildinfo",
+    // Inside `outDir` on purpose: `tsc` trusts its build info without checking that the
+    // output is still on disk, so build info that outlives `dist` makes the emit a no-op
+    // that exits 0 and produces nothing. Co-locating them means they share a fate.
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
     "rootDir": "src",
     "outDir": "dist",
     "module": "ES2022",

--- a/packages/modern-poalim-scraper/tsconfig.json
+++ b/packages/modern-poalim-scraper/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/modern-poalim-scraper.tsbuildinfo",
+    // Inside `outDir` on purpose: `tsc` trusts its build info without checking that the
+    // output is still on disk, so build info that outlives `dist` makes the emit a no-op
+    // that exits 0 and produces nothing. Co-locating them means they share a fate.
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
     "outDir": "dist",
     "rootDir": "./src",
     "exactOptionalPropertyTypes": true,

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -10,7 +10,15 @@
     // Its own build info, not the one `tsconfig.json` sets: this program emits, pins a
     // different `rootDir` and drops the tests, so sharing a file would make every `build`
     // invalidate the last `typecheck` and vice versa.
-    "tsBuildInfoFile": "../../node_modules/.cache/tsbuildinfo/server-build.tsbuildinfo",
+    //
+    // It lives inside `outDir`, unlike the type-checking programs' build info under
+    // `node_modules/.cache/tsbuildinfo/`, and that placement is load-bearing: `tsc` trusts
+    // the build info without ever checking that the output it describes is still on disk.
+    // Build info that outlives its `dist` makes `tsc` skip the emit and exit 0, leaving no
+    // `dist` at all — which is exactly what a deploy does, since it restores a cached
+    // `node_modules` over a fresh checkout that has no (git-ignored) `dist`. Keeping the two
+    // in one directory means they are always created and discarded together.
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
     "noEmit": false,
     "outDir": "dist",
     // Pinned rather than inferred, so a future import that escapes `src` fails loudly with

--- a/scripts/__tests__/tsbuildinfo-placement.test.ts
+++ b/scripts/__tests__/tsbuildinfo-placement.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 /**
@@ -94,6 +94,24 @@ function resolveOptions(configPath: string): CompilerOptions {
   };
 }
 
+/**
+ * Whether `file` sits under `dir`.
+ *
+ * Both halves matter, and neither is covered by a bare `startsWith('..')`:
+ *
+ * - `relative()` gives up and returns an *absolute* path when the two share no root at
+ *   all — different Windows drive letters, or a UNC path — and an absolute result starts
+ *   with neither `..` nor anything else recognizable. Reading that as "inside" would make
+ *   this whole file pass silently on exactly the paths it exists to reject.
+ * - A directory genuinely inside `dir` may be *named* something like `..cache`, whose
+ *   relative path starts with `..` without escaping anything. Hence the separator.
+ */
+function isInside(dir: string, file: string): boolean {
+  const rel = relative(dir, file);
+  if (isAbsolute(rel)) return false;
+  return rel !== '..' && !rel.startsWith(`..${sep}`);
+}
+
 type TscInvocation = {
   /** Workspace directory name under `packages/`. */
   pkg: string;
@@ -161,6 +179,23 @@ const packageDirs = readdirSync(packagesDir, { withFileTypes: true })
   .map(entry => entry.name)
   .sort();
 
+describe('isInside', () => {
+  const dir = resolve(sep, 'a', 'dist');
+
+  it.each([
+    ['the file itself', join(dir, '.tsbuildinfo'), true],
+    ['a nested file', join(dir, 'nested', '.tsbuildinfo'), true],
+    // `..cache` escapes nothing; `relative()` still returns it prefixed with two dots.
+    ['a directory whose name begins with two dots', join(dir, '..cache', 'x'), true],
+    ['the directory itself', dir, true],
+    ['a path that walks out', resolve(sep, 'a', 'node_modules', '.cache', 'x'), false],
+    // Shares `/a/dist` as a *string* prefix without being inside it.
+    ['a sibling with a shared prefix', resolve(sep, 'a', 'dist-2', 'x'), false],
+  ])('%s', (_case, file, expected) => {
+    expect(isInside(dir, file)).toBe(expected);
+  });
+});
+
 describe('TypeScript build-info placement', () => {
   it('finds the emitting builds it means to check', () => {
     const emitting = packageDirs.flatMap(emittingTscInvocations);
@@ -187,12 +222,12 @@ describe('TypeScript build-info placement', () => {
         if (tsBuildInfoFile === undefined) return;
 
         expect(
-          relative(outDir!, tsBuildInfoFile).startsWith('..'),
+          isInside(outDir!, tsBuildInfoFile),
           `${config} points tsBuildInfoFile at ${relative(repoRoot, tsBuildInfoFile)}, outside ` +
             `its outDir (${relative(repoRoot, outDir!)}). Build info that outlives the output ` +
             `makes this build emit nothing and still exit 0 — see the comment at the top of ` +
             `this file.`,
-        ).toBe(false);
+        ).toBe(true);
       });
     }
   }

--- a/scripts/__tests__/tsbuildinfo-placement.test.ts
+++ b/scripts/__tests__/tsbuildinfo-placement.test.ts
@@ -1,0 +1,199 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `tsc` trusts its build info without checking that the output it describes is still on
+ * disk. If the build info outlives its `outDir`, the next build decides everything is up
+ * to date, skips the emit, and exits 0 having produced nothing at all.
+ *
+ * Deploys and CI hit exactly that: a fresh checkout has no (git-ignored) `dist`, but a
+ * restored `node_modules` cache still has the build info. It broke the staging server
+ * with `ERR_MODULE_NOT_FOUND` on `dist/bootstrap-telemetry.js` — a green build followed
+ * by an empty `dist`.
+ *
+ * So every program that *emits* keeps its build info inside its own `outDir`, where the
+ * two are created and discarded together. Type-checking (`--noEmit`) programs have no
+ * output to fall out of sync with, and keep theirs in `node_modules/.cache/tsbuildinfo/`
+ * so CI can cache them.
+ */
+
+const repoRoot = join(import.meta.dirname, '../..');
+const packagesDir = join(repoRoot, 'packages');
+
+/** Strip `//` and `/* *\/` comments, leaving anything inside string literals alone. */
+function stripJsonComments(text: string): string {
+  let out = '';
+  let inString = false;
+  for (let i = 0; i < text.length; ) {
+    const char = text[i]!;
+    if (inString) {
+      if (char === '\\') {
+        out += text.slice(i, i + 2);
+        i += 2;
+        continue;
+      }
+      if (char === '"') inString = false;
+      out += char;
+      i += 1;
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      out += char;
+      i += 1;
+      continue;
+    }
+    if (char === '/' && text[i + 1] === '/') {
+      const newline = text.indexOf('\n', i);
+      i = newline === -1 ? text.length : newline;
+      continue;
+    }
+    if (char === '/' && text[i + 1] === '*') {
+      const close = text.indexOf('*/', i + 2);
+      i = close === -1 ? text.length : close + 2;
+      continue;
+    }
+    out += char;
+    i += 1;
+  }
+  return out;
+}
+
+type CompilerOptions = {
+  noEmit?: boolean;
+  outDir?: string;
+  tsBuildInfoFile?: string;
+};
+
+/**
+ * The three options this file cares about, resolved through the `extends` chain. A
+ * relative path is resolved against the directory of the config that *declares* it,
+ * which is what makes an inherited `outDir` point somewhere else entirely.
+ */
+function resolveOptions(configPath: string): CompilerOptions {
+  const raw = JSON.parse(stripJsonComments(readFileSync(configPath, 'utf8'))) as {
+    extends?: string;
+    compilerOptions?: Record<string, unknown>;
+  };
+  const own = raw.compilerOptions ?? {};
+  const configDir = dirname(configPath);
+
+  const inherited: CompilerOptions = raw.extends
+    ? resolveOptions(resolve(configDir, raw.extends))
+    : {};
+
+  return {
+    noEmit: 'noEmit' in own ? Boolean(own['noEmit']) : inherited.noEmit,
+    outDir:
+      typeof own['outDir'] === 'string' ? resolve(configDir, own['outDir']) : inherited.outDir,
+    tsBuildInfoFile:
+      typeof own['tsBuildInfoFile'] === 'string'
+        ? resolve(configDir, own['tsBuildInfoFile'])
+        : inherited.tsBuildInfoFile,
+  };
+}
+
+type TscInvocation = {
+  /** Workspace directory name under `packages/`. */
+  pkg: string;
+  /** The npm script the invocation was reached through, for failure messages. */
+  script: string;
+  configPath: string;
+};
+
+/**
+ * Every `tsc` invocation reachable from a package's `build` script that emits.
+ *
+ * `build` scripts chain (`yarn typecheck && tsup src/index.ts`), so `yarn <name>` is
+ * followed into the named script when the package declares one. Invocations passing
+ * `--noEmit`, and configs that set `noEmit`, are dropped: they produce no output, so
+ * where their build info lives cannot desynchronize from anything.
+ */
+function emittingTscInvocations(pkg: string): TscInvocation[] {
+  const pkgDir = join(packagesDir, pkg);
+  const manifest = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8')) as {
+    scripts?: Record<string, string>;
+  };
+  const scripts = manifest.scripts ?? {};
+
+  const found: TscInvocation[] = [];
+  const visited = new Set<string>();
+
+  function walk(scriptName: string) {
+    if (visited.has(scriptName)) return;
+    visited.add(scriptName);
+    const body = scripts[scriptName];
+    if (!body) return;
+
+    for (const command of body.split(/&&|\|\||;|\|/)) {
+      const words = command.trim().split(/\s+/).filter(Boolean);
+      if (words.length === 0) continue;
+
+      // `yarn <script>` delegates; `yarn tsc` runs the binary, since no package here
+      // declares a script by that name.
+      const [head, ...rest] = words[0] === 'yarn' ? words.slice(1) : words;
+      if (head === undefined) continue;
+      if (head !== 'tsc') {
+        if (words[0] === 'yarn' && head in scripts) walk(head);
+        continue;
+      }
+      if (rest.includes('--noEmit')) continue;
+
+      const projectFlag = rest.findIndex(word => word === '-p' || word === '--project');
+      const configPath = join(
+        pkgDir,
+        projectFlag === -1 ? 'tsconfig.json' : (rest[projectFlag + 1] ?? 'tsconfig.json'),
+      );
+      if (!existsSync(configPath)) continue;
+      if (resolveOptions(configPath).noEmit) continue;
+
+      found.push({ pkg, script: scriptName, configPath });
+    }
+  }
+
+  walk('build');
+  return found;
+}
+
+const packageDirs = readdirSync(packagesDir, { withFileTypes: true })
+  .filter(entry => entry.isDirectory() && existsSync(join(packagesDir, entry.name, 'package.json')))
+  .map(entry => entry.name)
+  .sort();
+
+describe('TypeScript build-info placement', () => {
+  it('finds the emitting builds it means to check', () => {
+    const emitting = packageDirs.flatMap(emittingTscInvocations);
+
+    // A parser that silently matches nothing would make every assertion below vacuous.
+    expect(emitting.map(({ configPath }) => relative(repoRoot, configPath)).sort()).toContain(
+      'packages/server/tsconfig.build.json',
+    );
+  });
+
+  for (const pkg of packageDirs) {
+    const emitting = emittingTscInvocations(pkg);
+    if (emitting.length === 0) continue;
+
+    for (const { script, configPath } of emitting) {
+      const config = relative(repoRoot, configPath);
+
+      it(`${config} (${pkg} \`${script}\`) keeps its build info inside outDir`, () => {
+        const { outDir, tsBuildInfoFile } = resolveOptions(configPath);
+
+        expect(outDir, `${config} emits but declares no outDir`).toBeDefined();
+
+        // Unset is fine: TypeScript's own default already sits inside `outDir`.
+        if (tsBuildInfoFile === undefined) return;
+
+        expect(
+          relative(outDir!, tsBuildInfoFile).startsWith('..'),
+          `${config} points tsBuildInfoFile at ${relative(repoRoot, tsBuildInfoFile)}, outside ` +
+            `its outDir (${relative(repoRoot, outDir!)}). Build info that outlives the output ` +
+            `makes this build emit nothing and still exit 0 — see the comment at the top of ` +
+            `this file.`,
+        ).toBe(false);
+      });
+    }
+  }
+});


### PR DESCRIPTION
## The failure

Staging stopped booting, on a build that reported success:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  '/opt/render/project/src/packages/server/dist/bootstrap-telemetry.js'
```

## Root cause

`tsc` trusts its build info without ever checking that the output it describes is still on disk. When the build info outlives its `dist`, the next build decides everything is up to date, skips the emit, and **exits 0 having produced nothing at all** — an absent `dist`, not a stale one.

#4418 moved the build info to `node_modules/.cache/tsbuildinfo/`, which is precisely the arrangement that pulls the two apart on a deploy: the platform restores a cached `node_modules` (build info intact) over a fresh checkout that has no git-ignored `dist`. `bootstrap-telemetry.js` was never written, and `start` (`node --import ./dist/bootstrap-telemetry.js dist/index.js`) failed on the file that was supposed to have just been built.

## Reproduced end-to-end

Against `packages/server` itself, simulating a deploy (remove `dist`, keep the `node_modules` cache):

| config | cold build | next build, `dist` removed |
| --- | --- | --- |
| before (`node_modules/.cache/…`) | exit 0, `bootstrap-telemetry.js` present | exit 0, **`dist` has 0 entries** |
| after (`dist/.tsbuildinfo`) | exit 0, `bootstrap-telemetry.js` present | exit 0, 22 entries, `bootstrap-telemetry.js` present |

Same before/after on `modern-poalim-scraper` (a package that builds with no codegen or DB), and in an isolated minimal project to confirm the `tsc` semantics rather than infer them.

## The fix

The four programs that emit via `tsc` now keep their build info at `dist/.tsbuildinfo`, so output and build info are created and discarded together:

- `packages/server/tsconfig.build.json`
- `packages/mcp-server/tsconfig.json`
- `packages/email-ingestion-gateway/tsconfig.json`
- `packages/modern-poalim-scraper/tsconfig.json`

The `--noEmit` type-checking programs (`server` `tsconfig.json`, `client`, and the `typecheck` scripts of the `tsup`-built packages) stay under `node_modules/.cache/tsbuildinfo/`. They produce no output that can fall out of sync, and that is where #4418's measured typecheck speedups came from (client `tsc` 58.2s → 5.4s), so the CI cache keeps covering them. The server's `build` loses nothing locally either: `dist` persists between dev builds, so the incremental win stands.

## CI had the same defect, and worse

Both `publish` jobs restore that cache and then run `yarn build`, so a cache hit could have published `@accounter/server` and `@accounter/modern-poalim-scraper` with no compiled output. The cache comment in `.github/actions/setup` claimed a stale restore "costs a full rebuild, never a wrong one" — true only for the `--noEmit` programs still cached there, and now scoped to say so.

## Regression guard

`scripts/__tests__/tsbuildinfo-placement.test.ts` walks each package's `build` script, resolves which tsconfig every `tsc` invocation actually uses (following `yarn <script>` chains, and `extends` for `noEmit`/`outDir`/`tsBuildInfoFile`), and fails if an emitting program points its build info outside its `outDir`.

It rediscovers exactly the four configs above from the build scripts rather than a hardcoded list — which is also how they were found — so a fifth emitting package is covered the day it is added. Verified in both directions: green as committed, and red with a one-line revert of the server config, naming the file and the offending path.

## Checks

- `yarn lint` — 0 errors (940 pre-existing `no-console` warnings, none in the new file)
- `yarn prettier:check` — clean
- new test — 6 passed

`yarn test` beyond that file needs a local Postgres, which this environment has no Docker for; the server typecheck likewise can't complete here without pgtyped codegen, so the emit checks above were run against the type errors that absence produces (`tsc` emits regardless, which is what the tables measure). Untouched by this change either way — it moves one path per config and adds a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3eCVL9fdf2RFENb4vmyku


---
_Generated by [Claude Code](https://claude.ai/code/session_01E3eCVL9fdf2RFENb4vmyku)_