### PR TITLE
perf(db): default new-row uuids to uuidv7() instead of gen_random_uuid()

### DIFF
--- a/.changeset/@accounter_client-4425-dependencies.md
+++ b/.changeset/@accounter_client-4425-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`lucide-react@1.43.0` ↗︎](https://www.npmjs.com/package/lucide-react/v/1.43.0) (from `1.42.0`, in `dependencies`)

--- a/.changeset/@accounter_server-4425-dependencies.md
+++ b/.changeset/@accounter_server-4425-dependencies.md
@@ -1,0 +1,8 @@
+---
+"@accounter/server": patch
+---
+dependencies updates:
+  - Updated dependency [`@ai-sdk/anthropic@4.0.50` ↗︎](https://www.npmjs.com/package/@ai-sdk/anthropic/v/4.0.50) (from `4.0.49`, in `dependencies`)
+  - Updated dependency [`@graphql-tools/utils@12.0.1` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/12.0.1) (from `12.0.0`, in `dependencies`)
+  - Updated dependency [`ai@7.0.95` ↗︎](https://www.npmjs.com/package/ai/v/7.0.95) (from `7.0.93`, in `dependencies`)
+  - Updated dependency [`googleapis@178.1.1` ↗︎](https://www.npmjs.com/package/googleapis/v/178.1.1) (from `178.0.0`, in `dependencies`)

--- a/.changeset/uuidv7-id-defaults.md
+++ b/.changeset/uuidv7-id-defaults.md
@@ -1,0 +1,64 @@
+---
+'@accounter/server': patch
+---
+
+Switch every `DEFAULT gen_random_uuid()` column in `accounter_schema` to PostgreSQL 18's `uuidv7()`.
+
+`gen_random_uuid()` produces v4 uuids — uniformly random, so consecutive inserts land in unrelated
+pages of the primary-key B-tree. Every insert is a candidate page split, the effective working set is
+the whole index rather than its right-hand edge, and the resulting page dirtying shows up as extra
+full-page images in WAL. `uuidv7()` puts a millisecond timestamp in the high 48 bits, so ids sort by
+creation time and inserts append instead of scattering. The tables where that matters are the
+append-heavy ones: `charges`, `transactions`, `documents`, `ledger_records`, and every scraper raw
+table.
+
+`2026-09-09T10-00-00.uuidv7-id-defaults.sql` is the whole change. Id generation for these tables is
+entirely a DB-side `DEFAULT` — no server code calls `gen_random_uuid()` — so altering the default is
+sufficient, and altering a default rewrites one `pg_attrdef` row per column without touching a single
+heap page. There is no backfill and no rewrite: existing v4 ids stay exactly as they are, and a
+column holding a mix of v4 and v7 values is well-formed, since both are 128-bit uuids compared and
+indexed byte-wise and nothing in the schema or the application reads a version nibble out of an id.
+
+The target columns — the `id` of each table, plus `business_users.user_id` — are discovered from
+`pg_attrdef` rather than listed in the migration, so it converts whatever the target database
+actually holds. An environment that is behind on migrations, or a table added between this being
+written and being deployed, converts the same way, and re-running finds nothing left to do. Running
+the full migration set into an empty database puts the count at 49 (the issue's audit says 50, which
+is why the exact number is deliberately not written into the migration). A guard raises a clear error
+on a server older than 18 instead of letting the first `ALTER` fail with a bare "function uuidv7()
+does not exist".
+
+Three sites are deliberately excluded. `shared/helpers/deterministic-uuid.ts` (uuid v5), used by
+`entity-ensure.provider.ts`, stays as it is: its determinism *is* the idempotency mechanism behind
+`ON CONFLICT (id) DO NOTHING` during ingestion, and a time-ordered id would re-insert every row on
+every run. The app-side `randomUUID()` callers in `auth/providers/invitations.provider.ts`,
+`email-ingestion-control.provider.ts` (`jti`) and `email-ingestion-ingest.provider.ts` are low volume
+and, being app-side, out of reach of a column default anyway. Neither category is affected by this
+migration even in principle.
+
+The trade-off, stated rather than assumed: a v7 id is no longer opaque about when its row was
+created — the leading 48 bits are a readable Unix millisecond timestamp — ids become roughly ordered,
+and a neighbouring id becomes guessable in a way a v4 id is not. That is acceptable here because none
+of these columns is a secret: every one of these tables already carries a `created_at`, access is
+gated by authentication and RLS rather than id unguessability, and the actual capability tokens are
+separate `TEXT` columns filled from `node:crypto` (`invitations.token`, `api_keys.key_hash`,
+`email_ingestion_replay_nonces.nonce`). A future column that needs an unguessable id should declare
+`DEFAULT gen_random_uuid()` explicitly and be added to the exemption set in the new test.
+
+`uuidv7-id-defaults.test.ts` runs the full migration set into a fresh database and asserts the
+catalog invariant — no uuid column in `accounter_schema` is left on `gen_random_uuid()` outside a
+named exemption set (empty today) — so a future table that ships with the v4 default is caught as it
+lands rather than by someone re-running the audit. It also names the four append-heavy tables and
+`business_users.user_id` explicitly, decodes the timestamp out of a freshly generated id to prove the
+default really is time-ordered, and inserts an explicit v4 id to pin down the coexistence the "no
+backfill" claim rests on.
+
+Verified locally by running the full migration set into an empty database and exercising the catalog
+loop against it: 49 columns converted, a second run converts 0, and the documented revert — the same
+loop with the two function names swapped — puts all 49 back. The version guard was confirmed to fire
+with its own message rather than a missing-function error. That run was on PostgreSQL 16 with a
+stand-in `uuidv7()`, so the v7-shaped assertions in the new test are exercised by CI, which runs
+`postgres:18-alpine`.
+
+The database is ~100 MB today and the benefit scales with insert volume and index size, so this is a
+"do it before it hurts" change rather than a fix for a measured regression.

--- a/packages/migrations/src/__tests__/uuidv7-id-defaults.test.ts
+++ b/packages/migrations/src/__tests__/uuidv7-id-defaults.test.ts
@@ -1,0 +1,168 @@
+import { createPool, sql, type DatabasePool } from 'slonik';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import z from 'zod';
+import { createConnectionString } from '../connection-string.js';
+import { env } from '../environment.js';
+import { assertLocalDatabase } from '../local-db-guard.js';
+import { runPGMigrations } from '../run-pg-migrations.js';
+
+const TEST_DB_NAME = `accounter_migration_test_uuidv7_${Date.now()}`;
+
+/**
+ * Columns in `accounter_schema` that are deliberately left on `gen_random_uuid()`.
+ *
+ * Empty today, and that is the point: an entry here is a column whose id must stay
+ * opaque about creation time and unguessable from a neighbouring id — the one
+ * property `uuidv7()` gives up. The migration itself runs once and is recorded, so
+ * a column added after it with `DEFAULT gen_random_uuid()` keeps that default; this
+ * set is what says whether that was deliberate. Add to it as `table.column`, and
+ * only alongside the reason.
+ */
+const UUIDV7_EXEMPT_COLUMNS = new Set<string>([]);
+
+/**
+ * The append-heavy tables named in the issue. Asserted by name so a future schema
+ * edit that quietly reverts one of them fails here rather than in a slow index.
+ */
+const HOT_TABLES = ['charges', 'transactions', 'documents', 'ledger_records'];
+
+describe('uuidv7 id defaults migration', () => {
+  let rootPool: DatabasePool;
+  let testPool: DatabasePool;
+
+  beforeAll(async () => {
+    // This suite CREATEs and DROPs a database and runs every migration into it, so it
+    // must never be pointed at a deployed server. Same guard, same reasoning as
+    // `rls-all-tables.test.ts`.
+    assertLocalDatabase({ ...env.postgres }, 'the uuidv7 id defaults migration suite');
+
+    rootPool = await createPool(createConnectionString({ ...env.postgres, db: 'postgres' }), {
+      statementTimeout: 5000,
+    });
+
+    await rootPool.query(sql.unsafe`CREATE DATABASE ${sql.identifier([TEST_DB_NAME])}`);
+
+    testPool = await createPool(createConnectionString({ ...env.postgres, db: TEST_DB_NAME }), {
+      statementTimeout: 60_000,
+    });
+
+    await runPGMigrations({ slonik: testPool });
+  }, 180_000);
+
+  afterAll(async () => {
+    if (testPool) {
+      await testPool.end();
+    }
+    if (rootPool) {
+      try {
+        await rootPool.query(sql.unsafe`
+          SELECT pg_terminate_backend(pg_stat_activity.pid)
+          FROM pg_stat_activity
+          WHERE pg_stat_activity.datname = ${TEST_DB_NAME}
+            AND pid <> pg_backend_pid();
+        `);
+        await rootPool.query(sql.unsafe`DROP DATABASE IF EXISTS ${sql.identifier([TEST_DB_NAME])}`);
+      } catch (e) {
+        console.error('Failed to cleanup test database', e);
+      }
+      await rootPool.end();
+    }
+  });
+
+  /** Every uuid column in `accounter_schema` that carries a column default. */
+  async function uuidDefaults() {
+    return testPool.any(
+      sql.type(
+        z.object({
+          table_name: z.string(),
+          column_name: z.string(),
+          default_expr: z.string(),
+        }),
+      )`
+        SELECT
+          c.relname AS table_name,
+          a.attname AS column_name,
+          pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS default_expr
+        FROM pg_catalog.pg_attribute a
+        JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_catalog.pg_attrdef d
+          ON d.adrelid = a.attrelid
+         AND d.adnum = a.attnum
+        WHERE n.nspname = 'accounter_schema'
+          AND c.relkind IN ('r', 'p')
+          AND NOT a.attisdropped
+          AND a.atttypid = 'uuid'::regtype
+        ORDER BY c.relname, a.attname
+      `,
+    );
+  }
+
+  it('leaves no uuid column defaulting to gen_random_uuid()', async () => {
+    const rows = await uuidDefaults();
+
+    // Guard against the catalog query silently matching nothing — otherwise a broken
+    // join would make the assertion below pass vacuously.
+    expect(rows.length).toBeGreaterThan(0);
+
+    const stragglers = rows
+      .filter(r => r.default_expr === 'gen_random_uuid()')
+      .filter(r => !UUIDV7_EXEMPT_COLUMNS.has(`${r.table_name}.${r.column_name}`))
+      .map(r => `${r.table_name}.${r.column_name}`);
+
+    expect(stragglers).toEqual([]);
+  }, 30_000);
+
+  it('converts the append-heavy tables named in the issue', async () => {
+    const rows = await uuidDefaults();
+    const byKey = new Map(rows.map(r => [`${r.table_name}.${r.column_name}`, r.default_expr]));
+
+    for (const table of HOT_TABLES) {
+      expect(byKey.get(`${table}.id`)).toBe('uuidv7()');
+    }
+
+    // `business_users.user_id` is the one converted column that is not named `id`;
+    // asserted explicitly so a narrowing of the migration's catalog filter is caught.
+    expect(byKey.get('business_users.user_id')).toBe('uuidv7()');
+  }, 30_000);
+
+  it('generates time-ordered version-7 ids for new rows', async () => {
+    // `audit_logs` is the cheapest converted table to insert into: `action` is its only
+    // NOT NULL column beyond the defaulted `id` and `created_at`, its `business_id` FK is
+    // nullable so no fixture rows are needed, and it carries no `owner_id` and therefore
+    // no RLS policy to work around.
+    const before = Date.now();
+    const { id } = await testPool.one(
+      sql.type(z.object({ id: z.string() }))`
+        INSERT INTO accounter_schema.audit_logs (action)
+        VALUES ('uuidv7-default-test')
+        RETURNING id
+      `,
+    );
+
+    // The version nibble is the first character of the third dash-separated group.
+    expect(id.split('-')[2]?.[0]).toBe('7');
+
+    // The leading 48 bits of a v7 uuid are a Unix millisecond timestamp. Reading them
+    // back is what actually distinguishes v7 from "a v4 with a 7 in the right place",
+    // and it is the property the whole change rests on: ids that sort by creation time
+    // append to the right-hand edge of the index instead of scattering.
+    const embeddedMs = Number.parseInt(id.replace(/-/g, '').slice(0, 12), 16);
+    expect(embeddedMs).toBeGreaterThanOrEqual(before - 60_000);
+    expect(embeddedMs).toBeLessThanOrEqual(Date.now() + 60_000);
+  }, 30_000);
+
+  it('accepts pre-existing v4 ids alongside the new default', async () => {
+    // No backfill happens, so both versions have to coexist in one column forever.
+    // Cheap to state, and it is the assumption the "no rewrite" claim rests on.
+    const { id } = await testPool.one(
+      sql.type(z.object({ id: z.string() }))`
+        INSERT INTO accounter_schema.audit_logs (id, action)
+        VALUES (gen_random_uuid(), 'uuidv7-coexistence-test')
+        RETURNING id
+      `,
+    );
+
+    expect(id.split('-')[2]?.[0]).toBe('4');
+  }, 30_000);
+});

--- a/packages/migrations/src/actions/2026-09-09T10-00-00.uuidv7-id-defaults.ts
+++ b/packages/migrations/src/actions/2026-09-09T10-00-00.uuidv7-id-defaults.ts
@@ -1,0 +1,135 @@
+import { sql } from 'slonik';
+import { type MigrationExecutor } from '../pg-migrator.js';
+
+/**
+ * Switch every `DEFAULT gen_random_uuid()` column in `accounter_schema` to
+ * PostgreSQL 18's `uuidv7()`.
+ *
+ * ## Why
+ *
+ * `gen_random_uuid()` produces v4 uuids — uniformly random, so consecutive
+ * inserts land in unrelated pages of the primary-key B-tree. That means page
+ * splits, a working set that is effectively the whole index rather than its
+ * right-hand edge, and more full-page images in WAL. `uuidv7()` puts a
+ * millisecond timestamp in the high bits, so inserts append instead of scatter.
+ *
+ * The append-heavy tables are the ones that matter here: `charges`,
+ * `transactions`, `documents`, `ledger_records`, and every scraper raw table.
+ *
+ * No backfill and no table rewrite: this only changes what the server generates
+ * for rows inserted from now on. Existing v4 ids stay exactly as they are, and a
+ * column holding a mix of v4 and v7 values is perfectly well-formed — both are
+ * 128-bit uuids, comparison and indexing are byte-wise, and nothing in the schema
+ * or the application parses a version nibble out of an id.
+ *
+ * ## Scope
+ *
+ * Every column in `accounter_schema` whose default is exactly
+ * `gen_random_uuid()`: the `id` of each table, plus `business_users.user_id`. In
+ * a database built from this repo's migration history at this commit that is 49
+ * columns, all `relkind = 'r'`, all in `accounter_schema` — counted from the
+ * catalog after running the full migration set into an empty database. (#4364's
+ * audit says 50; the count is not load-bearing either way, which is the point of
+ * discovering the columns from `pg_attrdef` rather than listing them here. An
+ * environment that is behind, or a table added between this being written and
+ * being deployed, converts the same way.) The `DEFAULT` is the whole of id
+ * generation for these tables; no server code calls `gen_random_uuid()`
+ * (verified by grep across `packages/`).
+ *
+ * ## What this deliberately does not touch
+ *
+ * - `shared/helpers/deterministic-uuid.ts` (uuid v5), used by
+ *   `entity-ensure.provider.ts`. Its determinism *is* the idempotency mechanism
+ *   behind `ON CONFLICT (id) DO NOTHING` during ingestion — a time-ordered id
+ *   would be different on every run and re-insert every row. It is also
+ *   app-side, so a column default cannot reach it anyway.
+ * - The other app-side `randomUUID()` callers —
+ *   `auth/providers/invitations.provider.ts`,
+ *   `email-ingestion-control.provider.ts` (`jti`) and
+ *   `email-ingestion-ingest.provider.ts`. Low volume, and again not reachable
+ *   from a column default. Worth revisiting on their own merits, not here.
+ * - Secrets. No uuid-defaulted column is one: `invitations.token` and
+ *   `api_keys.key_hash` are `TEXT` filled by the application from
+ *   `node:crypto`, and `email_ingestion_replay_nonces.nonce` is `TEXT` too. This
+ *   matters because the trade-off below would be a real problem for a
+ *   capability token.
+ *
+ * ## The trade-off
+ *
+ * A v7 id is not opaque about when its row was created: the first 48 bits are a
+ * Unix millisecond timestamp, readable by anyone holding the id. Ids also become
+ * roughly ordered, so two ids reveal which row came first, and neighbouring ids
+ * become guessable in a way v4 ids are not. For internal accounting ids behind
+ * authentication and RLS that is acceptable — every one of these tables already
+ * carries a `created_at`, and none of them relies on id unguessability for
+ * access control. It is still a deliberate choice rather than a free win: a
+ * future column that needs an id to be non-revealing or unguessable should be
+ * declared `DEFAULT gen_random_uuid()` explicitly and added to the exemption
+ * list in `uuidv7-id-defaults.test.ts`.
+ *
+ * ## Reverting
+ *
+ * `MigrationExecutor` has no `down` hook — the migrator is forward-only and no
+ * migration in this repo ships one — so the inverse is written out here instead
+ * of being executable. It is the same loop with the two function names swapped:
+ * match `'uuidv7()'` and `SET DEFAULT gen_random_uuid()`. Safe to run at any
+ * time, precisely because both id versions coexist happily in one column.
+ * Verified by running the loop and its inverse against a database built from the
+ * full migration history: 49 columns out, 49 back.
+ *
+ * Plain catalog-driven DDL, fast (a `pg_attrdef` row rewrite per column, no
+ * table access), and idempotent: re-running finds nothing left to convert. Runs
+ * in the default per-migration transaction, so either every column flips or none
+ * does.
+ */
+export default {
+  name: '2026-09-09T10-00-00.uuidv7-id-defaults.sql',
+  run: async ({ connection }) => {
+    // `uuidv7()` is PG18+. Without this the failure is a bare "function uuidv7()
+    // does not exist" from the first ALTER, which is a confusing way to learn
+    // that the server predates the upgrade in #4363.
+    await connection.query(sql.unsafe`
+      DO $$
+      BEGIN
+        IF current_setting('server_version_num')::int < 180000 THEN
+          RAISE EXCEPTION
+            'uuidv7() requires PostgreSQL 18 or newer; this server is %',
+            current_setting('server_version');
+        END IF;
+      END
+      $$;
+    `);
+
+    await connection.query(sql.unsafe`
+      DO $$
+      DECLARE
+        target record;
+      BEGIN
+        FOR target IN
+          SELECT c.relname AS table_name, a.attname AS column_name
+          FROM pg_catalog.pg_attribute a
+          JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+          JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+          JOIN pg_catalog.pg_attrdef d
+            ON d.adrelid = a.attrelid
+           AND d.adnum = a.attnum
+          WHERE n.nspname = 'accounter_schema'
+            -- Ordinary and partitioned tables. A partitioned table's default is
+            -- what an insert through the parent uses, so it is the one to set.
+            AND c.relkind IN ('r', 'p')
+            AND NOT a.attisdropped
+            AND a.atttypid = 'uuid'::regtype
+            AND pg_catalog.pg_get_expr(d.adbin, d.adrelid) = 'gen_random_uuid()'
+          ORDER BY c.relname, a.attname
+        LOOP
+          EXECUTE format(
+            'ALTER TABLE accounter_schema.%I ALTER COLUMN %I SET DEFAULT uuidv7()',
+            target.table_name,
+            target.column_name
+          );
+        END LOOP;
+      END
+      $$;
+    `);
+  },
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2026-09-09T10-00-00.uuidv7-id-defaults.ts
+++ b/packages/migrations/src/actions/2026-09-09T10-00-00.uuidv7-id-defaults.ts
@@ -96,7 +96,7 @@ export default {
             'uuidv7() requires PostgreSQL 18 or newer; this server is %',
             current_setting('server_version');
         END IF;
-      END
+      END;
       $$;
     `);
 
@@ -128,7 +128,7 @@ export default {
             target.column_name
           );
         END LOOP;
-      END
+      END;
       $$;
     `);
   },

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -204,6 +204,7 @@ import migration_2026_08_23T10_00_00_rls_scope_securities_tables from './actions
 import migration_2026_08_31T10_00_00_add_tenant_scoped_date_indexes from './actions/2026-08-31T10-00-00.add-tenant-scoped-date-indexes.js';
 import migration_2026_08_31T11_00_00_index_financial_entity_names from './actions/2026-08-31T11-00-00.index-financial-entity-names.js';
 import migration_2026_08_31T12_00_00_rls_reassert_salaries from './actions/2026-08-31T12-00-00.rls-reassert-salaries.js';
+import migration_2026_09_09T10_00_00_uuidv7_id_defaults from './actions/2026-09-09T10-00-00.uuidv7-id-defaults.js';
 import { runMigrations } from './pg-migrator.js';
 
 export const MIGRATIONS = [
@@ -412,6 +413,7 @@ export const MIGRATIONS = [
   migration_2026_08_31T10_00_00_add_tenant_scoped_date_indexes,
   migration_2026_08_31T11_00_00_index_financial_entity_names,
   migration_2026_08_31T12_00_00_rls_reassert_salaries,
+  migration_2026_09_09T10_00_00_uuidv7_id_defaults,
 ] as const;
 
 export const LATEST_MIGRATION_NAME = MIGRATIONS[MIGRATIONS.length - 1]?.name;


### PR DESCRIPTION
Closes #4364.

## What

`2026-09-09T10-00-00.uuidv7-id-defaults.sql` switches every `DEFAULT gen_random_uuid()` column in `accounter_schema` to PostgreSQL 18's `uuidv7()`.

`gen_random_uuid()` produces v4 uuids — uniformly random, so consecutive inserts land in unrelated pages of the primary-key B-tree. Every insert is a candidate page split, the effective working set is the whole index rather than its right-hand edge, and the resulting page dirtying shows up as extra full-page images in WAL. `uuidv7()` puts a millisecond timestamp in the high 48 bits, so ids sort by creation time and inserts append instead of scattering. The tables where that matters are the append-heavy ones: `charges`, `transactions`, `documents`, `ledger_records`, and every scraper raw table.

The migration is the whole change. Id generation for these tables is entirely a DB-side `DEFAULT` — no server code calls `gen_random_uuid()` — and altering a default rewrites one `pg_attrdef` row per column without touching a heap page. There is no backfill and no rewrite: existing v4 ids stay exactly as they are, and a column holding a mix of v4 and v7 values is well-formed, since both are 128-bit uuids compared and indexed byte-wise and nothing in the schema or the application reads a version nibble out of an id.

## Why the columns are discovered, not listed

The targets — the `id` of each table, plus `business_users.user_id` — come from `pg_attrdef` at run time rather than a hardcoded list, so the migration converts whatever the target database actually holds. An environment that is behind on migrations, or a table added between this being written and being deployed, converts the same way, and re-running finds nothing left to do.

That also resolves a small discrepancy worth flagging: **the issue's audit says 50 columns; running the full migration set into an empty database at this commit produces 49** (all in `accounter_schema`, all `relkind = 'r'`). I could not reproduce the 50th from the repo's migration history, so the audit was probably taken against production, which may carry a table the history no longer creates. The catalog loop makes the exact count non-load-bearing either way, which is why no number is written into the migration.

A guard raises a clear error on a server older than 18 instead of letting the first `ALTER` fail with a bare "function uuidv7() does not exist".

## Sites deliberately not converted

Per the issue:

- `shared/helpers/deterministic-uuid.ts` (uuid v5) → `entity-ensure.provider.ts`. Its determinism *is* the idempotency mechanism behind `ON CONFLICT (id) DO NOTHING` during ingestion; a time-ordered id would re-insert every row on every run. It is app-side, so a column default cannot reach it in any case.
- The app-side `randomUUID()` callers in `auth/providers/invitations.provider.ts`, `email-ingestion-control.provider.ts` (`jti`) and `email-ingestion-ingest.provider.ts` — low volume, and likewise out of reach of a column default.

## The trade-off

A v7 id is no longer opaque about when its row was created — the leading 48 bits are a readable Unix millisecond timestamp — ids become roughly ordered, so two of them reveal which row came first, and a neighbouring id becomes guessable in a way a v4 id is not.

That is acceptable here because **no uuid-defaulted column is a secret**, which I checked rather than assumed: every one of these tables already carries a `created_at`, access is gated by authentication and RLS rather than id unguessability, and the actual capability tokens are separate `TEXT` columns filled from `node:crypto` — `invitations.token`, `api_keys.key_hash`, `email_ingestion_replay_nonces.nonce`. It is still a deliberate choice: a future column that needs an unguessable id should declare `DEFAULT gen_random_uuid()` explicitly and be added to the exemption set in the new test.

## Tests

`packages/migrations/src/__tests__/uuidv7-id-defaults.test.ts` runs the full migration set into a fresh database (same shape as `rls-all-tables.test.ts`, same `assertLocalDatabase` guard) and asserts:

- the catalog invariant — no uuid column in `accounter_schema` is left on `gen_random_uuid()` outside a named exemption set, empty today — so a future table that ships with the v4 default is caught as it lands rather than by someone re-running the audit;
- the four append-heavy tables and `business_users.user_id` by name;
- that a freshly generated id really is time-ordered, by decoding the 48-bit timestamp back out of it — the property the whole change rests on, and the one thing "the version nibble is 7" does not prove;
- that an explicit v4 id still inserts alongside the new default, pinning down the coexistence the "no backfill" claim depends on.

## Verification

- Ran the full migration set into an empty database and exercised the catalog loop against it: **49 columns converted, a second run converts 0**, and the documented revert (same loop, function names swapped) puts all 49 back. The version guard was confirmed to fire with its own message rather than a missing-function error.
- That run was on PostgreSQL 16 with a stand-in `uuidv7()` — no Docker daemon in this environment, and the sandbox only has PG16 — so the **v7-shaped assertions in the new test are exercised by CI**, which runs `postgres:18-alpine`. Everything else above was checked locally.
- `yarn lint` (no new findings), `prettier --check .`, `tsc --noEmit` on the migrations package, and `yarn migration:check-conflicts` all pass.

## Note on `down`

`.claude/rules/migrations.md` asks for a down migration. `MigrationExecutor` has no `down` hook — the migrator is forward-only and no migration in this repo ships one — so the exact inverse is written out in the migration's header comment instead, and verified to work. Happy to add a real `down` if the migrator grows one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dyr2F4nSgQ8shB7KZDjj86

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dyr2F4nSgQ8shB7KZDjj86)_