### PR TITLE
fix(email-ingestion-gateway): stop body→PDF render hanging on remote assets

### DIFF
--- a/.changeset/email-gateway-body-pdf-render-budget.md
+++ b/.changeset/email-gateway-body-pdf-render-budget.md
@@ -1,0 +1,30 @@
+---
+'@accounter/email-ingestion-gateway': patch
+---
+
+Stop the email body→PDF render from hanging on remote assets, and keep it off the network entirely.
+
+`html-to-pdf.ts` waited for `networkidle` with no explicit timeout. `networkidle` needs 500 ms with
+zero open connections, which a marketing body full of tracking pixels and beacons never reaches — so
+Playwright's default 30 s timeout expired, the render threw, and `treatment.ts` dropped the document.
+For an unrecognised business the body is often the *only* document, so the email then quarantined as
+`NO_DOCUMENTS`. One observed message spent ~31 s of its 43 s in this render, on a path where the
+Cloudflare Worker is holding an open HTTP request.
+
+- Every remote subresource is now aborted through `page.route()`. The render is a static document, so
+  there is nothing to wait for; and no `<img src>` from an untrusted body is fetched from the
+  gateway's IP any more, which also stops confirming delivery to senders' tracking endpoints. None of
+  `link-fetcher.ts`'s SSRF guards applied to a Chromium-issued request, so this closes that gap too.
+- `setContent` waits for `domcontentloaded` with an explicit timeout, followed by a best-effort
+  `load` that cannot fail the render. `load` alone would not have been enough — measured against a
+  host that accepts the connection and never answers, both `networkidle` and `load` burn the full
+  timeout while `domcontentloaded` settles in ~20 ms.
+- `inline-css` ran with `applyLinkTags` on, which made it fetch every `<link rel=stylesheet>` href
+  itself, unbounded, and *throw* when one failed — a second way an unreachable host in the body could
+  drop the document, before Chromium was even involved. It is now off; `removeLinkTags` already
+  stripped those tags from the render, so only styling the body declined to inline is lost.
+- All of it is capped by a single `RENDER_TIMEOUT_MS` (5 s), set as the page's default timeout as
+  well as on the explicit waits, so one pathological body cannot dominate an email's processing time.
+
+Measured on the reported body shape, the render goes from a 30 s timeout that lost the document to
+~120 ms that produces it.

--- a/packages/email-ingestion-gateway/CLAUDE.md
+++ b/packages/email-ingestion-gateway/CLAUDE.md
@@ -83,7 +83,10 @@ read back from the grant.
 - Internal-link fetching keeps the SSRF guard stack in `link-fetcher.ts` (host/path allowlist,
   private-IP + resolved-IP block, http(s)-only, `redirect: 'error'`, content-type allowlist,
   streamed size cap). Don't loosen any of these without review.
-- Body HTML renders with `javaScriptEnabled: false`.
+- Body HTML renders with `javaScriptEnabled: false`, with all remote subresources aborted via
+  `page.route()` and with `inline-css`'s `applyLinkTags` off — an untrusted body must not cause any
+  outbound fetch. Waits are `domcontentloaded` + best-effort `load`, never `networkidle`, each
+  capped at `RENDER_TIMEOUT_MS`.
 - `CF_WEBHOOK_SECRET` is required in production (`index.ts` throws on startup if missing).
 
 ## Testing

--- a/packages/email-ingestion-gateway/README.md
+++ b/packages/email-ingestion-gateway/README.md
@@ -254,7 +254,9 @@ body→PDF rendering (caught and logged; the body document is simply omitted).
 - **SSRF hardening** for internal-link fetching: host/path allowlist, private/loopback host +
   resolved-IP blocks, http(s)-only, redirects disabled, content-type allowlist, streamed size cap.
   See `src/link-fetcher.ts`.
-- **Untrusted HTML**: email bodies render with JavaScript disabled in headless Chromium.
+- **Untrusted HTML**: email bodies render with JavaScript disabled in headless Chromium, and with
+  every remote subresource aborted — no image, stylesheet or tracking pixel in an email body is ever
+  fetched from the gateway's IP. See `src/html-to-pdf.ts`.
 
 ## Troubleshooting
 

--- a/packages/email-ingestion-gateway/TROUBLESHOOTING.md
+++ b/packages/email-ingestion-gateway/TROUBLESHOOTING.md
@@ -160,7 +160,9 @@ Treatment (`src/treatment.ts`) assembles the final set from three sources:
    business config allowlists only `PDF` and the mail carries a PNG, the PNG is dropped.
 2. **Body → PDF**, only when **no business is recognized** _or_ `config.emailBody === true`, and the
    body is non-empty. Render failures are logged (`treatment: body→PDF render failed`) and the body
-   document is omitted — check for a missing/broken Chromium in the runtime.
+   document is omitted — check for a missing/broken Chromium in the runtime. Remote subresources are
+   blocked and every render step is capped at `RENDER_TIMEOUT_MS`, so a render failure is a Chromium
+   problem, not a slow asset in the body.
 3. **Internal-link documents**, fetched for each configured `config.internalEmailLinks` pattern
    found in the body. Failures log `treatment: internal-link fetch failed`. Note the SSRF guards in
    `src/link-fetcher.ts` will silently return `[]` if the link host isn't allowlisted, resolves to a

--- a/packages/email-ingestion-gateway/src/__tests__/html-to-pdf.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/html-to-pdf.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RENDER_TIMEOUT_MS, closeBrowser, renderHtmlToPdf } from '../html-to-pdf.js';
+
+/**
+ * A Chromium stand-in that models only the behaviour this module depends on,
+ * calibrated against a real headless Chromium:
+ *
+ * - a subresource whose host accepts the connection and never answers (a
+ *   rate-limiting tracking pixel — routine in marketing bodies) stays in flight
+ *   forever;
+ * - neither `load` nor `networkidle` settles while anything is in flight, so a
+ *   `setContent` waiting for either burns its whole timeout and throws;
+ * - `domcontentloaded` settles regardless of what is in flight;
+ * - a `route()` handler that aborts a request takes it out of flight;
+ * - `data:` resources are never routed.
+ */
+const harness = vi.hoisted(() => {
+  interface FakeRoute {
+    request(): { url(): string };
+    abort(): Promise<void>;
+    continue(): Promise<void>;
+  }
+  type RouteHandler = (route: FakeRoute) => unknown;
+
+  interface SetContentCall {
+    html: string;
+    options?: { waitUntil?: string; timeout?: number };
+  }
+
+  const state = {
+    launches: 0,
+    contextOptions: [] as { javaScriptEnabled?: boolean }[],
+    defaultTimeouts: [] as number[],
+    setContentCalls: [] as SetContentCall[],
+    loadStateCalls: [] as { state?: string; timeout?: number }[],
+    /** URLs a route handler aborted before they could leave the browser. */
+    aborted: [] as string[],
+    /** URLs no route handler stopped — in flight, and never answered. */
+    inFlight: [] as string[],
+    /** Whether `route()` was registered before the first `setContent`. */
+    routedBeforeSetContent: false,
+    closedPages: 0,
+    closedContexts: 0,
+    /** Test knob: make `waitForLoadState` reject as if `load` never fired. */
+    failLoadState: false,
+    /** Test knob: make `pdf()` reject. */
+    failPdf: false,
+    reset() {
+      state.launches = 0;
+      state.contextOptions = [];
+      state.defaultTimeouts = [];
+      state.setContentCalls = [];
+      state.loadStateCalls = [];
+      state.aborted = [];
+      state.inFlight = [];
+      state.routedBeforeSetContent = false;
+      state.closedPages = 0;
+      state.closedContexts = 0;
+      state.failLoadState = false;
+      state.failPdf = false;
+    },
+  };
+
+  /** Every http(s) subresource a real Chromium would request for this document. */
+  function subresourceUrls(html: string): string[] {
+    const urls: string[] = [];
+    for (const match of html.matchAll(/(?:src|href)\s*=\s*(?:"([^"]*)"|'([^']*)')/gi)) {
+      const url = match[1] ?? match[2] ?? '';
+      if (/^https?:\/\//i.test(url)) {
+        urls.push(url);
+      }
+    }
+    return urls;
+  }
+
+  function timeoutError(call: string, timeout: number): Error {
+    return Object.assign(new Error(`${call}: Timeout ${timeout}ms exceeded.`), {
+      name: 'TimeoutError',
+    });
+  }
+
+  function createPage() {
+    const routes: RouteHandler[] = [];
+    let defaultTimeout = 30_000;
+    let rendered = '';
+
+    async function dispatch(url: string): Promise<void> {
+      for (const handler of routes) {
+        const outcome: { value: 'aborted' | 'continued' | null } = { value: null };
+        await handler({
+          request: () => ({ url: () => url }),
+          abort: async () => {
+            outcome.value = 'aborted';
+          },
+          continue: async () => {
+            outcome.value = 'continued';
+          },
+        });
+        if (outcome.value === 'aborted') {
+          state.aborted.push(url);
+          return;
+        }
+        if (outcome.value === 'continued') {
+          break;
+        }
+      }
+      state.inFlight.push(url);
+    }
+
+    return {
+      setDefaultTimeout(timeout: number) {
+        defaultTimeout = timeout;
+        state.defaultTimeouts.push(timeout);
+      },
+      async route(_pattern: string, handler: RouteHandler) {
+        if (state.setContentCalls.length === 0) {
+          state.routedBeforeSetContent = true;
+        }
+        routes.push(handler);
+      },
+      async setContent(html: string, options?: { waitUntil?: string; timeout?: number }) {
+        state.setContentCalls.push({ html, options });
+        rendered = html;
+        for (const url of subresourceUrls(html)) {
+          await dispatch(url);
+        }
+        const waitUntil = options?.waitUntil ?? 'load';
+        if (waitUntil !== 'domcontentloaded' && state.inFlight.length > 0) {
+          throw timeoutError('page.setContent', options?.timeout ?? defaultTimeout);
+        }
+      },
+      async waitForLoadState(loadState?: string, options?: { timeout?: number }) {
+        state.loadStateCalls.push({ state: loadState, timeout: options?.timeout });
+        if (state.failLoadState || (loadState !== 'domcontentloaded' && state.inFlight.length > 0)) {
+          throw timeoutError('page.waitForLoadState', options?.timeout ?? defaultTimeout);
+        }
+      },
+      async pdf() {
+        if (state.failPdf) {
+          throw new Error('pdf failed');
+        }
+        return Buffer.from(`%PDF-1.4\n${rendered}`);
+      },
+      async close() {
+        state.closedPages += 1;
+      },
+    };
+  }
+
+  const chromium = {
+    async launch() {
+      state.launches += 1;
+      return {
+        on() {},
+        async newContext(options?: { javaScriptEnabled?: boolean }) {
+          state.contextOptions.push(options ?? {});
+          return {
+            async newPage() {
+              return createPage();
+            },
+            async close() {
+              state.closedContexts += 1;
+            },
+          };
+        },
+        async close() {},
+      };
+    },
+  };
+
+  return { state, chromium };
+});
+
+vi.mock('playwright', () => ({ chromium: harness.chromium }));
+
+const { state } = harness;
+
+/** An invoice body carrying the assets that made the old render hang. */
+const HANGING_ASSETS_BODY = `<html><head>
+  <link rel="stylesheet" href="http://tracker.invalid.test/style.css">
+  <style>.total { color: red; }</style>
+</head><body>
+  <h1>Invoice 12345</h1>
+  <p class="total">Total: 100.00 ILS</p>
+  <img src="http://tracker.invalid.test/pixel.gif" width="1" height="1">
+  <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">
+</body></html>`;
+
+afterEach(async () => {
+  await closeBrowser();
+  state.reset();
+});
+
+describe('renderHtmlToPdf — hanging remote assets', () => {
+  it('renders a body whose remote assets never answer instead of dropping the document', async () => {
+    const doc = await renderHtmlToPdf(HANGING_ASSETS_BODY);
+
+    expect(doc.filename).toBe('body.pdf');
+    expect(doc.mimeType).toBe('application/pdf');
+    expect(doc.size).toBeGreaterThan(0);
+    expect(doc.content.subarray(0, 5).toString()).toBe('%PDF-');
+    // Nothing was left waiting on the network — the render never blocked.
+    expect(state.inFlight).toEqual([]);
+  });
+
+  it('aborts every remote subresource rather than fetching it from the gateway', async () => {
+    await renderHtmlToPdf(HANGING_ASSETS_BODY);
+
+    expect(state.aborted).toContain('http://tracker.invalid.test/pixel.gif');
+    expect(state.inFlight).toEqual([]);
+  });
+
+  it('blocks subresources before the content that requests them is set', async () => {
+    await renderHtmlToPdf(HANGING_ASSETS_BODY);
+
+    expect(state.routedBeforeSetContent).toBe(true);
+  });
+
+  it('keeps `inline-css` off the network, so an unreachable stylesheet cannot fail the render', async () => {
+    const doc = await renderHtmlToPdf(HANGING_ASSETS_BODY);
+
+    // `inline-css` fetches `<link rel=stylesheet>` hrefs itself when
+    // `applyLinkTags` is on, and throws when one fails — the link never reaches
+    // Chromium, and the render must not depend on it.
+    const html = state.setContentCalls[0]?.html ?? '';
+    expect(html).not.toContain('tracker.invalid.test/style.css');
+    // The styling the body did inline is still applied.
+    expect(html).toContain('color: red');
+    expect(doc.size).toBeGreaterThan(0);
+  });
+});
+
+describe('renderHtmlToPdf — wait strategy and budget', () => {
+  it('waits only for `domcontentloaded`, with an explicit timeout', async () => {
+    await renderHtmlToPdf('<p>hello</p>');
+
+    expect(state.setContentCalls).toHaveLength(1);
+    // `networkidle` never settles while an asset hangs, and `load` waits on the
+    // very same assets — either one costs the full timeout and the document.
+    expect(state.setContentCalls[0]?.options).toEqual({
+      waitUntil: 'domcontentloaded',
+      timeout: RENDER_TIMEOUT_MS,
+    });
+  });
+
+  it('caps every timeout-taking step at the render budget', async () => {
+    await renderHtmlToPdf('<p>hello</p>');
+
+    expect(state.defaultTimeouts).toEqual([RENDER_TIMEOUT_MS]);
+    expect(state.loadStateCalls).toEqual([{ state: 'load', timeout: RENDER_TIMEOUT_MS }]);
+  });
+
+  it('keeps the budget well under the ingest budget', () => {
+    expect(RENDER_TIMEOUT_MS).toBeLessThanOrEqual(10_000);
+  });
+
+  it('still produces a PDF when the load state never settles', async () => {
+    state.failLoadState = true;
+
+    const doc = await renderHtmlToPdf('<p>hello</p>');
+
+    expect(doc.filename).toBe('body.pdf');
+    expect(doc.size).toBeGreaterThan(0);
+  });
+});
+
+describe('renderHtmlToPdf — browser hygiene', () => {
+  it('renders with JavaScript disabled', async () => {
+    await renderHtmlToPdf('<p>hello</p>');
+
+    expect(state.contextOptions).toEqual([{ javaScriptEnabled: false }]);
+  });
+
+  it('reuses one browser across renders', async () => {
+    await renderHtmlToPdf('<p>one</p>');
+    await renderHtmlToPdf('<p>two</p>');
+
+    expect(state.launches).toBe(1);
+  });
+
+  it('closes the page and context even when the render fails', async () => {
+    state.failPdf = true;
+
+    await expect(renderHtmlToPdf('<p>hello</p>')).rejects.toThrow('pdf failed');
+    expect(state.closedPages).toBe(1);
+    expect(state.closedContexts).toBe(1);
+  });
+});

--- a/packages/email-ingestion-gateway/src/html-to-pdf.ts
+++ b/packages/email-ingestion-gateway/src/html-to-pdf.ts
@@ -3,6 +3,17 @@ import inlineCss from 'inline-css';
 import { chromium, type Browser, type Page } from 'playwright';
 import type { ExtractedDocument } from './mime-extractor.js';
 
+/**
+ * Budget for a single body→PDF render, applied to every Playwright step below.
+ *
+ * Email bodies are static documents and their remote subresources are blocked
+ * (see {@link renderHtmlToPdf}), so there is nothing to settle: a render that is
+ * not finished in a few seconds is hung, not slow. The cap sits well under the
+ * ingest budget — the Cloudflare Worker holds an open HTTP request for the whole
+ * orchestration — so one pathological body cannot dominate an email.
+ */
+export const RENDER_TIMEOUT_MS = 5000;
+
 // A single shared browser instance is reused across renders to bound memory and
 // avoid the cost of launching Chromium per request. It is created lazily on the
 // first render and kept warm for the lifetime of the gateway process.
@@ -48,8 +59,34 @@ export async function renderHtmlToPdf(rawHtml: string): Promise<ExtractedDocumen
   let page: Page | undefined;
   try {
     page = await context.newPage();
-    const html = await inlineCss(rawHtml, { url: '/' });
-    await page.setContent(html, { waitUntil: 'networkidle' });
+    // Bound every Playwright call that takes a timeout, not just the explicit
+    // ones below, so no step can outlive the render budget.
+    page.setDefaultTimeout(RENDER_TIMEOUT_MS);
+    // Nothing leaves this browser. The remote subresources of an untrusted email
+    // body are a liability rather than content:
+    //   - tracking pixels, beacons and images on hosts that hang or rate-limit
+    //     are routine in marketing bodies, and each one is a request the render
+    //     would otherwise wait on;
+    //   - every such fetch goes out from the gateway's IP with none of
+    //     `link-fetcher.ts`'s SSRF guards applying to a Chromium-issued request,
+    //     and confirms delivery to the sender's tracking endpoint.
+    // Inline (`data:`) images are unaffected — Playwright does not route them.
+    await page.route('**/*', route => route.abort());
+    // `applyLinkTags` (on by default) makes `inline-css` itself fetch every
+    // `<link rel=stylesheet>` href over the network, unbounded, and *throw* when
+    // one fails — an unreachable stylesheet host in the body would drop the
+    // document before Chromium is even involved. `removeLinkTags` already
+    // strips the tags, so the rendered output only loses styling the body
+    // declined to inline.
+    const html = await inlineCss(rawHtml, { url: '/', applyLinkTags: false });
+    // `domcontentloaded` is the only wait guaranteed to settle for a static
+    // document. `networkidle` (500 ms with zero connections) never settles for a
+    // body whose assets hang, and `load` waits on those same assets — both burn
+    // the whole timeout and lose the document. `load` is then awaited
+    // best-effort, so inline images get a chance to decode without a body that
+    // never reaches it being dropped.
+    await page.setContent(html, { waitUntil: 'domcontentloaded', timeout: RENDER_TIMEOUT_MS });
+    await page.waitForLoadState('load', { timeout: RENDER_TIMEOUT_MS }).catch(() => {});
     const pdf = Buffer.from(await page.pdf());
     return {
       filename: 'body.pdf',


### PR DESCRIPTION
Fixes #4349

## Problem

`html-to-pdf.ts` waited for `networkidle` with no explicit timeout. That condition needs 500 ms with zero open connections, which an email body carrying tracking pixels, beacons or images on hosts that hang never reaches — so Playwright's default 30 s timeout expired, the render threw, and `treatment.ts` dropped the document. For an unrecognised business the body is often the *only* document, so the email then quarantined as `NO_DOCUMENTS`.

While fixing it I found a **second, independent way the same body dropped the document**: `inline-css` runs with `applyLinkTags` on by default, which makes it fetch every `<link rel=stylesheet>` href itself over axios — unbounded, and it *throws* when one fails, before Chromium is ever involved:

```
$ node -e "... inlineCss('<link rel=stylesheet href=https://example.com/style.css>', { url: '/' })"
THREW: AxiosError: Request failed with status code 404
```

## Changes

- **Abort every remote subresource** via `page.route('**/*', route => route.abort())`. The render is a static document, so there is nothing to wait for — and no `<img src>` from an untrusted body is fetched from the gateway's IP any more, which also stops confirming delivery to senders' tracking endpoints. None of `link-fetcher.ts`'s SSRF guard stack applied to a Chromium-issued request, so this closes that gap too. Inline `data:` images are unaffected (Playwright does not route them).
- **`setContent` waits for `domcontentloaded`** with an explicit timeout, followed by a best-effort `load` that cannot fail the render.
- **`inline-css` runs with `applyLinkTags: false`**. `removeLinkTags` already stripped those tags from the render, so only styling the body declined to inline is lost.
- **`RENDER_TIMEOUT_MS` (5 s)** caps both waits, set as the page's default timeout as well as explicitly, so one pathological body cannot dominate an email's processing time. It is deliberately *not* an end-to-end deadline — `inline-css` and `page.pdf()` take no timeout — but with `applyLinkTags` off and subresources blocked neither does any I/O, so what remains is CPU-bound work over a body already capped at `MAX_RAW_MIME_BYTES` (25 MB).

## Measurements

Against a local host that accepts the connection and never answers — the real-world shape of a rate-limiting tracking pixel — on real headless Chromium:

| `waitUntil` | outcome |
| --- | --- |
| `networkidle` (before) | **FAILED after 30003 ms** — `TimeoutError: page.setContent: Timeout 30000ms exceeded` (the issue's log line, exactly) |
| `load` | **FAILED after 30002 ms** — so `load` alone would *not* have fixed this |
| `domcontentloaded` | ok in 23 ms |
| this PR (route-abort + `domcontentloaded`) | ok in 28 ms |

End to end through `renderHtmlToPdf`, on a body with both a hanging stylesheet `<link>` and a hanging tracking pixel:

```
cold: 991ms  size=17667  magic=%PDF-  name=body.pdf
warm: 170ms  size=17667  magic=%PDF-  name=body.pdf
requests that reached the hanging host: 0
```

Previously that same body threw twice over. Now: 170 ms, and nothing left the process.

## Test

New `src/__tests__/html-to-pdf.test.ts` (11 tests). Per the package convention that unit tests avoid Chromium and the network, it drives the module against a Chromium stand-in **calibrated on the real browser** using the measurements above: a subresource on a host that never answers stays in flight forever, neither `load` nor `networkidle` settles while anything is in flight, `domcontentloaded` settles regardless, an aborting `route()` handler takes a request out of flight, and `data:` resources are never routed.

Reverting each of the four changes fails the suite:

| reverted | tests failing |
| --- | --- |
| back to `waitUntil: 'networkidle'` | 1 |
| remove the `page.route()` block | 3 |
| restore `applyLinkTags` default | 4 |
| remove `setDefaultTimeout` | 1 |

## Notes for the reviewer

- `link-fetcher.ts` also calls `renderHtmlToPdf`, for HTML fetched from an allowlisted vendor host, and its subresources are now blocked as well. This is deliberate: `setContent` is given no base URL, so relative assets on those pages never resolved anyway, and applying the block uniformly keeps one posture for both callers rather than two. An invoice page loses remote logos, not content.
- Also updated the invariants in `README.md` ("Security model"), `CLAUDE.md` ("Security invariants") and `TROUBLESHOOTING.md`, since all three documented only `javaScriptEnabled: false` for this path.

## Verification

- `yarn vitest run --project unit packages/email-ingestion-gateway` — 17 files, 342 tests passing
- `yarn workspace @accounter/email-ingestion-gateway typecheck` — clean
- `yarn lint` — 0 errors
- `yarn prettier:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cz3si4WZCtCZKjkDTU9Pb3