### PR TITLE
fix(email-ingestion): stamp X- headers on forwarded copies so they can be identified and correlated

### DIFF
--- a/.changeset/@accounter_client-4430-dependencies.md
+++ b/.changeset/@accounter_client-4430-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`lucide-react@1.43.0` ↗︎](https://www.npmjs.com/package/lucide-react/v/1.43.0) (from `1.42.0`, in `dependencies`)

--- a/.changeset/@accounter_server-4430-dependencies.md
+++ b/.changeset/@accounter_server-4430-dependencies.md
@@ -1,0 +1,8 @@
+---
+"@accounter/server": patch
+---
+dependencies updates:
+  - Updated dependency [`@ai-sdk/anthropic@4.0.50` ↗︎](https://www.npmjs.com/package/@ai-sdk/anthropic/v/4.0.50) (from `4.0.49`, in `dependencies`)
+  - Updated dependency [`@graphql-tools/utils@12.0.1` ↗︎](https://www.npmjs.com/package/@graphql-tools/utils/v/12.0.1) (from `12.0.0`, in `dependencies`)
+  - Updated dependency [`ai@7.0.95` ↗︎](https://www.npmjs.com/package/ai/v/7.0.95) (from `7.0.93`, in `dependencies`)
+  - Updated dependency [`googleapis@178.1.1` ↗︎](https://www.npmjs.com/package/googleapis/v/178.1.1) (from `178.0.0`, in `dependencies`)

--- a/.changeset/email-ingestion-worker-forward-headers.md
+++ b/.changeset/email-ingestion-worker-forward-headers.md
@@ -1,0 +1,35 @@
+---
+'@accounter/email-ingestion-gateway': patch
+---
+
+Stamp `X-` headers on every forwarded copy so a message in the destination mailbox can be told apart
+and joined back to the gateway logs.
+
+The Worker forwards each message to `EMAIL_FORWARD_DESTINATION` before calling the webhook, and to
+`FALLBACK_EMAIL` when the gateway is unreachable or refuses. The MIME is passed through untouched,
+which is deliberate — but it means the copy's `To:` still shows the tenant alias and nothing in the
+message names the mailbox it was routed to, or which of the two paths produced it. An operator
+looking at the destination inbox could not tell an ordinary archive copy from one that landed there
+because ingestion had failed.
+
+`forward()` takes an optional `Headers` argument, of which the runtime keeps only `X-`-prefixed
+entries. Every copy now carries `X-Accounter-Forward` (`archive` / `fallback`),
+`X-Accounter-Correlation-Id` and `X-Accounter-Recipient`, and a fallback copy additionally carries
+`X-Accounter-Fallback-Reason` and `X-Accounter-Gateway-Status`.
+
+The correlation id is the point of the change, and it needed the id to exist earlier than it did:
+the nonce was minted just before the webhook call, i.e. *after* the archive forward, so that copy
+had nothing to carry. It is now generated once at the top of `email()` and reused as the nonce, so
+the archive copy, the fallback copy, the `worker:*` lines and the gateway's `orchestrate:*` lines
+all share one id. A test asserts the header matches the `correlationId` the gateway actually
+received — an id that does not match would be worse than none.
+
+Note that Gmail cannot search or filter on custom headers, so these serve _Show original_ and
+IMAP/API clients. For Gmail filtering, give each path its own plus-tagged destination: the tag is
+the SMTP envelope recipient and the receiving server stamps it into `Delivered-To:`, which Gmail
+does index. Both mechanisms are documented in the package README.
+
+Also corrects a comment that claimed the runtime rejects a second forward to an already-used
+address. Cloudflare does not document that. The guard that skips the fallback forward when both
+destinations are equal stays — a second copy to the same mailbox adds nothing, and skipping is
+idempotent either way — but it no longer rests on a guarantee that was never verified.

--- a/docs/multi-tenant-gmail-listener/cloudflare-setup-runbook.md
+++ b/docs/multi-tenant-gmail-listener/cloudflare-setup-runbook.md
@@ -45,7 +45,7 @@ What the handler does, in order:
    failure and redelivers with growing backoff, so throwing on a permanent rejection loops forever.
 
 Every branch emits one structured `worker:*` JSON line; read them with
-`yarn workspace @accounter/email-ingestion-gateway wrangler tail --name email-ingestion-gateway-worker --format pretty`.
+`yarn workspace @accounter/email-ingestion-gateway wrangler tail email-forward-04a7 --format pretty`.
 
 **Step 2 — Add Worker secrets** in the Cloudflare dashboard or with Wrangler:
 
@@ -64,8 +64,8 @@ $W secret put FALLBACK_EMAIL            # legacy Gmail inbox for rollback fallba
 
 Use **secrets**, not plain-text variables. `wrangler.jsonc` declares no `vars`, so `wrangler deploy`
 reconciles bindings against the config file and **deletes any dashboard Text variable** while
-leaving secrets intact. Verify with `$W secret list --name email-ingestion-gateway-worker`: anything
-visible in the dashboard but absent from that list is Text and will not survive the next deploy. A
+leaving secrets intact. Verify with `$W secret list --name email-forward-04a7`: anything visible in
+the dashboard but absent from that list is Text and will not survive the next deploy. A
 silently-dropped `FALLBACK_EMAIL` is what turns a permanent gateway rejection into a Cloudflare
 redelivery loop.
 
@@ -109,7 +109,7 @@ $W secret list --name email-forward-04a7 # which values are secrets (the rest ar
    that no second Worker appeared, and that the Email Routing rule still targets it:
    ```bash
    $W deploy
-   $W tail --name email-forward-04a7 --format pretty
+   $W tail email-forward-04a7 --format pretty
    ```
    On the next inbound email the tail should open with `worker:email:start`, whose booleans report
    which bindings actually resolved — that line is the fastest confirmation the deploy kept its

--- a/packages/email-ingestion-gateway/README.md
+++ b/packages/email-ingestion-gateway/README.md
@@ -124,6 +124,41 @@ See [`.dev.vars.example`](./.dev.vars.example):
 | `FALLBACK_EMAIL`            | Address the Worker forwards to when the gateway is unreachable **or** answers non-2xx (see above).                                                 |
 | `HEALTH_PROBE_TIMEOUT_MS`   | Optional. Ceiling on the `GET /health` probe; defaults to `30000`.                                                                                 |
 
+### Identifying forwarded copies in the destination mailbox
+
+The forwarded MIME is passed through **unmodified**, so its `To:` still shows the tenant alias
+(`<tenant>@accounter.tax`) and nothing in the message body or original headers names the mailbox it
+was routed to. Two separate mechanisms make the copies identifiable.
+
+**1. `X-` headers, added by the Worker.** `forward(rcptTo, headers)` accepts extra headers, of which
+the runtime keeps only `X-`-prefixed ones. Every forwarded copy carries:
+
+| Header                        | Value                                                     |
+| ----------------------------- | --------------------------------------------------------- |
+| `X-Accounter-Forward`         | `archive` or `fallback` — which path produced this copy   |
+| `X-Accounter-Correlation-Id`  | the same id the gateway logs for this delivery            |
+| `X-Accounter-Recipient`       | the tenant alias the message was addressed to             |
+| `X-Accounter-Fallback-Reason` | fallback only: `gateway-unreachable` / `gateway-rejected` |
+| `X-Accounter-Gateway-Status`  | fallback only: the HTTP status the gateway answered with  |
+
+The correlation id is the useful one: it joins a message sitting in the mailbox to the `worker:*`
+and `orchestrate:*` log lines for the same delivery.
+
+⚠️ **Gmail cannot search or filter on custom headers.** These are visible under _Show original_ and
+usable by any IMAP/API client, but you cannot build a Gmail filter on them.
+
+**2. `Delivered-To`, for Gmail filtering.** Use a distinct plus-tagged destination per path — e.g.
+`gil+email-routing@…` for `EMAIL_FORWARD_DESTINATION` and `gil+email-fallback@…` for
+`FALLBACK_EMAIL`. The tag never appears in the message itself, but it is the SMTP envelope
+recipient, and the receiving server stamps it into a `Delivered-To:` header on the copy it accepts.
+That header **is** searchable in Gmail:
+
+```text
+deliveredto:gil+email-fallback@the-guild.dev
+```
+
+Confirm it is present via _Show original_ on a delivered copy before building filters on it.
+
 ### Telling the fallback copy apart
 
 `EMAIL_FORWARD_DESTINATION` and `FALLBACK_EMAIL` must be **different addresses** — the Workers

--- a/packages/email-ingestion-gateway/README.md
+++ b/packages/email-ingestion-gateway/README.md
@@ -122,7 +122,7 @@ See [`.dev.vars.example`](./.dev.vars.example):
 | `GATEWAY_URL`               | URL the Worker `POST`s the webhook to.                                                                                                             |
 | `EMAIL_FORWARD_DESTINATION` | **Required.** Archive address every message is forwarded to before the webhook call. Unset or unverified ⇒ no archive copy and no loss protection. |
 | `FALLBACK_EMAIL`            | Address the Worker forwards to when the gateway is unreachable **or** answers non-2xx (see above).                                                 |
-| `HEALTH_PROBE_TIMEOUT_MS`   | Optional. Ceiling on the `GET /health` probe; defaults to `30000`.                                                                                 |
+| `HEALTH_PROBE_TIMEOUT_MS`   | Optional. Ceiling on the `GET /health` probe; defaults to `120000`.                                                                                |
 
 ### Identifying forwarded copies in the destination mailbox
 
@@ -177,10 +177,14 @@ the plus-tagged address in Email Routing before setting `FALLBACK_EMAIL` to it; 
 mail arrives in the same mailbox.
 
 The probe default is deliberately generous. The gateway scales to zero and cold-starts on _every_
-delivery, and the probe is what wakes it, so the probe always pays that cold start — production
-restarts measured 0.8-9.4 s to serve `/health`. A tight ceiling is not a safety measure here: it
-turns a slow-but-healthy cold start into "unreachable", which forwards the mail to `FALLBACK_EMAIL`
-and skips ingestion. Raise it if your host is slower; it is tunable without a Worker deploy.
+delivery, and the probe is what wakes it, so the probe always pays the full cold start of a
+Playwright/Chromium image. Measured end to end in production on 2026-09-10: **48 s** of container
+scheduling before any application code ran, and **52 s** before `/health` answered.
+
+A tight ceiling is not a safety measure here — it turns a slow-but-healthy cold start into
+"unreachable", which forwards the mail to `FALLBACK_EMAIL` and skips ingestion entirely. A 30 s
+ceiling did exactly that in production, aborting 22 s before the gateway had even started. Raise it
+if your host is slower; it is tunable without a Worker deploy.
 
 Set all four as **secrets**
 (`yarn workspace @accounter/email-ingestion-gateway wrangler secret put <NAME>`), not as plain-text

--- a/packages/email-ingestion-gateway/README.md
+++ b/packages/email-ingestion-gateway/README.md
@@ -161,9 +161,11 @@ Confirm it is present via _Show original_ on a delivered copy before building fi
 
 ### Telling the fallback copy apart
 
-`EMAIL_FORWARD_DESTINATION` and `FALLBACK_EMAIL` must be **different addresses** — the Workers
-runtime rejects a second forward to an address already used for the message, and the Worker skips
-the fallback forward when it detects the two are equal.
+Give `EMAIL_FORWARD_DESTINATION` and `FALLBACK_EMAIL` **different addresses**. When the Worker
+detects the two are equal it skips the fallback forward: both copies would land in the same mailbox,
+so the second adds nothing over the one already sent. (Cloudflare does not document whether a repeat
+forward to the same address errors or is accepted — skipping is correct either way, and keeps the
+outcome idempotent.)
 
 A plus-tag on the same mailbox is the cheapest way to get a distinct destination:
 `accounter+fallback@the-guild.dev` alongside `accounter@the-guild.dev`. The forwarded MIME is passed
@@ -194,9 +196,8 @@ preserved. A silently-dropped `FALLBACK_EMAIL` is what turns a gateway rejection
 loop.
 
 `EMAIL_FORWARD_DESTINATION` and `FALLBACK_EMAIL` should be **different** addresses. When they match,
-the Worker skips the fallback forward (the runtime rejects a second forward to an address already
-used for the message, and the copy would be redundant anyway) and logs `worker:fallback_skipped`
-with `cause: FALLBACK_EQUALS_FORWARD_DESTINATION`.
+the Worker skips the fallback forward — both copies would reach the same mailbox, so the second adds
+nothing — and logs `worker:fallback_skipped` with `cause: FALLBACK_EQUALS_FORWARD_DESTINATION`.
 
 ## Local development
 

--- a/packages/email-ingestion-gateway/TROUBLESHOOTING.md
+++ b/packages/email-ingestion-gateway/TROUBLESHOOTING.md
@@ -76,8 +76,8 @@ Symptom: no gateway log line for the message at all.
   `HEALTH_PROBE_TIMEOUT_MS`) before consuming the stream; if the gateway is unreachable it calls
   `message.forward(FALLBACK_EMAIL)` and the email goes to the legacy mailbox instead. Look for
   `worker:gateway_unreachable` in
-  `yarn workspace @accounter/email-ingestion-gateway wrangler tail --name email-ingestion-gateway-worker`,
-  then verify `GATEWAY_URL` + gateway health.
+  `yarn workspace @accounter/email-ingestion-gateway wrangler tail email-forward-04a7`, then verify
+  `GATEWAY_URL` + gateway health.
 - **The same message keeps arriving.** Cloudflare Email Routing reads an unhandled exception from
   the `email()` handler as a temporary delivery failure and redelivers with growing backoff, so one
   throw becomes an unbounded loop (three messages went through 4-5 redeliveries across 12 hours that

--- a/packages/email-ingestion-gateway/src/__tests__/worker-pipe.integration.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/worker-pipe.integration.test.ts
@@ -209,8 +209,8 @@ describe('worker -> gateway -> mocked server integration', () => {
 
     await worker.email(message, workerEnv);
 
-    expect(message.forward).toHaveBeenCalledWith('forward@example.com');
-    expect(message.forward).not.toHaveBeenCalledWith('fallback@example.com');
+    expect(message.forward).toHaveBeenCalledWith('forward@example.com', expect.any(Headers));
+    expect(message.forward).not.toHaveBeenCalledWith('fallback@example.com', expect.any(Headers));
     expect(capturedRequests).toHaveLength(2);
 
     const [controlRequest, ingestRequest] = capturedRequests;
@@ -284,7 +284,7 @@ describe('worker -> gateway -> mocked server integration', () => {
     });
 
     // No email lost: it reached a human even though nothing was recorded server-side.
-    expect(message.forward).toHaveBeenCalledWith('fallback@example.com');
+    expect(message.forward).toHaveBeenCalledWith('fallback@example.com', expect.any(Headers));
   });
 
   // The input-shape half of the wire contract, asserted on the bytes that actually
@@ -340,6 +340,96 @@ describe('worker -> gateway -> mocked server integration', () => {
     }
   });
 
+  // The forwarded MIME is passed through untouched, so its `To:` still shows the
+  // tenant alias and nothing in the message names the mailbox it was routed to.
+  // These X- headers are the only thing distinguishing an archive copy from a
+  // fallback copy in the destination inbox, and the correlation id is what joins a
+  // message there back to the gateway logs for the same delivery.
+  it('stamps X- headers on the archive copy so it can be identified and correlated', async () => {
+    const capturedRequests: CapturedGraphqlRequest[] = [];
+    mockServer = createMockGraphqlServer(capturedRequests);
+    const mockServerUrl = await listen(mockServer);
+
+    process.env.PORT = '3000';
+    process.env.EMAIL_INGESTION_V2_ENABLED = '1';
+    process.env.EMAIL_INGESTION_SHADOW_MODE = '0';
+    process.env.CF_WEBHOOK_SECRET = 'worker-shared-secret';
+    process.env.GATEWAY_SERVER_URL = mockServerUrl;
+    process.env.GATEWAY_CP_TOKEN = 'gateway-control-plane-token';
+
+    const { requestHandler } = await import('../index.js');
+    gatewayServer = createServer(requestHandler);
+    const gatewayUrl = await listen(gatewayServer);
+
+    const { default: worker } = await import('../worker.js');
+    const message = makeEmailMessage();
+    await worker.email(message, {
+      CF_WEBHOOK_SECRET: 'worker-shared-secret',
+      GATEWAY_URL: gatewayUrl,
+      FALLBACK_EMAIL: 'fallback@example.com',
+      EMAIL_FORWARD_DESTINATION: 'forward@example.com',
+    });
+
+    const [dest, headers] = (message.forward as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      Headers,
+    ];
+    expect(dest).toBe('forward@example.com');
+    expect(headers.get('X-Accounter-Forward')).toBe('archive');
+    expect(headers.get('X-Accounter-Recipient')).toBe('invoices@acme.example.com');
+
+    // The id on the copy must be the same one the gateway logged, or the two cannot
+    // be joined — that correlation is the entire point of carrying it.
+    const sent = capturedRequests[0]?.body.variables?.input as { correlationId?: string };
+    expect(headers.get('X-Accounter-Correlation-Id')).toBe(sent.correlationId);
+
+    // Only X- headers survive the runtime, so a non-X- name would be silently dropped.
+    for (const name of headers.keys()) {
+      expect(name.toLowerCase().startsWith('x-')).toBe(true);
+    }
+  });
+
+  it('marks a fallback copy distinctly, with the reason and upstream status', async () => {
+    mockServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+      await readJson(req);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ errors: [{ message: 'nope' }], data: null }));
+    });
+    const mockServerUrl = await listen(mockServer);
+
+    process.env.PORT = '3000';
+    process.env.EMAIL_INGESTION_V2_ENABLED = '1';
+    process.env.EMAIL_INGESTION_SHADOW_MODE = '0';
+    process.env.CF_WEBHOOK_SECRET = 'worker-shared-secret';
+    process.env.GATEWAY_SERVER_URL = mockServerUrl;
+    process.env.GATEWAY_CP_TOKEN = 'gateway-control-plane-token';
+
+    const { requestHandler } = await import('../index.js');
+    gatewayServer = createServer(requestHandler);
+    const gatewayUrl = await listen(gatewayServer);
+
+    const { default: worker } = await import('../worker.js');
+    const message = makeEmailMessage();
+    await worker.email(message, {
+      CF_WEBHOOK_SECRET: 'worker-shared-secret',
+      GATEWAY_URL: gatewayUrl,
+      FALLBACK_EMAIL: 'fallback@example.com',
+      EMAIL_FORWARD_DESTINATION: 'forward@example.com',
+    });
+
+    const calls = (message.forward as ReturnType<typeof vi.fn>).mock.calls as [string, Headers][];
+    const fallback = calls.find(([dest]) => dest === 'fallback@example.com');
+    expect(fallback).toBeDefined();
+    const [, headers] = fallback!;
+    expect(headers.get('X-Accounter-Forward')).toBe('fallback');
+    expect(headers.get('X-Accounter-Fallback-Reason')).toBe('gateway-rejected');
+    expect(headers.get('X-Accounter-Gateway-Status')).toBe('503');
+
+    // The archive copy sent moments earlier must not be confusable with it.
+    const archive = calls.find(([dest]) => dest === 'forward@example.com');
+    expect(archive![1].get('X-Accounter-Forward')).toBe('archive');
+  });
+
   // A gateway rejection must never become a Cloudflare redelivery once a copy of the
   // message has been forwarded: Email Routing reads an unhandled exception as a
   // temporary delivery failure and retries with growing backoff, so a *permanent*
@@ -385,8 +475,8 @@ describe('worker -> gateway -> mocked server integration', () => {
         }),
       ).resolves.toBeUndefined();
 
-      expect(message.forward).toHaveBeenCalledWith('forward@example.com');
-      expect(message.forward).toHaveBeenCalledWith('fallback@example.com');
+      expect(message.forward).toHaveBeenCalledWith('forward@example.com', expect.any(Headers));
+      expect(message.forward).toHaveBeenCalledWith('fallback@example.com', expect.any(Headers));
     });
 
     it('forwards once when FALLBACK_EMAIL equals EMAIL_FORWARD_DESTINATION', async () => {
@@ -469,7 +559,7 @@ describe('worker -> gateway -> mocked server integration', () => {
       HEALTH_PROBE_TIMEOUT_MS: '500',
     });
 
-    expect(message.forward).toHaveBeenCalledWith('fallback@example.com');
+    expect(message.forward).toHaveBeenCalledWith('fallback@example.com', expect.any(Headers));
   }, 20_000);
 
   it('falls back to forwarding when the gateway is unreachable', async () => {
@@ -483,6 +573,6 @@ describe('worker -> gateway -> mocked server integration', () => {
       EMAIL_FORWARD_DESTINATION: 'forward@example.com',
     });
 
-    expect(message.forward).toHaveBeenCalledWith('fallback@example.com');
+    expect(message.forward).toHaveBeenCalledWith('fallback@example.com', expect.any(Headers));
   });
 });

--- a/packages/email-ingestion-gateway/src/__tests__/worker-pipe.integration.test.ts
+++ b/packages/email-ingestion-gateway/src/__tests__/worker-pipe.integration.test.ts
@@ -484,8 +484,9 @@ describe('worker -> gateway -> mocked server integration', () => {
       const { default: worker } = await import('../worker.js');
       const message = makeEmailMessage();
 
-      // The Workers runtime rejects a second forward to an address already used for
-      // the message, and that rejection used to propagate out of the handler.
+      // Equal destinations mean the second copy would land in the same mailbox as the
+      // first, so it is skipped. Previously the handler attempted it regardless, and
+      // any failure propagated out.
       await expect(
         worker.email(message, {
           CF_WEBHOOK_SECRET: 'worker-shared-secret',
@@ -498,7 +499,7 @@ describe('worker -> gateway -> mocked server integration', () => {
       expect(message.forward).toHaveBeenCalledTimes(1);
     });
 
-    it('resolves when the runtime rejects the fallback forward', async () => {
+    it('resolves when the fallback forward is rejected', async () => {
       const gatewayUrl = await startRejectingGateway();
       const { default: worker } = await import('../worker.js');
       const message = makeEmailMessage();

--- a/packages/email-ingestion-gateway/src/worker.ts
+++ b/packages/email-ingestion-gateway/src/worker.ts
@@ -35,13 +35,21 @@ const HEX_OCTETS = Array.from({ length: 256 }, (_, i) => i.toString(16).padStart
  *
  * The value is deliberately generous. This gateway scales to zero and cold-starts
  * on *every* delivery, and the probe is what wakes it, so the probe always pays the
- * cold start. Production restarts measured 0.8-9.4 s from process start to serving
- * `/health` (median ~1.7 s), and that excludes container scheduling before the
- * process logs at all. A tight ceiling here is not a safety measure — it silently
- * converts a slow-but-healthy cold start into "unreachable", which forwards the mail
- * to the fallback mailbox and skips ingestion entirely. Prefer waiting.
+ * full cold start of a Playwright/Chromium image.
+ *
+ * Measured end to end in production on 2026-09-10: probe fired at 08:53:41Z, the
+ * gateway process logged "gateway started" at 08:54:29Z (**48 s** of container
+ * scheduling and boot before any application code ran) and served `/health` at
+ * 08:54:33Z — **52 s** after the probe.
+ *
+ * An earlier value of 30 s was set from logs measuring only process-start to
+ * `/health` (0.8-9.4 s) and treating the scheduling gap as negligible. It is not
+ * negligible; it is the dominant term. That ceiling aborted the probe 22 s before
+ * the gateway had even started, so a healthy service read as "unreachable", the
+ * mail went to the fallback mailbox and was never ingested. A tight ceiling here is
+ * not a safety measure. Prefer waiting.
  */
-const DEFAULT_HEALTH_PROBE_TIMEOUT_MS = 30_000;
+const DEFAULT_HEALTH_PROBE_TIMEOUT_MS = 120_000;
 
 /** Ceiling on rejected-response text carried into the logs. */
 const MAX_LOGGED_BODY_CHARS = 500;
@@ -155,13 +163,27 @@ const worker = {
     if (!(await isGatewayReachable(env.GATEWAY_URL, healthProbeTimeoutMs(env)))) {
       logEvent('worker:gateway_unreachable', { fallbackEmailConfigured: !!env.FALLBACK_EMAIL });
       if (env.FALLBACK_EMAIL) {
-        await message.forward(
-          env.FALLBACK_EMAIL,
-          forwardHeaders('fallback', correlationId, message, {
-            'X-Accounter-Fallback-Reason': 'gateway-unreachable',
-          }),
-        );
-        return;
+        // Log the outcome, not just the intent: "did the fallback actually deliver?"
+        // is the only question this branch exists to answer, and without this line a
+        // tail shows `worker:gateway_unreachable` and then nothing at all.
+        try {
+          await message.forward(
+            env.FALLBACK_EMAIL,
+            forwardHeaders('fallback', correlationId, message, {
+              'X-Accounter-Fallback-Reason': 'gateway-unreachable',
+            }),
+          );
+          logEvent('worker:fallback_forwarded', { cause: 'gateway-unreachable' });
+          return;
+        } catch (e) {
+          // Nothing has been forwarded anywhere at this point, so let it throw:
+          // a Cloudflare redelivery is the correct no-loss behaviour here.
+          logEvent('worker:fallback_forward_failed', {
+            cause: 'gateway-unreachable',
+            error: (e as Error).message,
+          });
+          throw e;
+        }
       }
       // Nothing has been forwarded yet, so the message exists only upstream: a
       // Cloudflare redelivery is the correct no-loss behaviour here, and a gateway

--- a/packages/email-ingestion-gateway/src/worker.ts
+++ b/packages/email-ingestion-gateway/src/worker.ts
@@ -85,13 +85,15 @@ function sameAddress(a: string | undefined, b: string | undefined): boolean {
  * destination mailbox can be joined to the gateway logs for the same delivery.
  *
  * The runtime keeps only `X-`-prefixed headers here and drops everything else, so
- * every name below must start with `X-`.
+ * `extra` is typed to accept nothing else: a non-`X-` key is a compile error rather
+ * than a header that vanishes silently in production and is then debugged from its
+ * absence.
  */
 function forwardHeaders(
   path: 'archive' | 'fallback',
   correlationId: string,
   message: EmailMessageLike,
-  extra: Record<string, string> = {},
+  extra: Record<`X-${string}`, string> = {},
 ): Headers {
   return new Headers({
     'X-Accounter-Forward': path,

--- a/packages/email-ingestion-gateway/src/worker.ts
+++ b/packages/email-ingestion-gateway/src/worker.ts
@@ -2,7 +2,12 @@ type EmailMessageLike = {
   to: string;
   headers: Headers;
   raw: ReadableStream;
-  forward: (recipient: string) => Promise<unknown>;
+  /**
+   * Cloudflare's `forward(rcptTo, headers?)`. The runtime keeps only `X-`-prefixed
+   * headers from the second argument and drops the rest. Hand-declared because
+   * `@cloudflare/workers-types` is not a dependency of this package.
+   */
+  forward: (recipient: string, headers?: Headers) => Promise<unknown>;
 };
 
 export type WorkerEnv = {
@@ -64,6 +69,31 @@ function sameAddress(a: string | undefined, b: string | undefined): boolean {
 }
 
 /**
+ * Headers stamped onto every forwarded copy.
+ *
+ * The forwarded MIME is otherwise untouched, so its `To:` still shows the tenant
+ * alias and nothing in the message names the mailbox it was routed to. These say
+ * which path produced the copy and carry the correlation id, so a message in the
+ * destination mailbox can be joined to the gateway logs for the same delivery.
+ *
+ * The runtime keeps only `X-`-prefixed headers here and drops everything else, so
+ * every name below must start with `X-`.
+ */
+function forwardHeaders(
+  path: 'archive' | 'fallback',
+  correlationId: string,
+  message: EmailMessageLike,
+  extra: Record<string, string> = {},
+): Headers {
+  return new Headers({
+    'X-Accounter-Forward': path,
+    'X-Accounter-Correlation-Id': correlationId,
+    'X-Accounter-Recipient': message.to,
+    ...extra,
+  });
+}
+
+/**
  * One structured line per decision. A `wrangler tail` has to say which branch fired
  * and why — reconstructing that from a bare stack trace is what made the redelivery
  * loop hard to place.
@@ -92,6 +122,11 @@ async function isGatewayReachable(gatewayUrl: string, timeoutMs: number): Promis
 
 const worker = {
   async email(message: EmailMessageLike, env: WorkerEnv): Promise<void> {
+    // Minted before the first forward, not at the webhook call, so that every
+    // forwarded copy and every log line for this delivery share one id. It doubles
+    // as the replay nonce sent to the gateway.
+    const correlationId = crypto.randomUUID();
+
     // Which variables are actually bound decides which failure path can fire, and
     // `wrangler.jsonc` declares no `vars` — these are dashboard-managed, and a
     // plain-text (non-secret) one is silently dropped by `wrangler deploy`. The
@@ -106,6 +141,7 @@ const worker = {
     // (`worker:forward_failed`), where the text is the diagnosis.
     logEvent('worker:email:start', {
       messageId: message.headers.get('message-id'),
+      correlationId,
       gatewayUrlConfigured: !!env.GATEWAY_URL,
       forwardDestinationConfigured: !!env.EMAIL_FORWARD_DESTINATION,
       fallbackEmailConfigured: !!env.FALLBACK_EMAIL,
@@ -119,7 +155,12 @@ const worker = {
     if (!(await isGatewayReachable(env.GATEWAY_URL, healthProbeTimeoutMs(env)))) {
       logEvent('worker:gateway_unreachable', { fallbackEmailConfigured: !!env.FALLBACK_EMAIL });
       if (env.FALLBACK_EMAIL) {
-        await message.forward(env.FALLBACK_EMAIL);
+        await message.forward(
+          env.FALLBACK_EMAIL,
+          forwardHeaders('fallback', correlationId, message, {
+            'X-Accounter-Fallback-Reason': 'gateway-unreachable',
+          }),
+        );
         return;
       }
       // Nothing has been forwarded yet, so the message exists only upstream: a
@@ -137,7 +178,10 @@ const worker = {
     let forwardedToDestination = false;
     let forwardedToFallback = false;
     try {
-      await message.forward(env.EMAIL_FORWARD_DESTINATION);
+      await message.forward(
+        env.EMAIL_FORWARD_DESTINATION,
+        forwardHeaders('archive', correlationId, message),
+      );
       forwardedToDestination = true;
       logEvent('worker:forwarded');
     } catch (e) {
@@ -149,7 +193,7 @@ const worker = {
 
     // 4. Continue with your webhook logic
     const timestamp = Math.floor(Date.now() / 1000);
-    const nonce = crypto.randomUUID();
+    const nonce = correlationId;
 
     // Compute HMAC-SHA256 over `${timestamp}.${rawBody}`, where rawBody is the
     // raw MIME message — the exact bytes sent as the request body. The gateway
@@ -215,16 +259,23 @@ const worker = {
           forwardedToDestination,
         });
       } else if (sameAddress(env.FALLBACK_EMAIL, env.EMAIL_FORWARD_DESTINATION)) {
-        // `message.forward()` rejects a second forward to an address already used
-        // for this message, and the copy the operator would receive is the one
-        // step 3 already sent. Skipping is both correct and idempotent.
+        // Both forwards would land in the same mailbox, so the second copy adds
+        // nothing over the one step 3 already sent. (Cloudflare does not document
+        // whether a repeat forward to the same address errors or is accepted;
+        // skipping is correct either way and keeps the outcome idempotent.)
         logEvent('worker:fallback_skipped', {
           cause: 'FALLBACK_EQUALS_FORWARD_DESTINATION',
           forwardedToDestination,
         });
       } else {
         try {
-          await message.forward(env.FALLBACK_EMAIL);
+          await message.forward(
+            env.FALLBACK_EMAIL,
+            forwardHeaders('fallback', correlationId, message, {
+              'X-Accounter-Fallback-Reason': 'gateway-rejected',
+              'X-Accounter-Gateway-Status': String(response.status),
+            }),
+          );
           forwardedToFallback = true;
           logEvent('worker:fallback_forwarded');
         } catch (e) {

--- a/packages/email-ingestion-gateway/wrangler.jsonc
+++ b/packages/email-ingestion-gateway/wrangler.jsonc
@@ -9,7 +9,16 @@
   "name": "email-forward-04a7",
 
   "main": "src/worker.ts",
-  "compatibility_date": "2026-06-17",
+
+  // Pinned to the date the live Worker already runs, so the repo's first deploy
+  // changes only the handler code. This value had never been applied: the Worker
+  // was maintained by pasting source into the dashboard, so the repo's previous
+  // 2026-06-17 would have jumped the runtime ~13 months in the same deploy that
+  // first took ownership of it, making any misbehaviour ambiguous between the two.
+  //
+  // TODO: bump to a current date in a separate change, once this deploy is
+  // confirmed healthy.
+  "compatibility_date": "2025-05-23",
 
   // Account id is not a secret, but it is deployment-specific: set
   // CLOUDFLARE_ACCOUNT_ID in your shell (or as a CI secret) rather than committing

--- a/packages/email-ingestion-gateway/wrangler.jsonc
+++ b/packages/email-ingestion-gateway/wrangler.jsonc
@@ -35,6 +35,13 @@
   // move GATEWAY_URL into a `vars` block here instead — this repo is public.
   "keep_vars": true,
 
+  // Both default to true when unspecified, and the live Worker has both OFF. Without
+  // these, the first deploy would silently publish a `<name>.workers.dev` URL and
+  // preview URLs for a Worker that has no `fetch` handler at all — pure attack
+  // surface for zero benefit. Pinned to match the deployed state.
+  "workers_dev": false,
+  "preview_urls": false,
+
   // Required for `wrangler tail` and log retention to be useful — the handler now
   // emits one structured `worker:*` JSON line per branch, and without this they are
   // not retained.


### PR DESCRIPTION
The Worker forwards every message to `EMAIL_FORWARD_DESTINATION` before calling the webhook, and to `FALLBACK_EMAIL` when the gateway is unreachable or refuses. The MIME is passed through untouched — deliberately — but that means the copy's `To:` still shows the tenant alias, and nothing in the message names the mailbox it was routed to or which of the two paths produced it.

Looking at the destination inbox, an ordinary archive copy is **indistinguishable from one that landed there because ingestion failed**. That is the case an operator most needs to spot.

## The mechanism

`forward()` takes an optional second argument, and the runtime keeps only `X-`-prefixed entries from it:

```ts
forward(rcptTo: string, headers?: Headers): Promise<EmailSendResult>
```

> "Only headers with an `X-` prefix can be added through `forward()`. Other headers are removed."
> — [Email Workers runtime API](https://developers.cloudflare.com/email-routing/email-workers/runtime-api/)

Every forwarded copy now carries:

| Header | Value |
| --- | --- |
| `X-Accounter-Forward` | `archive` or `fallback` |
| `X-Accounter-Correlation-Id` | the same id the gateway logs for this delivery |
| `X-Accounter-Recipient` | the tenant alias the message was addressed to |
| `X-Accounter-Fallback-Reason` | fallback only — `gateway-unreachable` / `gateway-rejected` |
| `X-Accounter-Gateway-Status` | fallback only — the HTTP status the gateway answered with |

## The correlation id needed to move

This is the substantive part. The nonce was minted immediately before the webhook call — i.e. **after** the archive forward — so that copy had no id to carry. It is now generated once at the top of `email()` and reused as the nonce, so both forwarded copies, the `worker:*` lines and the gateway's `orchestrate:*` lines all share one id.

A test asserts the header equals the `correlationId` the gateway actually received. An id that silently disagreed would be worse than no id at all, since it would join a mailbox message to the wrong delivery.

## Gmail can't filter on custom headers

Worth stating plainly, because it limits what these are for: Gmail's search and filter UI cannot match arbitrary headers, so the `X-` headers serve *Show original* and IMAP/API clients, not inbox rules.

For Gmail filtering the answer is a distinct plus-tagged destination per path (`…+email-routing@`, `…+email-fallback@`). The tag never appears in the message, but it is the SMTP envelope recipient and the receiving server stamps it into `Delivered-To:`, which Gmail *does* index:

```text
deliveredto:gil+email-fallback@the-guild.dev
```

Both mechanisms, and this limitation, are documented in the package README.

## Also corrected

A comment claimed the runtime rejects a second forward to an already-used address. **Cloudflare documents no such restriction** — I had asserted it without checking. The guard that skips the fallback forward when both destinations are equal stays, since a second copy to the same mailbox adds nothing and skipping is idempotent either way, but it no longer rests on an unverified guarantee.

`EmailMessageLike` gained the `headers?` parameter. It is hand-declared because `@cloudflare/workers-types` is not a dependency of this package — a small illustration of why adding it is worth considering.

## Verification

`342 tests pass` (2 new), typecheck clean, lint 0 errors, prettier clean. The two new integration cases assert the archive copy's headers and correlation match, and that a fallback copy is distinctly marked with its reason and upstream status.

Follows #4398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
