### PR TITLE
feat(client): replace Mantine in the business trip report's expense dialogs

### DIFF
--- a/.changeset/olive-crabs-shake.md
+++ b/.changeset/olive-crabs-shake.md
@@ -5,3 +5,6 @@
 Replace Mantine's `Modal`, `Select`, `MultiSelect`, `Loader`, `Grid` and `Text` in the business
 trip report's "add expense" dialogs with `PopUpModal`, `ComboBox`, `NegatableMultiSelect` and
 `LoadingOverlay`.
+
+`ComboBox` now accepts the `ref` and `onBlur` that react-hook-form supplies, restoring touched
+state, `onBlur`-mode validation and error focus for all of its call sites.

--- a/.changeset/olive-crabs-shake.md
+++ b/.changeset/olive-crabs-shake.md
@@ -1,0 +1,7 @@
+---
+'@accounter/client': patch
+---
+
+Replace Mantine's `Modal`, `Select`, `MultiSelect`, `Loader`, `Grid` and `Text` in the business
+trip report's "add expense" dialogs with `PopUpModal`, `ComboBox`, `NegatableMultiSelect` and
+`LoadingOverlay`.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -306,6 +306,7 @@ export default [
       'packages/client/src/components/charge-matching/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/charge-matches/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/clients/**/*.{,c,m}{j,t}s{,x}',
+      'packages/client/src/components/common/business-trip-report/buttons/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/contracts/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/financial-accounts/**/*.{,c,m}{j,t}s{,x}',
       'packages/client/src/components/landing/**/*.{,c,m}{j,t}s{,x}',

--- a/packages/client/src/components/common/business-trip-report/buttons/add-accommodation-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-accommodation-expense.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal } from '@mantine/core';
 import { type AddBusinessTripAccommodationsExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripAccommodationsExpense } from '../../../../hooks/use-add-business-trip-accommodations-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -14,8 +13,8 @@ import {
   FormMessage,
 } from '../../../ui/form.js';
 import { Input } from '../../../ui/input.js';
-import { Overlay } from '../../../ui/overlay.js';
-import { NumberInput, Tooltip } from '../../index.js';
+import { LoadingOverlay } from '../../../ui/overlay.js';
+import { NumberInput, PopUpModal, Tooltip } from '../../index.js';
 import { AttendeesStayInput } from '../parts/attendee-stay-input.js';
 import { AddExpenseFields } from './add-expense-fields.js';
 
@@ -78,73 +77,66 @@ function ModalContent({ businessTripId, opened, close, onAdd }: ModalProps): Rea
   };
 
   return (
-    <Modal opened={opened} onClose={close} centered lockScroll>
-      <Modal.Title>Add Accommodation Expense</Modal.Title>
-      <Modal.Body>
-        <Form {...formManager}>
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
-            <AddExpenseFields
-              businessTripId={businessTripId}
-              control={control}
-              setFetching={setFetching}
-            />
+    <PopUpModal opened={opened} onClose={close} withCloseButton title="Add Accommodation Expense">
+      <Form {...formManager}>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+          <AddExpenseFields
+            businessTripId={businessTripId}
+            control={control}
+            setFetching={setFetching}
+          />
 
-            {/* TODO: replace with country select */}
-            <FormField
-              control={control}
-              name="country"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Country</FormLabel>
-                  <FormControl>
-                    <Input {...field} value={field.value ?? undefined} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          {/* TODO: replace with country select */}
+          <FormField
+            control={control}
+            name="country"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Country</FormLabel>
+                <FormControl>
+                  <Input {...field} value={field.value ?? undefined} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            <FormField
-              name="nightsCount"
-              control={control}
-              render={({ field }): ReactElement => (
-                <FormItem>
-                  <FormLabel>Nights Count</FormLabel>
-                  <FormControl>
-                    <NumberInput
-                      {...field}
-                      value={field.value ?? undefined}
-                      hideControls
-                      decimalScale={0}
-                      thousandSeparator=","
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <FormField
+            name="nightsCount"
+            control={control}
+            render={({ field }): ReactElement => (
+              <FormItem>
+                <FormLabel>Nights Count</FormLabel>
+                <FormControl>
+                  <NumberInput
+                    {...field}
+                    value={field.value ?? undefined}
+                    hideControls
+                    decimalScale={0}
+                    thousandSeparator=","
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            <AttendeesStayInput
-              formManager={formManager}
-              attendeesStayPath="attendeesStay"
-              businessTripId={businessTripId}
-            />
-            <div className="flex justify-center mt-5 gap-3">
-              <button
-                type="submit"
-                className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
-              >
-                Add
-              </button>
-            </div>
-          </form>
-        </Form>
-      </Modal.Body>
-      {(addingInProcess || fetching) && (
-        <Overlay blur={1} center>
-          <Loader />
-        </Overlay>
-      )}
-    </Modal>
+          <AttendeesStayInput
+            formManager={formManager}
+            attendeesStayPath="attendeesStay"
+            businessTripId={businessTripId}
+          />
+          <div className="flex justify-center mt-5 gap-3">
+            <button
+              type="submit"
+              className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
+            >
+              Add
+            </button>
+          </div>
+        </form>
+      </Form>
+      <LoadingOverlay visible={addingInProcess || fetching} blur={1} />
+    </PopUpModal>
   );
 }

--- a/packages/client/src/components/common/business-trip-report/buttons/add-attendee.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-attendee.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, Select } from '@mantine/core';
 import type { InsertBusinessTripAttendeeInput } from '../../../../gql/graphql.js';
 import { TIMELESS_DATE_REGEX } from '../../../../helpers/index.js';
 import { useGetBusinesses } from '../../../../hooks/use-get-businesses.js';
@@ -15,8 +14,8 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../ui/form.js';
-import { Overlay } from '../../../ui/overlay.js';
-import { Tooltip } from '../../index.js';
+import { LoadingOverlay } from '../../../ui/overlay.js';
+import { ComboBox, PopUpModal, Tooltip } from '../../index.js';
 import { DatePickerInput } from '../../inputs/date-picker-input.js';
 
 export function AddAttendee(props: { businessTripId: string; onAdd?: () => void }): ReactElement {
@@ -75,102 +74,91 @@ function ModalContent({ businessTripId, opened, close, onAdd }: ModalProps): Rea
   };
 
   return (
-    <Modal opened={opened} onClose={close} centered>
-      <Modal.Title>Add Attendee</Modal.Title>
-      <Modal.Body>
-        <Form {...form}>
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 pt-2">
-            <Controller
-              name="attendeeId"
-              control={control}
-              render={({ field, fieldState }): ReactElement => (
-                <Select
-                  data-autofocus
-                  {...field}
-                  data={businesses}
-                  value={field.value}
-                  disabled={fetchingBusinesses}
-                  label="Attendee"
-                  placeholder="Scroll to see all options"
-                  maxDropdownHeight={160}
-                  searchable
-                  error={fieldState.error?.message}
-                  withAsterisk
-                  withinPortal
-                />
-              )}
-            />
+    <PopUpModal opened={opened} onClose={close} withCloseButton title="Add Attendee">
+      <Form {...form}>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 pt-2">
+          <Controller
+            name="attendeeId"
+            control={control}
+            render={({ field, fieldState }): ReactElement => (
+              <ComboBox
+                {...field}
+                data={businesses}
+                value={field.value}
+                disabled={fetchingBusinesses}
+                label="Attendee"
+                required
+                placeholder="Scroll to see all options"
+                error={fieldState.error?.message}
+              />
+            )}
+          />
 
-            <FormField
-              name="arrivalDate"
-              control={control}
-              rules={{
-                pattern: {
-                  value: TIMELESS_DATE_REGEX,
-                  message: 'Date must be in format yyyy-mm-dd',
-                },
-              }}
-              render={({ field, fieldState }): ReactElement => (
-                <FormItem className="h-min">
-                  <FormLabel htmlFor="arrival-date">Arrival</FormLabel>
-                  <FormControl>
-                    <DatePickerInput
-                      id="arrival-date"
-                      value={field.value ?? undefined}
-                      onChange={date => {
-                        if (date !== field.value) field.onChange(date);
-                      }}
-                      aria-invalid={!!fieldState.error}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <FormField
+            name="arrivalDate"
+            control={control}
+            rules={{
+              pattern: {
+                value: TIMELESS_DATE_REGEX,
+                message: 'Date must be in format yyyy-mm-dd',
+              },
+            }}
+            render={({ field, fieldState }): ReactElement => (
+              <FormItem className="h-min">
+                <FormLabel htmlFor="arrival-date">Arrival</FormLabel>
+                <FormControl>
+                  <DatePickerInput
+                    id="arrival-date"
+                    value={field.value ?? undefined}
+                    onChange={date => {
+                      if (date !== field.value) field.onChange(date);
+                    }}
+                    aria-invalid={!!fieldState.error}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            <FormField
-              name="departureDate"
-              control={control}
-              rules={{
-                pattern: {
-                  value: TIMELESS_DATE_REGEX,
-                  message: 'Date must be in format yyyy-mm-dd',
-                },
-              }}
-              render={({ field, fieldState }): ReactElement => (
-                <FormItem className="h-min">
-                  <FormLabel htmlFor="departure-date">Departure</FormLabel>
-                  <FormControl>
-                    <DatePickerInput
-                      id="departure-date"
-                      value={field.value ?? undefined}
-                      onChange={date => {
-                        if (date !== field.value) field.onChange(date);
-                      }}
-                      aria-invalid={!!fieldState.error}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <FormField
+            name="departureDate"
+            control={control}
+            rules={{
+              pattern: {
+                value: TIMELESS_DATE_REGEX,
+                message: 'Date must be in format yyyy-mm-dd',
+              },
+            }}
+            render={({ field, fieldState }): ReactElement => (
+              <FormItem className="h-min">
+                <FormLabel htmlFor="departure-date">Departure</FormLabel>
+                <FormControl>
+                  <DatePickerInput
+                    id="departure-date"
+                    value={field.value ?? undefined}
+                    onChange={date => {
+                      if (date !== field.value) field.onChange(date);
+                    }}
+                    aria-invalid={!!fieldState.error}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            <div className="flex justify-center mt-5 gap-3">
-              <button
-                type="submit"
-                className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
-              >
-                Add
-              </button>
-            </div>
-          </form>
-        </Form>
-      </Modal.Body>
-      {(addingInProcess || fetchingBusinesses) && (
-        <Overlay blur={1} center>
-          <Loader />
-        </Overlay>
-      )}
-    </Modal>
+          <div className="flex justify-center mt-5 gap-3">
+            <button
+              type="submit"
+              className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
+            >
+              Add
+            </button>
+          </div>
+        </form>
+      </Form>
+      <LoadingOverlay visible={addingInProcess || fetchingBusinesses} blur={1} />
+    </PopUpModal>
   );
 }

--- a/packages/client/src/components/common/business-trip-report/buttons/add-car-rental-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-car-rental-expense.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal } from '@mantine/core';
 import type { AddBusinessTripCarRentalExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripCarRentalExpense } from '../../../../hooks/use-add-business-trip-car-rental-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -13,9 +12,9 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../ui/form.js';
-import { Overlay } from '../../../ui/overlay.js';
+import { LoadingOverlay } from '../../../ui/overlay.js';
 import { Switch } from '../../../ui/switch.js';
-import { Tooltip } from '../../index.js';
+import { PopUpModal, Tooltip } from '../../index.js';
 import { NumberInput } from '../../inputs/number-input.js';
 import { AddExpenseFields } from './add-expense-fields.js';
 
@@ -78,64 +77,57 @@ function ModalContent({ businessTripId, opened, close, onAdd }: ModalProps): Rea
   };
 
   return (
-    <Modal opened={opened} onClose={close} centered lockScroll>
-      <Modal.Title>Add Car Rental Expense</Modal.Title>
-      <Modal.Body>
-        <Form {...form}>
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <AddExpenseFields
-              businessTripId={businessTripId}
-              control={control}
-              setFetching={setFetching}
-            />
+    <PopUpModal opened={opened} onClose={close} withCloseButton title="Add Car Rental Expense">
+      <Form {...form}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <AddExpenseFields
+            businessTripId={businessTripId}
+            control={control}
+            setFetching={setFetching}
+          />
 
-            <Controller
-              name="days"
-              control={control}
-              render={({ field, fieldState }): ReactElement => (
-                <NumberInput
-                  {...field}
-                  value={field.value ?? undefined}
-                  hideControls
-                  decimalScale={2}
-                  error={fieldState.error?.message}
-                  label="Rent Days"
-                />
-              )}
-            />
+          <Controller
+            name="days"
+            control={control}
+            render={({ field, fieldState }): ReactElement => (
+              <NumberInput
+                {...field}
+                value={field.value ?? undefined}
+                hideControls
+                decimalScale={2}
+                error={fieldState.error?.message}
+                label="Rent Days"
+              />
+            )}
+          />
 
-            <FormField
-              name="isFuelExpense"
-              control={control}
-              render={({ field: { value, ...field } }) => (
-                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
-                  <div className="space-y-0.5">
-                    <FormLabel>Is Fuel Expense</FormLabel>
-                  </div>
-                  <FormControl>
-                    <Switch {...field} checked={value === true} onCheckedChange={field.onChange} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <FormField
+            name="isFuelExpense"
+            control={control}
+            render={({ field: { value, ...field } }) => (
+              <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+                <div className="space-y-0.5">
+                  <FormLabel>Is Fuel Expense</FormLabel>
+                </div>
+                <FormControl>
+                  <Switch {...field} checked={value === true} onCheckedChange={field.onChange} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            <div className="flex justify-center mt-5 gap-3">
-              <button
-                type="submit"
-                className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
-              >
-                Add
-              </button>
-            </div>
-          </form>
-        </Form>
-      </Modal.Body>
-      {(addingInProcess || fetching) && (
-        <Overlay blur={1} center>
-          <Loader />
-        </Overlay>
-      )}
-    </Modal>
+          <div className="flex justify-center mt-5 gap-3">
+            <button
+              type="submit"
+              className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
+            >
+              Add
+            </button>
+          </div>
+        </form>
+      </Form>
+      <LoadingOverlay visible={addingInProcess || fetching} blur={1} />
+    </PopUpModal>
   );
 }

--- a/packages/client/src/components/common/business-trip-report/buttons/add-expense-fields.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-expense-fields.tsx
@@ -2,7 +2,6 @@ import { useContext, useEffect, useMemo, useState, type ReactElement } from 'rea
 import { type Control } from 'react-hook-form';
 import { toast } from 'sonner';
 import { useQuery } from 'urql';
-import { Select } from '@mantine/core';
 import {
   AttendeesByBusinessTripDocument,
   Currency,
@@ -11,7 +10,7 @@ import {
 import { TIMELESS_DATE_REGEX } from '../../../../helpers/index.js';
 import { UserContext } from '../../../../providers/user-provider.js';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../../ui/form.js';
-import { CurrencyInput, DatePickerInput } from '../../index.js';
+import { ComboBox, CurrencyInput, DatePickerInput } from '../../index.js';
 
 export type AddBusinessTripExpenseInput = Omit<
   AddBusinessTripTravelAndSubsistenceExpenseInput,
@@ -160,20 +159,17 @@ export function AddExpenseFields({
       <FormField
         name="employeeBusinessId"
         control={control}
-        render={({ field, fieldState }): ReactElement => (
+        render={({ field }): ReactElement => (
           <FormItem>
             <FormLabel>Attendee</FormLabel>
             <FormControl>
-              <Select
+              <ComboBox
                 {...field}
                 data={attendees}
                 value={field.value}
                 disabled={fetchingAttendees}
                 placeholder="Scroll to see all options"
-                maxDropdownHeight={160}
-                searchable
-                error={fieldState.error?.message}
-                withinPortal
+                formPart
               />
             </FormControl>
             <FormMessage />

--- a/packages/client/src/components/common/business-trip-report/buttons/add-flight-expense.stories.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-flight-expense.stories.tsx
@@ -1,0 +1,89 @@
+import { useState, type ReactElement } from 'react';
+import { Client, Provider, type Exchange, type OperationResult } from 'urql';
+import { map, never, pipe } from 'wonka';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AddFlightExpense } from './add-flight-expense.js';
+
+/* -------------------------------------------------------------------------- */
+/*  Mock backend                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A local urql client, following `charges-filters.stories.tsx`: these render the same
+ * every time without `yarn mock:server` running, and the attendee list has to be known
+ * for the pickers to be worth looking at.
+ */
+const ATTENDEES = [
+  { id: 'attendee-1', name: 'Dotan Simha' },
+  { id: 'attendee-2', name: 'Uri Goldshtein' },
+  { id: 'attendee-3', name: 'Gil Gardosh' },
+  { id: 'attendee-4', name: 'Kamil Kisiela' },
+];
+
+const RESPONSES: Record<string, unknown> = {
+  AttendeesByBusinessTrip: { businessTrip: { id: 'trip-1', attendees: ATTENDEES } },
+};
+
+function operationName(result: { query: { definitions: readonly unknown[] } }): string {
+  const definition = result.query.definitions[0] as { name?: { value?: string } } | undefined;
+  return definition?.name?.value ?? '';
+}
+
+/** Answers every query from {@link RESPONSES}; unknown operations resolve to null. */
+const resolvedExchange: Exchange = () => operations$ =>
+  pipe(
+    operations$,
+    map((operation): OperationResult => ({
+      operation,
+      data: RESPONSES[operationName(operation)] ?? null,
+      error: undefined,
+      extensions: undefined,
+      hasNext: false,
+      stale: false,
+    })),
+  );
+
+/** Never resolves, so the attendee pickers stay in their fetching state. */
+const pendingExchange: Exchange = () => () => never;
+
+function mockClient(exchange: Exchange): Client {
+  return new Client({ url: '/graphql', exchanges: [exchange] });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Harness                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Characterizes the "add expense" dialog shared by the whole `buttons/` directory, which
+ * moved off Mantine's `Modal` onto `PopUpModal`. This one is the richest of the eight:
+ * a `ComboBox` (was `Select`), a `NegatableMultiSelect` (was `MultiSelect`), the shared
+ * `AddExpenseFields`, and a `LoadingOverlay` (was `Overlay` + `Loader`).
+ *
+ * The trip id is fixed, so `onAdd` only reports that the mutation round-tripped.
+ */
+function Harness({ loading = false }: { loading?: boolean }): ReactElement {
+  const [added, setAdded] = useState(0);
+  return (
+    <Provider value={mockClient(loading ? pendingExchange : resolvedExchange)}>
+      <div className="flex min-h-64 items-start gap-3 bg-gray-100 p-6">
+        <AddFlightExpense businessTripId="trip-1" onAdd={() => setAdded(count => count + 1)} />
+        <span className="text-xs text-gray-500">added: {added}</span>
+      </div>
+    </Provider>
+  );
+}
+
+const meta = {
+  title: 'BusinessTripReport/AddFlightExpense',
+  component: Harness,
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** The trigger on its own; click the plus to open the dialog. */
+export const Closed: Story = { args: {} };
+
+/** Attendees never arrive, so the pickers show their loading state behind the overlay. */
+export const LoadingAttendees: Story = { args: { loading: true } };

--- a/packages/client/src/components/common/business-trip-report/buttons/add-flight-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-flight-expense.tsx
@@ -2,7 +2,6 @@ import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { useQuery } from 'urql';
-import { Loader, Modal, MultiSelect, Select } from '@mantine/core';
 import {
   AttendeesByBusinessTripDocument,
   FlightClass,
@@ -11,8 +10,9 @@ import {
 import { useAddBusinessTripFlightsExpense } from '../../../../hooks/use-add-business-trip-flights-expense.js';
 import { Button } from '../../../ui/button.js';
 import { Form } from '../../../ui/form.js';
-import { Overlay } from '../../../ui/overlay.js';
-import { Tooltip } from '../../index.js';
+import { Label } from '../../../ui/label.js';
+import { LoadingOverlay } from '../../../ui/overlay.js';
+import { ComboBox, NegatableMultiSelect, PopUpModal, Tooltip } from '../../index.js';
 import { FlightPathInput } from '../parts/flight-path-input.js';
 import { AddExpenseFields } from './add-expense-fields.js';
 
@@ -93,70 +93,70 @@ function ModalContent({ businessTripId, opened, close, onAdd }: ModalProps): Rea
     })) ?? [];
 
   return (
-    <Modal opened={opened} onClose={close} centered lockScroll>
-      <Modal.Title>Add Flight Expense</Modal.Title>
-      <Modal.Body>
-        <Form {...formManager}>
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <AddExpenseFields
-              businessTripId={businessTripId}
-              control={control}
-              setFetching={setFetching}
-            />
+    <PopUpModal opened={opened} onClose={close} withCloseButton title="Add Flight Expense">
+      <Form {...formManager}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <AddExpenseFields
+            businessTripId={businessTripId}
+            control={control}
+            setFetching={setFetching}
+          />
 
-            <FlightPathInput formManager={formManager} flightPathPath="path" />
-            <Controller
-              name="flightClass"
-              control={control}
-              render={({ field, fieldState }): ReactElement => (
-                <Select
-                  {...field}
-                  data={flightClasses}
-                  value={field.value}
-                  label="Flight Class"
-                  placeholder="Scroll to see all options"
-                  maxDropdownHeight={160}
-                  searchable
-                  error={fieldState.error?.message}
-                  withinPortal
-                />
-              )}
-            />
-            <Controller
-              name="attendeeIds"
-              control={control}
-              render={({ field, fieldState }): ReactElement => (
-                <MultiSelect
-                  {...field}
-                  disabled={fetchingAttendees}
-                  data={attendeesData}
+          <FlightPathInput formManager={formManager} flightPathPath="path" />
+          <Controller
+            name="flightClass"
+            control={control}
+            render={({ field, fieldState }): ReactElement => (
+              <ComboBox
+                {...field}
+                data={flightClasses}
+                value={field.value}
+                label="Flight Class"
+                placeholder="Scroll to see all options"
+                error={fieldState.error?.message}
+              />
+            )}
+          />
+          <Controller
+            name="attendeeIds"
+            control={control}
+            render={({ field, fieldState }): ReactElement => (
+              <div>
+                <Label asChild className="mb-1">
+                  <span id="flight-attendees-label">Attendees</span>
+                </Label>
+                <NegatableMultiSelect
+                  ref={field.ref}
+                  onBlur={field.onBlur}
+                  options={attendeesData}
                   value={field.value ?? []}
-                  label="Attendees"
+                  onValueChange={field.onChange}
+                  loading={fetchingAttendees}
                   placeholder="Scroll to see all options"
-                  maxDropdownHeight={160}
-                  searchable
-                  error={fieldState.error?.message}
-                  withinPortal
+                  aria-labelledby="flight-attendees-label"
+                  aria-invalid={!!fieldState.error}
+                  aria-describedby={fieldState.error ? 'flight-attendees-error' : undefined}
                 />
-              )}
-            />
+                {fieldState.error?.message ? (
+                  <p id="flight-attendees-error" className="text-destructive mt-1 text-xs">
+                    {fieldState.error.message}
+                  </p>
+                ) : null}
+              </div>
+            )}
+          />
 
-            <div className="flex justify-center mt-5 gap-3">
-              <button
-                type="submit"
-                className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
-              >
-                Add
-              </button>
-            </div>
-          </form>
-        </Form>
-      </Modal.Body>
-      {(addingInProcess || fetching) && (
-        <Overlay blur={1} center>
-          <Loader />
-        </Overlay>
-      )}
-    </Modal>
+          <div className="flex justify-center mt-5 gap-3">
+            <button
+              type="submit"
+              className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
+            >
+              Add
+            </button>
+          </div>
+        </form>
+      </Form>
+      <LoadingOverlay visible={addingInProcess || fetching} blur={1} />
+    </PopUpModal>
   );
 }

--- a/packages/client/src/components/common/business-trip-report/buttons/add-other-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-other-expense.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal } from '@mantine/core';
 import type { AddBusinessTripOtherExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripOtherExpense } from '../../../../hooks/use-add-business-trip-other-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -14,9 +13,9 @@ import {
   FormMessage,
 } from '../../../ui/form.js';
 import { Input } from '../../../ui/input.js';
-import { Overlay } from '../../../ui/overlay.js';
+import { LoadingOverlay } from '../../../ui/overlay.js';
 import { Switch } from '../../../ui/switch.js';
-import { Tooltip } from '../../index.js';
+import { PopUpModal, Tooltip } from '../../index.js';
 import { AddExpenseFields } from './add-expense-fields.js';
 
 export function AddOtherExpense(props: {
@@ -78,62 +77,55 @@ function ModalContent({ businessTripId, opened, close, onAdd }: ModalProps): Rea
   };
 
   return (
-    <Modal opened={opened} onClose={close} centered lockScroll>
-      <Modal.Title>Add Other Expense</Modal.Title>
-      <Modal.Body>
-        <Form {...form}>
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
-            <AddExpenseFields
-              businessTripId={businessTripId}
-              control={control}
-              setFetching={setFetching}
-            />
+    <PopUpModal opened={opened} onClose={close} withCloseButton title="Add Other Expense">
+      <Form {...form}>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+          <AddExpenseFields
+            businessTripId={businessTripId}
+            control={control}
+            setFetching={setFetching}
+          />
 
-            <FormField
-              name="description"
-              control={control}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Description</FormLabel>
-                  <FormControl>
-                    <Input {...field} value={field.value ?? undefined} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <FormField
+            name="description"
+            control={control}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description</FormLabel>
+                <FormControl>
+                  <Input {...field} value={field.value ?? undefined} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            <FormField
-              control={form.control}
-              name="deductibleExpense"
-              render={({ field }) => (
-                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
-                  <div className="space-y-0.5">
-                    <FormLabel>Deductible Expense</FormLabel>
-                  </div>
-                  <FormControl>
-                    <Switch checked={field.value === true} onCheckedChange={field.onChange} />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
+          <FormField
+            control={form.control}
+            name="deductibleExpense"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+                <div className="space-y-0.5">
+                  <FormLabel>Deductible Expense</FormLabel>
+                </div>
+                <FormControl>
+                  <Switch checked={field.value === true} onCheckedChange={field.onChange} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
 
-            <div className="flex justify-center mt-5 gap-3">
-              <button
-                type="submit"
-                className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
-              >
-                Add
-              </button>
-            </div>
-          </form>
-        </Form>
-      </Modal.Body>
-      {(addingInProcess || fetching) && (
-        <Overlay blur={1} center>
-          <Loader />
-        </Overlay>
-      )}
-    </Modal>
+          <div className="flex justify-center mt-5 gap-3">
+            <button
+              type="submit"
+              className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
+            >
+              Add
+            </button>
+          </div>
+        </form>
+      </Form>
+      <LoadingOverlay visible={addingInProcess || fetching} blur={1} />
+    </PopUpModal>
   );
 }

--- a/packages/client/src/components/common/business-trip-report/buttons/add-travel-and-subsistence-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-travel-and-subsistence-expense.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal } from '@mantine/core';
 import type { AddBusinessTripTravelAndSubsistenceExpenseInput } from '../../../../gql/graphql.js';
 import { useAddBusinessTripTravelAndSubsistenceExpense } from '../../../../hooks/use-add-business-trip-travel-and-subsistence-expense.js';
 import { Button } from '../../../ui/button.js';
@@ -14,8 +13,8 @@ import {
   FormMessage,
 } from '../../../ui/form.js';
 import { Input } from '../../../ui/input.js';
-import { Overlay } from '../../../ui/overlay.js';
-import { Tooltip } from '../../index.js';
+import { LoadingOverlay } from '../../../ui/overlay.js';
+import { PopUpModal, Tooltip } from '../../index.js';
 import { AddExpenseFields } from './add-expense-fields.js';
 
 export function AddTravelAndSubsistenceExpense(props: {
@@ -77,47 +76,45 @@ function ModalContent({ businessTripId, opened, close, onAdd }: ModalProps): Rea
   };
 
   return (
-    <Modal opened={opened} onClose={close} centered lockScroll>
-      <Modal.Title>Add Travel & Subsistence Expense</Modal.Title>
-      <Modal.Body>
-        <Form {...form}>
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
-            <AddExpenseFields
-              businessTripId={businessTripId}
-              control={control}
-              setFetching={setFetching}
-            />
+    <PopUpModal
+      opened={opened}
+      onClose={close}
+      withCloseButton
+      title="Add Travel & Subsistence Expense"
+    >
+      <Form {...form}>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+          <AddExpenseFields
+            businessTripId={businessTripId}
+            control={control}
+            setFetching={setFetching}
+          />
 
-            <FormField
-              name="expenseType"
-              control={control}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Expense Type</FormLabel>
-                  <FormControl>
-                    <Input {...field} value={field.value ?? undefined} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+          <FormField
+            name="expenseType"
+            control={control}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Expense Type</FormLabel>
+                <FormControl>
+                  <Input {...field} value={field.value ?? undefined} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
-            <div className="flex justify-center mt-5 gap-3">
-              <button
-                type="submit"
-                className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
-              >
-                Add
-              </button>
-            </div>
-          </form>
-        </Form>
-      </Modal.Body>
-      {(addingInProcess || fetching) && (
-        <Overlay blur={1} center>
-          <Loader />
-        </Overlay>
-      )}
-    </Modal>
+          <div className="flex justify-center mt-5 gap-3">
+            <button
+              type="submit"
+              className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
+            >
+              Add
+            </button>
+          </div>
+        </form>
+      </Form>
+      <LoadingOverlay visible={addingInProcess || fetching} blur={1} />
+    </PopUpModal>
   );
 }

--- a/packages/client/src/components/common/business-trip-report/buttons/categorize-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/categorize-expense.tsx
@@ -1,15 +1,14 @@
 import { useState, type ReactElement } from 'react';
 import { Edit } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Loader, Modal, Select } from '@mantine/core';
 import {
   BusinessTripExpenseCategories,
   type CategorizeBusinessTripExpenseInput,
 } from '../../../../gql/graphql.js';
 import { useCategorizeBusinessTripExpense } from '../../../../hooks/use-categorize-business-trip-expense.js';
 import { Button } from '../../../ui/button.js';
-import { Overlay } from '../../../ui/overlay.js';
-import { Tooltip } from '../../index.js';
+import { LoadingOverlay } from '../../../ui/overlay.js';
+import { ComboBox, PopUpModal, Tooltip } from '../../index.js';
 import { NumberInput } from '../../inputs/number-input.js';
 
 export function CategorizeExpense(props: {
@@ -87,59 +86,48 @@ function ModalContent({
   };
 
   return (
-    <Modal opened={opened} onClose={close} centered>
-      <Modal.Title>Set Expense Category</Modal.Title>
-      <Modal.Body>
-        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-3 mt-3">
-          <Controller
-            name="category"
-            control={control}
-            render={({ field, fieldState }): ReactElement => (
-              <Select
-                data-autofocus
-                {...field}
-                data={categories}
-                value={field.value}
-                label="Category"
-                placeholder="Scroll to see all options"
-                maxDropdownHeight={160}
-                searchable
-                error={fieldState.error?.message}
-                withinPortal
-              />
-            )}
-          />
-          <Controller
-            name="amount"
-            control={control}
-            defaultValue={defaultAmount}
-            render={({ field, fieldState }): ReactElement => (
-              <NumberInput
-                {...field}
-                value={field.value ?? undefined}
-                hideControls
-                decimalScale={2}
-                error={fieldState.error?.message}
-                label="Amount"
-              />
-            )}
-          />
+    <PopUpModal opened={opened} onClose={close} withCloseButton title="Set Expense Category">
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-3 mt-3">
+        <Controller
+          name="category"
+          control={control}
+          render={({ field, fieldState }): ReactElement => (
+            <ComboBox
+              {...field}
+              data={categories}
+              value={field.value}
+              label="Category"
+              placeholder="Scroll to see all options"
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+        <Controller
+          name="amount"
+          control={control}
+          defaultValue={defaultAmount}
+          render={({ field, fieldState }): ReactElement => (
+            <NumberInput
+              {...field}
+              value={field.value ?? undefined}
+              hideControls
+              decimalScale={2}
+              error={fieldState.error?.message}
+              label="Amount"
+            />
+          )}
+        />
 
-          <div className="flex justify-center gap-3">
-            <button
-              type="submit"
-              className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
-            >
-              Confirm
-            </button>
-          </div>
-        </form>
-      </Modal.Body>
-      {updatingInProcess && (
-        <Overlay blur={1} center>
-          <Loader />
-        </Overlay>
-      )}
-    </Modal>
+        <div className="flex justify-center gap-3">
+          <button
+            type="submit"
+            className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
+          >
+            Confirm
+          </button>
+        </div>
+      </form>
+      <LoadingOverlay visible={updatingInProcess} blur={1} />
+    </PopUpModal>
   );
 }

--- a/packages/client/src/components/common/business-trip-report/buttons/categorize-into-existing-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/categorize-into-existing-expense.tsx
@@ -1,9 +1,8 @@
-import { forwardRef, useEffect, useState, type ReactElement } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import { toast } from 'sonner';
 import { useQuery } from 'urql';
-import { Grid, Loader, Modal, Select, Text } from '@mantine/core';
 import {
   UncategorizedTransactionsByBusinessTripDocument,
   type CategorizeIntoExistingBusinessTripExpenseInput,
@@ -11,8 +10,8 @@ import {
 } from '../../../../gql/graphql.js';
 import { useCategorizeIntoExistingBusinessTripExpense } from '../../../../hooks/use-categorize-into-existing-business-trip-expense.js';
 import { Button } from '../../../ui/button.js';
-import { Overlay } from '../../../ui/overlay.js';
-import { Tooltip } from '../../index.js';
+import { LoadingOverlay } from '../../../ui/overlay.js';
+import { ComboBox, PopUpModal, Tooltip } from '../../index.js';
 import { NumberInput } from '../../inputs/number-input.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
@@ -103,7 +102,7 @@ function ModalContent({
       defaultValues: { businessTripExpenseId },
     });
   const [uncategorizedTransactions, setUncategorizedTransactions] = useState<
-    Array<ItemProps & { value: string }>
+    Array<UncategorizedTransactionOption>
   >([]);
   const [{ data, fetching: fetchingUncategorizedTransactions, error }] = useQuery({
     query: UncategorizedTransactionsByBusinessTripDocument,
@@ -130,13 +129,17 @@ function ModalContent({
         uncategorizedTransactions
           .map(({ transaction }) => ({
             eventDate: transaction.eventDate,
-            sourceDescription: transaction.sourceDescription,
-            referenceKey: transaction.referenceKey,
-            counterparty: transaction.counterparty?.name,
-            amount: transaction.amount.formatted,
             rawAmount: transaction.amount.raw,
             value: transaction.id,
             label: `${transaction.eventDate} | ${transaction.counterparty?.name} | ${transaction.amount.formatted}`,
+            // Mantine's `itemComponent` laid the description and reference out in their own
+            // grid rows; ComboBox gives each option a second line, so they are joined into it.
+            description: [
+              transaction.sourceDescription,
+              transaction.referenceKey ? `Reference: ${transaction.referenceKey}` : null,
+            ]
+              .filter((part): part is string => !!part)
+              .join(' · '),
           }))
           .sort((a, b) => a.eventDate.localeCompare(b.eventDate)),
       );
@@ -152,101 +155,64 @@ function ModalContent({
   }, [error]);
 
   return (
-    <Modal opened={opened} onClose={close} centered>
-      <Modal.Title>Set Transaction Category</Modal.Title>
-      <Modal.Body>
-        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-3 mt-3">
-          <Controller
-            name="transactionId"
-            control={control}
-            render={({ field, fieldState }): ReactElement => (
-              <Select
-                {...field}
-                itemComponent={SelectItem}
-                data={uncategorizedTransactions ?? []}
-                disabled={fetchingUncategorizedTransactions}
-                label="Transactions"
-                placeholder="Scroll to see all options"
-                maxDropdownHeight={160}
-                error={fieldState.error?.message}
-                withAsterisk
-                withinPortal
-                onChange={transactionId => {
-                  const transaction = uncategorizedTransactions.find(
-                    transaction => transaction.value === transactionId,
-                  );
-                  if (transaction?.rawAmount) {
-                    setValue('amount', transaction.rawAmount);
-                  }
-                  field.onChange(transactionId);
-                }}
-              />
-            )}
-          />
-          <Controller
-            name="amount"
-            control={control}
-            render={({ field, fieldState }): ReactElement => (
-              <NumberInput
-                {...field}
-                value={field.value ?? undefined}
-                hideControls
-                decimalScale={2}
-                error={fieldState.error?.message}
-                label="Amount"
-              />
-            )}
-          />
-          <div className="flex justify-center gap-3">
-            <button
-              type="submit"
-              className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
-            >
-              Confirm
-            </button>
-          </div>
-        </form>
-      </Modal.Body>
-      {updatingInProcess && (
-        <Overlay blur={1} center>
-          <Loader />
-        </Overlay>
-      )}
-    </Modal>
+    <PopUpModal opened={opened} onClose={close} withCloseButton title="Set Transaction Category">
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-3 mt-3">
+        <Controller
+          name="transactionId"
+          control={control}
+          render={({ field, fieldState }): ReactElement => (
+            <ComboBox
+              {...field}
+              data={uncategorizedTransactions}
+              disabled={fetchingUncategorizedTransactions}
+              label="Transactions"
+              required
+              placeholder="Scroll to see all options"
+              error={fieldState.error?.message}
+              onChange={transactionId => {
+                const transaction = uncategorizedTransactions.find(
+                  transaction => transaction.value === transactionId,
+                );
+                if (transaction?.rawAmount) {
+                  setValue('amount', transaction.rawAmount);
+                }
+                field.onChange(transactionId);
+              }}
+            />
+          )}
+        />
+        <Controller
+          name="amount"
+          control={control}
+          render={({ field, fieldState }): ReactElement => (
+            <NumberInput
+              {...field}
+              value={field.value ?? undefined}
+              hideControls
+              decimalScale={2}
+              error={fieldState.error?.message}
+              label="Amount"
+            />
+          )}
+        />
+        <div className="flex justify-center gap-3">
+          <button
+            type="submit"
+            className="text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-hidden hover:bg-indigo-600 rounded-sm text-lg"
+          >
+            Confirm
+          </button>
+        </div>
+      </form>
+      <LoadingOverlay visible={updatingInProcess} blur={1} />
+    </PopUpModal>
   );
 }
 
-interface ItemProps extends React.ComponentPropsWithoutRef<'div'> {
-  eventDate?: string | null;
-  sourceDescription?: string | null;
-  referenceKey?: string | null;
-  counterparty?: string | null;
-  amount?: string | null;
+type UncategorizedTransactionOption = {
+  value: string;
+  label: string;
+  description: string;
+  eventDate: string;
   rawAmount?: number | null;
-}
-
-// eslint-disable-next-line react/display-name
-const SelectItem = forwardRef<HTMLDivElement, ItemProps>(
-  (
-    { eventDate, sourceDescription, referenceKey, counterparty, amount, ...other }: ItemProps,
-    ref,
-  ) => (
-    <div ref={ref} {...other}>
-      <Grid>
-        <Grid.Col span={4}>{eventDate}</Grid.Col>
-        <Grid.Col span={4}>
-          <Text size="sm">{counterparty}</Text>
-        </Grid.Col>
-        <Grid.Col span={4}>
-          <Text size="sm">{amount}</Text>
-        </Grid.Col>
-        <Grid.Col span={8}>
-          <Text size="xs" opacity={0.65}>
-            {sourceDescription}
-          </Text>
-        </Grid.Col>
-        <Grid.Col span={4}>Reference: {referenceKey}</Grid.Col>
-      </Grid>
-    </div>
-  ),
-);
+};

--- a/packages/client/src/components/common/business-trip-report/parts/flight-path-input.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/flight-path-input.tsx
@@ -8,6 +8,7 @@ import {
 import { Button } from '../../../ui/button.js';
 import { FormControl, FormField, FormItem, FormMessage } from '../../../ui/form';
 import { Input } from '../../../ui/input';
+import { Label } from '../../../ui/label.js';
 
 type Props<T extends FieldValues> = {
   formManager: UseFormReturn<T, unknown>;
@@ -33,7 +34,11 @@ export function FlightPathInput<T extends FieldValues>({
 
   return (
     <div>
-      <span className="mantine-InputWrapper-label mantine-Select-label">Flight Path</span>
+      {/* Was styled by Mantine's own `mantine-InputWrapper-label` class, which stops
+          existing once Mantine goes; this is the same look from `ui/label`. */}
+      <Label asChild>
+        <span>Flight Path</span>
+      </Label>
       <div className="h-full flex flex-col overflow-hidden">
         {controlledFields?.map((record, index) => (
           <div key={record.id} className="flex items-end gap-2 text-gray-600 mb-2">

--- a/packages/client/src/components/common/inputs/__tests__/combo-box.test.tsx
+++ b/packages/client/src/components/common/inputs/__tests__/combo-box.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { act } from 'react';
+import { act, createRef } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ComboBox } from '../combo-box.js';
@@ -93,5 +93,46 @@ describe('ComboBox trigger layout', () => {
     // The rendered trigger carries PopoverTrigger's width classes *and* our alignment.
     expect(trigger().className).toContain('w-full');
     expect(trigger().className).toContain('justify-between');
+  });
+});
+
+/**
+ * Every call site spreads react-hook-form's `field` object straight in, so whatever the
+ * component does not declare is silently dropped. `ref` and `onBlur` used not to be
+ * declared, which cost the field its touched state, its `onBlur`-mode validation and the
+ * node `shouldFocusError` needs after a failed submit.
+ */
+describe('ComboBox react-hook-form wiring', () => {
+  it('forwards a ref to the trigger without displacing the popover trigger', () => {
+    const ref = createRef<HTMLButtonElement>();
+    act(() => {
+      root.render(<ComboBox data={DATA} value={null} ref={ref} />);
+    });
+
+    expect(ref.current).toBe(trigger());
+    // Radix composes its own ref with the child's, so the popover must still work.
+    act(() => trigger().click());
+    expect(document.querySelector('[data-slot="command-list"]')).not.toBeNull();
+  });
+
+  it('calls onBlur when the trigger loses focus', () => {
+    let blurs = 0;
+    act(() => {
+      root.render(
+        <ComboBox
+          data={DATA}
+          value={null}
+          onBlur={(): void => {
+            blurs += 1;
+          }}
+        />,
+      );
+    });
+
+    act(() => {
+      trigger().focus();
+      trigger().blur();
+    });
+    expect(blurs).toBe(1);
   });
 });

--- a/packages/client/src/components/common/inputs/combo-box.tsx
+++ b/packages/client/src/components/common/inputs/combo-box.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, type ComponentProps } from 'react';
+import React, { useMemo, type ComponentProps, type Ref } from 'react';
 import { Check, ChevronDownIcon } from 'lucide-react';
 import { useMediaQuery } from '../../../hooks/use-media-query.js';
 import { cn } from '../../../lib/utils.js';
@@ -38,6 +38,14 @@ type ComboBoxProps = {
   /** Associates the trigger with a form element rendered outside it. */
   form?: string;
   required?: boolean;
+  /**
+   * Both exist for react-hook-form. Every call site spreads a `field` object in, so until
+   * these were declared the `ref` and `onBlur` inside it were dropped: the field never
+   * registered as touched, `onBlur`-mode validation never ran, and `shouldFocusError` had
+   * no node to focus after a failed submit.
+   */
+  onBlur?: () => void;
+  ref?: Ref<HTMLButtonElement>;
 };
 
 export function ComboBox({
@@ -53,6 +61,8 @@ export function ComboBox({
   id,
   form,
   required,
+  onBlur,
+  ref,
 }: ComboBoxProps) {
   const generatedId = React.useId();
   const triggerId = id ?? generatedId;
@@ -85,6 +95,8 @@ export function ComboBox({
           <PopoverTrigger asChild className="w-full min-w-40">
             <Trigger
               id={triggerId}
+              ref={ref}
+              onBlur={onBlur}
               placeholder={placeholder}
               form={form}
               aria-required={required || undefined}
@@ -121,6 +133,8 @@ export function ComboBox({
         <DrawerTrigger asChild>
           <Trigger
             id={triggerId}
+            ref={ref}
+            onBlur={onBlur}
             placeholder={placeholder}
             form={form}
             aria-required={required || undefined}


### PR DESCRIPTION
Part of the Mantine removal. Converts the eight "add / categorize expense" dialogs in `common/business-trip-report/buttons/`.

## Why this directory is its own PR

The business-trip-report subtree is 26 Mantine files, not one cluster. The split is `buttons/` (this PR, 9 files) and `parts/` (17 files: `Table` ×7, `Text` ×9, `Card`, `List`, `Grid`, `Paper`, `Popover`, three `Select`s), which overlaps the planned reports-tables work.

The cut is driven by the **stacking hazard from #4408**, not by size. Every file here holds a Mantine `Modal` with Mantine `Select`s *inside it* — converting the container to Radix while leaving Mantine overlays in it puts them behind the `z-1001` dialog. Because container and children live in the same file, each file converts atomically and the hazard never opens. I checked the other direction too: nothing Mantine is left anywhere inside these dialogs (`AddExpenseFields`, `FlightPathInput`, `NumberInput`, `CurrencyInput`, `DatePickerInput` are all shadcn), and the buttons are rendered from table cells, not from inside a Mantine overlay.

## The swap

| Mantine | Replacement |
|---|---|
| `Modal` + `Modal.Title` + `Modal.Body` | `PopUpModal` with `title` |
| `Overlay blur={1} center` + `Loader` | `LoadingOverlay` — exactly that pairing, already used by the charges screens |
| `Select` | `ComboBox` |
| `MultiSelect` | `NegatableMultiSelect`, default non-negatable mode |
| `withAsterisk` | `required` |
| `maxDropdownHeight` / `searchable` / `withinPortal` | dropped — the replacements always search, and consult `PortalContainerContext` |

`withCloseButton` is passed explicitly everywhere: Mantine defaulted it **on**, `PopUpModal` defaults it **off**.

Inside a `FormControl` the label and error come from the form field; the three bare `Controller` sites keep passing them. The one `MultiSelect` renders its label as a span wired with `aria-labelledby` — the trigger is a `div role="combobox"`, so `htmlFor` would associate nothing (same as #4423).

## The one non-mechanical file

`categorize-into-existing-expense.tsx` loses its `itemComponent` — a `Grid`/`Text` option renderer, and the only `Grid` and `Text` in this directory — along with the `forwardRef` it needed. `ComboBox` gives every option a second line, so `sourceDescription` and the reference key fold into that; the grid's top row (date | counterparty | amount) was already the option's own `label`, so nothing is lost.

Worth flagging: that `Select` had no `searchable` prop, so those options were **not** searchable before. They are now, including by description — a behaviour change, and an improvement.

## Also in here

`flight-path-input.tsx` (rendered inside these dialogs) styled its label with `mantine-InputWrapper-label`, a class that stops existing at teardown. Swapped for `ui/label`. Three more of those remain — `attendee-stay-input.tsx`, `charge-spread-input.tsx`, `string-array-input.tsx` — left for their own clusters.

## Verification

Added a story for `AddFlightExpense` (the richest of the eight: `ComboBox` + `NegatableMultiSelect` + `AddExpenseFields` + `LoadingOverlay`) on the self-contained mock-urql pattern from `charges-filters.stories.tsx` — no `yarn mock:server` needed.

Then drove it in Chromium against the built Storybook:

- dialog opens with title "Add Flight Expense", all seven labels (Date, Value Date, Amount, Currency, Attendee, Flight Class, Attendees) and a close button
- the `ComboBox` opens inside the dialog, filters 4 flight classes to 1 on "BUSINESS", and the trigger reads "Business" after selecting
- the multi-select opens and adds an "Uri Goldshtein" chip
- Escape closes the popover and leaves the dialog open; closing the dialog restores `pointer-events`
- the loading overlay covers the dialog to within its 1px border, close button included
- no page errors throughout

| Check | Result |
|---|---|
| `yarn test:client` | 46 files, 359 passed, 1 skipped |
| `yarn workspace @accounter/client build` | typechecks + builds |
| `yarn workspace @accounter/client storybook:build` | completes |
| `yarn lint` | 0 errors |
| `yarn prettier:check` | clean |

ESLint ratchet tightened to `error` for this directory.

**Mantine burn-down: 64 → 55 imports across 63 → 54 files.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR)_