### PR TITLE
docs(client): correct the CLAUDE.md testing section

### DIFF
--- a/.changeset/urql-step-0-test-docs.md
+++ b/.changeset/urql-step-0-test-docs.md
@@ -1,0 +1,15 @@
+---
+'@accounter/client': patch
+---
+
+Correct the Testing section of `packages/client/CLAUDE.md`.
+
+It claimed the package uses jsdom. The vitest `client` project sets `environment: 'happy-dom'`
+(`vitest.config.ts`), and happy-dom is the package's devDependency — jsdom is not installed at all.
+
+Also records two things that are easy to lose an afternoon to: the package has no
+`@testing-library`, so tests render by hand with `createRoot` + `act`; and `yarn generate` must run
+before `yarn test:client`, because `src/gql/` is git-ignored and 16 of the 46 test files fail to
+resolve their generated documents without it.
+
+Documentation only.

--- a/packages/client/CLAUDE.md
+++ b/packages/client/CLAUDE.md
@@ -47,7 +47,11 @@ React SPA built with Vite, urql (GraphQL), shadcn/ui, and Tailwind CSS.
 
 - Primary test directory: `src/__tests__/`
 - Colocated tests also exist (e.g. `src/components/__tests__/`)
-- Uses jsdom environment.
+- Uses the happy-dom environment (the vitest `client` project sets it, so the per-file
+  `// @vitest-environment happy-dom` pragmas are redundant).
+- There is no `@testing-library` in this package — tests render by hand with `createRoot` + `act`.
+- Run `yarn generate` first. `src/gql/` is git-ignored, and every test that imports a generated
+  document fails to resolve without it.
 
 ## Commands
 


### PR DESCRIPTION
**Step 0 of 10** in the urql quick-wins sequence — see the tracking doc in #4437.

Establishes a verified test baseline before any behavior changes, and fixes the documentation that describes it.

## Baseline

| | |
|---|---|
| `yarn install` | exit 0 (on Node 22, despite the repo pinning 26.8.1) |
| `yarn test:client` | **46 files, 358 passed, 1 skipped** |
| `yarn lint` | 0 errors, 929 warnings (all pre-existing) |

The single skip is `use-logout.test.ts`'s `it.skip('calls urqlClient.resetStore()')`. Step 4 of this sequence un-skips it — `resetStore()` is an Apollo API that urql does not have, which is why it was parked.

Everything is green, so any red in a later step of this sequence is that step's own doing.

## What changed

`packages/client/CLAUDE.md` claimed the package uses jsdom. It doesn't — the vitest `client` project sets `environment: 'happy-dom'` (`vitest.config.ts:56-70`), happy-dom is the package's devDependency, and jsdom is not installed anywhere in the repo.

Two further notes added, both surfaced by the baseline run itself:

- **No `@testing-library` in this package.** Tests render by hand with `createRoot` + `act`. Worth stating, because the natural assumption is the opposite.
- **`yarn generate` must run before `yarn test:client`.** `src/gql/` is git-ignored, so on a fresh checkout **16 of the 46 test files fail** with `Failed to resolve import "../../../../../gql/graphql.js"`. That is what a first-time run looks like, and it reads like a real breakage rather than a missing setup step.

## Notes

- Documentation and a changeset only — no source changes, so there is nothing to test beyond the baseline above.
- The `ECONNREFUSED 127.0.0.1:4000` line in the test output is expected noise: `stories.test.tsx` mounts stories against a real urql client pointed at the mock server, which isn't running. It does not fail the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbrGL3NndzRiEwJkwHxnbm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbrGL3NndzRiEwJkwHxnbm)_