### PR TITLE
feat(client): replace Mantine in the business trip report's rows and header

### DIFF
--- a/.changeset/@accounter_client-4439-dependencies.md
+++ b/.changeset/@accounter_client-4439-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@accounter/client": patch
+---
+dependencies updates:
+  - Updated dependency [`react@19.3.0` ↗︎](https://www.npmjs.com/package/react/v/19.3.0) (from `19.2.8`, in `dependencies`)
+  - Updated dependency [`react-dom@19.3.0` ↗︎](https://www.npmjs.com/package/react-dom/v/19.3.0) (from `19.2.8`, in `dependencies`)

--- a/.changeset/@accounter_scraper-app-4439-dependencies.md
+++ b/.changeset/@accounter_scraper-app-4439-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@accounter/scraper-app": patch
+---
+dependencies updates:
+  - Updated dependency [`react@19.3.0` ↗︎](https://www.npmjs.com/package/react/v/19.3.0) (from `19.2.8`, in `dependencies`)
+  - Updated dependency [`react-dom@19.3.0` ↗︎](https://www.npmjs.com/package/react-dom/v/19.3.0) (from `19.2.8`, in `dependencies`)

--- a/.changeset/@accounter_server-4439-dependencies.md
+++ b/.changeset/@accounter_server-4439-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@accounter/server": patch
+---
+dependencies updates:
+  - Updated dependency [`auth0@7.0.0` ↗︎](https://www.npmjs.com/package/auth0/v/7.0.0) (from `6.4.0`, in `dependencies`)
+  - Added dependency [`uuid@14.0.2` ↗︎](https://www.npmjs.com/package/uuid/v/14.0.2) (to `dependencies`)

--- a/.changeset/tidy-hoops-drive.md
+++ b/.changeset/tidy-hoops-drive.md
@@ -1,0 +1,6 @@
+---
+'@accounter/client': patch
+---
+
+Replace Mantine's `Text`, `List`, `Card`, `Grid`, `Select` and `MultiSelect` in the business trip
+report's row components and header with Tailwind, `ui/card`, `ComboBox` and `NegatableMultiSelect`.

--- a/packages/client/src/components/common/business-trip-report/parts/accommodations-row.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/accommodations-row.tsx
@@ -163,7 +163,7 @@ export const AccommodationsRow = ({ data, businessTripId, onChange }: Props): Re
                 </li>
               ))
             ) : (
-              <div className="text-red-500 text-sm">Missing</div>
+              <li className="list-none text-red-500 text-sm">Missing</li>
             )}
           </ul>
         )}

--- a/packages/client/src/components/common/business-trip-report/parts/accommodations-row.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/accommodations-row.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react';
 import { Check, Edit } from 'lucide-react';
 import { useForm, type Control, type SubmitHandler } from 'react-hook-form';
-import { List, Text } from '@mantine/core';
 import {
   BusinessTripReportAccommodationsRowFieldsFragmentDoc,
   type UpdateBusinessTripAccommodationsExpenseInput,
@@ -107,9 +106,9 @@ export const AccommodationsRow = ({ data, businessTripId, onChange }: Props): Re
                 )}
               />
             ) : (
-              <Text c={accommodationExpense.country ? undefined : 'red'}>
+              <div className={accommodationExpense.country ? undefined : 'text-red-500'}>
                 {accommodationExpense.country?.name ?? 'Missing'}
-              </Text>
+              </div>
             )}
           </form>
         </Form>
@@ -140,9 +139,9 @@ export const AccommodationsRow = ({ data, businessTripId, onChange }: Props): Re
               />
             </Form>
           ) : (
-            <Text c={accommodationExpense.nightsCount ? undefined : 'red'}>
+            <div className={accommodationExpense.nightsCount ? undefined : 'text-red-500'}>
               {accommodationExpense.nightsCount ?? 'Missing'}
-            </Text>
+            </div>
           )}
         </div>
       </td>
@@ -156,19 +155,17 @@ export const AccommodationsRow = ({ data, businessTripId, onChange }: Props): Re
             />
           </Form>
         ) : (
-          <List listStyleType="disc">
+          <ul className="list-disc list-inside">
             {accommodationExpense.attendeesStay?.length ? (
               accommodationExpense.attendeesStay.map(attendeeStay => (
-                <List.Item key={attendeeStay.id}>
+                <li key={attendeeStay.id}>
                   {attendeeStay.attendee.name} ({attendeeStay.nightsCount})
-                </List.Item>
+                </li>
               ))
             ) : (
-              <Text c="red" fz="sm">
-                Missing
-              </Text>
+              <div className="text-red-500 text-sm">Missing</div>
             )}
-          </List>
+          </ul>
         )}
       </td>
       <td>

--- a/packages/client/src/components/common/business-trip-report/parts/attendee-row.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/attendee-row.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react';
 import { Check, Edit } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Card } from '@mantine/core';
 import {
   BusinessTripReportAttendeeRowFieldsFragmentDoc,
   type BusinessTripAttendeeUpdateInput,
@@ -10,6 +9,7 @@ import { getFragmentData, type FragmentType } from '../../../../gql/index.js';
 import { TIMELESS_DATE_REGEX } from '../../../../helpers/consts.js';
 import { useUpdateBusinessTripAttendee } from '../../../../hooks/use-update-business-trip-attendee.js';
 import { Button } from '../../../ui/button.js';
+import { Card } from '../../../ui/card.js';
 import {
   Form,
   FormControl,
@@ -191,7 +191,10 @@ export const AttendeeRow = ({ data, businessTripId, onChange }: Props): ReactEle
       {isExtended && (
         <tr key={`${attendee.id}-expension`}>
           <td colSpan={4}>
-            <Card shadow="sm" withBorder>
+            {/* Mantine's `Card shadow="sm" withBorder` carried its own 16px padding; shadcn's has
+                none. The radius and shadow are the house Card's now, so this panel matches the
+                app's other cards rather than Mantine's 4px corners. */}
+            <Card className="p-4">
               <div className="flex flex-col gap-2">
                 {attendee.flights && (
                   <>

--- a/packages/client/src/components/common/business-trip-report/parts/attendee-stay-input.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/attendee-stay-input.tsx
@@ -8,13 +8,14 @@ import {
   type UseFormReturn,
 } from 'react-hook-form';
 import { useQuery } from 'urql';
-import { Select } from '@mantine/core';
 import { AttendeesByBusinessTripDocument } from '../../../../gql/graphql.js';
 import {
   useControlledFieldArray,
   type FieldArrayItem,
 } from '../../../../hooks/use-controlled-field-array.js';
 import { Button } from '../../../ui/button.js';
+import { Label } from '../../../ui/label.js';
+import { ComboBox } from '../../inputs/combo-box.js';
 import { NumberInput } from '../../inputs/number-input.js';
 
 type Props<T extends FieldValues> = {
@@ -96,7 +97,11 @@ export function AttendeesStayInput<T extends FieldValues>({
 
   return (
     <div>
-      <span className="mantine-InputWrapper-label mantine-Select-label">Employees Stay</span>
+      {/* Was styled by Mantine's own `mantine-InputWrapper-label` class, which stops
+          existing once Mantine goes; this is the same look from `ui/label`. */}
+      <Label asChild>
+        <span>Employees Stay</span>
+      </Label>
       <div className="h-full flex flex-col overflow-hidden">
         {controlledFields?.map((record, index) => (
           <div key={record.id} className="flex items-end gap-2 text-gray-600 mb-2">
@@ -108,17 +113,14 @@ export function AttendeesStayInput<T extends FieldValues>({
                   required: 'Required',
                 }}
                 render={({ field, fieldState }): ReactElement => (
-                  <Select
+                  <ComboBox
                     {...field}
                     disabled={fetching}
                     data={attendees}
                     value={field.value ?? undefined}
                     label="Attendee"
                     placeholder="Scroll to see all options"
-                    maxDropdownHeight={160}
-                    searchable
                     error={fieldState.error?.message}
-                    withinPortal
                     required
                   />
                 )}

--- a/packages/client/src/components/common/business-trip-report/parts/car-rental-row.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/car-rental-row.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react';
 import { Car, Check, Edit, Fuel } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { Text } from '@mantine/core';
 import {
   BusinessTripReportCarRentalRowFieldsFragmentDoc,
   type UpdateBusinessTripCarRentalExpenseInput,
@@ -88,9 +87,9 @@ export const CarRentalRow = ({ data, businessTripId, onChange }: Props): ReactEl
                     )}
                   />
                 ) : (
-                  <Text c={carRentalExpense.days ? undefined : 'red'}>
+                  <div className={carRentalExpense.days ? undefined : 'text-red-500'}>
                     {carRentalExpense.days ?? 'Missing'}
-                  </Text>
+                  </div>
                 ))}
             </div>
           </form>

--- a/packages/client/src/components/common/business-trip-report/parts/core-expense-row.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/core-expense-row.tsx
@@ -4,7 +4,6 @@ import { type Control } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useQuery } from 'urql';
-import { Select, Text } from '@mantine/core';
 import { ROUTES } from '@/router/routes.js';
 import {
   AttendeesByBusinessTripDocument,
@@ -15,7 +14,7 @@ import {
 import { getFragmentData, type FragmentType } from '../../../../gql/index.js';
 import { TIMELESS_DATE_REGEX } from '../../../../helpers/consts.js';
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '../../../ui/form.js';
-import { CurrencyInput, DatePickerInput } from '../../index.js';
+import { ComboBox, CurrencyInput, DatePickerInput } from '../../index.js';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- used by codegen
 /* GraphQL */ `
@@ -161,10 +160,10 @@ export const CoreExpenseRow = ({
           ) : (
             <>
               {businessTripExpense.date && format(new Date(businessTripExpense.date), 'dd/MM/yy')}
-              <Text fz="sm" c="dimmed">
+              <div className="text-sm text-gray-500">
                 {businessTripExpense.valueDate &&
                   format(new Date(businessTripExpense.valueDate), 'dd/MM/yy')}
-              </Text>
+              </div>
             </>
           )}
         </div>
@@ -212,7 +211,7 @@ export const CoreExpenseRow = ({
               control={control}
               defaultValue={businessTripExpense.employee?.id}
               render={({ field, fieldState }): ReactElement => (
-                <Select
+                <ComboBox
                   form={`form ${businessTripExpense.id}`}
                   {...field}
                   data={attendees}
@@ -220,19 +219,16 @@ export const CoreExpenseRow = ({
                   disabled={fetchingAttendees}
                   label="Attendee"
                   placeholder="Scroll to see all options"
-                  maxDropdownHeight={160}
-                  searchable
                   error={fieldState.error?.message}
-                  withinPortal
                 />
               )}
             />
           ) : (
             <div className="flex flex-row gap-2 items-center">
               {businessTripExpense.payedByEmployee && (
-                <Text c={businessTripExpense.employee?.name ? undefined : 'red'}>
+                <div className={businessTripExpense.employee?.name ? undefined : 'text-red-500'}>
                   {businessTripExpense.employee?.name ?? 'Missing'}
-                </Text>
+                </div>
               )}
             </div>
           )}

--- a/packages/client/src/components/common/business-trip-report/parts/flights-row.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/flights-row.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactElement } from 'react';
+import { Fragment, useState, type ReactElement } from 'react';
 import { Check, Edit } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
 import {
@@ -97,13 +97,14 @@ export const FlightsRow = ({ data, businessTripId, onChange, attendees }: Props)
                 <div className="flex gap-2 items-center">
                   {flightExpense.path?.length ? (
                     flightExpense.path.map((destination, i) => (
-                      <>
-                        <div className="font-bold" key={i}>
-                          {destination}
-                        </div>
+                      // Keyed on the fragment, not the inner div: the fragment is what `.map`
+                      // returns. The index is the key because a path can repeat a destination,
+                      // which is exactly the case the separator below distinguishes.
+                      <Fragment key={i}>
+                        <div className="font-bold">{destination}</div>
                         {i < flightExpense.path!.length - 1 &&
                           (destination === flightExpense.path![i + 1] ? ' | ' : ' → ')}
-                      </>
+                      </Fragment>
                     ))
                   ) : (
                     <div className="flex gap-2 items-center font-bold text-red-500">Missing</div>
@@ -176,7 +177,7 @@ export const FlightsRow = ({ data, businessTripId, onChange, attendees }: Props)
             {flightExpense.attendees?.length ? (
               flightExpense.attendees.map(attendee => <li key={attendee.id}>{attendee.name}</li>)
             ) : (
-              <div className="text-red-500 text-sm">Missing</div>
+              <li className="list-none text-red-500 text-sm">Missing</li>
             )}
           </ul>
         )}

--- a/packages/client/src/components/common/business-trip-report/parts/flights-row.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/flights-row.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react';
 import { Check, Edit } from 'lucide-react';
 import { Controller, useForm, type SubmitHandler } from 'react-hook-form';
-import { List, MultiSelect, Select, Text } from '@mantine/core';
 import {
   BusinessTripReportFlightsRowFieldsFragmentDoc,
   FlightClass,
@@ -9,9 +8,11 @@ import {
 } from '../../../../gql/graphql.js';
 import { getFragmentData, type FragmentType } from '../../../../gql/index.js';
 import { useUpdateBusinessTripFlightsExpense } from '../../../../hooks/use-update-business-trip-flights-expense.js';
+import { cn } from '../../../../lib/utils.js';
 import { Button } from '../../../ui/button.js';
 import { Form } from '../../../ui/form.js';
-import { Tooltip } from '../../index.js';
+import { Label } from '../../../ui/label.js';
+import { ComboBox, NegatableMultiSelect, Tooltip } from '../../index.js';
 import { CategorizeIntoExistingExpense } from '../buttons/categorize-into-existing-expense.js';
 import { DeleteBusinessTripExpense } from '../buttons/delete-business-trip-expense.js';
 import { CoreExpenseRow } from './core-expense-row.js';
@@ -97,17 +98,15 @@ export const FlightsRow = ({ data, businessTripId, onChange, attendees }: Props)
                   {flightExpense.path?.length ? (
                     flightExpense.path.map((destination, i) => (
                       <>
-                        <Text fw={700} key={i}>
+                        <div className="font-bold" key={i}>
                           {destination}
-                        </Text>
+                        </div>
                         {i < flightExpense.path!.length - 1 &&
                           (destination === flightExpense.path![i + 1] ? ' | ' : ' → ')}
                       </>
                     ))
                   ) : (
-                    <Text fw={700} className="flex gap-2 items-center" c="red">
-                      Missing
-                    </Text>
+                    <div className="flex gap-2 items-center font-bold text-red-500">Missing</div>
                   )}
                 </div>
               )}
@@ -119,26 +118,21 @@ export const FlightsRow = ({ data, businessTripId, onChange, attendees }: Props)
                     (flightExpense.class as FlightClass | null | undefined) ?? undefined
                   }
                   render={({ field, fieldState }): ReactElement => (
-                    <Select
+                    <ComboBox
                       form={`form ${flightExpense.id}`}
-                      data-autofocus
                       {...field}
                       data={flightClasses}
                       value={field.value}
                       label="Flight Class"
                       placeholder="Scroll to see all options"
-                      maxDropdownHeight={160}
-                      searchable
                       error={fieldState.error?.message}
-                      withinPortal
                     />
                   )}
                 />
               ) : (
-                <Text
-                  c={flightExpense.class ? undefined : 'red'}
-                  fz="sm"
-                >{`Class: ${flightExpense.class ?? 'Missing'}`}</Text>
+                <div
+                  className={cn('text-sm', flightExpense.class ? undefined : 'text-red-500')}
+                >{`Class: ${flightExpense.class ?? 'Missing'}`}</div>
               )}
             </div>
           </form>
@@ -151,32 +145,40 @@ export const FlightsRow = ({ data, businessTripId, onChange, attendees }: Props)
             control={control}
             defaultValue={flightExpense.attendees?.map(attendee => attendee.id) ?? undefined}
             render={({ field, fieldState }): ReactElement => (
-              <MultiSelect
-                {...field}
-                form={`form ${flightExpense.id}`}
-                data={attendeesData}
-                value={field.value ?? []}
-                label="Attendees"
-                placeholder="Scroll to see all options"
-                maxDropdownHeight={160}
-                searchable
-                error={fieldState.error?.message}
-                withinPortal
-              />
+              <div>
+                {/*
+                  `form` is not carried over: the replacement renders no native form control to
+                  associate, and the value reaches submission through react-hook-form either way.
+                  The label is a span wired by `aria-labelledby` — the trigger is a div, so
+                  `htmlFor` would associate nothing.
+                */}
+                <Label asChild className="mb-1">
+                  <span id={`flight-attendees-label-${flightExpense.id}`}>Attendees</span>
+                </Label>
+                <NegatableMultiSelect
+                  ref={field.ref}
+                  onBlur={field.onBlur}
+                  options={attendeesData}
+                  value={field.value ?? []}
+                  onValueChange={field.onChange}
+                  placeholder="Scroll to see all options"
+                  aria-labelledby={`flight-attendees-label-${flightExpense.id}`}
+                  aria-invalid={!!fieldState.error}
+                />
+                {fieldState.error?.message ? (
+                  <p className="text-destructive mt-1 text-xs">{fieldState.error.message}</p>
+                ) : null}
+              </div>
             )}
           />
         ) : (
-          <List listStyleType="disc">
+          <ul className="list-disc list-inside">
             {flightExpense.attendees?.length ? (
-              flightExpense.attendees.map(attendee => (
-                <List.Item key={attendee.id}>{attendee.name}</List.Item>
-              ))
+              flightExpense.attendees.map(attendee => <li key={attendee.id}>{attendee.name}</li>)
             ) : (
-              <Text c="red" fz="sm">
-                Missing
-              </Text>
+              <div className="text-red-500 text-sm">Missing</div>
             )}
-          </List>
+          </ul>
         )}
       </td>
       <td>

--- a/packages/client/src/components/common/business-trip-report/parts/other-row.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/other-row.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react';
 import { Check, Edit } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Text } from '@mantine/core';
 import {
   BusinessTripReportOtherRowFieldsFragmentDoc,
   type UpdateBusinessTripOtherExpenseInput,
@@ -87,9 +86,9 @@ export const OtherRow = ({ data, businessTripId, onChange }: Props): ReactElemen
                 )}
               />
             ) : (
-              <Text c={otherExpense.description ? undefined : 'red'}>
+              <div className={otherExpense.description ? undefined : 'text-red-500'}>
                 {otherExpense.description ?? 'Missing'}
-              </Text>
+              </div>
             )}
           </form>
         </Form>
@@ -116,13 +115,13 @@ export const OtherRow = ({ data, businessTripId, onChange }: Props): ReactElemen
               />
             </Form>
           ) : (
-            <Text c={otherExpense.deductibleExpense ? undefined : 'red'}>
+            <div className={otherExpense.deductibleExpense ? undefined : 'text-red-500'}>
               {otherExpense.deductibleExpense === true
                 ? 'Yes'
                 : otherExpense.deductibleExpense === false
                   ? 'No'
                   : 'Missing'}
-            </Text>
+            </div>
           )}
         </div>
       </td>

--- a/packages/client/src/components/common/business-trip-report/parts/report-header.stories.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/report-header.stories.tsx
@@ -1,0 +1,61 @@
+import type { ReactElement } from 'react';
+import { Client, Provider, type Exchange, type OperationResult } from 'urql';
+import { map, pipe } from 'wonka';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { BusinessTripReportHeaderFieldsFragmentDoc } from '../../../../gql/graphql.js';
+import type { FragmentType } from '../../../../gql/index.js';
+import { ReportHeader } from './report-header.js';
+
+/** Answers everything with null; nothing here fetches on mount. */
+const nullExchange: Exchange = () => operations$ =>
+  pipe(
+    operations$,
+    map((operation): OperationResult => ({
+      operation,
+      data: null,
+      error: undefined,
+      extensions: undefined,
+      hasNext: false,
+      stale: false,
+    })),
+  );
+
+/**
+ * `getFragmentData` is an identity function at runtime, so a plain object stands in for the
+ * masked fragment.
+ */
+const TRIP = {
+  id: 'trip-1',
+  name: 'GraphQL Conf 2026 — San Francisco',
+  dates: { start: '2026-09-08', end: '2026-09-14' },
+  purpose: 'Speaking at GraphQL Conf and meeting the platform team',
+  destination: { id: 'dest-1', name: 'San Francisco, USA' },
+  accountantApproval: 'APPROVED',
+} as unknown as FragmentType<typeof BusinessTripReportHeaderFieldsFragmentDoc>;
+
+/**
+ * Characterizes the header's grid, which replaced Mantine's `Grid`. Mantine's `Grid.Col`
+ * breakpoints are min-width based on its own scale (md 992, lg 1200, xl 1408) and do not line
+ * up with Tailwind's, so the columns use arbitrary `min-[…]` variants. Resize the preview
+ * across those three thresholds: the five fields go 1 per row, then 2, then 4, then 6 — and
+ * from 992px up "Description" moves to the end of the row.
+ */
+function Harness(): ReactElement {
+  return (
+    <Provider value={new Client({ url: '/graphql', exchanges: [nullExchange] })}>
+      <div className="p-4">
+        <ReportHeader data={TRIP} onChange={() => void 0} />
+      </div>
+    </Provider>
+  );
+}
+
+const meta = {
+  title: 'BusinessTripReport/ReportHeader',
+  component: Harness,
+} satisfies Meta<typeof Harness>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/packages/client/src/components/common/business-trip-report/parts/report-header.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/report-header.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 import { differenceInDays, format, setHours } from 'date-fns';
-import { Grid, Text } from '@mantine/core';
 import { ROUTES } from '@/router/routes.js';
 import { BusinessTripReportHeaderFieldsFragmentDoc } from '../../../../gql/graphql.js';
 import { getFragmentData, type FragmentType } from '../../../../gql/index.js';
@@ -36,10 +35,15 @@ export const ReportHeader = ({ data, onChange }: Props): ReactElement => {
 
   const { name, dates, purpose, destination } = businessTrip;
 
+  // Mantine's 12-column `Grid`, with its own breakpoints preserved: `Grid.Col`'s xl/lg/md
+  // props are min-width based on Mantine v6's scale (md 992, lg 1200, xl 1408), which does not
+  // line up with Tailwind's md/lg/xl (768/1024/1280). Hence the arbitrary `min-[…]` variants —
+  // the same call the `SimpleGrid` replacement made, so the migration does not also move the
+  // layout. `Grid.Col` defaults to span 12, and `Grid`'s default gutter is 16px.
   return (
-    <Grid>
-      <Grid.Col span={12} className="flex flex-row justify-between items-center">
-        <Text fz="xl">{name}</Text>
+    <div className="grid grid-cols-12 gap-4">
+      <div className="col-span-12 flex flex-row justify-between items-center">
+        <div className="text-xl">{name}</div>
         <div className="flex flex-row gap-2">
           <AccountantApproval data={businessTrip} onChange={onChange} />
           <CopyToClipboardButton
@@ -48,28 +52,33 @@ export const ReportHeader = ({ data, onChange }: Props): ReactElement => {
           />
           <BusinessTripToggleMenu businessTripId={businessTrip.id} />
         </div>
-      </Grid.Col>
-      <Grid.Col xl={2} lg={3} md={6}>
+      </div>
+      <div className="col-span-12 min-[992px]:col-span-6 min-[1200px]:col-span-3 min-[1408px]:col-span-2">
         From Date:
-        <Text fz="lg">{dates?.start ? format(new Date(dates.start), 'dd/MM/yy') : 'Missing'}</Text>
-      </Grid.Col>
-      <Grid.Col xl={2} lg={3} md={6}>
+        <div className="text-lg">
+          {dates?.start ? format(new Date(dates.start), 'dd/MM/yy') : 'Missing'}
+        </div>
+      </div>
+      <div className="col-span-12 min-[992px]:col-span-6 min-[1200px]:col-span-3 min-[1408px]:col-span-2">
         To Date:
-        <Text fz="lg">{dates?.end ? format(new Date(dates.end), 'dd/MM/yy') : 'Missing'}</Text>
-      </Grid.Col>
-      <Grid.Col xl={2} lg={3} md={6}>
+        <div className="text-lg">
+          {dates?.end ? format(new Date(dates.end), 'dd/MM/yy') : 'Missing'}
+        </div>
+      </div>
+      <div className="col-span-12 min-[992px]:col-span-6 min-[1200px]:col-span-3 min-[1408px]:col-span-2">
         Destination:
-        <Text fz="lg">{destination?.name}</Text>
-      </Grid.Col>
-      <Grid.Col xl={4} lg={6} md={12} orderMd={6}>
+        <div className="text-lg">{destination?.name}</div>
+      </div>
+      {/* `orderMd={6}` moved this column last from 992px up; every sibling keeps order 0. */}
+      <div className="col-span-12 min-[992px]:order-6 min-[1200px]:col-span-6 min-[1408px]:col-span-4">
         Description:
-        <Text fz="lg">{purpose}</Text>
-      </Grid.Col>
-      <Grid.Col xl={2} lg={3} md={6}>
+        <div className="text-lg">{purpose}</div>
+      </div>
+      <div className="col-span-12 min-[992px]:col-span-6 min-[1200px]:col-span-3 min-[1408px]:col-span-2">
         Total Days:
-        <Text fz="lg">{dates ? getDaysDiff(dates.start, dates.end) : 'Missing'}</Text>
-      </Grid.Col>
-    </Grid>
+        <div className="text-lg">{dates ? getDaysDiff(dates.start, dates.end) : 'Missing'}</div>
+      </div>
+    </div>
   );
 };
 

--- a/packages/client/src/components/common/business-trip-report/parts/travel-and-subsistence-row.tsx
+++ b/packages/client/src/components/common/business-trip-report/parts/travel-and-subsistence-row.tsx
@@ -1,7 +1,6 @@
 import { useState, type ReactElement } from 'react';
 import { Check, Edit } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
-import { Text } from '@mantine/core';
 import {
   BusinessTripReportTravelAndSubsistenceRowFieldsFragmentDoc,
   type UpdateBusinessTripTravelAndSubsistenceExpenseInput,
@@ -92,9 +91,9 @@ export const TravelAndSubsistenceRow = ({
                 )}
               />
             ) : (
-              <Text c={travelAndSubsistenceExpense.expenseType ? undefined : 'red'}>
+              <div className={travelAndSubsistenceExpense.expenseType ? undefined : 'text-red-500'}>
                 {travelAndSubsistenceExpense.expenseType ?? 'Missing'}
-              </Text>
+              </div>
             )}
           </form>
         </Form>


### PR DESCRIPTION
Part of the Mantine removal, and the second half of the business trip report after #4435 did `buttons/`.

Nine of the seventeen files under `common/business-trip-report/parts/`: the eight row/input components plus the report header. The remaining eight are the `Table` shells, which are their own PR — no file appears in both, so they can land in either order.

## The swaps

| Mantine | Replacement | Note |
|---|---|---|
| `Text` | `<div>` | **not `<span>`** — see below |
| `c="red"` / `c="dimmed"` | `text-red-500` / `text-gray-500` | |
| `fz="sm"` / `"lg"` / `"xl"` | `text-sm` / `text-lg` / `text-xl` | Mantine's 14/18/20px map 1:1 |
| `fw={700}` | `font-bold` | |
| `List listStyleType="disc"` | `<ul className="list-disc list-inside">` | |
| `Card shadow="sm" withBorder` | `ui/card` + `p-4` | |
| `Grid` / `Grid.Col` | 12-column Tailwind grid | see below |
| `Select` | `ComboBox` | |
| `MultiSelect` | `NegatableMultiSelect` | |

## Three things that needed checking rather than assuming

**`Text` is a `<div>`, not a `<span>`.** The migration plan said to rewrite it as `<span className=…>`, but Mantine v6's `Text` renders `component: span ? "span" : "div"` — a div unless you pass `span`. None of these sites do, so a span would have turned block elements inline and quietly reflowed every table cell.

**`list-inside`, not `pl-5`.** Mantine's `List` sets `listStylePosition: 'inside'` with `paddingLeft: 0` (it only pads when given `withPadding`). `list-disc list-inside` matches that; the `pl-5` the plan suggested would have indented the bullets.

**The grid breakpoints are Mantine's, not Tailwind's.** `Grid.Col`'s `md`/`lg`/`xl` are min-width based on Mantine v6's scale — 992/1200/1408 — which does not line up with Tailwind's md/lg/xl at 768/1024/1280. Using Tailwind's own variants would have moved the layout, which is exactly the regression review caught on the `SimpleGrid` work, so these are arbitrary `min-[…]` variants on Mantine's thresholds. Also: an unset `span` is 12 (`const colSpan = span || ctx.columns`), and `orderMd={6}` becomes `min-[992px]:order-6`.

I didn't want to take that on trust, so I measured it in Chromium against a built Storybook, sampling either side of each threshold:

| viewport | From / To / Destination / Total Days | Description | visual order |
|---|---|---|---|
| 800, 991 | 12 | 12 | source order |
| 992, 1199 | 6 | 12 | Description last |
| 1200, 1407 | 3 | 6 | Description last |
| 1408, 1500 | 2 | 4 | Description last |

That is `xl={2} lg={3} md={6}` and `xl={4} lg={6} md={12} orderMd={6}` exactly, with the transitions landing on the right pixel. A `ReportHeader` story is included so this stays checkable.

## Smaller notes

- `maxDropdownHeight`, `searchable`, `withinPortal` and `data-autofocus` are dropped as before.
- `form` is **kept** on the `ComboBox`es, which support it, and **dropped** on the multi-select: `NegatableMultiSelect` renders no native form control to associate, and the value reaches submission through react-hook-form either way.
- The `Card` panel now has the house Card's radius and shadow rather than Mantine's 4px corners, so it matches the app's other cards. Padding is added explicitly (`p-4`) because Mantine's card carried its own 16px and shadcn's carries none.
- Drops the last `mantine-InputWrapper-label` in this directory, in `attendee-stay-input.tsx`. Two remain elsewhere (`charge-spread-input.tsx`, `string-array-input.tsx`) plus `mantine-Carousel-indicator` in `documents-gallery.tsx` — these have no import, so neither the burn-down count nor the ESLint rule sees them. Worth a `grep -r 'mantine-'` before teardown.
- **No ESLint ratchet in this PR**: `parts/` still holds the eight `Table` files and the rule takes directory globs. It goes in with the tables PR.

## Verification

| Check | Result |
|---|---|
| `yarn test:client` | 46 files, 362 passed, 1 skipped |
| `yarn workspace @accounter/client build` | typechecks + builds |
| `yarn workspace @accounter/client storybook:build` | completes |
| `yarn lint` | 0 errors |
| `yarn prettier:check` | clean |

**Mantine burn-down: 55 → 46 imports across 54 → 45 files.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGLamjMKnUa7d4AedKw3XR)_