### PR TITLE
fix(client): stop double-toasting failed mutations

### DIFF
--- a/.changeset/urql-mutation-error-toast-dedupe.md
+++ b/.changeset/urql-mutation-error-toast-dedupe.md
@@ -1,0 +1,24 @@
+---
+'@accounter/client': patch
+---
+
+Stop showing two error toasts for every failed mutation.
+
+Two independent layers reported the same failure. `handleUrqlError` runs globally as
+`mapExchange({ onResult })` on the urql client and toasted `"Operation Error"` with the raw GraphQL
+message, no toast id, for 5s. Every mutation hook in `src/hooks/` separately ran its result through
+`handleCommonErrors`, which toasts `"Error"` under a stable per-entity id, for 100s, with a close
+button. A failing mutation raised both.
+
+The hook layer's toast is the better one: it names the entity that failed, it is dismissible, and
+its id is the same one the preceding `toast.loading` used, so the loading toast is replaced in place
+instead of being stacked on. `handleUrqlError` now returns early for
+`result.operation?.kind === 'mutation'` and leaves mutation reporting to the hooks.
+
+Queries are unchanged — they have no hook-level equivalent, so the global handler is still their
+only error surface. Network errors are also unchanged for both kinds: that branch stays above the
+new guard, because a mutation that never reached the server is the one case the hook layer cannot
+describe (`handleCommonErrors` can only call it "Error occurred").
+
+Optional chaining is load-bearing: a result with no `operation` at all still toasts, which is what
+the existing `ONBOARDING_REQUIRED` suppression test depends on.

--- a/packages/client/src/__tests__/urql-error-handler.test.ts
+++ b/packages/client/src/__tests__/urql-error-handler.test.ts
@@ -10,9 +10,21 @@ vi.mock('sonner', () => ({
   toast: { error: toastErrorMock },
 }));
 
-function resultWithCode(code: string): OperationResult {
+type OperationKind = 'query' | 'mutation' | 'subscription' | 'teardown';
+
+// `kind` is omitted by default on purpose: a result carrying no `operation` at
+// all must still toast, and the two original cases below cover that.
+function resultWithCode(code: string, kind?: OperationKind): OperationResult {
   return {
     error: { graphQLErrors: [{ message: 'nope', extensions: { code } }] },
+    ...(kind ? { operation: { kind } } : {}),
+  } as unknown as OperationResult;
+}
+
+function networkErrorResult(kind?: OperationKind): OperationResult {
+  return {
+    error: { networkError: new Error('offline') },
+    ...(kind ? { operation: { kind } } : {}),
   } as unknown as OperationResult;
 }
 
@@ -33,5 +45,29 @@ describe('handleUrqlError', () => {
     handleUrqlError(resultWithCode('ONBOARDING_REQUIRED'));
 
     expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('stays silent for a failing mutation', () => {
+    // Mutations already toast through `handleCommonErrors`, which produces the
+    // better message: entity-scoped, dismissible, and keyed so the loading
+    // toast is replaced in place rather than stacked on.
+    handleUrqlError(resultWithCode('FORBIDDEN', 'mutation'));
+
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('toasts a failing query', () => {
+    handleUrqlError(resultWithCode('FORBIDDEN', 'query'));
+
+    expect(toastErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still toasts a network error on a mutation', () => {
+    // A mutation that never reached the server is the one case the hook layer
+    // cannot describe — `handleCommonErrors` only manages a generic "Error
+    // occurred" for it — so the global handler keeps this one.
+    handleUrqlError(networkErrorResult('mutation'));
+
+    expect(toastErrorMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/client/src/providers/urql-error-handler.ts
+++ b/packages/client/src/providers/urql-error-handler.ts
@@ -12,6 +12,17 @@ export function handleUrqlError(result: OperationResult) {
     return;
   }
 
+  // Mutations own their error reporting: every mutation hook in `src/hooks/`
+  // runs its result through `handleCommonErrors`, which toasts an
+  // entity-scoped message under a stable id, so the loading toast it replaces
+  // never stacks. Toasting again here produced two notifications per failure —
+  // this generic one and the specific one — with only the generic one able to
+  // say nothing useful. Network errors are handled above and deliberately stay
+  // ours: `handleCommonErrors` can only report those as "Error occurred".
+  if (result.operation?.kind === 'mutation') {
+    return;
+  }
+
   // Handle common GraphQL errors with toast notifications
   if (result.error?.graphQLErrors?.length) {
     const graphqlError = result.error.graphQLErrors[0];


### PR DESCRIPTION
**Step 1 of 10** in the urql quick-wins sequence — tracking doc in #4437. Not stacked: step 0 (#4438) is merged, so this branches off `main`.

## The problem

Two independent layers reported every mutation failure:

| | Message | Toast id | Duration |
|---|---|---|---|
| `handleUrqlError` — global, via `mapExchange({ onResult })` | `"Operation Error"` + raw GraphQL message | none | 5s |
| `handleCommonErrors` — per hook, in all 97 mutation hooks | `"Error"` + entity-scoped message | stable, per entity | 100s, dismissible |

A failing mutation raised both.

## The fix

The hook layer's toast is strictly better — it names the entity that failed, it's dismissible, and its id is the same one the preceding `toast.loading` used, so the loading toast gets **replaced in place** instead of stacked on. `handleUrqlError` now returns early for `result.operation?.kind === 'mutation'` and leaves mutation reporting to the hooks.

Two things deliberately unchanged:

- **Queries** keep the global handler — they have no hook-level equivalent, so it's their only error surface.
- **Network errors** keep it too, for mutations as well. That branch sits *above* the new guard, because a mutation that never reached the server is the one failure `handleCommonErrors` cannot describe — it can only call it `"Error occurred"`.

## On the optional chaining

`result.operation?.kind` is load-bearing, not defensive. A result carrying no `operation` at all must still toast — that's what the existing `ONBOARDING_REQUIRED` suppression test depends on. The test helper gained an optional operation kind that stays **absent by default**, so both original cases still exercise that path.

## Testing

Written test-first; the mutation case was confirmed failing against the old code before the guard went in.

Three cases added to `urql-error-handler.test.ts`:
- a failing mutation → no toast
- a failing query → exactly one toast
- a **network** error on a mutation → still one toast (locks in the deliberate exception)

```
yarn test:client   46 files, 364 passed, 1 skipped
yarn lint          0 errors, 920 warnings (all pre-existing)
```

The remaining skip is `use-logout.test.ts`'s `it.skip`, which step 4 un-skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbrGL3NndzRiEwJkwHxnbm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbrGL3NndzRiEwJkwHxnbm)_