### PR TITLE
feat(client): select country in the add accommodation expense modal

### DIFF
--- a/.changeset/business-trip-accommodation-country-select.md
+++ b/.changeset/business-trip-accommodation-country-select.md
@@ -1,0 +1,11 @@
+---
+'@accounter/client': patch
+---
+
+Replace the free-text country field in the "Add Accommodation Expense" modal with the searchable
+`ComboBox`, matching the country picker already used by the issue-document client form.
+
+Options are built once at module scope from the `CountryCode` enum in `helpers/countries.ts`, so the
+label is the country name and the submitted value is the ISO alpha-3 code the
+`AddBusinessTripAccommodationsExpenseInput.country` field expects. Previously any typed string was
+sent through, including values the server could not resolve to a country.

--- a/packages/client/src/components/common/business-trip-report/buttons/add-accommodation-expense.tsx
+++ b/packages/client/src/components/common/business-trip-report/buttons/add-accommodation-expense.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactElement } from 'react';
 import { Plus } from 'lucide-react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 import { type AddBusinessTripAccommodationsExpenseInput } from '../../../../gql/graphql.js';
+import { CountryCode } from '../../../../helpers/countries.js';
 import { useAddBusinessTripAccommodationsExpense } from '../../../../hooks/use-add-business-trip-accommodations-expense.js';
 import { Button } from '../../../ui/button.js';
 import {
@@ -12,11 +13,12 @@ import {
   FormLabel,
   FormMessage,
 } from '../../../ui/form.js';
-import { Input } from '../../../ui/input.js';
 import { LoadingOverlay } from '../../../ui/overlay.js';
-import { NumberInput, PopUpModal, Tooltip } from '../../index.js';
+import { ComboBox, NumberInput, PopUpModal, Tooltip } from '../../index.js';
 import { AttendeesStayInput } from '../parts/attendee-stay-input.js';
 import { AddExpenseFields } from './add-expense-fields.js';
+
+const countries = Object.entries(CountryCode).map(([label, value]) => ({ value, label }));
 
 export function AddAccommodationExpense(props: {
   businessTripId: string;
@@ -86,16 +88,19 @@ function ModalContent({ businessTripId, opened, close, onAdd }: ModalProps): Rea
             setFetching={setFetching}
           />
 
-          {/* TODO: replace with country select */}
           <FormField
             control={control}
             name="country"
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Country</FormLabel>
-                <FormControl>
-                  <Input {...field} value={field.value ?? undefined} />
-                </FormControl>
+                <ComboBox
+                  onChange={field.onChange}
+                  data={countries}
+                  value={field.value ?? null}
+                  placeholder="Select country"
+                  formPart
+                />
                 <FormMessage />
               </FormItem>
             )}


### PR DESCRIPTION
The country field in the business trip report's "Add Accommodation Expense" modal was a free-text `Input`, carrying a `TODO: replace with country select`. Any typed string was submitted as-is, including values the server could not resolve to a country.

It is now the searchable `ComboBox`, matching the country picker already used by the issue-document client form (`forms/issue-document/client-form.tsx`).

## Changes

- `buttons/add-accommodation-expense.tsx`: `Input` → `ComboBox` with `formPart`, so the trigger renders inside the shadcn `FormControl` and keeps label/message wiring.
- Options are built once at module scope from the `CountryCode` enum in `helpers/countries.ts`: the label is the country name, the value is the ISO alpha-3 code that `AddBusinessTripAccommodationsExpenseInput.country` expects.
- Dropped the now-unused `Input` import and the `TODO` comment.

## Validation

- `yarn generate:graphql`, then `tsc --noEmit` on `@accounter/client` — clean.
- `prettier --check` and `eslint` on the changed files — clean.

The modal is a `PopUpModal` (vaul drawer); `ComboBox` already portals into the dialog container in that case, so the search input stays focusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bm3cBjh1F6n8KRTqJVEXKL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bm3cBjh1F6n8KRTqJVEXKL)_