### PR TITLE
fix(client): discard the urql client on logout

### DIFF
--- a/.changeset/urql-logout-client-reset.md
+++ b/.changeset/urql-logout-client-reset.md
@@ -1,0 +1,23 @@
+---
+'@accounter/client': patch
+---
+
+Discard the urql client on logout.
+
+`useLogout` cleared `sessionStorage` and handed off to Auth0, but left the urql client untouched. The
+call that would have fixed it was commented out with a `// TODO: clear URQL cache`, and pointed at
+`urqlClient.resetStore?.()` — an Apollo method that urql does not implement, so uncommenting it would
+have silently done nothing.
+
+`useLogout` now calls `resetUrqlClientAndNotify()`, which drops the singleton and pushes a fresh
+client into the Provider. It runs *before* `logout()`, because that triggers a full-page redirect and
+anything queued behind it may never run.
+
+This has no visible effect today: the redirect tears down module state anyway, and the client holds
+no cache to leak. It stops being harmless the moment a cache exists — a normalized cache surviving a
+logout-then-login inside one page lifetime would serve the previous user's entities to the next one.
+Landing it before `@urql/exchange-graphcache` keeps that from ever being reachable.
+
+`resetUrqlClientAndNotify` is extracted from `setBusinessScope`, which already paired
+`resetUrqlClient()` with the `onClientReset` swap. Both callers need both halves, so they now share
+one function instead of each remembering to make the second call.

--- a/packages/client/src/hooks/__tests__/use-logout.test.ts
+++ b/packages/client/src/hooks/__tests__/use-logout.test.ts
@@ -7,19 +7,27 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useLogout } from '../use-logout.js';
 import { ROUTES } from '../../router/routes.js';
 
-const { useAuth0Mock, useClientMock, logoutMock, resetStoreMock } = vi.hoisted(() => ({
-  useAuth0Mock: vi.fn(),
-  useClientMock: vi.fn(),
-  logoutMock: vi.fn(),
-  resetStoreMock: vi.fn(),
-}));
+const { useAuth0Mock, logoutMock, resetClientMock, callOrder } = vi.hoisted(() => {
+  const order: string[] = [];
+  return {
+    useAuth0Mock: vi.fn(),
+    logoutMock: vi.fn(() => {
+      order.push('logout');
+      return Promise.resolve();
+    }),
+    resetClientMock: vi.fn(() => {
+      order.push('reset');
+    }),
+    callOrder: order,
+  };
+});
 
 vi.mock('@auth0/auth0-react', () => ({
   useAuth0: useAuth0Mock,
 }));
 
-vi.mock('urql', () => ({
-  useClient: useClientMock,
+vi.mock('../../providers/urql.js', () => ({
+  resetUrqlClientAndNotify: resetClientMock,
 }));
 
 function LogoutHarness(): React.ReactElement {
@@ -63,12 +71,11 @@ describe('useLogout', () => {
     localStorage.clear();
     sessionStorage.clear();
 
-    logoutMock.mockResolvedValue(undefined);
+    callOrder.length = 0;
     useAuth0Mock.mockReturnValue({ logout: logoutMock });
-    useClientMock.mockReturnValue({ resetStore: resetStoreMock });
   });
 
-  it.skip('calls urqlClient.resetStore()', async () => {
+  it('discards the urql client on logout', async () => {
     const { container, cleanup } = await renderHarness();
     const button = container.querySelector('button');
 
@@ -77,7 +84,23 @@ describe('useLogout', () => {
       await Promise.resolve();
     });
 
-    expect(resetStoreMock).toHaveBeenCalledTimes(1);
+    expect(resetClientMock).toHaveBeenCalledTimes(1);
+
+    await cleanup();
+  });
+
+  it('discards the client before Auth0 navigates away', async () => {
+    // `logout()` triggers a full-page redirect, so anything queued after it is
+    // not guaranteed to run. The reset has to happen first.
+    const { container, cleanup } = await renderHarness();
+    const button = container.querySelector('button');
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(callOrder).toEqual(['reset', 'logout']);
 
     await cleanup();
   });

--- a/packages/client/src/hooks/use-logout.ts
+++ b/packages/client/src/hooks/use-logout.ts
@@ -1,16 +1,18 @@
-// import { useClient } from 'urql';
 import { useAuth0 } from '@auth0/auth0-react';
+import { resetUrqlClientAndNotify } from '../providers/urql.js';
 import { ROUTES } from '../router/routes.js';
 
 export function useLogout(): () => Promise<void> {
   const { logout } = useAuth0();
-  // const urqlClient = useClient();
 
   return async () => {
     sessionStorage.clear();
 
-    // TODO: clear URQL cache
-    // urqlClient.resetStore?.();
+    // Before `logout()`, not after: it navigates away, so anything queued
+    // behind it may never run. Dropping the client here discards the bearer
+    // token and hands the Provider a fresh one, so nothing a later session
+    // renders can be served from the previous user's state.
+    resetUrqlClientAndNotify();
 
     await logout({
       logoutParams: {

--- a/packages/client/src/providers/urql.tsx
+++ b/packages/client/src/providers/urql.tsx
@@ -92,8 +92,7 @@ export function setBusinessScope(ids: string[]): void {
   } catch {
     // ignore
   }
-  resetUrqlClient();
-  onClientReset?.(getUrqlClient());
+  resetUrqlClientAndNotify();
 }
 
 /**
@@ -325,6 +324,20 @@ export function resetUrqlClient(): void {
   globalClient = null;
   bearerToken = null;
   loginRedirectInProgress = false;
+}
+
+/**
+ * Discards the client and hands the Provider a fresh one.
+ *
+ * `resetUrqlClient` alone only clears the singleton, so anything already
+ * holding the old `Client` — every mounted `useQuery`, via the Provider — keeps
+ * using it, along with its bearer token and any cache an exchange is holding.
+ * Both callers need the swap as well, so they share this rather than each
+ * remembering to make the second call.
+ */
+export function resetUrqlClientAndNotify(): void {
+  resetUrqlClient();
+  onClientReset?.(getUrqlClient());
 }
 
 export function UrqlProvider({ children }: { children?: ReactNode }): ReactNode {


### PR DESCRIPTION
**Step 4 of 10** in the urql quick-wins sequence — tracking doc in #4437.

> ⚠️ **Stacked on #4443** (step 3) → #4442 → #4440. Retarget as the stack merges.

## The problem

`useLogout` cleared `sessionStorage` and handed off to Auth0, but left the urql client alone. The call that would have fixed it was commented out:

```ts
// TODO: clear URQL cache
// urqlClient.resetStore?.();
```

`resetStore()` is an **Apollo** method. urql does not implement it — so uncommenting that line would have silently done nothing, and the optional call would have swallowed the mistake. Its test was parked as `it.skip` for the same reason.

## The fix

`useLogout` now calls `resetUrqlClientAndNotify()` — **before** `logout()`, not after, because `logout()` triggers a full-page redirect and work queued behind it may never run.

## Why this matters later rather than now

Be clear about the severity: **this has no visible effect today.** The redirect tears down module state anyway, and the client currently holds no cache to leak.

It stops being harmless the moment a cache exists. A normalized cache surviving a logout-then-login inside a single page lifetime would serve the previous user's entities to the next one — and this is a multi-tenant app. Landing it now, before `@urql/exchange-graphcache`, means that window never opens.

## The extraction

`resetUrqlClient()` alone only nulls the singleton. Everything already holding the old `Client` through the Provider — every mounted `useQuery` — keeps using it, along with its bearer token.

`setBusinessScope` already knew this and paired the reset with the `onClientReset` swap. That pair is now `resetUrqlClientAndNotify()`, shared by both callers rather than each remembering to make the second call.

## Testing

Test-first: both new cases confirmed failing before the implementation, with the pre-existing Auth0 case still passing.

- the skipped test un-skipped and rewritten against the real API → asserts `resetUrqlClientAndNotify` is called once
- a new ordering case → asserts `['reset', 'logout']`, locking in the redirect constraint above

`urql-client.test.ts`'s 14 auth cases exercise `setBusinessScope` and still pass through the refactored helper.

```
yarn test:client   47 files, 371 passed, 0 skipped
yarn lint          0 errors, 909 warnings (all pre-existing)
tsc --noEmit       clean
```

**The suite has no skipped tests for the first time** — that `it.skip` was the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbrGL3NndzRiEwJkwHxnbm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbrGL3NndzRiEwJkwHxnbm)_