### PR TITLE
Add accounter_list_sort_codes tool to MCP connector

### DIFF
--- a/.changeset/mcp-sort-codes-tool.md
+++ b/.changeset/mcp-sort-codes-tool.md
@@ -1,0 +1,28 @@
+---
+'@accounter/mcp-server': minor
+---
+
+Add `accounter_list_sort_codes` to the MCP connector.
+
+The sort code (kod miyun) is the chart-of-accounts grouping every financial report buckets by —
+revenue, cost of sales, research and development, marketing, financial expenses. The connector's
+glossary already told the model that a profit-and-loss shaped question groups by sort code rather
+than by entity name, and tax-category rows already carried their own `sortCode` as `{ key, name }`,
+but nothing enumerated the groupings themselves. A model could read a code off a row it happened to
+hold; it could not learn which buckets exist, or that a key seen elsewhere has a name at all.
+
+The new read-only tool returns `{ id, key, name, ownerId, defaultIrsCode }`, filtered by `keys`,
+`nameContains` and the usual `memberBusinessIds`. `defaultIrsCode` comes along because this is the
+only place it is defined: an entity's own `irsCode` overrides it, so without the default there is no
+way to tell a deliberate override from an inherited code. `name` stays `null` for a code created
+without one rather than becoming an empty string, and an unnamed code is excluded from a name search
+instead of matching every needle.
+
+Rows are ordered by numeric `key`, tie-broken by `ownerId`, rather than by the name-then-id order
+the other lookups use: a sort code *is* its number, reports group by ranges of codes, and the name
+is nullable — sorting by it would scatter the ranges. Upstream's per-owner
+`allSortCodesByBusiness(ownerId:)` is deliberately not used, so a multi-membership scope stays a
+single query; scoping is the same defense-in-depth owner filter `accounter_list_clients` applies on
+top of RLS. The glossary's `sort-code` and `irs-code` entries now point at the tool, and it is
+registered directly after `accounter_list_tax_categories` — where the model first meets a
+`sortCode.key`.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -18,18 +18,18 @@ Phase 1 (read-only) is feature-complete. The server provides: strict startup env
 transport with `/health`, `/metrics`, the OAuth protected-resource metadata endpoint, and the MCP
 route (`POST /mcp`, JSON-RPC 2.0) with graceful shutdown; Auth0 bearer-token verification; identity
 mapping to an internal user + business-membership context with memberships resolved from the
-Accounter GraphQL server; a curated registry of fifteen read-only tools
+Accounter GraphQL server; a curated registry of sixteen read-only tools
 (`accounter_list_business_memberships`, `accounter_explain_terminology`, `accounter_search_charges`,
 `accounter_get_charges`, `accounter_get_transactions`, `accounter_get_documents`,
 `accounter_get_ledger_records`, `accounter_list_clients`, `accounter_get_contracts`,
 `accounter_list_security_holdings`, `accounter_get_security_executions`, `accounter_list_tags`,
-`accounter_list_tax_categories`, `accounter_list_businesses`, `accounter_balance_report`) each gated
-by strict input validation, a per-tool authorization policy, and business-scope narrowing forwarded
-upstream as `x-business-scope`; a hardened upstream GraphQL client (timeout, bounded retries, header
-propagation, sanitized errors); a unified error taxonomy; per-`tools/call` rate limiting; in-process
-operational metrics (request/outcome counters, a latency histogram, auth-failure counters) exposed
-at `GET /metrics`; and OpenTelemetry tracing exported to Grafana Tempo (opt-in), correlated with the
-backend via `traceparent` and `X-Correlation-Id`.
+`accounter_list_tax_categories`, `accounter_list_sort_codes`, `accounter_list_businesses`,
+`accounter_balance_report`) each gated by strict input validation, a per-tool authorization policy,
+and business-scope narrowing forwarded upstream as `x-business-scope`; a hardened upstream GraphQL
+client (timeout, bounded retries, header propagation, sanitized errors); a unified error taxonomy;
+per-`tools/call` rate limiting; in-process operational metrics (request/outcome counters, a latency
+histogram, auth-failure counters) exposed at `GET /metrics`; and OpenTelemetry tracing exported to
+Grafana Tempo (opt-in), correlated with the backend via `traceparent` and `X-Correlation-Id`.
 
 Phase 2 (write scope) has landed its first two tools — `accounter_update_charges_tags` and
 `accounter_upload_documents` — behind the `MCP_ENABLE_WRITE_TOOLS` flag, which is **off by
@@ -223,6 +223,18 @@ scope, because it _is_ the scope.
 - **`accounter_list_tax_categories`** — list tax categories (id, name, `ownerId`, IRS code,
   bookkeeping sort code, active flag), optionally filtered by name, active status, or
   `memberBusinessIds`. Same deterministic sort + cap.
+- **`accounter_list_sort_codes`** — list the chart-of-accounts sort codes (kod miyun): the numeric
+  groupings — revenue, cost of sales, research and development, marketing, financial expenses — that
+  every financial report buckets by. Rows are `{ id, key, name, ownerId, defaultIrsCode }`,
+  optionally filtered by `keys`, name, or `memberBusinessIds`. This is the other half of
+  `accounter_list_tax_categories`: a tax-category row already carries its `sortCode` as
+  `{ key, name }`, but nothing enumerated the groupings themselves, so a profit-and-loss shaped
+  question had no way to learn which buckets exist. `defaultIrsCode` lives only here — an entity's
+  own `irsCode` overrides it, so without the default there is no telling a deliberate override from
+  an inherited code. Ordered by numeric `key` (tie-broken by `ownerId`) rather than by name, which
+  is the order a chart of accounts is read in and is also nullable; upstream's per-owner
+  `allSortCodesByBusiness` is deliberately not used, so a multi-membership scope stays one query,
+  narrowed by the same defense-in-depth owner filter `accounter_list_clients` applies.
 - **`accounter_list_businesses`** — list the full business directory (id, name, `ownerId`, active
   flag, `isClient`, and the matched `taxCategory` as `{ id, name }`, or `null` when the business has
   none mapped) — every business visible to the caller, not just their memberships — optionally

--- a/packages/mcp-server/docs/spec.md
+++ b/packages/mcp-server/docs/spec.md
@@ -279,7 +279,7 @@ Recommended initial groups:
   their transactions and documents nested inline), `accounter_get_transactions`,
   `accounter_get_documents`. These narrow to the caller's businesses via RLS (`x-business-scope`),
   with an owner-scope filter as defense-in-depth where an owner is resolvable.
-- Tags and tax-category lookups
+- Tags, tax-category and sort-code lookups
 - Counterparty/business entity lookups
 - Selected report generation queries (read-only)
 - Ledger/query inspection (read-only)

--- a/packages/mcp-server/src/__tests__/mcp-e2e.test.ts
+++ b/packages/mcp-server/src/__tests__/mcp-e2e.test.ts
@@ -138,6 +138,17 @@ function upstreamData(query: string, authorization?: string): unknown {
       ],
     };
   }
+  if (query.includes('allSortCodes')) {
+    return {
+      allSortCodes: [
+        { id: `${AUTHORIZED_BUSINESS}|910`, key: 910, name: 'Revenue', ownerId: AUTHORIZED_BUSINESS, defaultIrsCode: 100 },
+        // An unnamed code, and one belonging to a business the caller is not a
+        // member of — the scope filter must drop the latter, not the former.
+        { id: `${AUTHORIZED_BUSINESS}|920`, key: 920, name: null, ownerId: AUTHORIZED_BUSINESS, defaultIrsCode: null },
+        { id: 'bb000000-0000-4000-8000-000000000002|900', key: 900, name: 'Someone else', ownerId: 'bb000000-0000-4000-8000-000000000002', defaultIrsCode: null },
+      ],
+    };
+  }
   if (query.includes('taxCategories')) {
     return {
       taxCategories: [
@@ -390,6 +401,7 @@ describe('authenticated tool invocation', () => {
         'accounter_search_charges',
         'accounter_list_tags',
         'accounter_list_tax_categories',
+        'accounter_list_sort_codes',
         'accounter_balance_report',
         'accounter_list_security_holdings',
         'accounter_get_security_executions',
@@ -429,6 +441,25 @@ describe('authenticated tool invocation', () => {
     // Green Invoice's id is flattened up out of its nested wrapper, and the five
     // unconfigured integrations are absent rather than null.
     expect(clients[0].integrations).toEqual({ greenInvoiceId: 'gi-1', hiveId: 'hive-1' });
+    expect(scope.memberBusinessIds).toEqual([AUTHORIZED_BUSINESS]);
+  });
+
+  it('lists sort codes in key order, scoped to the caller', async () => {
+    const result = await callTool('accounter_list_sort_codes', {}, 'owner-token');
+    expect(result.isError).toBeUndefined();
+    const { sortCodes, scope } = result.structuredContent as {
+      sortCodes: Array<{ key: number; name: string | null; ownerId: string; defaultIrsCode: number | null }>;
+      scope: { memberBusinessIds: string[] };
+    };
+
+    // The third fixture row belongs to another business: RLS would normally not
+    // have returned it at all, and the tool's own owner filter is what makes
+    // that a guarantee rather than an assumption.
+    expect(sortCodes.map(row => row.key)).toEqual([910, 920]);
+    expect(sortCodes[0].name).toBe('Revenue');
+    expect(sortCodes[0].defaultIrsCode).toBe(100);
+    expect(sortCodes[1].name).toBeNull();
+    expect(sortCodes.every(row => row.ownerId === AUTHORIZED_BUSINESS)).toBe(true);
     expect(scope.memberBusinessIds).toEqual([AUTHORIZED_BUSINESS]);
   });
 

--- a/packages/mcp-server/src/tools/__tests__/description-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/description-contract.test.ts
@@ -30,6 +30,7 @@ const LIST_TOOLS: ReadonlyArray<readonly [tool: string, itemsKey: string]> = [
   ['accounter_get_security_executions', 'executions'],
   ['accounter_list_tags', 'tags'],
   ['accounter_list_tax_categories', 'taxCategories'],
+  ['accounter_list_sort_codes', 'sortCodes'],
   ['accounter_list_businesses', 'businesses'],
   ['accounter_balance_report', 'rows'],
 ];

--- a/packages/mcp-server/src/tools/__tests__/lookups.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/lookups.test.ts
@@ -3,7 +3,12 @@ import { buildAuthContext, type McpAuthContext } from '../../auth/identity.js';
 import type { AuthPrincipal } from '../../auth/token.js';
 import { UpstreamGraphQLClient } from '../../upstream/graphql-client.js';
 import { executeRegisteredTool } from '../execute.js';
-import { listBusinessesTool, listTagsTool, listTaxCategoriesTool } from '../lookups.js';
+import {
+  listBusinessesTool,
+  listSortCodesTool,
+  listTagsTool,
+  listTaxCategoriesTool,
+} from '../lookups.js';
 
 function authContext(memberBusinessIds: string[]): McpAuthContext {
   const principal: AuthPrincipal = {
@@ -34,7 +39,11 @@ function clientReturning(data: unknown, capture?: (init: RequestInit) => void) {
 }
 
 const runTool = (
-  tool: typeof listTagsTool | typeof listTaxCategoriesTool | typeof listBusinessesTool,
+  tool:
+    | typeof listTagsTool
+    | typeof listTaxCategoriesTool
+    | typeof listSortCodesTool
+    | typeof listBusinessesTool,
   client: UpstreamGraphQLClient,
   auth: McpAuthContext,
   rawArgs: unknown,
@@ -138,6 +147,121 @@ describe('listTaxCategoriesTool', () => {
     });
     const rows = (result.structuredContent as { taxCategories: Array<{ name: string }> }).taxCategories;
     expect(rows.map(r => r.name)).toEqual(['Income']);
+  });
+});
+
+describe('listSortCodesTool', () => {
+  const client = () =>
+    clientReturning({
+      allSortCodes: [
+        { id: 'b1|930', key: 930, name: 'Marketing', ownerId: 'b1', defaultIrsCode: 300 },
+        { id: 'b1|910', key: 910, name: 'Revenue', ownerId: 'b1', defaultIrsCode: 100 },
+        // Unnamed and with no inherited IRS code: both are real upstream states,
+        // and both must survive as `null` rather than becoming '' or 0.
+        { id: 'b1|920', key: 920, name: null, ownerId: 'b1', defaultIrsCode: null },
+        // Another owner's chart of accounts, reusing a key — `key` is unique per
+        // owner, not globally, which is why the tie-break exists.
+        { id: 'b2|910', key: 910, name: 'Revenue', ownerId: 'b2', defaultIrsCode: 100 },
+      ],
+    });
+
+  it('returns sort codes ordered by numeric key, then ownerId', async () => {
+    const result = await runTool(listSortCodesTool, client(), authContext(['b1', 'b2']), {});
+    const rows = (
+      result.structuredContent as { sortCodes: Array<{ key: number; ownerId: string }> }
+    ).sortCodes;
+
+    expect(rows.map(row => [row.key, row.ownerId])).toEqual([
+      [910, 'b1'],
+      [910, 'b2'],
+      [920, 'b1'],
+      [930, 'b1'],
+    ]);
+  });
+
+  it('keeps a missing name and a missing defaultIrsCode as null', async () => {
+    const result = await runTool(listSortCodesTool, client(), authContext(['b1']), { keys: [920] });
+    const rows = (result.structuredContent as { sortCodes: unknown[] }).sortCodes;
+
+    expect(rows).toEqual([
+      { id: 'b1|920', key: 920, name: null, ownerId: 'b1', defaultIrsCode: null },
+    ]);
+  });
+
+  it('filters by keys', async () => {
+    const result = await runTool(listSortCodesTool, client(), authContext(['b1', 'b2']), {
+      keys: [930],
+    });
+    const structured = result.structuredContent as {
+      sortCodes: Array<{ name: string | null }>;
+      totalCount: number;
+    };
+
+    expect(structured.sortCodes.map(row => row.name)).toEqual(['Marketing']);
+    expect(structured.totalCount).toBe(1);
+  });
+
+  it('filters by nameContains (case-insensitive) and never matches an unnamed code', async () => {
+    const result = await runTool(listSortCodesTool, client(), authContext(['b1']), {
+      nameContains: 'reven',
+    });
+    const structured = result.structuredContent as {
+      sortCodes: Array<{ key: number }>;
+      totalCount: number;
+    };
+
+    // 920 has no name, so a name search excludes it rather than treating its
+    // null as an empty string that matches everything.
+    expect(structured.sortCodes.map(row => row.key)).toEqual([910]);
+    expect(structured.totalCount).toBe(1);
+  });
+
+  /**
+   * The defense-in-depth owner filter, which is what makes `memberBusinessIds`
+   * narrowing observable here: the upstream query takes no arguments, so a row
+   * belonging to an owner outside the resolved scope must be dropped locally or
+   * it reaches the caller.
+   */
+  it('drops rows owned outside the resolved scope', async () => {
+    const result = await runTool(listSortCodesTool, client(), authContext(['b1', 'b2']), {
+      memberBusinessIds: ['b2'],
+    });
+    const structured = result.structuredContent as {
+      sortCodes: Array<{ id: string; ownerId: string }>;
+      totalCount: number;
+    };
+
+    expect(structured.sortCodes.map(row => row.id)).toEqual(['b2|910']);
+    expect(structured.totalCount).toBe(1);
+  });
+
+  it('caps results and flags truncation', async () => {
+    const result = await runTool(listSortCodesTool, client(), authContext(['b1', 'b2']), {
+      limit: 2,
+    });
+    const structured = result.structuredContent as {
+      sortCodes: unknown[];
+      totalCount: number;
+      truncated: boolean;
+      continuation: { reason: string };
+    };
+
+    expect(structured.sortCodes).toHaveLength(2);
+    expect(structured.totalCount).toBe(4);
+    expect(structured.truncated).toBe(true);
+    expect(structured.continuation.reason).toBe('result_cap');
+  });
+
+  it('enforces business scope (denies a caller with no memberships)', async () => {
+    const result = await runTool(listSortCodesTool, client(), authContext([]), {});
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('AUTHORIZATION_ERROR');
+  });
+
+  it('rejects unknown input fields', async () => {
+    const result = await runTool(listSortCodesTool, client(), authContext(['b1']), { bogus: 1 });
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as { code: string }).code).toBe('VALIDATION_ERROR');
   });
 });
 
@@ -353,6 +477,9 @@ describe('lookups — business scoping', () => {
       { id: '1', name: 'a', ownerId: 'b2', irsCode: null, isActive: true, sortCode: null },
     ],
   };
+  const SORT_CODES = {
+    allSortCodes: [{ id: 'b2|910', key: 910, name: 'a', ownerId: 'b2', defaultIrsCode: null }],
+  };
   const BUSINESSES = {
     allBusinesses: { nodes: [{ id: '1', name: 'a', ownerId: 'b2', isActive: true }] },
   };
@@ -360,6 +487,7 @@ describe('lookups — business scoping', () => {
   it.each([
     ['accounter_list_tags', listTagsTool, TAGS, 'tags'],
     ['accounter_list_tax_categories', listTaxCategoriesTool, TAX_CATEGORIES, 'taxCategories'],
+    ['accounter_list_sort_codes', listSortCodesTool, SORT_CODES, 'sortCodes'],
     ['accounter_list_businesses', listBusinessesTool, BUSINESSES, 'businesses'],
   ] as const)('%s narrows to a requested subset and reflects it in scope', async (
     _name,
@@ -390,6 +518,7 @@ describe('lookups — business scoping', () => {
   it.each([
     ['accounter_list_tags', listTagsTool, TAGS],
     ['accounter_list_tax_categories', listTaxCategoriesTool, TAX_CATEGORIES],
+    ['accounter_list_sort_codes', listSortCodesTool, SORT_CODES],
     ['accounter_list_businesses', listBusinessesTool, BUSINESSES],
   ] as const)('%s denies ids outside the caller memberships', async (_name, tool, data) => {
     const result = await runTool(tool, clientReturning(data), authContext(['b1']), {

--- a/packages/mcp-server/src/tools/__tests__/scope-contract.test.ts
+++ b/packages/mcp-server/src/tools/__tests__/scope-contract.test.ts
@@ -10,7 +10,12 @@ import { getContractsTool } from '../contracts.js';
 import { getDocumentsTool } from '../document-details.js';
 import { executeRegisteredTool } from '../execute.js';
 import { getLedgerRecordsTool } from '../ledger.js';
-import { listBusinessesTool, listTagsTool, listTaxCategoriesTool } from '../lookups.js';
+import {
+  listBusinessesTool,
+  listSortCodesTool,
+  listTagsTool,
+  listTaxCategoriesTool,
+} from '../lookups.js';
 import type { ToolExecutionContext, ToolResult } from '../registry.js';
 import { balanceReportTool } from '../reports.js';
 import { getSecurityExecutionsTool, listSecurityHoldingsTool } from '../securities.js';
@@ -63,6 +68,7 @@ const BUSINESS_SCOPED_TOOLS = [
   getSecurityExecutionsTool,
   listTagsTool,
   listTaxCategoriesTool,
+  listSortCodesTool,
   listBusinessesTool,
   balanceReportTool,
 ];
@@ -80,6 +86,7 @@ const MULTI_BUSINESS_TOOLS = [
   getSecurityExecutionsTool,
   listTagsTool,
   listTaxCategoriesTool,
+  listSortCodesTool,
 ];
 
 describe('uniform business-scope input', () => {
@@ -186,6 +193,11 @@ describe('echoed effective scope', () => {
         ],
       },
       'taxCategories',
+    ],
+    [
+      listSortCodesTool,
+      { allSortCodes: [{ id: 'b1|910', key: 910, name: 'Revenue', ownerId: 'b1', defaultIrsCode: 100 }] },
+      'sortCodes',
     ],
     [
       listBusinessesTool,

--- a/packages/mcp-server/src/tools/lookups.ts
+++ b/packages/mcp-server/src/tools/lookups.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type {
   McpListBusinessesQuery,
+  McpListSortCodesQuery,
   McpListTagsQuery,
   McpListTaxCategoriesQuery,
 } from '../gql/index.js';
@@ -9,16 +10,19 @@ import type { ToolDefinition, ToolExecutionContext, ToolResult } from './registr
 import { memberBusinessIdsInput, SCOPE_DESCRIPTION_SUFFIX } from './scope-input.js';
 
 /**
- * Tool 2: read-only lookups for tags, tax categories, and businesses (spec §8.2).
+ * Tool 2: read-only lookups for tags, tax categories, sort codes, and businesses
+ * (spec §8.2).
  *
  * These are reference-data lookups. Input is minimal, output is deterministically
- * sorted (by name, then id) and size-capped. A caller must belong to at least
- * one business (scope-gated) to browse them.
+ * sorted (by name, then id — sort codes by their numeric key, see
+ * {@link byKeyThenOwner}) and size-capped. A caller must belong to at least one
+ * business (scope-gated) to browse them.
  */
 
 export const LIST_TAGS_TOOL_NAME = 'accounter_list_tags';
 export const LIST_TAX_CATEGORIES_TOOL_NAME = 'accounter_list_tax_categories';
 export const LIST_BUSINESSES_TOOL_NAME = 'accounter_list_businesses';
+export const LIST_SORT_CODES_TOOL_NAME = 'accounter_list_sort_codes';
 
 /** Hard cap on returned rows (spec §9.3). */
 export const MAX_LOOKUP_RESULTS = 1000;
@@ -187,6 +191,163 @@ export const listTaxCategoriesTool: ToolDefinition<typeof listTaxCategoriesInput
   inputSchema: listTaxCategoriesInput,
   policy: { requiresBusinessScope: true, dataClassification: 'business' },
   handler: listTaxCategoriesHandler,
+};
+
+// ---------------------------------------------------------------------------
+// Sort codes
+// ---------------------------------------------------------------------------
+
+/**
+ * The chart-of-accounts grouping (kod miyun) every financial report buckets by.
+ *
+ * This is the missing half of the tax-category lookup. A tax category already
+ * carries its `sortCode` as `{ key, name }`, so a model could read the grouping
+ * off a row it happened to have — but nothing enumerated the groupings
+ * themselves, so "show me the profit and loss by sort code" had no way to learn
+ * which buckets exist, which are revenue and which are expense, or that a code
+ * seen on one row has a name at all. The glossary already tells the model the
+ * sort code is the grouping key for report-shaped questions; this is the tool
+ * that makes acting on that possible.
+ *
+ * `defaultIrsCode` comes along because it is the only place it is defined: a
+ * financial entity's own `irsCode` overrides it, and without the default the
+ * model cannot tell an entity that was deliberately overridden from one simply
+ * inheriting its group's code.
+ */
+
+/** Upper bound on `keys` entries, matching the other id-filter caps. */
+export const MAX_SORT_CODE_KEY_FILTERS = 50;
+
+const listSortCodesInput = z.object({
+  memberBusinessIds: memberBusinessIdsInput,
+  nameContains,
+  keys: z
+    .array(z.number().int())
+    .max(MAX_SORT_CODE_KEY_FILTERS)
+    .optional()
+    .describe(
+      'Only these sort codes, by numeric `key` — the value a tax category reports as ' +
+        '`sortCode.key`. Use it to resolve codes already seen on other rows; omit it to browse ' +
+        'every group.',
+    ),
+  limit,
+});
+type ListSortCodesInput = z.infer<typeof listSortCodesInput>;
+
+// Upstream also offers `allSortCodesByBusiness(ownerId:)`, deliberately not used
+// here: it takes exactly one owner, so honoring a multi-membership scope would
+// mean one aliased query per owner for a table that is tens of rows per business
+// — the same reasoning that keeps `allClients` unfiltered upstream. The owner
+// narrowing happens below instead, where it doubles as the defense-in-depth
+// filter the other scoped tools apply.
+const LIST_SORT_CODES_QUERY = /* GraphQL */ `
+  query McpListSortCodes {
+    allSortCodes {
+      id
+      key
+      name
+      ownerId
+      defaultIrsCode
+    }
+  }
+`;
+
+/** A sort code as this tool returns it. */
+interface NormalizedSortCode {
+  id: string;
+  /** The numeric chart-of-accounts code. Unique per owner, not globally. */
+  key: number;
+  /** Null for a code that was created with no name yet — a real state upstream. */
+  name: string | null;
+  ownerId: string;
+  /** IRS code inherited by entities in this group unless they override it. */
+  defaultIrsCode: number | null;
+}
+
+/**
+ * Stable order: by numeric `key` ascending, tie-broken by `ownerId`.
+ *
+ * Deliberately not the name-then-id order the other lookups use. A sort code IS
+ * its number — accountants read a chart of accounts in code order, ranges of
+ * codes are what reports group by, and the name is nullable, so sorting by it
+ * would scatter the ranges and bunch the unnamed rows together at one end.
+ * `(key, ownerId)` is also the upstream uniqueness constraint, so the tie-break
+ * makes the order total rather than merely stable-ish across owners.
+ */
+function byKeyThenOwner(a: NormalizedSortCode, b: NormalizedSortCode): number {
+  return a.key - b.key || (a.ownerId < b.ownerId ? -1 : a.ownerId > b.ownerId ? 1 : 0);
+}
+
+async function listSortCodesHandler(
+  input: ListSortCodesInput,
+  context: ToolExecutionContext,
+): Promise<ToolResult> {
+  const data = await context.client.query<McpListSortCodesQuery>(
+    { query: LIST_SORT_CODES_QUERY },
+    context.upstream,
+  );
+
+  // Defense-in-depth owner filter on top of RLS, matching `accounter_list_clients`:
+  // a second barrier that would catch an upstream scoping regression, which an
+  // upstream filter argument — running in the same server on the same connection
+  // — could not.
+  const scopeIds = new Set(context.readScope.memberBusinessIds);
+  const requestedKeys = input.keys?.length ? new Set(input.keys) : null;
+  const needle = input.nameContains?.toLowerCase();
+
+  const matched = (data.allSortCodes ?? [])
+    .filter(sortCode => scopeIds.has(sortCode.ownerId))
+    .filter(sortCode => requestedKeys === null || requestedKeys.has(sortCode.key))
+    // An unnamed sort code cannot match a name search — it is excluded rather
+    // than treated as an empty string, which would match every needle-free call
+    // only to vanish the moment one was given.
+    .filter(
+      sortCode => needle === undefined || (sortCode.name?.toLowerCase().includes(needle) ?? false),
+    )
+    .map((sortCode): NormalizedSortCode => ({
+      id: sortCode.id,
+      key: sortCode.key,
+      name: sortCode.name ?? null,
+      ownerId: sortCode.ownerId,
+      defaultIrsCode: sortCode.defaultIrsCode ?? null,
+    }))
+    .sort(byKeyThenOwner);
+
+  // `total` counts every match, so `truncated` and the continuation hint
+  // describe the cap rather than the page.
+  const total = matched.length;
+
+  return shapeListResult({
+    items: matched.slice(0, input.limit),
+    itemsKey: 'sortCodes',
+    total,
+    extra: { scope: { memberBusinessIds: context.readScope.memberBusinessIds } },
+    summarize: (shown, count, truncated) =>
+      count === 0
+        ? 'No sort codes matched the given filters.'
+        : `Found ${count} sort ${count === 1 ? 'code' : 'codes'}${
+            truncated ? `; showing ${shown}` : ''
+          }.`,
+  });
+}
+
+export const listSortCodesTool: ToolDefinition<typeof listSortCodesInput> = {
+  name: LIST_SORT_CODES_TOOL_NAME,
+  description:
+    'List the chart-of-accounts sort codes (kod miyun) — the numeric groupings every financial ' +
+    'report buckets by, such as revenue, cost of sales, research and development, or financial ' +
+    'expenses. Each row is `{ id, key, name, ownerId, defaultIrsCode }`, ordered by `key`, where ' +
+    '`key` is the number a tax category reports as `sortCode.key` and `defaultIrsCode` is the IRS ' +
+    'code entities in the group inherit unless they override it with their own. `name` is `null` ' +
+    'for a code created without one. This is the grouping key for profit-and-loss shaped questions ' +
+    '— group by sort code rather than by entity name — and pairs with ' +
+    '`accounter_list_tax_categories` to see which accounts fall in each group. Read-only. ' +
+    resultEnvelopeDescription('sortCodes') +
+    ' ' +
+    SCOPE_DESCRIPTION_SUFFIX,
+  inputSchema: listSortCodesInput,
+  policy: { requiresBusinessScope: true, dataClassification: 'business' },
+  handler: listSortCodesHandler,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp-server/src/tools/registry-instance.ts
+++ b/packages/mcp-server/src/tools/registry-instance.ts
@@ -6,7 +6,12 @@ import { getContractsTool } from './contracts.js';
 import { getDocumentsTool } from './document-details.js';
 import { uploadDocumentsTool } from './documents-write.js';
 import { getLedgerRecordsTool } from './ledger.js';
-import { listBusinessesTool, listTagsTool, listTaxCategoriesTool } from './lookups.js';
+import {
+  listBusinessesTool,
+  listSortCodesTool,
+  listTagsTool,
+  listTaxCategoriesTool,
+} from './lookups.js';
 import { ToolRegistry } from './registry.js';
 import { balanceReportTool } from './reports.js';
 import { getSecurityExecutionsTool, listSecurityHoldingsTool } from './securities.js';
@@ -55,6 +60,10 @@ toolRegistry.register(listSecurityHoldingsTool);
 toolRegistry.register(getSecurityExecutionsTool);
 toolRegistry.register(listTagsTool);
 toolRegistry.register(listTaxCategoriesTool);
+// Sort codes directly after tax categories: a sort code is the grouping a tax
+// category belongs to, and the tax-category rows carry `sortCode.key` — so the
+// tool that names those keys is listed where the model meets them.
+toolRegistry.register(listSortCodesTool);
 // The full business directory sits with the other reference-data lookups.
 toolRegistry.register(listBusinessesTool);
 toolRegistry.register(balanceReportTool);

--- a/packages/mcp-server/src/tools/terminology-data.ts
+++ b/packages/mcp-server/src/tools/terminology-data.ts
@@ -703,7 +703,7 @@ const ENTITY_ENTRIES: readonly GlossaryEntry[] = [
       'Attached to financial entities — both businesses and tax categories. Reports do not group by individual account but by sort-code range: revenue, cost of sales, research and development, marketing, management and general, financial expenses. If you want a profit-and-loss shaped answer, the sort code is the grouping key, not the entity name.',
     aliases: ['sortCode', 'SortCode', 'קוד מיון'],
     seeAlso: ['financial-entity', 'tax-category', 'irs-code'],
-    tools: ['accounter_list_tax_categories'],
+    tools: ['accounter_list_sort_codes', 'accounter_list_tax_categories'],
   },
   {
     term: 'irs-code',
@@ -714,7 +714,7 @@ const ENTITY_ENTRIES: readonly GlossaryEntry[] = [
       'A second, coarser classification alongside the sort code, used to aggregate entities into the line items of the statutory annual financial-statement filing. Sort codes supply a default IRS code, which individual entities can override.',
     aliases: ['irsCode'],
     seeAlso: ['sort-code', 'financial-entity', 'tax-category'],
-    tools: ['accounter_list_tax_categories'],
+    tools: ['accounter_list_sort_codes', 'accounter_list_tax_categories'],
   },
   {
     term: 'financial-account',


### PR DESCRIPTION
Adds a new read-only MCP tool to enumerate chart-of-accounts sort codes (kod miyun) — the numeric groupings that financial reports bucket by (revenue, cost of sales, R&D, marketing, financial expenses, etc.).

## Summary

The sort code is a fundamental financial reporting dimension, but was previously only accessible indirectly: tax-category rows carried their own `sortCode` as `{ key, name }`, but nothing enumerated the groupings themselves. This made it impossible for the model to learn which buckets exist, which are revenue vs. expense, or that a code seen on one row has a name at all.

The new tool returns `{ id, key, name, ownerId, defaultIrsCode }` and pairs with `accounter_list_tax_categories` to show which accounts fall in each group.

## Key Changes

- **New tool `accounter_list_sort_codes`**: lists sort codes with filtering by numeric `keys`, `nameContains`, and `memberBusinessIds`
  - Rows ordered by numeric `key` (ascending), tie-broken by `ownerId` — not the name-then-id order of other lookups, because sort codes *are* their numbers and reports group by code ranges
  - `name` and `defaultIrsCode` preserved as `null` (not empty string/0) when absent upstream
  - Unnamed codes excluded from name searches rather than matching every needle
  - Defense-in-depth owner filter on top of RLS, matching `accounter_list_clients`

- **Input schema**: `memberBusinessIds`, `nameContains`, `keys` (array of integers, max 50), `limit`

- **Test coverage**: unit tests for ordering, filtering, null handling, scope enforcement, and truncation; integration tests in e2e suite

- **Documentation**: updated README tool count (15→16), added tool description, updated glossary entries to reference the new tool

- **Registration**: tool registered directly after `accounter_list_tax_categories` in the registry, with explanatory comment about the relationship

## Implementation Details

- Upstream query `allSortCodes` takes no arguments, so multi-membership scoping stays a single query with local filtering
- `defaultIrsCode` is included because this is the only place it is defined; an entity's own `irsCode` overrides it, so without the default there is no way to distinguish a deliberate override from inheritance
- Sorting by `(key, ownerId)` is also the upstream uniqueness constraint, making the order total rather than merely stable across owners

https://claude.ai/code/session_01MCCoLH5JBuiAQE4AXQ3NQy